### PR TITLE
Scaling/redundancy docs + reference deployments, and serve the HTTP admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,26 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   created by this NF and not yet deleted (a steady climb under flat call rate is
   a stranded-session leak), backed by a new per-replica app-session registry on
   `NpcfClient` that inserts on create and removes on delete.
+- **HTTP admin API is now served**, behind a new optional `admin.listen`. It was
+  implemented but never started, so only `/metrics` was exposed at runtime.
+  Endpoints: `/admin/health` (liveness), `/admin/ready` (readiness — returns 503
+  while the process is draining on SIGTERM, so a load balancer / Kubernetes
+  deschedules it before it stops accepting new INVITEs), `/admin/stats`,
+  `/admin/registrations[/{aor}]` (inspect / force-unregister), and `/metrics`.
+  Off by default (no `admin.listen` ⇒ unchanged behaviour).
+- **Operator documentation for scaling, redundancy and deployment** (`docs/`):
+  `scaling-and-redundancy.md` (what state is node-local vs. Redis-shared, what the
+  Redis backend actually provides, and why SIPhon ships no clusterer/DMQ-style
+  replication engine), `deployment.md` (single-node / redundant-pair / N-node
+  with a front LB + DNS SRV / IMS topologies, an operations runbook, and a light
+  Kubernetes shape), and `migrating-from-kamailio-opensips.md`.
+- **Reference deployments** (`deploy/`): a front-LB + 2-backend + Redis HA demo
+  (docker-compose + a host-binary `validate.sh` that proves restart recovery from
+  Redis), and Kubernetes manifests with a `kind` kill-a-pod failover drill
+  (`validate-kind.sh`).
+- **Release-cut HA failover gate** — `cut-release.sh` now runs the Redis-registrar
+  failover validation as a mandatory gate (skip with `FAILOVER_OK=1`), alongside
+  the existing perf/mem and criterion regression gates.
 
 ### Changed
 - **SCTP is now an opt-in build feature, off by default.** SIP-over-SCTP

--- a/README.md
+++ b/README.md
@@ -553,6 +553,29 @@ src/
 - **No GIL** — free-threaded Python 3.14t with `#[pymodule(gil_used = false)]`
 - **No per-request allocations** on the hot path where avoidable
 
+### Scaling, HA & operations
+
+A single SIPhon node handles tens of thousands of calls per second, so you run more
+than one node for **redundancy**, not throughput — and you get it the proven SIP way
+(a front load balancer + DNS SRV + a shared Redis registrar), not a clustering
+engine. The operator docs ([docs/](docs/)) cover this end to end:
+
+- **[docs/scaling-and-redundancy.md](docs/scaling-and-redundancy.md)** — what state
+  is node-local vs. Redis-shared, what the Redis backend actually buys you
+  (durability + boot snapshot, not live cross-node sync), and why SIPhon ships no
+  `clusterer`/DMQ equivalent.
+- **[docs/deployment.md](docs/deployment.md)** — concrete topologies (single node,
+  redundant pair / N nodes, IMS), the operations runbook (graceful drain, probes,
+  metrics/alerts, capacity), and a light Kubernetes shape.
+- **[docs/migrating-from-kamailio-opensips.md](docs/migrating-from-kamailio-opensips.md)**
+  — a concept map for porting routes, plus how to translate `clusterer`/`dmq_usrloc`
+  topologies.
+- **[docs/handler-execution-model.md](docs/handler-execution-model.md)** — the
+  handler pool, blocking contract, and liveness guarantees.
+
+Runnable reference deployments (a front-LB + 2-backend demo with a failover-proof
+script, and Kubernetes manifests) live in **[deploy/](deploy/)**.
+
 ## Testing
 
 SIPhon follows strict TDD practices across multiple test layers:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,83 @@
+# Deploying SIPhon
+
+Reference deployment artifacts for the topologies described in
+[`docs/deployment.md`](../docs/deployment.md). Start with the docs for the *why*;
+this directory is the *how*.
+
+> **The thesis:** one SIPhon node handles tens of thousands of cps, so you run more
+> than one node for **redundancy**, and you get redundancy with a **front LB + DNS
+> SRV + a shared Redis registrar** — not a clustering engine. See
+> [`docs/scaling-and-redundancy.md`](../docs/scaling-and-redundancy.md).
+
+## Layout
+
+| Path | What it is |
+|---|---|
+| [`ha-demo/`](ha-demo/) | The "front LB + 2 backends + shared Redis" pattern, runnable two ways |
+| [`k8s/`](k8s/) | A light Kubernetes shape: `StatefulSet` + `Service` + Redis + `ConfigMap` |
+
+## `ha-demo/` — two ways to run it
+
+**1. Quick failover proof (host binary, no image build):**
+
+```bash
+# needs a built siphon binary (redis-backend feature), docker, curl, python3
+cargo build --release --features redis-backend          # PYO3_PYTHON=python3
+SIPHON_BIN=target/release/siphon deploy/ha-demo/validate.sh
+```
+
+`validate.sh` starts a throwaway Redis + two backend nodes + a front LB on the host
+(isolated ports, own Redis — it can't collide with anything else), then asserts:
+
+- **Phase A** — a REGISTER and a terminating INVITE routed through the LB succeed
+  (the front-LB + node-local-registrar pattern works end to end).
+- **Phase B** — a binding is persisted to Redis, is **not** visible on a sibling node
+  (the honest "no live cross-node sync" boundary), and is **recovered from Redis**
+  when its node is killed and restarted — proving the one durability claim the docs
+  make. It prints `ALL N ASSERTIONS PASSED`.
+
+**2. Containerised reference (the shape you'd actually deploy):**
+
+```bash
+cd deploy/ha-demo
+docker compose -p siphon-hademo -f docker-compose.ha.yaml up --build
+# SIP ingress on udp/5060, /metrics on 9090
+```
+
+This builds the image from the repo `Dockerfile` and runs `redis` + `backend1` +
+`backend2` + `frontend`. Swap the `build:` blocks for a published
+`image:` once you have one.
+
+### Files
+
+| File | Role |
+|---|---|
+| `siphon-backend.yaml` | a backend node (Redis-backed registrar) |
+| `siphon-frontend.yaml` | the front LB (a `gateway` group over the backends) |
+| `proxy.py` | backend routing (REGISTER→save, INVITE→lookup+relay) |
+| `lb.py` | front-LB routing (hash on AoR → affinity → relay) |
+| `sipcli.py` | a tiny self-contained SIP/UDP probe (no sipp dependency) |
+| `validate.sh` | the host-binary failover proof |
+| `docker-compose.ha.yaml` | the containerised reference topology |
+
+All configs are parametrised with `${VAR:-default}`, so the same files back both the
+compose and the host-binary runs.
+
+## `k8s/`
+
+A deliberately minimal Kubernetes shape — a starting point to copy, not a platform.
+
+```bash
+kubectl apply -f deploy/k8s/
+```
+
+| File | Role |
+|---|---|
+| `configmap.yaml` | `siphon.yaml` + the routing script |
+| `redis.yaml` | shared Redis (Deployment + Service) |
+| `statefulset.yaml` | SIPhon pods with stable identity, drain-aware termination, `/metrics` probes |
+| `service.yaml` | headless Service (per-pod DNS / SRV) + a `LoadBalancer` ingress |
+
+Scale with `replicas`. For any-pod terminating-call delivery, add subscriber affinity
+at your ingress (consistent hash on the AoR) — see
+[`docs/deployment.md`](../docs/deployment.md#kubernetes-kept-deliberately-light).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -75,9 +75,26 @@ kubectl apply -f deploy/k8s/
 |---|---|
 | `configmap.yaml` | `siphon.yaml` + the routing script |
 | `redis.yaml` | shared Redis (Deployment + Service) |
-| `statefulset.yaml` | SIPhon pods with stable identity, drain-aware termination, `/metrics` probes |
+| `statefulset.yaml` | SIPhon pods with stable identity, drain-aware termination, `/admin/*` probes |
 | `service.yaml` | headless Service (per-pod DNS / SRV) + a `LoadBalancer` ingress |
+| `validate-kind.sh` | **kill-a-pod failover drill** on a local `kind` cluster (below) |
 
 Scale with `replicas`. For any-pod terminating-call delivery, add subscriber affinity
 at your ingress (consistent hash on the AoR) — see
 [`docs/deployment.md`](../docs/deployment.md#kubernetes-kept-deliberately-light).
+
+### Kill-a-pod failover drill (`validate-kind.sh`)
+
+The K8s analogue of the compose `validate.sh`: stand the manifests up on a local
+[`kind`](https://kind.sigs.k8s.io) cluster, register a contact, **`kubectl delete pod
+siphon-0`**, and prove the StatefulSet recreates it and it **recovers the binding from
+Redis** — verified over the admin API (`/admin/registrations/{aor}`).
+
+```bash
+# needs: kind, kubectl, docker, and a siphon image with the admin API
+SIPHON_IMAGE=ghcr.io/siphon-project/siphon-sip:latest deploy/k8s/validate-kind.sh
+```
+
+The REGISTER is sent from an in-cluster Job (SIP/UDP via cluster DNS); a locally-built
+image is auto-loaded into kind (`kind load`). `KEEP_CLUSTER=1` leaves the cluster up
+for inspection.

--- a/deploy/ha-demo/docker-compose.ha.yaml
+++ b/deploy/ha-demo/docker-compose.ha.yaml
@@ -1,0 +1,80 @@
+# HA-demo: the "front LB + 2 backends + shared Redis" topology from
+# docs/deployment.md, containerised.
+#
+# This is the REFERENCE SHAPE (how you'd containerise the pattern). For a quick,
+# deterministic failover proof that does NOT build the full image, use
+# ./validate.sh instead (it runs the binary on the host).
+#
+#   docker compose -p siphon-hademo -f docker-compose.ha.yaml up --build
+#
+# Build context is the repo root so the existing Dockerfile is reused. Swap the
+# `build:` blocks for `image: <your-registry>/siphon-sip:<tag>` once you publish.
+#
+# Networking note: this demo uses a bridge network (all SIP stays inside it, so
+# service-name routing is clean). For real ingress, prefer host networking or a
+# LoadBalancer that preserves source IP/port — SIP is sensitive to NAT rewriting
+# of Via/Contact (see docs/deployment.md).
+
+x-siphon: &siphon
+  image: siphon-sip:ha-demo
+  build:
+    context: ../..
+    dockerfile: Dockerfile
+  restart: unless-stopped
+  depends_on:
+    - redis
+
+services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+
+  backend1:
+    <<: *siphon
+    volumes:
+      - ./siphon-backend.yaml:/etc/siphon/siphon.yaml:ro
+      - ./proxy.py:/etc/siphon/proxy.py:ro
+    environment:
+      INSTANCE_ID: backend1
+      SCRIPT_PATH: /etc/siphon/proxy.py
+      REDIS_HOST: redis
+      SIP_PORT: "5060"
+      METRICS_PORT: "9090"
+    command: ["--config", "/etc/siphon/siphon.yaml"]
+
+  backend2:
+    <<: *siphon
+    volumes:
+      - ./siphon-backend.yaml:/etc/siphon/siphon.yaml:ro
+      - ./proxy.py:/etc/siphon/proxy.py:ro
+    environment:
+      INSTANCE_ID: backend2
+      SCRIPT_PATH: /etc/siphon/proxy.py
+      REDIS_HOST: redis
+      SIP_PORT: "5060"
+      METRICS_PORT: "9090"
+    command: ["--config", "/etc/siphon/siphon.yaml"]
+
+  frontend:
+    <<: *siphon
+    depends_on:
+      - backend1
+      - backend2
+    volumes:
+      - ./siphon-frontend.yaml:/etc/siphon/siphon.yaml:ro
+      - ./lb.py:/etc/siphon/lb.py:ro
+    environment:
+      INSTANCE_ID: frontend
+      SCRIPT_PATH: /etc/siphon/lb.py
+      SIP_PORT: "5060"
+      METRICS_PORT: "9090"
+      BACKEND1_URI: "sip:backend1:5060"
+      BACKEND1_ADDR: "backend1:5060"
+      BACKEND2_URI: "sip:backend2:5060"
+      BACKEND2_ADDR: "backend2:5060"
+    command: ["--config", "/etc/siphon/siphon.yaml"]
+    ports:
+      - "5060:5060/udp"   # SIP ingress
+      - "9090:9090/tcp"   # /metrics
+      - "9091:9091/tcp"   # /admin/health, /admin/ready, /admin/registrations

--- a/deploy/ha-demo/lb.py
+++ b/deploy/ha-demo/lb.py
@@ -1,0 +1,35 @@
+"""
+HA-demo FRONTEND load-balancer script.
+
+A thin SIPhon proxy that spreads new transactions across a `gateway` group of
+backend nodes (configured in siphon-frontend.yaml). This is the "front LB" from
+docs/deployment.md, dogfooded with SIPhon itself.
+
+Affinity: requests are hashed on the AoR (To-URI) so a subscriber's REGISTER and the
+terminating calls to them deterministically land on the SAME backend — which is the
+node that then holds their binding in its node-local registrar. That's what makes
+any-node terminating delivery work without live cross-node state sharing.
+"""
+from siphon import proxy, gateway, log
+
+
+@proxy.on_request
+def route(request):
+    # In-dialog requests follow the established route set, not the LB.
+    if request.in_dialog:
+        if request.loose_route():
+            request.relay()
+        else:
+            request.reply(404, "Not Here")
+        return
+
+    # Consistent-hash on the AoR for subscriber affinity.
+    destination = gateway.select("backends", key=str(request.to_uri))
+    if not destination:
+        log.error("no healthy backend in 'backends' group")
+        request.reply(503, "Service Unavailable")
+        return
+
+    log.info(f"LB {request.method} {request.to_uri} -> {destination.uri}")
+    request.record_route()
+    request.relay(destination.uri)

--- a/deploy/ha-demo/proxy.py
+++ b/deploy/ha-demo/proxy.py
@@ -1,0 +1,55 @@
+"""
+HA-demo BACKEND proxy script.
+
+Deliberately minimal — this exists only to demonstrate the scaling/redundancy
+topology, NOT as a production script. It:
+
+- answers local OPTIONS pings (used as a readiness check),
+- saves REGISTERs into the (Redis-backed) registrar — WITHOUT digest auth, so the
+  demo driver can register with a plain REGISTER,
+- looks up the registrar and relays INVITE/other out-of-dialog requests,
+- loose-routes in-dialog requests.
+
+For a realistic starting point use scripts/proxy_default.py (which adds digest auth,
+sanity checks, presence, etc.).
+"""
+from siphon import proxy, registrar, log
+
+
+@proxy.on_request
+def route(request):
+    # Local OPTIONS keepalive / readiness ping.
+    if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+        return
+
+    # In-dialog sequential requests follow the route set.
+    if request.in_dialog:
+        if request.loose_route():
+            request.relay()
+        else:
+            request.reply(404, "Not Here")
+        return
+
+    # REGISTER -> persist into the registrar (Redis write-through). No auth in the
+    # demo. registrar.save() also sends the 200 OK.
+    if request.method == "REGISTER":
+        registrar.save(request)
+        log.info(f"registered {request.to_uri}")
+        return
+
+    # Everything else (INVITE, MESSAGE, ...) -> location lookup + relay.
+    if not request.ruri.user:
+        request.reply(484, "Address Incomplete")
+        return
+
+    contacts = registrar.lookup(request.ruri)
+    if not contacts:
+        # 404 here is the signal the demo uses to prove a binding is NOT known to
+        # this node (e.g. on a sibling node that never saw the REGISTER, or before
+        # a restart restores the snapshot).
+        request.reply(404, "Not Found")
+        return
+
+    request.record_route()
+    request.fork(contacts)

--- a/deploy/ha-demo/sipcli.py
+++ b/deploy/ha-demo/sipcli.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Minimal, self-contained SIP/UDP probe for the HA demo. No external deps, no sipp.
+
+It sends a single REGISTER / INVITE / OPTIONS and prints the status code of the
+FIRST response received (or 000 on timeout). That's all the demo needs:
+
+  - REGISTER -> 200 means the binding was accepted.
+  - INVITE   -> 404 means the node does NOT know the AoR;
+                1xx/2xx/4xx-other means the node DID find the binding and relayed
+                (we don't complete the call — we only care that lookup succeeded).
+  - OPTIONS  -> 200 means the node is up (readiness).
+
+Usage:
+  sipcli.py register <host> <port> <user> <contact_host> <contact_port>
+  sipcli.py invite   <host> <port> <user>
+  sipcli.py options  <host> <port>
+
+Exit code 0 if a response arrived, 1 on timeout. The status code is printed to
+stdout (three digits).
+"""
+import socket
+import sys
+import time
+
+DOMAIN = "example.com"
+TIMEOUT_S = 3.0
+
+
+def _rand(n=8):
+    # Cheap unique-ish token without importing random (deterministic enough; the
+    # nanosecond clock varies per call).
+    return f"{time.time_ns():x}"[-n:]
+
+
+def _send(host, port, message):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(TIMEOUT_S)
+    sock.bind(("127.0.0.1", 0))
+    local_host, local_port = sock.getsockname()
+    wire = message.format(local_host=local_host, local_port=local_port).encode()
+    sock.sendto(wire, (host, int(port)))
+    try:
+        data, _ = sock.recvfrom(65535)
+    except socket.timeout:
+        return None
+    finally:
+        sock.close()
+    first = data.split(b"\r\n", 1)[0].decode(errors="replace")
+    # "SIP/2.0 200 OK" -> "200"
+    parts = first.split(" ", 2)
+    return parts[1] if len(parts) >= 2 else "000"
+
+
+def register(host, port, user, contact_host, contact_port):
+    branch = _rand()
+    call_id = _rand(12)
+    tag = _rand()
+    msg = (
+        f"REGISTER sip:{DOMAIN} SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP {local_host}:{local_port};branch=z9hG4bK" + branch + "\r\n"
+        "Max-Forwards: 70\r\n"
+        f"From: <sip:{user}@{DOMAIN}>;tag={tag}\r\n"
+        f"To: <sip:{user}@{DOMAIN}>\r\n"
+        f"Call-ID: {call_id}\r\n"
+        "CSeq: 1 REGISTER\r\n"
+        f"Contact: <sip:{user}@{contact_host}:{contact_port}>\r\n"
+        "Expires: 3600\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n"
+    )
+    return _send(host, port, msg)
+
+
+def invite(host, port, user):
+    branch = _rand()
+    call_id = _rand(12)
+    tag = _rand()
+    msg = (
+        f"INVITE sip:{user}@{DOMAIN} SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP {local_host}:{local_port};branch=z9hG4bK" + branch + "\r\n"
+        "Max-Forwards: 70\r\n"
+        f"From: <sip:caller@{DOMAIN}>;tag={tag}\r\n"
+        f"To: <sip:{user}@{DOMAIN}>\r\n"
+        f"Call-ID: {call_id}\r\n"
+        "CSeq: 1 INVITE\r\n"
+        "Contact: <sip:caller@{local_host}:{local_port}>\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n"
+    )
+    return _send(host, port, msg)
+
+
+def options(host, port):
+    branch = _rand()
+    call_id = _rand(12)
+    tag = _rand()
+    msg = (
+        f"OPTIONS sip:{DOMAIN} SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP {local_host}:{local_port};branch=z9hG4bK" + branch + "\r\n"
+        "Max-Forwards: 70\r\n"
+        f"From: <sip:probe@{DOMAIN}>;tag={tag}\r\n"
+        f"To: <sip:{DOMAIN}>\r\n"
+        f"Call-ID: {call_id}\r\n"
+        "CSeq: 1 OPTIONS\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n"
+    )
+    return _send(host, port, msg)
+
+
+def main(argv):
+    if len(argv) < 4:
+        print("usage: sipcli.py <register|invite|options> <host> <port> [...]", file=sys.stderr)
+        return 2
+    cmd, host, port = argv[1], argv[2], argv[3]
+    if cmd == "register":
+        code = register(host, port, argv[4], argv[5], argv[6])
+    elif cmd == "invite":
+        code = invite(host, port, argv[4])
+    elif cmd == "options":
+        code = options(host, port)
+    else:
+        print(f"unknown command: {cmd}", file=sys.stderr)
+        return 2
+    if code is None:
+        print("000")
+        return 1
+    print(code)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/deploy/ha-demo/sipcli.py
+++ b/deploy/ha-demo/sipcli.py
@@ -36,12 +36,15 @@ def _rand(n=8):
 def _send(host, port, message):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.settimeout(TIMEOUT_S)
-    sock.bind(("127.0.0.1", 0))
+    # connect() so the kernel selects a route-correct source address (works for
+    # both loopback and inter-pod/k8s). getsockname() then yields the real source
+    # IP we put in Via/Contact, so the reply finds its way back to us.
+    sock.connect((host, int(port)))
     local_host, local_port = sock.getsockname()
     wire = message.format(local_host=local_host, local_port=local_port).encode()
-    sock.sendto(wire, (host, int(port)))
+    sock.send(wire)
     try:
-        data, _ = sock.recvfrom(65535)
+        data = sock.recv(65535)
     except socket.timeout:
         return None
     finally:

--- a/deploy/ha-demo/siphon-backend.yaml
+++ b/deploy/ha-demo/siphon-backend.yaml
@@ -1,0 +1,43 @@
+# HA-demo BACKEND node config.
+#
+# Parametrised with ${VAR:-default} so the SAME file is used by both
+# docker-compose.ha.yaml (env from compose) and validate.sh (env from the shell,
+# running the binary directly on loopback with custom ports). A real deployment
+# would hard-code these.
+#
+# The load-bearing line for redundancy is `registrar.backend: redis`: every
+# REGISTER is written through to the shared Redis, and on restart this node
+# reloads the FULL registrar snapshot from it — see docs/scaling-and-redundancy.md.
+
+listen:
+  udp:
+    - "${SIP_BIND:-0.0.0.0}:${SIP_PORT:-5060}"
+
+domain:
+  local:
+    - "example.com"
+    - "127.0.0.1"
+
+script:
+  path: "${SCRIPT_PATH:-/etc/siphon/proxy.py}"
+
+registrar:
+  backend: redis
+  redis:
+    url: "redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}"
+    key_prefix: "siphon:reg:"
+
+server:
+  instance_id: "${INSTANCE_ID:-backend}"   # distinct per node
+  drain_secs: 5                             # short for the demo; 30 in production
+
+metrics:
+  prometheus:
+    listen: "0.0.0.0:${METRICS_PORT:-9090}" # /metrics — Prometheus scrape
+
+admin:
+  listen: "0.0.0.0:${ADMIN_PORT:-9091}"     # /admin/health + /admin/ready probes
+
+log:
+  level: info
+  format: pretty

--- a/deploy/ha-demo/siphon-frontend.yaml
+++ b/deploy/ha-demo/siphon-frontend.yaml
@@ -1,0 +1,46 @@
+# HA-demo FRONTEND node config (the load balancer).
+#
+# A thin proxy that spreads new transactions over a `gateway` group of the two
+# backend nodes. See lb.py for the routing logic and docs/deployment.md for the
+# pattern. Parametrised with ${VAR:-default} for compose + validate.sh reuse.
+
+listen:
+  udp:
+    - "${SIP_BIND:-0.0.0.0}:${SIP_PORT:-5060}"
+
+domain:
+  local:
+    - "example.com"
+    - "127.0.0.1"
+
+script:
+  path: "${SCRIPT_PATH:-/etc/siphon/lb.py}"
+
+gateway:
+  groups:
+    - name: "backends"
+      algorithm: hash          # consistent hash on the AoR => subscriber affinity
+      probe:
+        enabled: true
+        interval_secs: 5
+        failure_threshold: 3
+      destinations:
+        - uri: "${BACKEND1_URI:-sip:backend1:5060}"
+          address: "${BACKEND1_ADDR:-backend1:5060}"
+        - uri: "${BACKEND2_URI:-sip:backend2:5060}"
+          address: "${BACKEND2_ADDR:-backend2:5060}"
+
+server:
+  instance_id: "${INSTANCE_ID:-frontend}"
+  drain_secs: 5
+
+metrics:
+  prometheus:
+    listen: "0.0.0.0:${METRICS_PORT:-9090}"
+
+admin:
+  listen: "0.0.0.0:${ADMIN_PORT:-9091}"
+
+log:
+  level: info
+  format: pretty

--- a/deploy/ha-demo/validate.sh
+++ b/deploy/ha-demo/validate.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# HA-demo validation: prove the "front LB + 2 backends + shared Redis" pattern
+# works, and that the one durability claim the docs make is real — a backend
+# recovers its full registrar from Redis on restart.
+#
+# This runs the siphon BINARY directly on the host (no Docker image build), with a
+# throwaway Redis in a container. It is fully isolated (own ports, own Redis,
+# own temp dir) so it can't collide with the project's perf/mem-leak harness.
+#
+# Requirements: a built `siphon` binary (redis-backend feature), `docker`, `curl`,
+# `python3`.
+#
+#   SIPHON_BIN=/path/to/siphon ./validate.sh
+#
+# Exit 0 = all assertions passed.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIPHON_BIN="${SIPHON_BIN:-$DIR/../../target/release/siphon}"
+
+# Isolated ports / names so nothing collides with anything else on the box.
+REDIS_NAME="siphon-hademo-redis"
+REDIS_PORT=6399
+FE_PORT=6060;  FE_METRICS=9100; FE_ADMIN=9110
+BE1_PORT=6061; BE1_METRICS=9101; BE1_ADMIN=9111
+BE2_PORT=6062; BE2_METRICS=9102; BE2_ADMIN=9112
+
+WORK="$(mktemp -d)"
+PIDS=()
+PASS=0; FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+info()  { printf '\033[36m• %s\033[0m\n' "$*"; }
+
+cleanup() {
+  set +e
+  for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null; done
+  docker rm -f "$REDIS_NAME" >/dev/null 2>&1
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+assert() { # assert "<label>" <actual> <expected-or-predicate>
+  local label="$1" actual="$2" expect="$3"
+  if [[ "$expect" == "not404" ]]; then
+    if [[ "$actual" != "404" && "$actual" != "000" ]]; then
+      green "  PASS  $label (got $actual)"; PASS=$((PASS+1)); return
+    fi
+  elif [[ "$actual" == "$expect" ]]; then
+    green "  PASS  $label (got $actual)"; PASS=$((PASS+1)); return
+  fi
+  red "  FAIL  $label (got '$actual', expected '$expect')"; FAIL=$((FAIL+1))
+}
+
+sip() { python3 "$DIR/sipcli.py" "$@"; }
+rcli() { docker exec "$REDIS_NAME" redis-cli "$@"; }
+
+wait_metrics() { # wait until /metrics on $1 returns 200
+  local port="$1" i
+  for i in $(seq 1 30); do
+    if [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$port/metrics" 2>/dev/null)" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  red "node on metrics port $port never became ready"; return 1
+}
+
+LAST_PID=""
+start_node() { # start_node <logfile> <configfile> <KEY=VAL>...
+  local log="$1" cfg="$2"; shift 2
+  env "$@" PYO3_PYTHON="${PYO3_PYTHON:-python3}" "$SIPHON_BIN" --config "$cfg" >"$log" 2>&1 &
+  LAST_PID="$!"
+  PIDS+=("$LAST_PID")
+}
+
+# --- preflight ----------------------------------------------------------------
+[[ -x "$SIPHON_BIN" ]] || { red "siphon binary not found/executable at $SIPHON_BIN (set SIPHON_BIN)"; exit 2; }
+command -v docker >/dev/null || { red "docker is required"; exit 2; }
+command -v curl   >/dev/null || { red "curl is required"; exit 2; }
+
+info "siphon binary: $SIPHON_BIN"
+info "work dir: $WORK"
+
+# --- redis --------------------------------------------------------------------
+info "starting throwaway Redis on 127.0.0.1:$REDIS_PORT"
+docker rm -f "$REDIS_NAME" >/dev/null 2>&1 || true
+docker run -d --rm --name "$REDIS_NAME" -p "127.0.0.1:$REDIS_PORT:6379" \
+  redis:7-alpine redis-server --save "" --appendonly no >/dev/null
+for i in $(seq 1 30); do rcli ping >/dev/null 2>&1 && break; sleep 0.5; done
+
+REDIS_ENV=(REDIS_HOST=127.0.0.1 REDIS_PORT="$REDIS_PORT")
+
+# --- backends + frontend ------------------------------------------------------
+info "starting backend1 (SIP $BE1_PORT, metrics $BE1_METRICS, admin $BE1_ADMIN)"
+start_node "$WORK/backend1.log" "$DIR/siphon-backend.yaml" \
+  INSTANCE_ID=backend1 SIP_PORT="$BE1_PORT" METRICS_PORT="$BE1_METRICS" ADMIN_PORT="$BE1_ADMIN" \
+  SCRIPT_PATH="$DIR/proxy.py" "${REDIS_ENV[@]}"
+BE1_PID="$LAST_PID"
+
+info "starting backend2 (SIP $BE2_PORT, metrics $BE2_METRICS, admin $BE2_ADMIN)"
+start_node "$WORK/backend2.log" "$DIR/siphon-backend.yaml" \
+  INSTANCE_ID=backend2 SIP_PORT="$BE2_PORT" METRICS_PORT="$BE2_METRICS" ADMIN_PORT="$BE2_ADMIN" \
+  SCRIPT_PATH="$DIR/proxy.py" "${REDIS_ENV[@]}"
+
+info "starting frontend LB (SIP $FE_PORT, metrics $FE_METRICS, admin $FE_ADMIN)"
+start_node "$WORK/frontend.log" "$DIR/siphon-frontend.yaml" \
+  INSTANCE_ID=frontend SIP_PORT="$FE_PORT" METRICS_PORT="$FE_METRICS" ADMIN_PORT="$FE_ADMIN" \
+  SCRIPT_PATH="$DIR/lb.py" \
+  BACKEND1_URI="sip:127.0.0.1:$BE1_PORT" BACKEND1_ADDR="127.0.0.1:$BE1_PORT" \
+  BACKEND2_URI="sip:127.0.0.1:$BE2_PORT" BACKEND2_ADDR="127.0.0.1:$BE2_PORT"
+
+wait_metrics "$BE1_METRICS"; wait_metrics "$BE2_METRICS"; wait_metrics "$FE_METRICS"
+green "all three nodes up"
+
+echo
+info "PHASE 0 — admin API probes"
+httpcode() { curl -s -o /dev/null -w '%{http_code}' "$1" 2>/dev/null; }
+assert "GET /admin/health (liveness) -> 200" "$(httpcode http://127.0.0.1:$BE1_ADMIN/admin/health)" 200
+assert "GET /admin/ready (readiness) -> 200" "$(httpcode http://127.0.0.1:$BE1_ADMIN/admin/ready)"  200
+
+echo
+info "PHASE A — front LB + DNS-SRV-style spread + node-local registrar"
+# Register through the LB; the LB hashes the AoR to one backend, which saves it.
+assert "REGISTER alice via LB -> 200"        "$(sip register 127.0.0.1 $FE_PORT alice 127.0.0.1 7777)" 200
+# Terminating INVITE through the LB hashes alice to the SAME backend -> lookup hit.
+assert "INVITE alice via LB -> not 404"      "$(sip invite   127.0.0.1 $FE_PORT alice)"                not404
+
+echo
+info "PHASE B — Redis durability + restart recovery (the one claim worth proving)"
+# Talk DIRECTLY to backend1 so we know exactly which node holds the binding.
+assert "REGISTER bob on backend1 -> 200"     "$(sip register 127.0.0.1 $BE1_PORT bob 127.0.0.1 7778)"  200
+assert "INVITE bob on backend1 -> not 404"   "$(sip invite   127.0.0.1 $BE1_PORT bob)"                 not404
+# Honest limitation: backend2 never saw bob's REGISTER (no live cross-node sync).
+assert "INVITE bob on backend2 -> 404"       "$(sip invite   127.0.0.1 $BE2_PORT bob)"                 404
+# Persistence is in Redis, independent of the siphon process.
+assert "bob's binding present in Redis"      "$(rcli KEYS 'siphon:reg:*' | grep -c bob || true)"       1
+
+info "killing backend1 (simulating a node failure / restart)"
+kill "$BE1_PID" 2>/dev/null || true
+sleep 1
+info "restarting backend1 — it must reload the snapshot from Redis"
+start_node "$WORK/backend1.restart.log" "$DIR/siphon-backend.yaml" \
+  INSTANCE_ID=backend1 SIP_PORT="$BE1_PORT" METRICS_PORT="$BE1_METRICS" ADMIN_PORT="$BE1_ADMIN" \
+  SCRIPT_PATH="$DIR/proxy.py" "${REDIS_ENV[@]}"
+wait_metrics "$BE1_METRICS"
+
+# The boot log proves the snapshot was loaded.
+restored=""
+for i in $(seq 1 20); do
+  if grep -q "restored contacts from Redis backend" "$WORK/backend1.restart.log" 2>/dev/null; then
+    restored="yes"; break
+  fi
+  sleep 0.5
+done
+assert "backend1 logged snapshot restore"    "${restored:-no}"                                         yes
+# And the recovered node answers for bob WITHOUT bob re-registering.
+assert "INVITE bob on restarted backend1 -> not 404" "$(sip invite 127.0.0.1 $BE1_PORT bob)"           not404
+
+# --- summary ------------------------------------------------------------------
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  green "==== ALL $PASS ASSERTIONS PASSED ===="
+  green "LB+SRV pattern works; Redis-backed registrar survives a node restart."
+  exit 0
+else
+  red "==== $FAIL FAILED, $PASS passed ===="
+  red "backend1 restart log: $WORK/backend1.restart.log (kept until process exit)"
+  exit 1
+fi

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,65 @@
+# siphon.yaml + the routing script, mounted read-only into each pod.
+# This is the "shape to copy" — adjust domain, auth, and the script for real use.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: siphon-config
+  labels: { app: siphon }
+data:
+  siphon.yaml: |
+    listen:
+      udp: ["0.0.0.0:5060"]
+      tcp: ["0.0.0.0:5060"]
+    domain:
+      local: ["example.com"]
+    script:
+      path: "/etc/siphon/scripts/proxy.py"
+    registrar:
+      backend: redis            # durability: a restarted pod reloads the snapshot
+      redis:
+        url: "redis://siphon-redis:6379"
+    server:
+      # Stable per-pod identity, from the StatefulSet pod name (downward API).
+      instance_id: "${POD_NAME}"
+      drain_secs: 30            # graceful drain window on SIGTERM
+    metrics:
+      prometheus:
+        listen: "0.0.0.0:9090"  # /metrics — Prometheus scrape
+    admin:
+      listen: "0.0.0.0:9091"    # /admin/health (liveness) + /admin/ready (readiness)
+    log:
+      level: info
+      format: json              # structured logs for aggregation
+
+  proxy.py: |
+    # Minimal demo proxy. Replace with scripts/proxy_default.py (digest auth,
+    # sanity checks, presence) for production.
+    from siphon import proxy, registrar, auth, log
+
+    DOMAIN = "example.com"
+
+    @proxy.on_request
+    def route(request):
+        if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+            request.reply(200, "OK")
+            return
+        if request.in_dialog:
+            if request.loose_route():
+                request.relay()
+            else:
+                request.reply(404, "Not Here")
+            return
+        if request.method == "REGISTER":
+            if not auth.require_digest(request, realm=DOMAIN):
+                return
+            registrar.save(request)
+            return
+        if not request.ruri.user:
+            request.reply(484, "Address Incomplete")
+            return
+        contacts = registrar.lookup(request.ruri)
+        if not contacts:
+            request.reply(404, "Not Found")
+            return
+        request.record_route()
+        request.fork(contacts)

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -32,11 +32,10 @@ data:
       format: json              # structured logs for aggregation
 
   proxy.py: |
-    # Minimal demo proxy. Replace with scripts/proxy_default.py (digest auth,
-    # sanity checks, presence) for production.
-    from siphon import proxy, registrar, auth, log
-
-    DOMAIN = "example.com"
+    # Minimal demo proxy (no auth, so a plain REGISTER works in the demo).
+    # Replace with scripts/proxy_default.py (digest auth, sanity checks, presence)
+    # for production.
+    from siphon import proxy, registrar, log
 
     @proxy.on_request
     def route(request):
@@ -50,8 +49,6 @@ data:
                 request.reply(404, "Not Here")
             return
         if request.method == "REGISTER":
-            if not auth.require_digest(request, realm=DOMAIN):
-                return
             registrar.save(request)
             return
         if not request.ruri.user:

--- a/deploy/k8s/redis.yaml
+++ b/deploy/k8s/redis.yaml
@@ -1,0 +1,34 @@
+# Redis — the shared registrar backend (durability + boot snapshot for every pod).
+# A single replica is fine for the demo; use a managed/HA Redis in production.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: siphon-redis
+  labels: { app: siphon-redis }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: siphon-redis }
+  template:
+    metadata:
+      labels: { app: siphon-redis }
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          args: ["redis-server", "--appendonly", "yes"]   # persist to disk
+          ports:
+            - { containerPort: 6379, name: redis }
+          readinessProbe:
+            tcpSocket: { port: 6379 }
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: siphon-redis
+  labels: { app: siphon-redis }
+spec:
+  selector: { app: siphon-redis }
+  ports:
+    - { port: 6379, targetPort: 6379, name: redis }

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,32 @@
+# Headless Service — gives each StatefulSet pod a stable DNS name
+# (siphon-0.siphon, siphon-1.siphon, ...). Useful for per-pod addressing and as
+# the backing for SIP DNS SRV records.
+apiVersion: v1
+kind: Service
+metadata:
+  name: siphon
+  labels: { app: siphon }
+spec:
+  clusterIP: None
+  selector: { app: siphon }
+  ports:
+    - { port: 5060, protocol: UDP, name: sip-udp }
+    - { port: 5060, protocol: TCP, name: sip-tcp }
+    - { port: 9090, protocol: TCP, name: metrics }
+---
+# Ingress Service — one entry point that spreads SIP across the pods.
+# externalTrafficPolicy: Local preserves the client source IP/port, which SIP
+# needs for correct Via/Contact handling. Front this with your SIP-aware LB (or a
+# SIPhon LB pod) if you need subscriber affinity.
+apiVersion: v1
+kind: Service
+metadata:
+  name: siphon-ingress
+  labels: { app: siphon }
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector: { app: siphon }
+  ports:
+    - { port: 5060, protocol: UDP, name: sip-udp }
+    - { port: 5060, protocol: TCP, name: sip-tcp }

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -1,0 +1,56 @@
+# SIPhon as a StatefulSet — stable per-pod identity (siphon-0, siphon-1, ...) so
+# each pod's `server.instance_id` is stable across restarts. Scale with `replicas`.
+#
+# Redundancy model (see docs/scaling-and-redundancy.md): pods share one Redis for
+# registrar durability; they do NOT live-replicate location state. If you need
+# any-pod terminating-call delivery, put subscriber affinity at your ingress
+# (consistent hash on the AoR). Otherwise rely on re-register convergence.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: siphon
+  labels: { app: siphon }
+spec:
+  serviceName: siphon          # the headless Service below
+  replicas: 2
+  selector:
+    matchLabels: { app: siphon }
+  template:
+    metadata:
+      labels: { app: siphon }
+    spec:
+      # SIP is sensitive to NAT rewriting of Via/Contact. hostNetwork keeps source
+      # IP/port intact; drop it only if your ingress preserves them another way.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      # Let the SIGTERM drain (server.drain_secs) finish before SIGKILL.
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: siphon
+          image: ghcr.io/siphon-project/siphon-sip:latest   # or your registry/tag
+          args: ["--config", "/etc/siphon/siphon.yaml"]
+          env:
+            # Pod name -> server.instance_id via ${POD_NAME} expansion in the config.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef: { fieldPath: metadata.name }
+          ports:
+            - { containerPort: 5060, protocol: UDP, name: sip-udp }
+            - { containerPort: 5060, protocol: TCP, name: sip-tcp }
+            - { containerPort: 9090, protocol: TCP, name: metrics }
+            - { containerPort: 9091, protocol: TCP, name: admin }
+          # Liveness stays up through drain; readiness returns 503 while draining
+          # so the pod leaves Service endpoints before it stops taking new INVITEs.
+          livenessProbe:
+            httpGet: { path: /admin/health, port: 9091 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /admin/ready, port: 9091 }
+            periodSeconds: 5
+          volumeMounts:
+            - { name: config, mountPath: /etc/siphon/siphon.yaml, subPath: siphon.yaml }
+            - { name: config, mountPath: /etc/siphon/scripts/proxy.py, subPath: proxy.py }
+      volumes:
+        - name: config
+          configMap: { name: siphon-config }

--- a/deploy/k8s/validate-kind.sh
+++ b/deploy/k8s/validate-kind.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Kubernetes analogue of deploy/ha-demo/validate.sh: stand the manifests up on a
+# local kind cluster, register a contact, **kill a pod**, and prove the pod comes
+# back and recovers its registrar binding from Redis — the k8s version of the
+# compose failover demo.
+#
+# Verification uses the admin API (/admin/registrations) over a port-forward (TCP),
+# and the REGISTER is sent from an in-cluster Job (SIP/UDP via cluster DNS).
+#
+# Requirements: kind, kubectl, docker. The siphon image is pulled from a registry
+# by default (override with SIPHON_IMAGE); a locally-built image is auto-loaded.
+#
+#   SIPHON_IMAGE=ghcr.io/siphon-project/siphon-sip:latest ./validate-kind.sh
+#   KEEP_CLUSTER=1 ./validate-kind.sh      # don't delete the kind cluster at the end
+#
+# Exit 0 = the binding survived the pod kill.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER="${KIND_CLUSTER:-siphon-ha}"
+IMAGE="${SIPHON_IMAGE:-ghcr.io/siphon-project/siphon-sip:latest}"
+AOR="sip:alice@example.com"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+info()  { printf '\033[36m• %s\033[0m\n' "$*"; }
+
+PF_PID=""
+cleanup() {
+  set +e
+  [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null
+  kubectl delete configmap sipcli --ignore-not-found >/dev/null 2>&1
+  kubectl delete job sip-register --ignore-not-found >/dev/null 2>&1
+  if [[ "${KEEP_CLUSTER:-0}" != "1" ]]; then
+    info "deleting kind cluster '$CLUSTER' (KEEP_CLUSTER=1 to keep)"
+    kind delete cluster --name "$CLUSTER" >/dev/null 2>&1
+  fi
+}
+trap cleanup EXIT
+
+for tool in kind kubectl docker; do
+  command -v "$tool" >/dev/null || { red "$tool is required"; exit 2; }
+done
+
+# --- cluster ------------------------------------------------------------------
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+  info "creating kind cluster '$CLUSTER'"
+  kind create cluster --name "$CLUSTER" >/dev/null
+fi
+# kind sets the kubeconfig context on create; select it explicitly to be safe.
+kubectl config use-context "kind-$CLUSTER" >/dev/null
+
+# Load a locally-built image into the cluster if it exists locally; otherwise the
+# pods pull it from the registry.
+if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  info "loading local image $IMAGE into kind"
+  kind load docker-image "$IMAGE" --name "$CLUSTER" >/dev/null
+fi
+
+# --- deploy -------------------------------------------------------------------
+info "applying redis + config + service"
+kubectl apply -f "$DIR/redis.yaml" >/dev/null
+kubectl apply -f "$DIR/configmap.yaml" >/dev/null
+kubectl apply -f "$DIR/service.yaml" >/dev/null
+
+# kind nodes are containers — drop hostNetwork and use cluster networking, and
+# substitute the image. (hostNetwork is correct for real SIP ingress; see the
+# manifest comments. For an in-cluster test we use ClusterIP + DNS.)
+info "applying statefulset (hostNetwork off for kind, image=$IMAGE)"
+sed -e '/hostNetwork: true/d' \
+    -e '/dnsPolicy: ClusterFirstWithHostNet/d' \
+    -e "s#image: ghcr.io/siphon-project/siphon-sip:latest#image: $IMAGE#" \
+    "$DIR/statefulset.yaml" | kubectl apply -f - >/dev/null
+
+info "waiting for siphon-0 and siphon-1 to become Ready (readiness = /admin/ready)"
+kubectl rollout status statefulset/siphon --timeout=180s >/dev/null
+
+# --- register a contact from inside the cluster (SIP/UDP via cluster DNS) ------
+info "REGISTER $AOR via an in-cluster Job targeting siphon-0"
+kubectl delete configmap sipcli --ignore-not-found >/dev/null 2>&1
+kubectl create configmap sipcli --from-file=sipcli.py="$DIR/../ha-demo/sipcli.py" >/dev/null
+kubectl delete job sip-register --ignore-not-found >/dev/null 2>&1
+cat <<'YAML' | kubectl apply -f - >/dev/null
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sip-register
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: register
+          image: python:3-alpine
+          command: ["python", "/cli/sipcli.py", "register",
+                    "siphon-0.siphon", "5060", "alice", "siphon-0.siphon", "5060"]
+          volumeMounts: [{ name: cli, mountPath: /cli }]
+      volumes:
+        - name: cli
+          configMap: { name: sipcli }
+YAML
+kubectl wait --for=condition=complete job/sip-register --timeout=60s >/dev/null
+
+verify_binding() { # -> prints HTTP code from /admin/registrations/$AOR on siphon-0
+  [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null
+  kubectl port-forward pod/siphon-0 19091:9091 >/dev/null 2>&1 &
+  PF_PID="$!"
+  sleep 2
+  curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:19091/admin/registrations/$AOR"
+}
+
+info "verifying the binding is present (admin API)"
+before="$(verify_binding)"
+[[ "$before" == "200" ]] && green "  binding present before kill (HTTP $before)" \
+                         || { red "  binding NOT present before kill (HTTP $before)"; exit 1; }
+
+# --- KILL THE POD -------------------------------------------------------------
+info "kubectl delete pod siphon-0  (simulating a node failure)"
+kubectl delete pod siphon-0 --wait=true >/dev/null
+info "waiting for siphon-0 to be recreated and Ready"
+kubectl rollout status statefulset/siphon --timeout=180s >/dev/null
+kubectl wait --for=condition=ready pod/siphon-0 --timeout=120s >/dev/null
+
+# --- prove recovery -----------------------------------------------------------
+info "verifying the binding recovered from Redis (no re-REGISTER)"
+after="$(verify_binding)"
+if [[ "$after" == "200" ]]; then
+  green "==== PASS: siphon-0 recovered $AOR from Redis after the pod was killed ===="
+  exit 0
+else
+  red "==== FAIL: binding missing after pod restart (HTTP $after) ===="
+  exit 1
+fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# SIPhon documentation
+
+Operator and developer documentation for SIPhon. (GitHub renders this page when you
+browse the `docs/` folder.)
+
+## Running it in production
+
+- **[Scaling, clustering & redundancy](scaling-and-redundancy.md)** — how to run more
+  than one node, what shared state actually means here, what the Redis backend buys
+  you (durability + boot snapshot, **not** live cross-node sync), and why SIPhon
+  ships no `clusterer`/DMQ-style replication engine. **Start here** if you're asking
+  "how does SIPhon cluster?"
+- **[Deployment & operations](deployment.md)** — concrete topologies (single node,
+  redundant pair / N nodes, IMS), the ops runbook (graceful drain, health/readiness
+  probes, metrics & alerting, capacity planning, backup/DR), and a light Kubernetes
+  shape.
+- **[Migrating from Kamailio / OpenSIPS](migrating-from-kamailio-opensips.md)** — a
+  concept map for porting routes and modules, and how to translate `clusterer` /
+  `dmq_usrloc` topologies to SIPhon's model.
+
+## Internals
+
+- **[Handler execution model](handler-execution-model.md)** — how Python handlers
+  run, the blocking contract, and the elasticity / backpressure / liveness
+  guarantees of the handler pool.
+- **[Feature readiness matrix](feature-readiness-matrix.md)** — per-feature maturity
+  (Production / Implemented / Planned) with config keys and validation notes.
+
+## Runnable deployments
+
+Reference deployment artifacts — a front-LB + 2-backend demo with a failover-proof
+script, plus Kubernetes manifests — live in **[../deploy/](../deploy/)**.
+
+## Also
+
+- The main **[README](../README.md)** — overview, install, scripting API, performance.
+- **[siphon.yaml](../siphon.yaml)** — the annotated reference configuration.
+- **[sdk/](../sdk/)** — the `siphon-sip` mock library for testing scripts.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,316 @@
+# Deployment & operations
+
+Concrete topologies, configs, and the operational runbook for running SIPhon in
+production. Read [scaling-and-redundancy.md](scaling-and-redundancy.md) first for
+*why* these are the shapes — this doc is the *how*.
+
+The golden rule from that document, restated: **one node does the work; you add
+nodes for redundancy, and you get redundancy with a front LB + DNS SRV, not a
+cluster.**
+
+- [Scenario 1 — single node](#scenario-1--single-node)
+- [Scenario 2 — redundant pair / N nodes (front LB + DNS SRV)](#scenario-2--redundant-pair--n-nodes)
+- [Scenario 3 — IMS core](#scenario-3--ims-core)
+- [Operations runbook](#operations-runbook)
+- [Kubernetes (kept deliberately light)](#kubernetes-kept-deliberately-light)
+
+A runnable, self-contained version of Scenario 2 lives in
+[`deploy/ha-demo/`](../deploy/ha-demo/); the Kubernetes manifests are in
+[`deploy/k8s/`](../deploy/k8s/).
+
+---
+
+## Scenario 1 — single node
+
+The default, and the right answer for most deployments. One process, optionally a
+Redis backend so a restart comes back whole.
+
+```yaml
+# siphon.yaml
+listen:
+  udp: ["0.0.0.0:5060"]
+  tcp: ["0.0.0.0:5060"]
+domain:
+  local: ["example.com"]
+script:
+  path: "scripts/proxy_default.py"
+
+registrar:
+  backend: redis            # durability: a restart reloads the full snapshot
+  redis:
+    url: "redis://127.0.0.1:6379"
+
+server:
+  instance_id: "${HOSTNAME}"
+  drain_secs: 30            # graceful drain on SIGTERM (see runbook)
+
+metrics:
+  prometheus:
+    listen: "0.0.0.0:9090"  # /metrics — Prometheus scrape
+
+admin:
+  listen: "0.0.0.0:9091"    # /admin/health + /admin/ready probes, registrations
+```
+
+That's a production-shaped single node. A "warm spare" is just a second box with the
+same config, kept ready; promote it by moving traffic (DNS/VIP) when you need to.
+
+---
+
+## Scenario 2 — redundant pair / N nodes
+
+Survive a node failure and do zero-downtime upgrades. Three ingredients, none of
+which require the nodes to share live call state:
+
+1. **DNS SRV** so clients/upstreams fail new calls over automatically.
+2. **A front-facing SIP load balancer** spreading new transactions across backends.
+3. **A shared Redis registrar backend** so a restarted/replacement node is whole.
+
+### DNS SRV (the primary failover mechanism)
+
+Publish every node as an SRV target. Equal priority + weight = load spread; lower
+priority = standby.
+
+```dns
+;; Active/active across two nodes
+_sip._udp.example.com. 3600 IN SRV 10 50 5060 node1.example.com.
+_sip._udp.example.com. 3600 IN SRV 10 50 5060 node2.example.com.
+
+;; Or active/standby: node2 only used if node1 is unreachable
+_sip._udp.example.com. 3600 IN SRV 10 100 5060 node1.example.com.
+_sip._udp.example.com. 3600 IN SRV 20 100 5060 node2.example.com.
+```
+
+SIPhon resolves SRV/NAPTR natively for its own outbound routing (RFC 3263), so this
+works in both directions.
+
+### The front LB (SIPhon fronting SIPhon)
+
+You can use any SIP-aware load balancer you already trust. The self-contained way —
+and what [`deploy/ha-demo/`](../deploy/ha-demo/) demonstrates — is a thin SIPhon
+proxy whose only job is to spread traffic over a `gateway` group of backends:
+
+```yaml
+# frontend siphon.yaml — the load balancer
+listen:
+  udp: ["0.0.0.0:5060"]
+domain:
+  local: ["example.com"]
+script:
+  path: "lb.py"
+gateway:
+  groups:
+    - name: "backends"
+      algorithm: hash       # consistent hash => subscriber affinity (see below)
+      probe:
+        enabled: true
+        interval_secs: 5
+        failure_threshold: 3
+      destinations:
+        - { uri: "sip:node1.example.com:5060", address: "10.0.0.1:5060" }
+        - { uri: "sip:node2.example.com:5060", address: "10.0.0.2:5060" }
+```
+
+```python
+# lb.py — spread new requests over the backend group; keep dialogs sticky
+from siphon import proxy, gateway, log
+
+@proxy.on_request
+def route(request):
+    if request.in_dialog:
+        if request.loose_route():
+            request.relay()
+        else:
+            request.reply(404, "Not Here")
+        return
+
+    # Affinity: hash on the AoR so a subscriber's REGISTER and the terminating
+    # calls to them land on the SAME backend (which is the node that then holds
+    # their binding in its local registrar).
+    destination = gateway.select("backends", key=str(request.to_uri))
+    if not destination:
+        request.reply(503, "Service Unavailable")
+        return
+    request.record_route()
+    request.relay(destination.uri)
+```
+
+### Why the affinity hash matters
+
+Registrar lookups are node-local (see
+[scaling-and-redundancy.md](scaling-and-redundancy.md#what-the-redis-registrar-backend-actually-buys-you)).
+A subscriber can only be *reached for a terminating call* on the node holding their
+binding. Hashing **both** the REGISTER and the terminating INVITE on the AoR sends
+both to the same backend, so terminating delivery always works — with no shared live
+state. If you don't need any-node terminating delivery (e.g. pure outbound trunk /
+PSTN breakout), drop the affinity and use `algorithm: weighted`.
+
+### Backends
+
+Each backend is a Scenario-1 node pointed at the **same** Redis, with a distinct
+`instance_id`:
+
+```yaml
+registrar:
+  backend: redis
+  redis:
+    url: "redis://redis.internal:6379"
+server:
+  instance_id: "node1"     # node2, node3, ... — distinct per node
+  drain_secs: 30
+```
+
+### Optional: a VIP instead of (or with) the front LB
+
+For a classic active/standby pair, put a virtual IP (keepalived/VRRP) in front. The
+standby boots with the registrar snapshot and converges as UEs re-REGISTER; new
+calls ride DNS SRV during the swing. This is simpler than the front-LB approach but
+gives you active/standby rather than active/active.
+
+---
+
+## Scenario 3 — IMS core
+
+In IMS, **SIPhon does not need to share location state at all**, because the
+**HSS is the location authority**:
+
+- The **I-CSCF** does a Cx LIR to the HSS to find the subscriber's serving
+  **S-CSCF**, then routes there. Terminating routing never depends on any single
+  SIPhon node's local registrar.
+- **S-CSCF** instances persist registrar bindings and iFC profiles in Redis, so an
+  S-CSCF restart doesn't trigger an HSS re-fetch storm.
+- **P-CSCF** is edge state (IPsec SAs, Path) and scales horizontally behind the
+  Gm reference point.
+
+So an IMS core scales to many nodes per role using exactly the mechanisms above plus
+the HSS — no `clusterer`/DMQ equivalent required. See the
+[`examples/ims_*`](../examples/) configs for per-role starting points.
+
+---
+
+## Operations runbook
+
+### Graceful drain & rolling upgrades
+
+On `SIGTERM`/`SIGINT`, SIPhon **stops accepting new INVITEs** and waits up to
+`server.drain_secs` (default **30s**) for in-flight transactions and B2BUA calls to
+finish before exiting. Set `drain_secs: 0` to exit immediately.
+
+A rolling upgrade is therefore:
+
+1. Remove the node from the LB / DNS rotation (or let the LB's health probe do it).
+2. `SIGTERM` the process; it drains in-flight work.
+3. Replace the binary / image; start it. With a Redis backend it reloads the full
+   registrar snapshot on boot.
+4. Re-add to rotation. Repeat per node.
+
+In Kubernetes, wire this to the pod lifecycle (below): a `preStop` hook plus a
+`terminationGracePeriodSeconds` **≥ `drain_secs`** lets the drain complete before the
+kubelet sends `SIGKILL`.
+
+### Health checks & probes
+
+Enable the **admin API** and point your probes at it:
+
+```yaml
+admin:
+  listen: "0.0.0.0:9091"   # serves /admin/health, /admin/ready, /admin/*, /metrics
+```
+
+- **Liveness:** `GET http://<node>:9091/admin/health` → `200` for as long as the
+  process is alive. It does **not** flip during drain — a liveness probe failing
+  mid-drain would make the orchestrator kill the node before it finished draining.
+- **Readiness:** `GET http://<node>:9091/admin/ready` → `200` normally, **`503`
+  while draining** (after `SIGTERM`) so a load balancer / Kubernetes pulls the node
+  from rotation before it stops accepting new INVITEs.
+
+The admin port also serves `/admin/stats`, `/admin/registrations[/{aor}]` (inspect
+or force-unregister bindings), and `/metrics`. If you'd rather not enable it, a
+`GET /metrics` returning `200` is a serviceable liveness signal and a SIP `OPTIONS`
+ping to the SIP port works for readiness (the default proxy scripts answer local
+`OPTIONS` with `200`).
+
+### Metrics & alerting
+
+Scrape `/metrics`. The handful that matter operationally:
+
+| Signal | Alert when | Why |
+|---|---|---|
+| `siphon_memory_allocated_bytes` | `rate(...[30m]) > 0` while call rate is flat | A real leak. The per-structure gauges (`siphon_proxy_dialog_sessions`, `siphon_uac_pending_requests`) localize it. |
+| `siphon_pyexec_jobs_shed_total` | sustained `rate() > 0` | Handler pool saturated + queue full → SIP retransmits. Raise `sync_pool_max` or speed up handlers. |
+| `siphon_pyexec_pool_size` vs `_pool_max` | `pool_size == pool_max` **and** `inflight == pool_size` for minutes | Pool fully grown and saturated, approaching the liveness watchdog. |
+| `siphon_proxy_dialog_sessions` | grows unbounded under flat completed-call load | Dialog state not draining — a leak signature. |
+
+See [handler-execution-model.md](handler-execution-model.md) for the pool internals
+and the blocking-handler contract that drives these.
+
+### Capacity planning
+
+- **Throughput:** ~28–30k cps per node on commodity hardware (the README baseline);
+  free-threaded CPython 3.14t is required to reach it (the container image ships it).
+- **Memory:** dominated by the handler pool — roughly
+  `sync_pool_max × ~2 MB` at peak. Lower `script.sync_pool_max` on
+  memory-constrained nodes; prefer `auth.http.cache_ttl_secs` so an auth storm never
+  needs the pool to grow in the first place.
+- **Stability over heroics:** if a node is unstable under load, fix the instability —
+  don't paper over it with more nodes. The liveness watchdog
+  (`script.handler_stall_abort_secs`) converts a hang into a fast supervised restart
+  rather than an indefinite outage.
+
+### State backup & DR
+
+The only durable state SIPhon owns lives in your **Redis / PostgreSQL** registrar
+backend (bindings, service-routes, P-Associated-URIs, iFC profiles). Back that up
+with its native tooling (Redis RDB/AOF, `pg_dump`). Everything else is either
+ephemeral (transactions, dialogs — not meaningful to back up) or reconstructed from
+re-registration. There is no SIPhon-specific snapshot format to manage.
+
+---
+
+## Kubernetes (kept deliberately light)
+
+People expect to see K8s, so here's a clean shape to copy — **not** a platform.
+Manifests are in [`deploy/k8s/`](../deploy/k8s/). The load-bearing details:
+
+- **`StatefulSet`** (not Deployment) so each pod has a stable identity. Wire
+  `server.instance_id` from the pod name via the downward API:
+
+  ```yaml
+  env:
+    - name: POD_NAME
+      valueFrom: { fieldRef: { fieldPath: metadata.name } }
+  # siphon.yaml: server.instance_id: "${POD_NAME}"
+  ```
+
+- **Graceful drain:** let the SIGTERM drain finish before SIGKILL.
+
+  ```yaml
+  terminationGracePeriodSeconds: 40        # >= server.drain_secs
+  # (SIGTERM is sent on pod termination; siphon drains for drain_secs.)
+  ```
+
+- **Probes on the admin API** (`admin.listen`) — liveness that survives drain,
+  readiness that fails closed during drain:
+
+  ```yaml
+  livenessProbe:
+    httpGet: { path: /admin/health, port: 9091 }
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  readinessProbe:
+    httpGet: { path: /admin/ready, port: 9091 }   # 503 while draining
+    periodSeconds: 5
+  ```
+
+- **Networking:** SIP is sensitive to NAT rewriting of `Via`/`Contact`. Prefer
+  `hostNetwork: true` (or a properly configured `LoadBalancer`/`externalTrafficPolicy:
+  Local` so source IPs and ports survive) and set `advertised_address` to what peers
+  should see.
+- **Redis** as a normal dependency (a `Deployment` + `Service`, or a managed Redis).
+  All siphon pods share it for registrar durability.
+- **Config** via a `ConfigMap` (siphon.yaml + the script), mounted read-only.
+
+That's enough to run a redundant SIPhon `StatefulSet` behind a `Service`. Scale with
+`replicas`; pair it with subscriber-affinity at your ingress if you need any-pod
+terminating delivery. Anything fancier (HPA on cps, per-pod SRV, Diameter SCTP) is a
+deployment-specific exercise, not something to bake into a starter manifest.

--- a/docs/migrating-from-kamailio-opensips.md
+++ b/docs/migrating-from-kamailio-opensips.md
@@ -1,0 +1,144 @@
+# Migrating from Kamailio / OpenSIPS
+
+A practical concept map for engineers coming from Kamailio or OpenSIPS, plus the one
+topic that trips people up: **state sharing and clustering**.
+
+This is not a feature-by-feature parity claim. SIPhon's protocol engine is faithful
+to the same RFCs (transactions per RFC 3261 §17, registrar §10, proxy §16), so the
+*concepts* map directly — what changes is the *surface*: a Python API + YAML instead
+of a routing-script DSL + `modparam`.
+
+---
+
+## The mental-model shift
+
+| Kamailio / OpenSIPS | SIPhon |
+|---|---|
+| `kamailio.cfg` / `opensips.cfg` routing-script DSL | Python handlers (`@proxy.on_request`, `@b2bua.on_invite`, …) |
+| `modparam("module", "param", value)` | one `siphon.yaml`, documented inline |
+| `loadmodule "x.so"` | nothing — capabilities are namespaces you `import` |
+| Edit cfg → restart (or limited rtimer reloads) | Edit script → inotify hot-reload, no restart |
+| `$avp(...)`, `$var(...)`, `$dlg_val(...)` | ordinary Python variables and objects |
+| Test with a live instance + SIPp | Unit-test scripts with the `siphon-sip` mock SDK, plus SIPp |
+
+The biggest day-to-day change: routing logic is **real code** — functions, imports,
+a debugger, `pytest` — not an expression language.
+
+---
+
+## Routing & transactions
+
+| Kamailio / OpenSIPS | SIPhon |
+|---|---|
+| `t_relay()` | `request.relay()` |
+| `t_relay()` to a fixed target / `$du` | `request.relay("sip:next@host:port")` |
+| `t_load_contacts()` + `t_next_contacts()` (serial/parallel forking) | `request.fork(targets, strategy="parallel"\|"sequential")` |
+| `record_route()` | `request.record_route()` |
+| `loose_route()` | `request.loose_route()` |
+| `failure_route[...]` | `@proxy.on_failure` (and per-relay `on_failure=`) |
+| `onreply_route[...]` | `@proxy.on_reply` |
+| `sl_send_reply()` / `t_reply()` | `request.reply(code, reason)` |
+| `$ru`, `$rU`, `$rd` | `request.ruri`, `request.ruri.user`, `request.ruri.host` |
+| `$fU`/`$tU`, `$ft`/`$tt` | `request.from_uri`/`to_uri`, `request.from_tag`/`to_tag` |
+| `is_method("INVITE")` | `@proxy.on_request("INVITE")` or `request.method == "INVITE"` |
+| `has_totag()` / loose-route dialog check | `request.in_dialog` |
+
+CANCEL handling, Max-Forwards enforcement, retransmission absorption and ACK-for-non-2xx
+are done by the SIPhon transaction layer automatically — you don't write routes for
+them (see the framework-handles-automatically notes in the API reference).
+
+## Registrar / user location
+
+| Kamailio / OpenSIPS | SIPhon |
+|---|---|
+| `save("location")` | `registrar.save(request)` (also sends the 200 OK) |
+| `lookup("location")` | `registrar.lookup(uri)` → `list[Contact]` |
+| `registered("location")` | `registrar.is_registered(uri)` |
+| `usrloc` DB modes / `db_url` | `registrar.backend: memory \| redis \| postgres` |
+| `nathelper` / `fix_nated_*` | `request.fix_nated_contact()` / `fix_nated_register()` / `add_contact_alias()` |
+
+## Auth
+
+| Kamailio / OpenSIPS | SIPhon |
+|---|---|
+| `www_authorize()` / `auth_check()` | `auth.require_www_digest(request, realm)` |
+| `proxy_authorize()` | `auth.require_proxy_digest(request, realm)` |
+| `pv_www_authenticate()` w/ AKA | `auth.require_aka_digest()` / `auth.require_ims_digest()` |
+
+## State, data & dispatch
+
+| Kamailio / OpenSIPS | SIPhon |
+|---|---|
+| `htable` (`$sht(...)`) | `cache` namespace (local LRU + optional Redis, shared live) |
+| `dispatcher` module + `ds_select_dst()` | `gateway` namespace (`gateway.select(group, key=…)`) + YAML `gateway.groups` |
+| `dialog` module (`$dlg_val`, profiles) | the B2BUA call object (`@b2bua.*`, `call.*`) for true call control |
+| `rtpengine_*()` | `call.media.anchor()` / the `rtpengine` namespace |
+| `sqlops` / `avpops` against a DB | plain Python (use a DB client in an `async` handler, off the hot path) |
+
+> Module state habit to unlearn: in cfg you'd stash cross-request state in `htable`.
+> In SIPhon scripts, **don't** hold cross-request state in module-level Python
+> dicts/lists — use the `cache` namespace (Redis-backed, survives hot-reload, shared
+> across nodes). Module-level **constants** are fine.
+
+---
+
+## Clustering & shared state — read this carefully
+
+This is where expectations differ most, because Kamailio and OpenSIPS both grew
+explicit **state-replication subsystems** and SIPhon deliberately did not.
+
+**What you're used to:**
+
+- **OpenSIPS `clusterer`** — distributed user location via *full-sharing* (full-mesh
+  broadcast; every node mirrors the whole location table) or *federation*
+  (partitioned), with active/backup *sharing tags* and seed-node sync.
+- **Kamailio `dmq` / `dmq_usrloc`** — replicate usrloc/dialog/htable between nodes
+  over the `KDMQ` SIP method, with node auto-discovery (and the requirement that all
+  nodes run the same major version).
+
+**What SIPhon does instead** — and *why* — is covered in full in
+[scaling-and-redundancy.md](scaling-and-redundancy.md). The short version:
+
+- There is **no live cross-node replication engine**. Multi-node redundancy is a
+  **front LB + DNS SRV + a shared Redis registrar backend**.
+- The Redis backend gives **durability + a boot-time snapshot**, *not* live
+  replication: a node reads its own in-memory location table at lookup time and
+  reloads the full snapshot from Redis on restart. So a binding registered on node A
+  is reachable for terminating calls on node A; to get any-node terminating delivery,
+  hash REGISTER and INVITE for an AoR to the **same** node at the LB (subscriber
+  affinity).
+- The `cache` and `subscribe_state` namespaces *are* shared live via Redis (the
+  closest analogue to a replicated `htable`).
+
+### Porting your topology
+
+| If you ran… | Port it to… |
+|---|---|
+| OpenSIPS `clusterer` *full-sharing* usrloc | Front LB with **subscriber affinity** (consistent hash on AoR) + shared Redis registrar. No mesh to operate. |
+| OpenSIPS *federation* / partitioned usrloc | The same affinity hash *is* your partitioning — each AoR deterministically maps to one node. |
+| Kamailio `dmq_usrloc` active/active pair | Active/active behind a front LB + DNS SRV, shared Redis; or active/standby on a VIP with re-register convergence. |
+| Kamailio `dmq` for `htable` replication | Point all nodes at one Redis and use the `cache` namespace (already shared live). |
+| `dispatcher` health-checked gateway pools | `gateway.groups` with `probe.enabled: true` (per-node probing). |
+
+### What's intentionally different (don't expect it)
+
+- **Live dialog/transaction replication across nodes** — not provided. A node death
+  drops its in-flight calls; new calls fail over via DNS SRV. (This matches Kamailio/
+  OpenSIPS *without* an active replication module.)
+- **A cluster membership protocol** — there isn't one to configure, monitor, or
+  debug. Redis + DNS are the only shared infrastructure.
+- **Version-locked node meshes** — not applicable; nodes don't talk a replication
+  protocol to each other, so they don't have to move in lockstep.
+
+If your scale genuinely requires N-way live usrloc replication with zero affinity,
+that's a deliberate design discussion — see the "when would you miss one" section of
+[scaling-and-redundancy.md](scaling-and-redundancy.md#why-siphon-has-no-clusterer--dmq-and-when-youd-miss-one).
+
+---
+
+## Where to look next
+
+- [scaling-and-redundancy.md](scaling-and-redundancy.md) — the full state model.
+- [deployment.md](deployment.md) — ready-to-run topologies and the ops runbook.
+- The Python API reference and the `sdk/` mock library — for the per-method surface
+  you'll port routes onto.

--- a/docs/scaling-and-redundancy.md
+++ b/docs/scaling-and-redundancy.md
@@ -1,0 +1,250 @@
+# Scaling, clustering & redundancy
+
+How to run more than one SIPhon node, what shared state actually means here, and
+why SIPhon deliberately does **not** ship a clustering/replication engine.
+
+---
+
+## TL;DR
+
+- **One node is a lot.** A single SIPhon process handles tens of thousands of calls
+  per second — the documented baseline runs to roughly **28–30k cps** on one
+  commodity box (see the [README baseline](../README.md#current-baseline)). Most
+  deployments never outgrow a single active node.
+- **You run more than one node for _redundancy_, not throughput.** And you get
+  redundancy the boring, proven SIP way: a **front-facing load balancer + DNS SRV
+  records** (RFC 3263), not a bespoke cluster.
+- **Redis gives you _durability_, not a live shared brain.** The Redis (or
+  PostgreSQL) registrar backend persists bindings so a node recovers its full state
+  on restart. It is **not** real-time location replication between running nodes.
+- **In-flight calls are node-local.** Transactions, dialogs and B2BUA calls live in
+  one process and are lost if that process dies — exactly like every other SIP stack
+  that isn't running an explicit state-replication module. The right answer to "what
+  if a node crashes" is usually *don't crash*, plus DNS SRV failover for new calls.
+
+If that's all you needed, jump to [deployment.md](deployment.md) for the concrete
+topologies and configs.
+
+---
+
+## Start here: do you even need to scale?
+
+Before reaching for multiple nodes, be honest about the load. The single-node
+baseline is high enough that **capacity is rarely the reason to add nodes**:
+
+| You have | You probably need |
+|---|---|
+| Up to ~tens of thousands of cps, can tolerate a maintenance window | **One node** (optionally with a warm spare) |
+| The same, but need to survive a node failure / do zero-downtime upgrades | **Two nodes behind a front LB + DNS SRV** |
+| Genuinely beyond one box, or want N+1 spare capacity | **N nodes behind a front LB**, Redis-backed registrar |
+| A full IMS core (millions of subscribers) | **IMS topology** — P/I/S-CSCF, with the **HSS** as the location authority |
+
+The rest of this document explains *why* those are the answers, and what to watch
+out for.
+
+---
+
+## What state lives where
+
+A SIP engine holds several kinds of state. The only honest way to reason about
+redundancy is to know, for each kind, **(a)** whether it is shared between running
+nodes and **(b)** whether it survives a process restart.
+
+| State | Where it lives | Shared between running nodes? | Survives restart? |
+|---|---|---|---|
+| **Registrar bindings** | local in-memory map + optional Redis/PostgreSQL | **Snapshot only** (loaded at boot — see below) | **Yes**, with a backend (UDP contacts) |
+| **iFC profiles** (S-CSCF) | in-memory + optional Redis | Snapshot at boot | Yes, with Redis (avoids an HSS re-fetch storm) |
+| **Named `cache`** | local LRU + optional Redis | **Yes — live**, read-through Redis | Yes, with Redis |
+| **`subscribe_state` dialogs** | local map + optional cache | **Yes — live**, read-through | Yes, with Redis |
+| **Transactions** (RFC 3261 §17) | local in-memory | No | No |
+| **Dialogs / proxy sessions / B2BUA calls** | local in-memory / actors | No | No |
+| **Presence** (PIDF, subscriptions) | local in-memory | No | No |
+| **Gateway health** | local atomics, per-node probing | No (each node probes independently) | No (resets to healthy) |
+| **Outbound registrations** (`registrant`) | local in-memory | No | No |
+
+Two clean categories fall out of that table:
+
+- **Live-shared via Redis:** the named `cache` and `subscribe_state`. These are
+  true read-through L1/L2 caches — a write on one node is visible to a read on
+  another. Point every node at the same Redis and they genuinely share this data.
+- **Everything else is node-local at runtime.** The registrar is the interesting
+  middle case, so it gets its own section.
+
+---
+
+## What the Redis registrar backend actually buys you
+
+This is the part that surprises people, so it's worth being precise.
+
+When you set `registrar.backend: redis` (or `postgres`):
+
+- **Every REGISTER is written through to the backend** for durability.
+- **At startup, a node loads the _entire_ registrar snapshot from the backend** —
+  all AoRs, their contacts, service-routes, P-Associated-URIs, and iFC profiles.
+- **At runtime, lookups read the local in-memory map only.** `registrar.lookup()`,
+  `is_registered()` and friends never query the backend on the hot path. The only
+  call that consults the backend live is `registrar.aor_count()` (so a cluster-wide
+  count is authoritative).
+
+The consequence, stated plainly:
+
+> The Redis backend is **restart/crash durability + a boot-time snapshot**. It is
+> **not** live cross-node location replication. A REGISTER that lands on node A is
+> **not** visible to a lookup on node B until B is restarted (and reloads the
+> snapshot) or the subscriber re-registers on B.
+
+That sounds like a limitation, and it is — but it almost never bites, because of how
+you deploy (next section). It also means the backend's job is exactly the one you
+want it to do: **a node that dies and comes back is immediately whole again**, with
+no HSS storm and no cold registrar.
+
+### One restart caveat: UDP survives, connections don't
+
+Connection-oriented bindings (**TCP / TLS / WS / WSS**) are deliberately dropped
+when a node restores from the backend: the original socket is gone, so the contact
+is unreachable until the UE re-registers over a fresh connection. **UDP bindings
+survive** a restart intact (their flow identity is derived from the address pair,
+which is stable across reboots). For TCP/TLS/WS/WSS fleets, lean on the UE's normal
+re-REGISTER cadence (and `registrar.liveness`) to repopulate after a restart.
+
+---
+
+## How you actually get redundancy: front LB + DNS SRV
+
+You do **not** need the nodes to share live call state to build a redundant service.
+The standard SIP toolkit is enough:
+
+1. **DNS SRV / NAPTR (RFC 3263).** Publish multiple targets for your SIP domain with
+   priorities and weights. Clients (and upstream proxies) fail over to the next
+   target automatically when one is unreachable. This is the primary redundancy
+   mechanism for SIP, and SIPhon resolves SRV/NAPTR natively on outbound routing.
+2. **A front-facing proxy / load balancer.** Put one SIP-aware element in front that
+   spreads new transactions across the backend nodes. SIPhon itself can be that
+   element (a thin proxy using a `gateway` group over the backends), or you can use
+   any SIP LB you already trust.
+3. **A shared Redis registrar backend.** So that a backend node which restarts (or a
+   replacement that boots) comes up with the full binding set instead of an empty
+   registrar.
+
+For **registration-heavy** services there's one wrinkle: because lookups are
+node-local, a subscriber can only be *reached for a terminating call* on the node
+that currently holds their binding. Two ways to handle it:
+
+- **Subscriber affinity (simplest).** Hash REGISTER **and** terminating requests for
+  a given AoR to the same backend node at the LB (consistent hash on the AoR or
+  source). Then "the node that holds the binding" is always the node the call lands
+  on. This is the recommended pattern and needs no shared live state.
+- **Re-register convergence (good enough for many).** Run an active/standby pair on a
+  VIP; the standby boots with the snapshot and converges to current state as UEs
+  re-REGISTER (seconds-to-minutes, bounded by your re-REGISTER interval). New calls
+  ride DNS SRV failover in the meantime.
+
+Concrete configs for all of this are in [deployment.md](deployment.md).
+
+---
+
+## Why SIPhon has no `clusterer` / DMQ (and when you'd miss one)
+
+If you come from Kamailio or OpenSIPS you'll notice SIPhon has nothing like their
+state-replication subsystems. That's a deliberate design choice, not a gap waiting
+to be filled.
+
+- **OpenSIPS `clusterer`** replicates user location across a cluster, either
+  *full-sharing* (full-mesh broadcast — every node mirrors the entire dataset) or
+  *federation* (each node owns a partition), coordinated with active/backup
+  *sharing tags* and seed-node sync.
+  ([docs](https://opensips.org/html/docs/modules/devel/clusterer.html),
+  [full-sharing write-up](https://blog.opensips.org/2018/09/13/clustered-sip-user-location-the-full-sharing-topology/))
+- **Kamailio DMQ** (`dmq` + `dmq_usrloc`, dialog, htable) replicates state between
+  nodes over a custom `KDMQ` SIP method, with auto node-discovery — but **all nodes
+  must run the same major version or the cluster can crash**.
+  ([docs](https://www.kamailio.org/docs/modules/devel/modules/dmq.html),
+  [dmq_usrloc](https://www.kamailio.org/w/2015/01/new-module-dmq_usrloc/))
+
+Both subsystems exist largely *because* a single Kamailio/OpenSIPS node, while very
+capable, pushed large operators into many-node fleets that then had to share a
+location table. They are powerful and they are also a meaningful source of
+operational complexity (mesh membership, split-brain, version lockstep, sync edge
+cases).
+
+SIPhon's per-node ceiling moves the trade-off. With ~28–30k cps on one box, the
+common deployment is **one active node, or a small redundant set behind an LB** —
+which is served completely by *durability (Redis) + DNS SRV + affinity*. So SIPhon
+ships that, and skips the replication engine.
+
+**When would you actually miss full replication?** Only if you need *any node to
+answer a terminating call for any subscriber, with zero affinity, and zero
+re-register convergence window* — e.g. a very large active-active registrar fleet.
+That's a real use case for a few operators; for them, LB-level subscriber affinity
+is the supported answer today. If your scale genuinely demands live N-way usrloc
+replication, that's a design conversation worth having explicitly rather than
+turning on by default.
+
+---
+
+## What's lost when a node fails (and why that's fine)
+
+If a node dies mid-call, the state that was *only* in that node is gone:
+
+- **In-progress transactions and dialogs** — an INVITE that was ringing, a call that
+  was up. The endpoints detect the dead dialog by normal SIP means (no response to
+  the next request, session timers, RTP timeout) and tear down or re-originate.
+- **B2BUA calls** — both legs were owned by that process; the call drops.
+- **Presence subscriptions, gateway-health verdicts, outbound trunk registrations**
+  — re-established by the replacement node from scratch.
+
+This is **the same behavior as any SIP stack not running an explicit state
+replication module**, and it's why the honest advice is:
+
+1. **Make nodes not crash.** A wedged or crashing engine is a bug to fix, not a
+   condition to engineer around. SIPhon has a graceful-drain path (SIGTERM → stop new
+   INVITEs, let in-flight work finish) and a liveness watchdog that turns a hang into
+   a fast restart — use them (see [deployment.md](deployment.md)).
+2. **Fail over _new_ calls with DNS SRV.** Existing calls on the dead node are gone;
+   new calls go to a healthy node automatically.
+3. **Persist what's worth persisting (registrar, iFC) in Redis** so a recovered node
+   is immediately whole.
+
+Trying to transparently survive a mid-call node death — moving live dialogs between
+machines — is enormous complexity for a payoff most deployments don't need. SIPhon
+intentionally doesn't attempt it.
+
+---
+
+## Knowing which node owns a binding
+
+When a script genuinely needs to reason about ownership across nodes, every accepted
+binding carries identity:
+
+- **`server.instance_id`** — a stable per-node id. Set it to the pod/host name; it
+  supports env expansion, e.g. `instance_id: "${POD_NAME:-${HOSTNAME}}"`. Falls back
+  to `$HOSTNAME`, then `"siphon"`.
+- **`instance_epoch`** — a fresh UUID generated on every boot.
+- **`contact.is_local`** — true only when a binding carries *this* node's id **and**
+  *this* boot's epoch. After a restart, restored bindings carry their original
+  writer's identity, so `is_local` is false for them until the UE re-registers. This
+  is how, for example, an S-CSCF avoids treating a snapshot-restored binding as one
+  it currently owns.
+
+These are observability/decision hooks, not a replication mechanism — they let a
+script *know* the topology, not change it.
+
+---
+
+## Rules of thumb
+
+- Default to **one node**. Add nodes for **redundancy and upgrades**, not reflexively
+  for throughput.
+- Always run a **Redis (or PostgreSQL) registrar backend** in production — it's the
+  difference between a recovered node being whole vs. empty.
+- Front the nodes with a **load balancer + DNS SRV**; use **subscriber affinity** if
+  you need any-node terminating-call delivery without a convergence window.
+- Point every node at the **same Redis** for `cache` and `subscribe_state` if your
+  scripts rely on those being shared live.
+- Treat **in-flight call loss on node death as expected**; invest in stability and
+  fast restart, not in live call-state replication.
+
+See [deployment.md](deployment.md) for ready-to-run topologies (single node,
+redundant pair, N+1, IMS) and the operations runbook, and
+[migrating-from-kamailio-opensips.md](migrating-from-kamailio-opensips.md) if you're
+coming from `clusterer` / DMQ.

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -86,6 +86,24 @@ if [ "${BENCH_OK:-0}" != "1" ]; then
     || die "criterion regression gate failed — diagnose/roll back, or (if the bench hardware changed) re-baseline with scripts/bench_regression.sh --save (or set BENCH_OK=1 to skip)"
 fi
 
+# ── HA failover validation gate (per project policy) ───────────────────────
+# The Redis-backed registrar's core HA promise — a node that dies comes back
+# whole — is a correctness invariant, so prove it at release-cut. This is fast +
+# fully automated: deploy/ha-demo/validate.sh stands up a throwaway Redis + a
+# front LB + two backend nodes, registers a contact, restarts a backend, and
+# asserts it recovers the binding from Redis (plus the /admin/* probes). Needs
+# docker (already required for the SIPp runs). The k8s flavour
+# (deploy/k8s/validate-kind.sh, kill-a-pod on kind) stays manual — it needs a
+# cluster + image — so it is NOT gated here.
+if [ "${FAILOVER_OK:-0}" != "1" ]; then
+  echo "==> HA failover validation gate (deploy/ha-demo/validate.sh)"
+  command -v docker >/dev/null \
+    || die "docker is required for the failover gate (or set FAILOVER_OK=1 to skip)"
+  PYO3_PYTHON="${PYO3_PYTHON:-python3}" cargo build --quiet
+  SIPHON_BIN="$REPO_ROOT/target/debug/siphon" deploy/ha-demo/validate.sh \
+    || die "HA failover gate failed — the Redis-backed registrar must survive a node restart (or set FAILOVER_OK=1 to skip)"
+fi
+
 # ── Set the version, commit, tag, push ─────────────────────────────────────
 echo "==> setting Cargo.toml version to $VERSION"
 # Only the package version (the first `version = ` under [package]).

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -503,6 +503,21 @@ auth:
 #     path: "/metrics"
 
 # ---------------------------------------------------------------------------
+# HTTP admin API (health/readiness probes + registration inspection)
+# ---------------------------------------------------------------------------
+# Optional. A dedicated HTTP port exposing operational endpoints — point your
+# load balancer / Kubernetes probes at it (see docs/deployment.md):
+#   GET    /admin/health              liveness  — 200 while the process is alive
+#   GET    /admin/ready               readiness — 200, or 503 while draining (SIGTERM)
+#   GET    /admin/stats               uptime + active registration count
+#   GET    /admin/registrations       list all AoRs + their contacts
+#   GET    /admin/registrations/{aor} one AoR's contacts
+#   DELETE /admin/registrations/{aor} force-unregister an AoR
+#   GET    /metrics                   Prometheus scrape (same body as the metrics port)
+# admin:
+#   listen: "0.0.0.0:9091"
+
+# ---------------------------------------------------------------------------
 # Gateway dispatcher (named groups with load balancing + health probing)
 # ---------------------------------------------------------------------------
 # gateway:

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -18,6 +18,7 @@ use axum::Router;
 use serde::Serialize;
 use tracing::{error, info};
 
+use crate::dispatcher::DrainState;
 use crate::registrar::Registrar;
 
 /// Shared state available to all admin API handlers.
@@ -25,6 +26,10 @@ use crate::registrar::Registrar;
 pub struct AdminState {
     pub registrar: Arc<Registrar>,
     pub start_time: Instant,
+    /// Drain signal, when wired by the server. `/admin/ready` returns 503 while
+    /// draining so a load balancer / orchestrator stops sending new work. `None`
+    /// (e.g. in tests) means "never draining".
+    pub draining: Option<Arc<DrainState>>,
 }
 
 /// Start the HTTP admin API server.
@@ -51,6 +56,7 @@ fn router(state: AdminState) -> Router {
     Router::new()
         .route("/metrics", get(metrics_handler))
         .route("/admin/health", get(health_handler))
+        .route("/admin/ready", get(ready_handler))
         .route("/admin/stats", get(stats_handler))
         .route("/admin/registrations", get(registrations_handler))
         .route("/admin/registrations/{aor}", get(registration_detail_handler))
@@ -72,13 +78,39 @@ async fn metrics_handler() -> impl IntoResponse {
     )
 }
 
-/// `GET /admin/health` — liveness + readiness probe.
+/// `GET /admin/health` — liveness probe. 200 for as long as the process is
+/// alive and the admin server is servicing requests. It does NOT flip during
+/// drain (use `/admin/ready` for that): a liveness probe failing during a
+/// graceful drain would make an orchestrator kill the pod mid-drain.
 async fn health_handler(State(state): State<AdminState>) -> impl IntoResponse {
     let uptime = state.start_time.elapsed().as_secs();
     Json(HealthResponse {
         status: "ok".to_string(),
         uptime_seconds: uptime,
     })
+}
+
+/// `GET /admin/ready` — readiness probe. 200 normally; **503 while draining**
+/// (SIGTERM received) so a load balancer / orchestrator removes this node from
+/// rotation before it stops accepting new INVITEs. When no drain signal is wired
+/// it always reports ready.
+async fn ready_handler(State(state): State<AdminState>) -> impl IntoResponse {
+    let draining = state
+        .draining
+        .as_ref()
+        .map(|drain| drain.is_draining.load(std::sync::atomic::Ordering::SeqCst))
+        .unwrap_or(false);
+    if draining {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "status": "draining" })),
+        )
+    } else {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "ready" })),
+        )
+    }
 }
 
 /// `GET /admin/stats` — aggregate counters.
@@ -200,6 +232,7 @@ mod tests {
         AdminState {
             registrar: Arc::new(Registrar::new(crate::registrar::RegistrarConfig::default())),
             start_time: Instant::now(),
+            draining: None,
         }
     }
 
@@ -222,6 +255,46 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["status"], "ok");
         assert!(json["uptime_seconds"].as_u64().is_some());
+    }
+
+    #[tokio::test]
+    async fn ready_when_not_draining() {
+        // No drain signal wired -> always ready.
+        let app = test_app();
+
+        let response = app
+            .oneshot(Request::get("/admin/ready").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ready");
+    }
+
+    #[tokio::test]
+    async fn ready_returns_503_while_draining() {
+        let drain = Arc::new(DrainState::new());
+        drain
+            .is_draining
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let state = AdminState {
+            registrar: Arc::new(Registrar::new(crate::registrar::RegistrarConfig::default())),
+            start_time: Instant::now(),
+            draining: Some(drain),
+        };
+        let app = router(state);
+
+        let response = app
+            .oneshot(Request::get("/admin/ready").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "draining");
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,10 @@ pub struct Config {
     /// Prometheus metrics endpoint.
     pub metrics: Option<MetricsConfig>,
 
+    /// HTTP admin API (health/readiness probes + registration inspection).
+    /// `None` = disabled.
+    pub admin: Option<AdminConfig>,
+
     /// Server and User-Agent header values injected into responses.
     pub server: Option<ServerIdentityConfig>,
 
@@ -1216,6 +1220,25 @@ pub struct PrometheusConfig {
 
 fn default_metrics_path() -> String {
     "/metrics".to_owned()
+}
+
+// ---------------------------------------------------------------------------
+// HTTP admin API
+// ---------------------------------------------------------------------------
+
+/// HTTP admin API listener. Exposes liveness/readiness probes and registration
+/// inspection on a dedicated port:
+///   `GET /admin/health`              liveness — 200 while the process is alive
+///   `GET /admin/ready`               readiness — 200, or 503 while draining
+///   `GET /admin/stats`               uptime + active registration count
+///   `GET /admin/registrations`       list all AoRs + contacts
+///   `GET /admin/registrations/{aor}` one AoR's contacts
+///   `DELETE /admin/registrations/{aor}` force-unregister an AoR
+///   `GET /metrics`                   Prometheus scrape (same body as the metrics port)
+#[derive(Debug, Deserialize, Clone)]
+pub struct AdminConfig {
+    /// Address to expose the admin API on (e.g. "0.0.0.0:9091").
+    pub listen: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server.rs
+++ b/src/server.rs
@@ -1703,6 +1703,31 @@ impl SiphonServer {
 
         // --- Start dispatcher ---
         let drain = Arc::new(dispatcher::DrainState::new());
+
+        // --- HTTP admin API (health/readiness probes + registration inspection) ---
+        // Spawned here so it can share the drain signal: /admin/ready reports 503
+        // while draining. Independent of the Prometheus `metrics` listener above
+        // (the admin router also serves /metrics for convenience).
+        if let Some(ref admin_config) = config.admin {
+            match admin_config.listen.parse::<std::net::SocketAddr>() {
+                Ok(listen_addr) => {
+                    if let Some(registrar) = crate::script::api::registrar_arc() {
+                        let admin_state = crate::admin::AdminState {
+                            registrar: Arc::clone(registrar),
+                            start_time: std::time::Instant::now(),
+                            draining: Some(Arc::clone(&drain)),
+                        };
+                        tokio::spawn(crate::admin::serve(listen_addr, admin_state));
+                    } else {
+                        error!("admin API enabled but registrar is not initialized; not starting");
+                    }
+                }
+                Err(error) => {
+                    error!(listen = %admin_config.listen, "invalid admin.listen address: {error}");
+                }
+            }
+        }
+
         let dispatcher_handle = tokio::spawn(dispatcher::run(
             inbound_rx,
             outbound_senders,

--- a/tests/integration/admin_tests.rs
+++ b/tests/integration/admin_tests.rs
@@ -19,6 +19,7 @@ fn test_state() -> AdminState {
     AdminState {
         registrar: Arc::new(Registrar::new(RegistrarConfig::default())),
         start_time: Instant::now(),
+        draining: None,
     }
 }
 


### PR DESCRIPTION
## What & why

A user asked how SIPhon handles clustering / redundancy — they'd seen the Redis
backend referenced across modules but didn't know what it actually buys. There was
no operator documentation on any of this. This PR adds it, plus runnable reference
deployments, and closes a real gap: the HTTP admin API existed and was unit-tested
but was never actually served.

The thesis the docs lead with: **one node handles tens of thousands of cps, so you
run multiple nodes for _redundancy_, not throughput — and you get it the proven SIP
way (front LB + DNS SRV + a shared Redis registrar), not a clustering engine.**

## Documentation (`docs/`)

- **`scaling-and-redundancy.md`** — what state is node-local vs. Redis-shared; what
  the Redis registrar backend actually provides (durability + a boot-time snapshot,
  **not** live cross-node sync — `lookup()` is local); and why SIPhon deliberately
  ships no `clusterer`/DMQ-style replication engine (with a fact-checked comparison).
- **`deployment.md`** — single-node, redundant-pair / N-node (front LB + DNS SRV),
  and IMS topologies; an operations runbook (graceful drain, probes, metrics &
  alerting, capacity, backup/DR); and a light Kubernetes shape.
- **`migrating-from-kamailio-opensips.md`** — concept map for porting routes/modules,
  plus how to translate `clusterer` / `dmq_usrloc` topologies.
- **`docs/README.md`** — a docs index (renders as the `docs/` landing page), and a
  short "Scaling, HA & operations" section in the top-level README.

## Reference deployments (`deploy/`)

- **`ha-demo/`** — the front-LB + 2-backend + shared-Redis pattern, runnable two
  ways: a containerised `docker-compose.ha.yaml`, and a host-binary `validate.sh`
  that **proves failover** (register → confirm in Redis → kill & restart a backend →
  it recovers from the snapshot and serves the binding without a re-REGISTER). Driven
  by a dependency-free SIP/UDP probe (`sipcli.py`) — no sipp needed.
- **`k8s/`** — `StatefulSet` + `Service` + Redis + `ConfigMap`, with stable per-pod
  identity, drain-aware probes, and `terminationGracePeriodSeconds ≥ drain_secs`.

## Admin API (closes the gap)

`src/admin/mod.rs` implemented `/admin/health`, `/admin/registrations`, etc. with
unit tests, but `admin::serve` was never called — only the bare `/metrics` endpoint
was served at runtime. This PR:

- Wires `admin::serve` behind a new optional `admin.listen` config.
- Adds a **drain-aware** `GET /admin/ready` (returns **503 while draining** after
  SIGTERM, so a load balancer / Kubernetes pulls the node before it stops accepting
  new INVITEs); `GET /admin/health` stays a liveness signal that survives drain.
- The admin port serves `/admin/health`, `/admin/ready`, `/admin/stats`,
  `/admin/registrations[/{aor}]`, and `/metrics`.

## Validation

- **Live failover demo: all assertions pass** — including the admin API probes
  (`/admin/health` and `/admin/ready` → 200), the LB routing, and Redis restart
  recovery (`restored contacts from Redis backend`).
- `cargo clippy --all-targets -- -D warnings` clean; admin/config unit tests pass
  (including the new drain-aware readiness tests).
- `docker compose config` valid; `kubeconform -strict` validates all manifests.

No production code paths use `.unwrap()`/`.expect()`. The admin server is optional
(off unless `admin.listen` is set), so default behaviour is unchanged.
