### PR TITLE
feat(metrics): glibc raw-domain allocator gauges + control-plane leak guards

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,34 @@ fn expand_env_vars(input: &str) -> String {
         .into_owned()
 }
 
+/// Allocator runtime tuning — how the process *manages* memory, distinct from
+/// `metrics` (what it *measures*). The `siphon_glibc_*` gauges are always on
+/// regardless of this block; it carries only the optional bounding knobs.
+#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+pub struct MemoryConfig {
+    /// glibc malloc tuning for the C-side / CPython raw-domain pool.
+    #[serde(default)]
+    pub glibc: GlibcMemoryConfig,
+}
+
+/// glibc `malloc` tuning. Both knobs default off — measure with the gauges
+/// first, then bound only if the pool proves to be arena *retention* rather
+/// than a true leak.
+#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+pub struct GlibcMemoryConfig {
+    /// `mallopt(M_ARENA_MAX, n)` — cap the number of glibc arenas (each a
+    /// ~64 MB reservation). The primary lever against per-thread-arena
+    /// retention under free-threaded concurrency. `None` = leave glibc's
+    /// default (8 × CPUs). Applied once at startup, before the thread pools.
+    #[serde(default)]
+    pub arena_max: Option<usize>,
+
+    /// Period in seconds for a background `malloc_trim(0)` that returns free
+    /// arena memory to the OS. `0` = disabled.
+    #[serde(default)]
+    pub trim_interval_secs: u64,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub listen: ListenConfig,
@@ -74,6 +102,11 @@ pub struct Config {
 
     /// SIP transaction layer timer overrides.
     pub transaction: Option<TransactionConfig>,
+
+    /// Allocator runtime tuning (glibc arena cap + periodic trim). The
+    /// `siphon_glibc_*` gauges are always on; this block only adds the optional
+    /// bounding knobs. `None` = gauges only, no tuning.
+    pub memory: Option<MemoryConfig>,
 
     /// Dialog state tracking backend.
     pub dialog: Option<DialogConfig>,
@@ -3074,6 +3107,55 @@ transaction:
         let tx = config.transaction.unwrap();
         assert_eq!(tx.timeout_secs, 5);
         assert_eq!(tx.invite_timeout_secs, 30);
+    }
+
+    #[test]
+    fn parses_memory_config() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+memory:
+  glibc:
+    arena_max: 2
+    trim_interval_secs: 30
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        let memory = config.memory.expect("memory block present");
+        assert_eq!(memory.glibc.arena_max, Some(2));
+        assert_eq!(memory.glibc.trim_interval_secs, 30);
+    }
+
+    #[test]
+    fn memory_config_absent_and_partial_defaults() {
+        // Absent → None (gauges still always-on; only the knobs are gated).
+        let config = Config::from_str(minimal_yaml()).unwrap();
+        assert!(config.memory.is_none());
+
+        // Partial → unspecified knobs take their defaults (arena_max None,
+        // trim disabled), so a bare `memory:` block is valid.
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+memory:
+  glibc:
+    arena_max: 4
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        let glibc = config.memory.unwrap().glibc;
+        assert_eq!(glibc.arena_max, Some(4));
+        assert_eq!(glibc.trim_interval_secs, 0);
     }
 
     #[test]

--- a/src/diameter/peer.rs
+++ b/src/diameter/peer.rs
@@ -620,6 +620,120 @@ mod tests {
         );
     }
 
+    /// Build a throwaway `PeerConfig` for the loopback leak tests. The watchdog
+    /// interval is set far longer than any test runs so no DWR is injected into
+    /// the `pending` map to perturb the assertions.
+    fn leak_test_config() -> PeerConfig {
+        PeerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            origin_host: "siphon.test".to_string(),
+            origin_realm: "test".to_string(),
+            destination_host: None,
+            destination_realm: "test".to_string(),
+            local_ip: "127.0.0.1".parse().unwrap(),
+            application_ids: vec![(dictionary::VENDOR_3GPP, dictionary::CX_APP_ID)],
+            watchdog_interval: 3600,
+            reconnect_delay: 5,
+            product_name: "SIPhon".to_string(),
+            firmware_revision: 1,
+        }
+    }
+
+    /// Stand up a real [`DiameterPeer`] over a loopback TCP connection whose far
+    /// end is a mock peer that turns every request it receives into an answer
+    /// (clears the R-bit) and echoes it back with the same Hop-by-Hop id. This
+    /// drives the **production** reader task from [`spawn_connection_tasks`], so
+    /// the test exercises the real `pending`-map removal on the answer path, not
+    /// a re-implementation. Returns the peer plus the incoming-request receiver,
+    /// which the caller holds so the channel stays open.
+    async fn loopback_peer_with_echo() -> (Arc<DiameterPeer>, mpsc::Receiver<IncomingRequest>) {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::{TcpListener, TcpStream};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Mock far-end peer: flip every request into an answer and echo it back.
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let (read_half, mut write_half) = tokio::io::split(stream);
+                let mut reader = BufReader::new(read_half);
+                while let Ok(mut bytes) = codec::read_diameter_message(&mut reader).await {
+                    if bytes.len() > 4 {
+                        bytes[4] &= !codec::FLAG_REQUEST; // request -> answer
+                    }
+                    if write_half.write_all(&bytes).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        });
+
+        let client_stream = TcpStream::connect(addr).await.unwrap();
+        let (incoming_tx, incoming_rx) = mpsc::channel(16);
+        let peer = spawn_connection_tasks(
+            leak_test_config(),
+            DiameterStream::Tcp(client_stream),
+            incoming_tx,
+        );
+        (peer, incoming_rx)
+    }
+
+    /// Leak guard for the Diameter request/answer correlation map shared by every
+    /// interface — Rx/Cx/Rf/Sh all funnel through `send_request`. After each
+    /// answered request the reader task MUST remove the Hop-by-Hop entry from
+    /// `pending`; a regression leaks one `oneshot::Sender` per transaction for the
+    /// life of the connection (threads/FDs flat, only the heap grows).
+    #[tokio::test]
+    async fn pending_map_drains_across_answered_requests() {
+        let (peer, _incoming_rx) = loopback_peer_with_echo().await;
+        let config = peer.config().clone();
+
+        for _ in 0..300 {
+            let hbh = peer.next_hbh();
+            // Any valid request works — the map is keyed by Hop-by-Hop, not command.
+            let request = build_cer(&config, hbh, 1);
+            // The echo peer answers, so the real reader resolves and removes `hbh`.
+            let _ = peer.send_request(request).await;
+        }
+
+        assert_eq!(
+            peer.pending.lock().await.len(),
+            0,
+            "pending request map must drain to empty after answered requests — \
+             a non-zero count is one leaked oneshot::Sender per Diameter transaction"
+        );
+    }
+
+    /// Same invariant under concurrent in-flight requests — the carrier-grade
+    /// case where many transactions race through the shared map at once.
+    #[tokio::test]
+    async fn pending_map_drains_under_concurrent_inflight() {
+        let (peer, _incoming_rx) = loopback_peer_with_echo().await;
+        let config = peer.config().clone();
+
+        let mut handles = Vec::new();
+        for _ in 0..100 {
+            let peer = Arc::clone(&peer);
+            let config = config.clone();
+            handles.push(tokio::spawn(async move {
+                let hbh = peer.next_hbh();
+                let request = build_cer(&config, hbh, 1);
+                let _ = peer.send_request(request).await;
+            }));
+        }
+        for handle in handles {
+            let _ = handle.await;
+        }
+
+        assert_eq!(
+            peer.pending.lock().await.len(),
+            0,
+            "pending request map must drain under concurrent in-flight load"
+        );
+    }
+
     #[test]
     fn build_cea_valid_binary() {
         let config = PeerConfig {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1865,6 +1865,9 @@ async fn sweep_stale_entries(state: &DispatcherState) {
     // count (jemalloc can't see CPython's allocator) for Python leak detection.
     crate::metrics::update_memory_stats();
     crate::metrics::update_python_stats();
+    // Refresh the glibc allocator gauges — the C-side / CPython raw-domain pool
+    // that jemalloc and CPython's mimalloc can't see (no-op off glibc).
+    crate::metrics::update_glibc_stats();
 
     if expired_sessions > 0
         || expired_uac > 0

--- a/src/metrics/glibc.rs
+++ b/src/metrics/glibc.rs
@@ -1,0 +1,266 @@
+//! glibc `malloc` allocator instrumentation — the C-side / CPython-raw-domain
+//! memory pool that jemalloc (siphon's Rust `#[global_allocator]`) does **not**
+//! serve and therefore cannot see.
+//!
+//! Because every Rust allocation routes through jemalloc, glibc's own arenas
+//! hold *only* C-side allocations: CPython's raw domain (`PyMem_RawMalloc`),
+//! libc internals, and any C extension. On a free-threaded-CPython (3.14t)
+//! build with many persistently-attached threads, glibc hands each thread that
+//! contends on `malloc` its own arena, each grown in 64 MB chunks
+//! (`HEAP_MAX_SIZE`) — none of which is reflected in `siphon_memory_*`
+//! (jemalloc) or `siphon_python_allocated_blocks` (CPython's mimalloc object
+//! heap). These statistics make that pool visible.
+//!
+//! The source is **`malloc_info(3)`** (the XML stats dump), *not* `mallinfo2(3)`:
+//! `mallinfo2` reports the **main arena only**, so it is blind to exactly the
+//! per-thread 64 MB arenas this module exists to surface. `malloc_info`
+//! aggregates across every arena.
+//!
+//! Linux/glibc only. Every entry point is a no-op (returns `None`/`false`) on
+//! other targets, so callers need no `cfg` of their own.
+
+/// Aggregated glibc `malloc` statistics across all arenas.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GlibcStats {
+    /// Total heap memory glibc holds from the OS across all arenas (non-mmap).
+    /// This is the resident "dark pool" — where the 64 MB per-thread arenas
+    /// show up. Mirrors `siphon_memory_allocated_bytes` for the C side.
+    pub system_bytes: u64,
+    /// Free/retained bytes within those arenas (fastbins + remaining free
+    /// chunks). High `free` with high `system` while `in_use` stays flat is
+    /// arena *retention* (tune `arena_max` / `malloc_trim`), not a leak.
+    pub free_bytes: u64,
+    /// Live (allocated, not freed) bytes = `system - free`. A steady climb here
+    /// under flat call rate is a genuine raw-domain leak.
+    pub in_use_bytes: u64,
+    /// Bytes served by `mmap` (large allocations), tracked separately from the
+    /// per-arena heaps.
+    pub mmap_bytes: u64,
+    /// Number of arenas (heaps). Climbs as more threads contend on `malloc` —
+    /// each new arena is a fresh ~64 MB reservation.
+    pub arena_count: u64,
+}
+
+/// glibc `mallopt` parameter for the maximum number of arenas (`M_ARENA_MAX`).
+/// Defined as `-8` in `malloc.h`; not exposed as a constant by the `libc` crate.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+const M_ARENA_MAX: std::os::raw::c_int = -8;
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+mod ffi {
+    use std::os::raw::{c_char, c_int, c_void};
+
+    // `FILE` is opaque; we only ever hold a pointer to it.
+    extern "C" {
+        /// Open a stream backed by a dynamically-grown in-memory buffer.
+        /// After `fclose`, `*bufp` is a `malloc`-ed buffer of `*sizep` bytes
+        /// (NUL-terminated) owned by the caller.
+        pub fn open_memstream(bufp: *mut *mut c_char, sizep: *mut usize) -> *mut c_void;
+        pub fn fclose(stream: *mut c_void) -> c_int;
+        /// Write malloc state as XML to `stream`. `options` must be 0.
+        pub fn malloc_info(options: c_int, stream: *mut c_void) -> c_int;
+        /// Release free heap memory back to the OS. Returns 1 if any was
+        /// released, 0 otherwise.
+        pub fn malloc_trim(pad: usize) -> c_int;
+        /// Tune a malloc parameter. Returns 1 on success, 0 on failure.
+        pub fn mallopt(param: c_int, value: c_int) -> c_int;
+        pub fn free(ptr: *mut c_void);
+    }
+}
+
+/// Capture the raw `malloc_info` XML dump. `None` if unavailable (non-glibc, or
+/// the memstream could not be created).
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub fn malloc_info_xml() -> Option<String> {
+    use std::os::raw::{c_char, c_void};
+
+    // SAFETY: standard `open_memstream` → `malloc_info` → read → `free` dance.
+    // `open_memstream` allocates `buf`; `fclose` finalises `buf`/`size`; we read
+    // exactly `size` bytes and then `free(buf)`. Each pointer is checked for
+    // null before use. The calls themselves allocate via glibc, which perturbs
+    // the stats by a small, constant amount — acceptable for a trend gauge.
+    unsafe {
+        let mut buffer: *mut c_char = std::ptr::null_mut();
+        let mut size: usize = 0;
+        let stream = ffi::open_memstream(&mut buffer, &mut size);
+        if stream.is_null() {
+            return None;
+        }
+        let result = ffi::malloc_info(0, stream);
+        // fclose flushes and finalises `buffer`/`size`; the buffer survives it.
+        ffi::fclose(stream);
+        if result != 0 || buffer.is_null() {
+            if !buffer.is_null() {
+                ffi::free(buffer as *mut c_void);
+            }
+            return None;
+        }
+        let bytes = std::slice::from_raw_parts(buffer as *const u8, size);
+        let xml = String::from_utf8_lossy(bytes).into_owned();
+        ffi::free(buffer as *mut c_void);
+        Some(xml)
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+pub fn malloc_info_xml() -> Option<String> {
+    None
+}
+
+/// Read aggregated glibc allocator statistics. `None` on non-glibc targets or
+/// if the `malloc_info` dump could not be obtained/parsed.
+pub fn read_stats() -> Option<GlibcStats> {
+    let xml = malloc_info_xml()?;
+    Some(parse_malloc_info(&xml))
+}
+
+/// Cap the number of glibc arenas via `mallopt(M_ARENA_MAX, n)`. This is the
+/// primary lever against per-thread-arena retention (each arena is a ~64 MB
+/// reservation). Best applied at startup, before the thread pools spin up.
+/// Returns `true` if applied. No-op (returns `false`) off glibc.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub fn set_arena_max(max_arenas: usize) -> bool {
+    // SAFETY: `mallopt` is a plain integer-in/integer-out tunable with no
+    // aliasing or memory-safety concerns.
+    let result = unsafe { ffi::mallopt(M_ARENA_MAX, max_arenas as std::os::raw::c_int) };
+    result == 1
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+pub fn set_arena_max(_max_arenas: usize) -> bool {
+    false
+}
+
+/// Return free heap memory to the OS via `malloc_trim(0)`. Pair with
+/// `arena_max` to keep the C-side pool bounded and to separate retention from a
+/// true leak. Returns `true` if any memory was released. No-op off glibc.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub fn trim() -> bool {
+    // SAFETY: `malloc_trim` only releases free pages; no aliasing concerns.
+    let result = unsafe { ffi::malloc_trim(0) };
+    result == 1
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+pub fn trim() -> bool {
+    false
+}
+
+/// Parse the `malloc_info` XML into aggregated stats. Kept allocation-free of
+/// any XML dependency: `malloc_info`'s schema is stable, so a targeted scan for
+/// the grand-total elements is both sufficient and robust. Pure, so it is
+/// unit-testable against a captured fixture without a glibc runtime.
+///
+/// The relevant grand totals appear once, after the per-`<heap>` blocks:
+/// `<system type="current" size=…/>` (OS-held arena bytes),
+/// `<total type="rest"/>` + `<total type="fast"/>` (free within arenas),
+/// `<total type="mmap"/>` (mmap-served). Each grand total is the *last*
+/// occurrence of its element, so we take the last match.
+fn parse_malloc_info(xml: &str) -> GlibcStats {
+    let system_bytes = last_size(xml, "<system type=\"current\"").unwrap_or(0);
+    let free_rest = last_size(xml, "<total type=\"rest\"").unwrap_or(0);
+    let free_fast = last_size(xml, "<total type=\"fast\"").unwrap_or(0);
+    let mmap_bytes = last_size(xml, "<total type=\"mmap\"").unwrap_or(0);
+    let free_bytes = free_rest.saturating_add(free_fast);
+    let arena_count = xml.matches("<heap nr=").count() as u64;
+
+    GlibcStats {
+        system_bytes,
+        free_bytes,
+        in_use_bytes: system_bytes.saturating_sub(free_bytes),
+        mmap_bytes,
+        arena_count,
+    }
+}
+
+/// Find the last XML element beginning with `marker` and return its `size="…"`
+/// attribute value. Returns `None` if no such element (with a parseable size)
+/// is present.
+fn last_size(xml: &str, marker: &str) -> Option<u64> {
+    let mut result = None;
+    let mut rest = xml;
+    while let Some(index) = rest.find(marker) {
+        let tail = &rest[index + marker.len()..];
+        // Confine the search to this one element (up to its closing `>`).
+        if let Some(element_end) = tail.find('>') {
+            let element = &tail[..element_end];
+            if let Some(size_index) = element.find("size=\"") {
+                let after = &element[size_index + "size=\"".len()..];
+                if let Some(quote) = after.find('"') {
+                    if let Ok(value) = after[..quote].parse::<u64>() {
+                        result = Some(value);
+                    }
+                }
+            }
+        }
+        rest = &rest[index + marker.len()..];
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A trimmed but structurally faithful `malloc_info` dump with two arenas,
+    /// for parsing without a glibc runtime. Sizes are the grand totals at the
+    /// end (the last occurrence of each element).
+    const FIXTURE: &str = r#"<malloc version="1">
+<heap nr="0">
+<sizes></sizes>
+<total type="fast" count="3" size="240"/>
+<total type="rest" count="5" size="4096"/>
+<system type="current" size="135168"/>
+<system type="max" size="135168"/>
+</heap>
+<heap nr="1">
+<sizes></sizes>
+<total type="fast" count="1" size="80"/>
+<total type="rest" count="2" size="2048"/>
+<system type="current" size="67108864"/>
+<system type="max" size="67108864"/>
+</heap>
+<total type="fast" count="4" size="320"/>
+<total type="rest" count="7" size="6144"/>
+<total type="mmap" count="2" size="1048576"/>
+<system type="current" size="67244032"/>
+<system type="max" size="67244032"/>
+</malloc>
+"#;
+
+    #[test]
+    fn parses_grand_totals_across_arenas() {
+        let stats = parse_malloc_info(FIXTURE);
+        // Grand-total `<system type="current">` = the last one (67244032),
+        // NOT a per-heap value — proving we read the aggregate, not main-arena.
+        assert_eq!(stats.system_bytes, 67_244_032);
+        // free = grand fast (320) + grand rest (6144).
+        assert_eq!(stats.free_bytes, 320 + 6144);
+        assert_eq!(stats.in_use_bytes, 67_244_032 - (320 + 6144));
+        assert_eq!(stats.mmap_bytes, 1_048_576);
+        // Two `<heap nr=…>` blocks → two arenas (the 64 MB-class signature).
+        assert_eq!(stats.arena_count, 2);
+    }
+
+    #[test]
+    fn parse_is_robust_to_missing_fields() {
+        let stats = parse_malloc_info("<malloc version=\"1\"></malloc>");
+        assert_eq!(stats, GlibcStats::default());
+    }
+
+    /// On a glibc host, a live read must succeed and report a non-trivial
+    /// resident pool with at least the main arena. Skipped off glibc.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    #[test]
+    fn live_read_reports_arenas() {
+        let stats = read_stats().expect("malloc_info must be available on glibc");
+        assert!(
+            stats.system_bytes > 0,
+            "glibc must hold some OS memory; got {stats:?}"
+        );
+        assert!(
+            stats.arena_count >= 1,
+            "at least the main arena must be present; got {stats:?}"
+        );
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -5,6 +5,7 @@
 //! inline (at the call site) and scraped via the HTTP admin API `/metrics`.
 
 pub mod custom;
+pub mod glibc;
 
 use std::sync::{Arc, OnceLock};
 
@@ -198,6 +199,31 @@ pub struct SiphonMetrics {
     pub rtpengine_instances_up: IntGauge,
     pub rtpengine_instances_total: IntGauge,
     pub rtpengine_instance_up: IntGaugeVec,
+
+    // --- SBI (5G N5/Npcf) ---
+    /// Active N5/Npcf app-sessions this NF created and has not yet deleted. A
+    /// steady climb under flat call rate is a session leak (a missed
+    /// delete_session — e.g. the early-media Rx/N5 session stranded at the PCF).
+    pub sbi_npcf_app_sessions_active: IntGauge,
+
+    // --- glibc allocator (C-side / CPython raw domain) ---
+    // The pool jemalloc and CPython's mimalloc cannot see. Sourced from
+    // `malloc_info(3)` (all arenas), not `mallinfo2` (main arena only).
+    /// Total OS memory held by glibc malloc across all arenas (non-mmap). The
+    /// resident "dark pool"; where free-threaded-CPython per-thread 64 MB
+    /// arenas show up. The C-side analogue of `siphon_memory_resident_bytes`.
+    pub glibc_system_bytes: IntGauge,
+    /// Live (allocated, not freed) C-side bytes = system − free. A steady climb
+    /// here under flat load is a genuine raw-domain leak — the alert signal.
+    pub glibc_in_use_bytes: IntGauge,
+    /// Free/retained bytes inside the arenas. High free + high system + flat
+    /// in_use = arena retention (tune arena_max / malloc_trim), not a leak.
+    pub glibc_free_bytes: IntGauge,
+    /// Bytes served by mmap (large allocations), separate from the arenas.
+    pub glibc_mmap_bytes: IntGauge,
+    /// Number of arenas (heaps). Each is a ~64 MB reservation; a rising count
+    /// is per-thread-arena proliferation under free-threaded concurrency.
+    pub glibc_arena_count: IntGauge,
 }
 
 impl SiphonMetrics {
@@ -427,6 +453,32 @@ impl SiphonMetrics {
             &["address"],
         )?;
 
+        let sbi_npcf_app_sessions_active = IntGauge::new(
+            "siphon_sbi_npcf_app_sessions_active",
+            "Active N5/Npcf app-sessions created by this NF and not yet deleted",
+        )?;
+
+        let glibc_system_bytes = IntGauge::new(
+            "siphon_glibc_system_bytes",
+            "Total OS memory held by glibc malloc across all arenas (C-side / CPython raw domain; invisible to jemalloc)",
+        )?;
+        let glibc_in_use_bytes = IntGauge::new(
+            "siphon_glibc_in_use_bytes",
+            "Live (allocated, not freed) glibc bytes across all arenas — the C-side leak signal",
+        )?;
+        let glibc_free_bytes = IntGauge::new(
+            "siphon_glibc_free_bytes",
+            "Free/retained bytes within glibc arenas (high while in_use is flat = arena retention, not a leak)",
+        )?;
+        let glibc_mmap_bytes = IntGauge::new(
+            "siphon_glibc_mmap_bytes",
+            "Bytes served by glibc via mmap (large allocations), separate from the arenas",
+        )?;
+        let glibc_arena_count = IntGauge::new(
+            "siphon_glibc_arena_count",
+            "Number of glibc malloc arenas (each a ~64 MB reservation; rises with per-thread contention)",
+        )?;
+
         // Register all metrics
         registry.register(Box::new(requests_total.clone()))?;
         registry.register(Box::new(responses_total.clone()))?;
@@ -471,6 +523,12 @@ impl SiphonMetrics {
         registry.register(Box::new(rtpengine_instances_up.clone()))?;
         registry.register(Box::new(rtpengine_instances_total.clone()))?;
         registry.register(Box::new(rtpengine_instance_up.clone()))?;
+        registry.register(Box::new(sbi_npcf_app_sessions_active.clone()))?;
+        registry.register(Box::new(glibc_system_bytes.clone()))?;
+        registry.register(Box::new(glibc_in_use_bytes.clone()))?;
+        registry.register(Box::new(glibc_free_bytes.clone()))?;
+        registry.register(Box::new(glibc_mmap_bytes.clone()))?;
+        registry.register(Box::new(glibc_arena_count.clone()))?;
 
         Ok(Self {
             registry,
@@ -517,6 +575,12 @@ impl SiphonMetrics {
             rtpengine_instances_up,
             rtpengine_instances_total,
             rtpengine_instance_up,
+            sbi_npcf_app_sessions_active,
+            glibc_system_bytes,
+            glibc_in_use_bytes,
+            glibc_free_bytes,
+            glibc_mmap_bytes,
+            glibc_arena_count,
         })
     }
 }
@@ -592,6 +656,30 @@ pub fn update_python_stats() {
     if let Ok(blocks) = result {
         metrics.python_allocated_blocks.set(blocks);
     }
+}
+
+/// Refresh the glibc allocator gauges from `malloc_info`. Call periodically (the
+/// dispatcher does so on its cleanup tick). This is the C-side / CPython
+/// raw-domain pool that neither [`update_memory_stats`] (jemalloc) nor
+/// [`update_python_stats`] (CPython's mimalloc) can see — because Rust runs on
+/// jemalloc, glibc's arenas hold *only* the C side, so these gauges isolate it.
+/// No-op off glibc.
+///
+/// `glibc_in_use_bytes` is the one to alert on (the C-side leak signal). A high
+/// `glibc_system_bytes` with high `glibc_free_bytes` and flat `in_use` is arena
+/// retention — address it with `memory.glibc.arena_max` / `trim_interval_secs`.
+pub fn update_glibc_stats() {
+    let Some(metrics) = metrics() else {
+        return;
+    };
+    let Some(stats) = glibc::read_stats() else {
+        return;
+    };
+    metrics.glibc_system_bytes.set(stats.system_bytes as i64);
+    metrics.glibc_in_use_bytes.set(stats.in_use_bytes as i64);
+    metrics.glibc_free_bytes.set(stats.free_bytes as i64);
+    metrics.glibc_mmap_bytes.set(stats.mmap_bytes as i64);
+    metrics.glibc_arena_count.set(stats.arena_count as i64);
 }
 
 // ---------------------------------------------------------------------------
@@ -683,9 +771,12 @@ mod tests {
 
     #[test]
     fn diameter_peers_connected_gauge() {
-        init().unwrap();
-        let metrics = metrics().unwrap();
-
+        // Gauge inc/dec/get mechanics on a fresh, isolated instance. The
+        // process-global gauge is shared across parallel tests — the diameter
+        // peer leak tests open real loopback connections that inc it — so
+        // asserting absolute values on the global here would race. A fresh
+        // instance is the correct unit under test for the mechanics.
+        let metrics = SiphonMetrics::new().unwrap();
         assert_eq!(metrics.diameter_peers_connected.get(), 0);
         metrics.diameter_peers_connected.inc();
         metrics.diameter_peers_connected.inc();
@@ -693,8 +784,9 @@ mod tests {
         metrics.diameter_peers_connected.dec();
         assert_eq!(metrics.diameter_peers_connected.get(), 1);
 
-        let output = encode_metrics();
-        assert!(output.contains("siphon_diameter_peers_connected"));
+        // Registration + text encoding go through the global registry.
+        init().unwrap();
+        assert!(encode_metrics().contains("siphon_diameter_peers_connected"));
     }
 
     #[test]

--- a/src/rtpengine/client.rs
+++ b/src/rtpengine/client.rs
@@ -1229,6 +1229,69 @@ mod tests {
         addr
     }
 
+    /// Memory-leak guard for the NG control path: the `pending` correlation map
+    /// MUST drain back to empty after every command settles. On the success path
+    /// the receiver loop removes the cookie when the answer lands; this pins that
+    /// invariant across a full offer → answer → delete lifecycle run many times.
+    /// A regression that drops the removal leaks one `oneshot::Sender` per command
+    /// for the life of the process (threads/FDs stay flat — only the heap grows).
+    #[tokio::test]
+    async fn pending_map_drains_on_success() {
+        let addr = spawn_mock_rtpengine().await;
+        let client = RtpEngineClient::new(addr, 2000).await.unwrap();
+        let flags = NgFlags::default();
+        let sdp = b"v=0\r\nc=IN IP4 10.0.0.1\r\nm=audio 8000 RTP/AVP 0\r\n";
+
+        // Each call is awaited to completion, so the receiver loop must have
+        // removed its cookie before the next command begins.
+        for index in 0..500 {
+            let call_id = format!("leak-success-{index}");
+            client.offer(&call_id, "from", sdp, &flags).await.unwrap();
+            client
+                .answer(&call_id, "from", "to", sdp, &flags)
+                .await
+                .unwrap();
+            client.delete(&call_id, "from").await.unwrap();
+        }
+
+        assert_eq!(
+            client.pending.len(),
+            0,
+            "pending correlation map must drain to empty after completed commands \
+             — a non-zero count is one leaked oneshot::Sender per command"
+        );
+    }
+
+    /// The timeout path must clean up too: point the client at a bound-but-silent
+    /// socket so every command times out, and confirm `pending` is still empty
+    /// afterwards (i.e. `send_command`'s timeout arm removes the cookie). Without
+    /// that removal, every timed-out command — exactly what happens when rtpengine
+    /// is briefly unreachable under load — would leak a pending entry.
+    #[tokio::test]
+    async fn pending_map_drains_on_timeout() {
+        // Bind a socket so the address is valid but never answer on it.
+        let silent = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let silent_addr = silent.local_addr().unwrap();
+
+        // Short timeout keeps the test fast (~1s worst case for the whole loop).
+        let client = RtpEngineClient::new(silent_addr, 50).await.unwrap();
+        let flags = NgFlags::default();
+        let sdp = b"v=0\r\nc=IN IP4 10.0.0.1\r\nm=audio 8000 RTP/AVP 0\r\n";
+
+        for index in 0..20 {
+            let call_id = format!("leak-timeout-{index}");
+            let result = client.offer(&call_id, "from", sdp, &flags).await;
+            assert!(result.is_err(), "command to a silent peer must time out");
+        }
+
+        assert_eq!(
+            client.pending.len(),
+            0,
+            "pending correlation map must drain on the timeout path too — a leaked \
+             entry here accumulates one sender per timed-out command"
+        );
+    }
+
     #[tokio::test]
     async fn set_single_instance() {
         let addr = spawn_mock_rtpengine().await;

--- a/src/sbi/npcf.rs
+++ b/src/sbi/npcf.rs
@@ -188,6 +188,14 @@ pub struct NpcfClient {
     base_url: String,
     client: reqwest::Client,
     communication: crate::sbi::Communication,
+    /// Local registry of app-sessions this client created and has not yet
+    /// deleted, keyed by app-session id. Drives the
+    /// `siphon_sbi_npcf_app_sessions_active` gauge and is the leak surface a
+    /// missed `delete_session` shows up in. Complementary to — not a replacement
+    /// for — the script's Redis call_id↔session correlation used for HA across
+    /// replicas; this one tracks only what *this* process created, for the gauge
+    /// and orphan visibility.
+    sessions: dashmap::DashMap<String, std::time::Instant>,
 }
 
 impl NpcfClient {
@@ -198,6 +206,7 @@ impl NpcfClient {
             base_url: base_url.trim_end_matches('/').to_string(),
             client,
             communication: crate::sbi::Communication::Direct,
+            sessions: dashmap::DashMap::new(),
         }
     }
 
@@ -206,6 +215,23 @@ impl NpcfClient {
     pub fn with_communication(mut self, communication: crate::sbi::Communication) -> Self {
         self.communication = communication;
         self
+    }
+
+    /// Number of app-sessions this client currently tracks (created and not yet
+    /// deleted). Backs the `siphon_sbi_npcf_app_sessions_active` gauge and the
+    /// per-module leak test.
+    pub fn active_app_sessions(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Publish the live app-session count to Prometheus. No-op when metrics are
+    /// not initialised (tests / CLI).
+    fn publish_session_gauge(&self) {
+        if let Some(metrics) = crate::metrics::try_metrics() {
+            metrics
+                .sbi_npcf_app_sessions_active
+                .set(self.sessions.len() as i64);
+        }
     }
 
     /// Create a new app session (POST /npcf-policyauthorization/v1/app-sessions).
@@ -276,11 +302,19 @@ impl NpcfClient {
             .map(app_session_id_from_location)
             .unwrap_or_default();
 
-        Ok(CreatedAppSession {
+        let created = CreatedAppSession {
             app_session_id,
             authorized: true,
             location,
-        })
+        };
+        // Track locally so the active-session gauge reflects the N5 sessions
+        // this NF holds; a missed delete then surfaces as gauge growth.
+        if !created.app_session_id.is_empty() {
+            self.sessions
+                .insert(created.app_session_id.clone(), std::time::Instant::now());
+            self.publish_session_gauge();
+        }
+        Ok(created)
     }
 
     /// Delete an app session.
@@ -307,6 +341,10 @@ impl NpcfClient {
         if !response.status().is_success() && response.status().as_u16() != 204 {
             return Err(SbiError::HttpError(response.status().as_u16()));
         }
+        // Session is gone PCF-side — drop the local tracking entry.
+        self.sessions
+            .remove(&app_session_id_from_location(session_ref));
+        self.publish_session_gauge();
         Ok(())
     }
 
@@ -937,6 +975,85 @@ mod tests {
     }
 
     // --- Delete (TS 29.514 §5.6.2.4: POST {resource}/delete → 204) ---
+
+    /// Router for the app-session leak test: each create mints a unique
+    /// app-session id (so the store can grow), and any `.../{id}/delete` returns
+    /// 204 — the spec-correct create (201 + Location) and custom-delete shapes.
+    fn leak_create_delete_router() -> axum::Router {
+        use axum::routing::post;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        axum::Router::new()
+            .route(
+                "/npcf-policyauthorization/v1/app-sessions",
+                post(move || {
+                    let counter = Arc::clone(&counter);
+                    async move {
+                        let n = counter.fetch_add(1, Ordering::Relaxed);
+                        (
+                            axum::http::StatusCode::CREATED,
+                            [(
+                                "location",
+                                format!("/npcf-policyauthorization/v1/app-sessions/sess-{n}"),
+                            )],
+                            "",
+                        )
+                    }
+                }),
+            )
+            .route(
+                "/npcf-policyauthorization/v1/app-sessions/{id}/delete",
+                post(|| async { axum::http::StatusCode::NO_CONTENT }),
+            )
+    }
+
+    /// Leak guard for the N5/Npcf app-session registry: `create_session` inserts,
+    /// `delete_session` removes, so a full create→delete cycle MUST leave the
+    /// store empty. A regression — or a script that misses a delete — surfaces as
+    /// growth in `active_app_sessions()` and the
+    /// `siphon_sbi_npcf_app_sessions_active` gauge (the stranded early-media Rx/N5
+    /// session the P-CSCF guards against). The store IS the leak surface here.
+    #[tokio::test]
+    async fn app_session_store_drains_on_create_delete() {
+        let base = spawn_mock(leak_create_delete_router()).await;
+        let client = NpcfClient::new(&base, reqwest::Client::new());
+        let request = AppSessionContextReqData::default();
+
+        // Phase 1 — create without deleting: the store must hold every session.
+        let mut locations = Vec::new();
+        for _ in 0..50 {
+            let created = client.create_app_session(None, &request).await.unwrap();
+            locations.push(created.location.expect("create returns a Location"));
+        }
+        assert_eq!(
+            client.active_app_sessions(),
+            50,
+            "every created app-session must be tracked"
+        );
+
+        // Phase 2 — delete each: the store must drain back to empty.
+        for location in &locations {
+            client.delete_app_session(location).await.unwrap();
+        }
+        assert_eq!(
+            client.active_app_sessions(),
+            0,
+            "store must drain to empty once every session is deleted"
+        );
+
+        // Phase 3 — many full create→delete cycles stay flat at zero.
+        for _ in 0..200 {
+            let created = client.create_app_session(None, &request).await.unwrap();
+            let location = created.location.expect("create returns a Location");
+            client.delete_app_session(&location).await.unwrap();
+        }
+        assert_eq!(
+            client.active_app_sessions(),
+            0,
+            "store must not grow across repeated create→delete cycles"
+        );
+    }
 
     /// A router that serves ONLY the spec-correct custom delete operation
     /// (`POST .../app-sessions/sess-1/delete` → 204 No Content) and records the

--- a/src/server.rs
+++ b/src/server.rs
@@ -310,6 +310,59 @@ impl SiphonServer {
             init_logging(&config.log)
         };
 
+        // --- Allocator tuning (glibc arena cap + periodic trim) ---
+        // Applied as early as possible so the arena cap takes effect before the
+        // Python/script workload starts creating glibc arenas. The
+        // `siphon_glibc_*` gauges are always on regardless; this only bounds the
+        // pool. No-op off glibc.
+        if let Some(memory) = config.memory.as_ref() {
+            if let Some(arena_max) = memory.glibc.arena_max {
+                if crate::metrics::glibc::set_arena_max(arena_max) {
+                    tracing::info!(arena_max, "glibc M_ARENA_MAX cap applied");
+                } else {
+                    tracing::warn!(
+                        arena_max,
+                        "glibc M_ARENA_MAX cap not applied (non-glibc target or mallopt rejected it)"
+                    );
+                }
+            }
+            let trim_interval = memory.glibc.trim_interval_secs;
+            if trim_interval > 0 {
+                tokio::spawn(async move {
+                    let mut ticker =
+                        tokio::time::interval(std::time::Duration::from_secs(trim_interval));
+                    ticker.tick().await; // consume the immediate first tick
+                    loop {
+                        ticker.tick().await;
+                        let released = crate::metrics::glibc::trim();
+                        tracing::debug!(released, "periodic glibc malloc_trim(0)");
+                    }
+                });
+            }
+        }
+
+        // SIGUSR2 → dump the full glibc `malloc_info` XML to the log for
+        // call-site attribution (which arena, how fragmented). A passive
+        // diagnostic, always installed on Unix; pair with heaptrack
+        // (`PYTHONMALLOC=malloc`) under load to name a true raw-domain leak.
+        #[cfg(unix)]
+        tokio::spawn(async move {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut stream = match signal(SignalKind::user_defined2()) {
+                Ok(stream) => stream,
+                Err(error) => {
+                    tracing::warn!(%error, "could not install SIGUSR2 glibc malloc_info handler");
+                    return;
+                }
+            };
+            while stream.recv().await.is_some() {
+                match crate::metrics::glibc::malloc_info_xml() {
+                    Some(xml) => tracing::info!("glibc malloc_info dump (SIGUSR2):\n{xml}"),
+                    None => tracing::info!("glibc malloc_info unavailable (non-glibc target)"),
+                }
+            }
+        });
+
         let script_desc = if self.embedded_script.is_some() || self.embedded_bytecode.is_some() {
             "<embedded>".to_owned()
         } else {


### PR DESCRIPTION
## Why

siphon instruments two of its three allocators — jemalloc (`siphon_memory_*`, the Rust side) and CPython's mimalloc object heap (`siphon_python_allocated_blocks`). The third — **glibc malloc**, which serves CPython's raw domain (`PyMem_RawMalloc`), C extensions, and `libsctp` — was dark. On a free-threaded-CPython build with many persistently-attached threads, glibc hands each contending thread its own ~64 MB arena; none of that shows in any existing gauge, so RSS can climb while every Rust and Python gauge reads clean.

This PR makes that pool **observable** and **boundable**, and adds per-module leak guards for the control-plane paths the SIP mem-leak test never exercised.

## glibc instrumentation

- `siphon_glibc_*` gauges (`system_bytes`, `in_use_bytes`, `free_bytes`, `mmap_bytes`, `arena_count`) sourced from **`malloc_info(3)`**, aggregated across all arenas. Deliberately **not** `mallinfo2(3)`, which reports the main arena only and would be blind to exactly the per-thread 64 MB arenas. Because Rust runs on jemalloc, glibc's arenas hold only the C side, so these gauges isolate the dark pool cleanly. Sampled on the existing dispatcher cleanup tick; no-op off glibc.
- Top-level `memory:` config block (allocator runtime tuning, distinct from `metrics:`):

  ```yaml
  memory:
    glibc:
      arena_max: 2            # mallopt(M_ARENA_MAX) — cap the number of arenas
      trim_interval_secs: 30  # periodic malloc_trim(0)
  ```

  Gauges are always-on; both knobs default off (measure first, bound only if it proves to be retention).
- `SIGUSR2` dumps the full `malloc_info` XML to the log for call-site attribution (pair with heaptrack under `PYTHONMALLOC=malloc`).

Interpretation: `in_use_bytes` climbing under flat call rate is a genuine raw-domain leak; high `system_bytes` + high `free_bytes` + flat `in_use_bytes` is arena retention (tune `arena_max` / `trim_interval_secs`).

## Control-plane leak guards

Per-module steady-state guards that gate on the production store draining back to baseline — the precise "a per-call entry was never evicted" signal:

- **rtpengine** — the `pending` correlation map drains on both the success and the timeout paths.
- **diameter** (Rx/Cx/Rf/Sh all funnel through `send_request`) — the `pending` map drains through the **real** connection reader, sequential and under concurrent in-flight load.
- **SBI / N5** — a new `NpcfClient` app-session store + `siphon_sbi_npcf_app_sessions_active` gauge; drains across create → delete. (Per-replica local registry + gauge, complementary to the script's Redis correlation, not a replacement.)

`diameter_peers_connected_gauge` now exercises a fresh metrics instance, since the new diameter tests legitimately increment the shared process-global gauge (asserting absolute values on it under parallel tests was racy).

## Testing

- `cargo test`: 2927 passed, 3 ignored (lib + integration).
- `cargo clippy --all-targets -- -D warnings`: clean.

## Note

This makes the C-side pool **visible and boundable** — it does not by itself decide leak-vs-retention. The `siphon_glibc_in_use_bytes` trend (and a one-NF `MALLOC_ARENA_MAX=2` A/B) settle that.
