### PR TITLE
feat(build): gate SCTP behind opt-in `sctp` Cargo feature (off by default)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,21 @@ env:
 
 jobs:
   # ── Rust unit + integration tests ────────────────────────────────────────
+  # Run twice: the default build (no SCTP — proves the crate compiles and the
+  # suite passes WITHOUT the libsctp system dependency) and the `sctp` feature
+  # (exercises the gated SIP/Diameter-over-SCTP transport code).
   rust-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: default
+            flags: ""
+            sctp: false
+          - name: sctp
+            flags: "--features sctp"
+            sctp: true
+    name: rust-tests (${{ matrix.name }})
     steps:
       - uses: actions/checkout@v7
 
@@ -23,7 +36,8 @@ jobs:
         with:
           python-version: "3.14-dev"
 
-      - name: Install system dependencies
+      - name: Install SCTP system dependency
+        if: ${{ matrix.sctp }}
         run: sudo apt-get update && sudo apt-get install -y libsctp-dev
 
       - uses: dtolnay/rust-toolchain@stable
@@ -31,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run tests
-        run: PYO3_PYTHON=python3.14 cargo test
+        run: PYO3_PYTHON=python3.14 cargo test ${{ matrix.flags }}
 
   # ── Clippy lint gate ────────────────────────────────────────────────────
   # Mirrors the rust-tests build env (free-threaded Python 3.14 + libsctp-dev
@@ -57,7 +71,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run clippy
+      # Lint both feature configs: the default build (SCTP off — guards against
+      # unused imports/variables that only surface when the feature is disabled)
+      # and `--all-features` (SCTP on — compiles the gated libsctp code).
+      - name: Run clippy (default features)
+        run: PYO3_PYTHON=python3.14 cargo clippy --all-targets -- -D warnings
+
+      - name: Run clippy (all features)
         run: PYO3_PYTHON=python3.14 cargo clippy --all-targets --all-features -- -D warnings
 
   # ── Python SDK tests ──────────────────────────────────────────────────
@@ -221,9 +241,6 @@ jobs:
         uses: deadsnakes/action@v3.2.0
         with:
           python-version: "3.14-dev"
-
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libsctp-dev
 
       - uses: dtolnay/rust-toolchain@nightly
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,9 +64,8 @@ jobs:
         with:
           python-version: "3.14-dev"
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libsctp-dev
-
+      # Default release build excludes SCTP (the `sctp` Cargo feature is off by
+      # default), so no libsctp system dependency is needed here.
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -136,9 +135,8 @@ jobs:
         with:
           python-version: "3.14-dev"
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libsctp-dev
-
+      # `cargo publish` verifies with default features (SCTP off), so the
+      # libsctp system dependency is not required to publish.
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Authenticate to crates.io (OIDC Trusted Publishing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to SIPhon are documented here. The format loosely follows
 [Keep a Changelog](https://keepachangelog.com/). Versioning is lockstep across
 the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
+## [Unreleased]
+
+### Changed
+- **SCTP is now an opt-in build feature, off by default.** SIP-over-SCTP
+  (RFC 4168) and Diameter-over-SCTP link the `libsctp` system library, which
+  only exists on Linux. Moving them behind the `sctp` Cargo feature lets the
+  default build — including the official Docker image and the prebuilt release
+  packages (`.deb` / `.rpm` / tarball) — drop the `libsctp-dev` / `libsctp1`
+  dependency and build cleanly on macOS and Windows.
+  - **To enable SCTP:** build with `--features sctp` (on Linux, install
+    `libsctp-dev` first). The official Docker image and release binaries do
+    **not** include SCTP — you must build it yourself.
+  - **No config or scripting-API breakage:** the `Transport::Sctp` variant and
+    the `listen.sctp` config block still exist, so existing configs parse
+    unchanged whether or not the feature is enabled.
+  - **When built without SCTP:** a configured `listen.sctp` listener is skipped
+    with a warning, and a Diameter peer set to `transport: sctp` fails at
+    connect with `ErrorKind::Unsupported` (no silent fallback to TCP).
+  - CI builds and tests both configurations (default and `--features sctp`).
+
 ## [1.0.0] — 2026-06-26
 
 First stable release. A love letter to Kamailio and OpenSIPS — their proven

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,12 @@ rustls-pki-types = { version = "1", features = ["std"] }
 webpki-roots = "1"
 tokio-tungstenite = "0.28"
 futures-util = "0.3"
-tokio-sctp = "0.2"
+# SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
+# links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
+# and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
+# it. Gated behind the `sctp` feature (off by default); enable with
+# `--features sctp`.
+tokio-sctp = { version = "0.2", optional = true }
 http = "1"
 
 # Diameter AVP decoding
@@ -150,6 +155,13 @@ rcgen = "0.14"
 default = ["redis-backend", "postgres-backend"]
 redis-backend = ["dep:redis"]
 postgres-backend = ["dep:tokio-postgres"]
+# SIP-over-SCTP + Diameter-over-SCTP transport. Off by default because it pulls
+# the `libsctp` system library and kernel SCTP module; enable with
+# `--features sctp` (CI exercises this via `--all-features`). When disabled, the
+# `Transport::Sctp` enum variant still exists (config still parses), but no SCTP
+# listener is started and a configured `listen.sctp` block is ignored with a
+# loud warning; a Diameter peer with `transport: sctp` errors at connect time.
+sctp = ["dep:tokio-sctp"]
 
 # --- Lint policy ---
 # The codebase is clippy-clean (see `clippy.toml` for the one tuned threshold).

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         pkg-config \
         libssl-dev \
-        libsctp-dev \
         xz-utils \
     && rm -rf /var/lib/apt/lists/*
+# NOTE: the default build excludes SIP/Diameter-over-SCTP (the `sctp` Cargo
+# feature is off by default), so libsctp-dev is not needed. To build an
+# SCTP-capable image, add `libsctp-dev` here, `libsctp1` to the runtime stage,
+# and pass `--features sctp` to the `cargo build` below.
 
 # uv: standalone Python installer + project manager. Pulls
 # python-build-standalone binaries (no apt python needed).
@@ -80,7 +83,6 @@ FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         libssl3 \
-        libsctp1 \
         iproute2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This isn't a replacement for Kamailio or OpenSIPS. It's what happens when someon
 | **TCP Transport** | RFC 3261 §18 | Unit tests, connection pool |
 | **TLS Transport** | RFC 5246 (TLS 1.3) | Unit tests |
 | **WebSocket (WS/WSS)** | RFC 7118 | Unit tests |
-| **SCTP Transport** | RFC 4168 | Unit tests |
+| **SCTP Transport** | RFC 4168 | Unit tests (opt-in `sctp` feature) |
 | **NAT Traversal (rport)** | RFC 3581 | Unit tests |
 | **Outbound / Flow Tokens** | RFC 5626 | Unit tests |
 | **DNS SRV/NAPTR** | RFC 3263 | Unit + integration tests |
@@ -146,6 +146,14 @@ cargo install siphon-sip
 cargo install siphon-sip --features redis-backend,postgres-backend
 ```
 
+**SCTP transport is off by default.** SIP/Diameter-over-SCTP (RFC 4168) links
+the `libsctp` system library and is Linux-only, so it is gated behind the `sctp`
+Cargo feature. Enable it explicitly (and install `libsctp-dev` first on Linux):
+
+```bash
+cargo install siphon-sip --features sctp
+```
+
 ### Option 2: Docker
 
 ```bash
@@ -154,6 +162,11 @@ docker pull ghcr.io/siphon-project/siphon-sip:latest
 # Or build locally
 docker build -t siphon .
 ```
+
+> **Note:** the published Docker image is the default build — it does **not**
+> include SCTP. If you need SIP/Diameter-over-SCTP, build a custom image with the
+> `sctp` feature (add `libsctp-dev`/`libsctp1` and `cargo build --features sctp`
+> to the [Dockerfile](Dockerfile)).
 
 ### Option 3: Debian/Ubuntu (.deb)
 

--- a/src/diameter/transport.rs
+++ b/src/diameter/transport.rs
@@ -5,20 +5,28 @@
 //!
 //! SCTP uses `tokio-sctp` with a duplex bridge: background tasks do
 //! recvmsg/sendmsg while the user-facing side implements AsyncRead/AsyncWrite.
+//! It links the `libsctp` system library, so the whole SCTP half of this module
+//! is gated behind the `sctp` Cargo feature (off by default). When the feature
+//! is disabled, only the TCP transport is compiled in and
+//! [`connect`] rejects `transport == "sctp"` with `ErrorKind::Unsupported`.
 
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+#[cfg(feature = "sctp")]
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tokio::net::{TcpListener, TcpStream};
+#[cfg(feature = "sctp")]
 use tokio_sctp::{SctpListener, SctpStream, SendOptions};
 
 // ── SCTP AsyncRead/AsyncWrite bridge ────────────────────────────────────
 
 /// Wrapper around `tokio_sctp::SctpStream` that implements `AsyncRead + AsyncWrite`
 /// by bridging through background tasks that call recvmsg/sendmsg on SCTP stream 0.
+#[cfg(feature = "sctp")]
 pub struct SctpAsyncStream {
     reader: DuplexStream,
     writer: DuplexStream,
@@ -26,6 +34,7 @@ pub struct SctpAsyncStream {
     peer_addr: SocketAddr,
 }
 
+#[cfg(feature = "sctp")]
 impl SctpAsyncStream {
     pub fn new(stream: SctpStream) -> Self {
         let fallback_addr = SocketAddr::from(([0, 0, 0, 0], 0));
@@ -99,6 +108,7 @@ impl SctpAsyncStream {
     }
 }
 
+#[cfg(feature = "sctp")]
 impl AsyncRead for SctpAsyncStream {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -109,6 +119,7 @@ impl AsyncRead for SctpAsyncStream {
     }
 }
 
+#[cfg(feature = "sctp")]
 impl AsyncWrite for SctpAsyncStream {
     fn poll_write(
         mut self: Pin<&mut Self>,
@@ -132,6 +143,7 @@ impl AsyncWrite for SctpAsyncStream {
 /// A Diameter transport stream, either TCP or SCTP.
 pub enum DiameterStream {
     Tcp(TcpStream),
+    #[cfg(feature = "sctp")]
     Sctp(SctpAsyncStream),
 }
 
@@ -139,6 +151,7 @@ impl DiameterStream {
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         match self {
             DiameterStream::Tcp(s) => s.peer_addr(),
+            #[cfg(feature = "sctp")]
             DiameterStream::Sctp(s) => s.peer_addr(),
         }
     }
@@ -146,6 +159,7 @@ impl DiameterStream {
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         match self {
             DiameterStream::Tcp(s) => s.local_addr(),
+            #[cfg(feature = "sctp")]
             DiameterStream::Sctp(s) => s.local_addr(),
         }
     }
@@ -153,6 +167,7 @@ impl DiameterStream {
     pub fn transport_name(&self) -> &'static str {
         match self {
             DiameterStream::Tcp(_) => "TCP",
+            #[cfg(feature = "sctp")]
             DiameterStream::Sctp(_) => "SCTP",
         }
     }
@@ -164,6 +179,7 @@ impl From<TcpStream> for DiameterStream {
     }
 }
 
+#[cfg(feature = "sctp")]
 impl From<SctpAsyncStream> for DiameterStream {
     fn from(s: SctpAsyncStream) -> Self {
         DiameterStream::Sctp(s)
@@ -178,6 +194,7 @@ impl AsyncRead for DiameterStream {
     ) -> Poll<io::Result<()>> {
         match self.get_mut() {
             DiameterStream::Tcp(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "sctp")]
             DiameterStream::Sctp(s) => Pin::new(s).poll_read(cx, buf),
         }
     }
@@ -191,6 +208,7 @@ impl AsyncWrite for DiameterStream {
     ) -> Poll<io::Result<usize>> {
         match self.get_mut() {
             DiameterStream::Tcp(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "sctp")]
             DiameterStream::Sctp(s) => Pin::new(s).poll_write(cx, buf),
         }
     }
@@ -198,6 +216,7 @@ impl AsyncWrite for DiameterStream {
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.get_mut() {
             DiameterStream::Tcp(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "sctp")]
             DiameterStream::Sctp(s) => Pin::new(s).poll_flush(cx),
         }
     }
@@ -205,6 +224,7 @@ impl AsyncWrite for DiameterStream {
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.get_mut() {
             DiameterStream::Tcp(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "sctp")]
             DiameterStream::Sctp(s) => Pin::new(s).poll_shutdown(cx),
         }
     }
@@ -215,6 +235,7 @@ impl AsyncWrite for DiameterStream {
 /// A Diameter listener, either TCP or SCTP.
 pub enum DiameterListener {
     Tcp(TcpListener),
+    #[cfg(feature = "sctp")]
     Sctp(SctpListener),
 }
 
@@ -226,6 +247,7 @@ impl DiameterListener {
     }
 
     /// Bind an SCTP listener.
+    #[cfg(feature = "sctp")]
     pub fn bind_sctp(addr: SocketAddr) -> io::Result<Self> {
         let listener = SctpListener::bind(addr)?;
         Ok(DiameterListener::Sctp(listener))
@@ -238,6 +260,7 @@ impl DiameterListener {
                 let (stream, addr) = l.accept().await?;
                 Ok((DiameterStream::Tcp(stream), addr))
             }
+            #[cfg(feature = "sctp")]
             DiameterListener::Sctp(l) => {
                 let (stream, addr) = l.accept().await?;
                 Ok((DiameterStream::Sctp(SctpAsyncStream::new(stream)), addr))
@@ -248,6 +271,7 @@ impl DiameterListener {
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         match self {
             DiameterListener::Tcp(l) => l.local_addr(),
+            #[cfg(feature = "sctp")]
             DiameterListener::Sctp(l) => l.local_addr(),
         }
     }
@@ -255,6 +279,7 @@ impl DiameterListener {
     pub fn transport_name(&self) -> &'static str {
         match self {
             DiameterListener::Tcp(_) => "TCP",
+            #[cfg(feature = "sctp")]
             DiameterListener::Sctp(_) => "SCTP",
         }
     }
@@ -263,6 +288,7 @@ impl DiameterListener {
 /// Connect to a Diameter peer over TCP or SCTP.
 pub async fn connect(addr: &str, transport: &str) -> io::Result<DiameterStream> {
     match transport {
+        #[cfg(feature = "sctp")]
         "sctp" => {
             let addr: SocketAddr = addr.parse().map_err(|e| {
                 io::Error::new(io::ErrorKind::InvalidInput, format!("bad address: {}", e))
@@ -270,6 +296,12 @@ pub async fn connect(addr: &str, transport: &str) -> io::Result<DiameterStream> 
             let stream = SctpAsyncStream::connect(addr).await?;
             Ok(DiameterStream::Sctp(stream))
         }
+        #[cfg(not(feature = "sctp"))]
+        "sctp" => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Diameter-over-SCTP requested but this binary was built without the `sctp` feature; \
+             rebuild with `--features sctp`",
+        )),
         _ => {
             let stream = TcpStream::connect(addr).await?;
             Ok(DiameterStream::Tcp(stream))

--- a/src/server.rs
+++ b/src/server.rs
@@ -904,7 +904,14 @@ impl SiphonServer {
         let (tls_outbound_tx, tls_outbound_rx) = flume::unbounded::<transport::OutboundMessage>();
         let (ws_outbound_tx, ws_outbound_rx) = flume::unbounded::<transport::OutboundMessage>();
         let (wss_outbound_tx, wss_outbound_rx) = flume::unbounded::<transport::OutboundMessage>();
+        // The `sctp` sender always exists on the OutboundRouter so the
+        // `Transport::Sctp` routing arm stays infallible; the receiver is only
+        // consumed by the SCTP listener loop, which is compiled in under the
+        // `sctp` feature. Without it the receiver is intentionally unused.
+        #[cfg(feature = "sctp")]
         let (sctp_outbound_tx, sctp_outbound_rx) = flume::unbounded::<transport::OutboundMessage>();
+        #[cfg(not(feature = "sctp"))]
+        let (sctp_outbound_tx, _sctp_outbound_rx) = flume::unbounded::<transport::OutboundMessage>();
 
         // UDP listeners get a dedicated outbound channel each — required
         // for IPsec sec-agree on the P-CSCF role (3GPP TS 33.203 §7.4)
@@ -1182,23 +1189,37 @@ impl SiphonServer {
             }
         }
 
-        // SCTP
-        let sctp_connection_map = Arc::new(dashmap::DashMap::new());
-        for entry in &config.listen.sctp {
-            let addr: std::net::SocketAddr = entry.address().parse().unwrap_or_else(|error| {
-                eprintln!("Invalid SCTP listen address '{}': {error}", entry.address());
-                std::process::exit(1);
-            });
-            if first_listen_addr.is_none() {
-                first_listen_addr = Some(addr);
+        // SCTP — compiled in only under the `sctp` feature (links libsctp).
+        #[cfg(feature = "sctp")]
+        {
+            let sctp_connection_map = Arc::new(dashmap::DashMap::new());
+            for entry in &config.listen.sctp {
+                let addr: std::net::SocketAddr = entry.address().parse().unwrap_or_else(|error| {
+                    eprintln!("Invalid SCTP listen address '{}': {error}", entry.address());
+                    std::process::exit(1);
+                });
+                if first_listen_addr.is_none() {
+                    first_listen_addr = Some(addr);
+                }
+                listen_addrs.entry(transport::Transport::Sctp).or_insert(addr);
+                if let Some(adv) = entry.advertise() {
+                    advertised_addrs.entry(transport::Transport::Sctp).or_insert_with(|| adv.to_string());
+                }
+                let tos = resolve_tos(entry);
+                info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting SCTP transport");
+                transport::sctp::listen(addr, inbound_tx.clone(), sctp_outbound_rx.clone(), Arc::clone(&sctp_connection_map), Arc::clone(&transport_acl), tos).await;
             }
-            listen_addrs.entry(transport::Transport::Sctp).or_insert(addr);
-            if let Some(adv) = entry.advertise() {
-                advertised_addrs.entry(transport::Transport::Sctp).or_insert_with(|| adv.to_string());
-            }
-            let tos = resolve_tos(entry);
-            info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting SCTP transport");
-            transport::sctp::listen(addr, inbound_tx.clone(), sctp_outbound_rx.clone(), Arc::clone(&sctp_connection_map), Arc::clone(&transport_acl), tos).await;
+        }
+        // Built without the `sctp` feature: any configured SCTP listener cannot
+        // be honoured. Warn loudly rather than silently dropping it so the
+        // misconfiguration is visible (rebuild with `--features sctp`).
+        #[cfg(not(feature = "sctp"))]
+        if !config.listen.sctp.is_empty() {
+            tracing::warn!(
+                count = config.listen.sctp.len(),
+                "listen.sctp configured but this binary was built without the `sctp` feature; \
+                 SCTP listeners are ignored. Rebuild with `--features sctp` to enable SIP-over-SCTP."
+            );
         }
 
         let local_addr = first_listen_addr.unwrap_or_else(|| {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -5,6 +5,7 @@ pub mod udp;
 pub mod tcp;
 pub mod tls;
 pub mod ws;
+#[cfg(feature = "sctp")]
 pub mod sctp;
 pub mod pool;
 pub mod rate_limit;


### PR DESCRIPTION
## What

Makes SCTP an **opt-in Cargo feature (`sctp`), off by default**. SIP-over-SCTP (RFC 4168) and Diameter-over-SCTP link the `libsctp` system library, which is **Linux-only** — gating them lets the default build (and the official Docker image / release packages) drop the `libsctp-dev` / `libsctp1` dependency and build cleanly on macOS and Windows.

## Why

`libsctp` requires the kernel SCTP module and only exists on Linux. Most SIP proxy / B2BUA deployments never use SCTP, and contributors on macOS/Windows shouldn't need a Linux-only system library just to `cargo build`.

## Design

Only the code that actually touches `tokio-sctp` is gated. The pure-Rust `Transport::Sctp` enum variant, the `OutboundRouter.sctp` routing arm, the `listen.sctp` config schema, and every `;transport=sctp` / HEP / DNS / scripting-API match arm stay compiled in unconditionally — so **configs parse identically whether or not the feature is enabled**, and none of the dozens of match sites needed touching.

Gated pieces:
- `src/transport/mod.rs` — `#[cfg(feature = "sctp")] pub mod sctp;`
- `src/server.rs` — the SCTP listener loop. Built **without** the feature, a configured `listen.sctp` block is **ignored with a loud warning** (not silently dropped).
- `src/diameter/transport.rs` — `SctpAsyncStream`, the `DiameterStream::Sctp` / `DiameterListener::Sctp` variants + arms, `bind_sctp`. A Diameter peer with `transport: sctp` now **fails at connect with `ErrorKind::Unsupported`** instead of silently falling back to TCP.

## Build / CI / release

- **Dockerfile** — drops `libsctp-dev` / `libsctp1` from both stages.
- **ci.yaml** — `rust-tests` is now a matrix (`default` without libsctp, `sctp` with it); `clippy` lints **both** configs; `fuzz` drops libsctp.
- **release.yaml** — binary `build` + `crates-io` jobs drop libsctp.

⚠️ **The official Docker image and release binaries (`.deb` / `.rpm` / tarball) ship _without_ SCTP.** Operators who need Diameter/SIP-over-SCTP must build with `--features sctp` (and re-add `libsctp-dev` / `libsctp1`). This is intentional — see README/CHANGELOG.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean (default)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean (sctp on)
- `cargo test` — **2917 passed**, 3 ignored (default)
- `cargo test --features sctp` — **2920 passed**, 3 ignored (+3 = gated SCTP transport tests)

SIPp functional + B2BUA suites run on this PR via CI. No perf-baseline run: this is a compile-time gate that removes a module from the default build with no change to the proxy/B2BUA hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
