### PR TITLE
feat(diameter): ISDNAddressString AVP type — decode MSISDN/SC-Address to E.164 in scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **ISDN-AddressString AVPs decode to E.164 in scripts** — MSISDN (701),
+  SC-Address (3300), SGSN-Number (1489) and MME-Number-for-MT-SMS (1645) are
+  now dictionary-typed `ISDNAddressString` (3GPP TS 29.002 §17.7.8) instead of
+  raw `OctetString`. `req.get_avp("MSISDN")` now returns the decoded E.164
+  digit string (e.g. `"31612345678"`) rather than raw `0x91`+TBCD bytes, and
+  setting one of these AVPs from a digit string (`set_avp` / the generic
+  `diameter.send_request(msisdn=…)` kwargs) now TBCD-encodes it correctly on
+  the wire — previously the generic path shipped raw ASCII, which conformant
+  HSSes rejected. Two new script helpers cover raw/unknown AVPs and
+  hand-built messages: `diameter.decode_isdn_address(value)` (accepts bytes or
+  an already-decoded str — idempotent) and
+  `diameter.encode_isdn_address(digits, ton_npi=0x91)`.
 - **Generic Diameter server mode** — the Diameter stack was client-only
   (originate toward HSS/PCRF); it now also accepts inbound Diameter from
   authenticated peers, runs the CER/CEA handshake and the DWR/DWA watchdog, and

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -2842,6 +2842,62 @@ class MockDiameterAnswer:
         return [(code, vendor, value) for (code, vendor), value in self._avps.items()]
 
 
+# ── ISDN-AddressString / TBCD (3GPP TS 29.002 §17.7.8) ──────────────────────
+# Mirrors siphon's Rust codec so the mock decodes MSISDN / SC-Address /
+# SGSN-Number / MME-Number-for-MT-SMS exactly like the real server path.
+
+# (code, vendor) of the AVPs dictionary-typed ISDNAddressString — vendor 3GPP.
+_ISDN_ADDRESS_AVPS = {
+    (701, 10415),   # MSISDN
+    (1489, 10415),  # SGSN-Number
+    (1645, 10415),  # MME-Number-for-MT-SMS
+    (3300, 10415),  # SC-Address
+}
+
+# International, E.164 ToN/NPI octet (bit7=ext, ToN=001, NPI=0001).
+TON_NPI_INTERNATIONAL_E164 = 0x91
+
+
+def _encode_tbcd_digits(digits: str) -> bytes:
+    """Pack a digit string as TBCD — two digits per octet, low nibble first,
+    odd length padded with 0xF (TS 29.002 §17.7.8). Non-digits are dropped."""
+    nibbles = [ord(c) - ord("0") for c in digits if c.isdigit()]
+    out = bytearray()
+    for i in range(0, len(nibbles), 2):
+        lo = nibbles[i]
+        hi = nibbles[i + 1] if i + 1 < len(nibbles) else 0x0F
+        out.append((hi << 4) | lo)
+    return bytes(out)
+
+
+def _decode_tbcd_digits(data: bytes) -> str:
+    """Decode TBCD octets back to a digit string (low nibble first); nibbles
+    above 9 (filler/extended) are skipped, matching the Rust decoder."""
+    out = []
+    for byte in data:
+        lo = byte & 0x0F
+        hi = (byte >> 4) & 0x0F
+        if lo <= 9:
+            out.append(chr(ord("0") + lo))
+        if hi <= 9:
+            out.append(chr(ord("0") + hi))
+    return "".join(out)
+
+
+def encode_isdn_address_string(digits: str, ton_npi: int = TON_NPI_INTERNATIONAL_E164) -> bytes:
+    """Encode an E.164 digit string as ISDN-AddressString — one ToN/NPI octet
+    then the TBCD digits. A leading ``+`` is stripped."""
+    return bytes([ton_npi]) + _encode_tbcd_digits(digits)
+
+
+def decode_isdn_address_string(data: bytes) -> str:
+    """Decode ISDN-AddressString bytes to an E.164 digit string. Tolerates a
+    missing ToN/NPI byte (bit 7 clear → treat the whole buffer as TBCD)."""
+    if data and (data[0] & 0x80):
+        return _decode_tbcd_digits(data[1:])
+    return _decode_tbcd_digits(data)
+
+
 class MockDiameterRequest:
     """Mock ``DiameterRequest`` passed to ``@diameter.on_request`` in tests.
 
@@ -2869,7 +2925,13 @@ class MockDiameterRequest:
         self._avps = dict(avps or {})
 
     def get_avp(self, code: int, vendor: int = 0):
-        return self._avps.get((code, vendor))
+        value = self._avps.get((code, vendor))
+        # ISDNAddressString AVPs surface as a decoded E.164 digit string, like
+        # the real server path. Tolerate a test storing either raw bytes or an
+        # already-decoded str.
+        if value is not None and (code, vendor) in _ISDN_ADDRESS_AVPS and isinstance(value, (bytes, bytearray)):
+            return decode_isdn_address_string(bytes(value))
+        return value
 
     def set_avp(self, code_or_name, value, vendor: int = 0) -> None:
         self._avps[(code_or_name, vendor)] = value
@@ -2958,6 +3020,54 @@ class MockDiameter:
             Count of peers that are marked as connected.
         """
         return sum(1 for v in self._peers.values() if v)
+
+    # -- ISDN-AddressString helpers (3GPP TS 29.002 §17.7.8) --
+
+    def decode_isdn_address(self, value) -> str:
+        """Decode an ISDN-AddressString to its E.164 digit string.
+
+        Accepts the raw AVP bytes (``0x91`` ToN/NPI + TBCD digits) **or** an
+        already-decoded ``str`` — the latter is returned unchanged, so it is
+        safe to call on the result of ``req.get_avp("MSISDN")`` regardless of
+        the AVP's dictionary type. A missing ToN/NPI byte is tolerated.
+
+        Args:
+            value: ``bytes`` (raw ISDN-AddressString) or ``str`` (digits).
+
+        Returns:
+            The E.164 digit string (no leading ``+``).
+
+        Example:
+            >>> diameter.decode_isdn_address(req.get_avp("MSISDN"))
+            '31612345678'
+        """
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            return decode_isdn_address_string(bytes(value))
+        raise TypeError("decode_isdn_address expects bytes or str")
+
+    def encode_isdn_address(self, digits: str, ton_npi: int = TON_NPI_INTERNATIONAL_E164) -> bytes:
+        """Encode an E.164 digit string as an ISDN-AddressString — one ToN/NPI
+        octet followed by the TBCD digit string.
+
+        Use when building a raw OctetString AVP by hand for an unknown code;
+        dictionary-typed AVPs (MSISDN / SC-Address / SGSN-Number /
+        MME-Number-for-MT-SMS) encode digit strings automatically. A leading
+        ``+`` is stripped.
+
+        Args:
+            digits: The E.164 number as a digit string.
+            ton_npi: ToN/NPI byte (default ``0x91`` = international E.164).
+
+        Returns:
+            The encoded ISDN-AddressString ``bytes``.
+
+        Example:
+            >>> diameter.encode_isdn_address("31612345678")
+            b'\\x91\\x13\\x16\\x32\\x54\\x76\\xf8'
+        """
+        return encode_isdn_address_string(digits, ton_npi)
 
     # -- Cx: HSS integration (I-CSCF / S-CSCF) --
 

--- a/sdk/tests/test_diameter_server_mock.py
+++ b/sdk/tests/test_diameter_server_mock.py
@@ -166,6 +166,41 @@ def test_peer_pool_tenant_defaults_to_single_domain():
     assert pool.pick_round_robin().name == "backend"
 
 
+def test_isdn_address_helpers_roundtrip_and_idempotent():
+    _fresh_diameter()
+    from siphon import diameter as d
+
+    # encode → exact ISDN-AddressString (0x91 ToN/NPI + TBCD), decode → digits.
+    encoded = d.encode_isdn_address("31612345678")
+    assert encoded == bytes([0x91, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8])
+    assert d.decode_isdn_address(encoded) == "31612345678"
+
+    # Bare TBCD (no ToN/NPI byte) is tolerated.
+    assert d.decode_isdn_address(bytes([0x13, 0x16, 0x32, 0x54, 0x76, 0xF8])) == "31612345678"
+
+    # Idempotent on an already-decoded str.
+    assert d.decode_isdn_address("31612345678") == "31612345678"
+
+    # A leading '+' is stripped (international form is the ToN/NPI byte).
+    assert d.encode_isdn_address("+31612345678") == encoded
+
+
+def test_get_avp_decodes_isdn_address_avps():
+    """get_avp on MSISDN (701/3GPP) surfaces the decoded E.164 string, like
+    the real server path — whether stored as raw bytes or already-decoded."""
+    raw = bytes([0x91, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8])
+    req = mock_module.MockDiameterRequest(
+        application_name="S6c",
+        command_name="ALR",
+        avps={(701, 10415): raw},  # MSISDN
+    )
+    assert req.get_avp(701, 10415) == "31612345678"
+
+    # An already-decoded str passes through unchanged.
+    req2 = mock_module.MockDiameterRequest(avps={(3300, 10415): "31611111111"})
+    assert req2.get_avp(3300, 10415) == "31611111111"  # SC-Address
+
+
 def test_ip_in_cidr_and_fnmatch_helpers():
     from siphon import diameter as d
 

--- a/src/diameter/codec.rs
+++ b/src/diameter/codec.rs
@@ -215,6 +215,7 @@ fn decode_avp_value(avp_type: AvpType, data: &[u8]) -> Value {
             }
         }
         AvpType::OctetString => Value::String(hex::encode(data)),
+        AvpType::ISDNAddressString => Value::String(decode_isdn_address_string(data)),
         AvpType::Address => decode_address(data),
         AvpType::Time => {
             if data.len() >= 4 {

--- a/src/diameter/dictionary.rs
+++ b/src/diameter/dictionary.rs
@@ -20,6 +20,11 @@ pub enum AvpType {
     Address,
     Time,
     DiameterIdentity,
+    /// ISDN-AddressString (3GPP TS 29.002 §17.7.8): one ToN/NPI octet
+    /// followed by the TBCD-packed E.164 digit string. Surfaces to scripts
+    /// as a plain digit string, not raw bytes — see
+    /// [`crate::diameter::codec::decode_isdn_address_string`].
+    ISDNAddressString,
 }
 
 impl AvpType {
@@ -181,7 +186,7 @@ static AVP_TABLE: &[AvpDef] = &[
     AvpDef { code: 633,  vendor_id: TGPP, name: "Originating-Request",                data_type: AvpType::Enumerated },
     // Sh (TS 29.329)
     AvpDef { code: 700,  vendor_id: TGPP, name: "User-Identity",                      data_type: AvpType::Grouped },
-    AvpDef { code: 701,  vendor_id: TGPP, name: "MSISDN",                             data_type: AvpType::OctetString },
+    AvpDef { code: 701,  vendor_id: TGPP, name: "MSISDN",                             data_type: AvpType::ISDNAddressString },
     AvpDef { code: 702,  vendor_id: TGPP, name: "User-Data-Sh",                       data_type: AvpType::OctetString },
     AvpDef { code: 703,  vendor_id: TGPP, name: "Data-Reference",                     data_type: AvpType::Enumerated },
     AvpDef { code: 704,  vendor_id: TGPP, name: "Service-Indication",                 data_type: AvpType::OctetString },
@@ -283,9 +288,9 @@ static AVP_TABLE: &[AvpDef] = &[
     AvpDef { code: 1449, vendor_id: TGPP, name: "AUTN",                               data_type: AvpType::OctetString },
     AvpDef { code: 1450, vendor_id: TGPP, name: "KASME",                              data_type: AvpType::OctetString },
     // S6c served-node identifiers (TS 29.336 / 29.272)
-    AvpDef { code: 1489, vendor_id: TGPP, name: "SGSN-Number",                        data_type: AvpType::OctetString },
+    AvpDef { code: 1489, vendor_id: TGPP, name: "SGSN-Number",                        data_type: AvpType::ISDNAddressString },
     AvpDef { code: 1635, vendor_id: TGPP, name: "PUR-Flags",                          data_type: AvpType::Unsigned32 },
-    AvpDef { code: 1645, vendor_id: TGPP, name: "MME-Number-for-MT-SMS",              data_type: AvpType::OctetString },
+    AvpDef { code: 1645, vendor_id: TGPP, name: "MME-Number-for-MT-SMS",              data_type: AvpType::ISDNAddressString },
     // SMS-Information block (TS 32.299 §7.2.79 / §7.2.158 / §7.2.171)
     AvpDef { code: 2000, vendor_id: TGPP, name: "SMS-Information",                    data_type: AvpType::Grouped },
     AvpDef { code: 2001, vendor_id: TGPP, name: "Data-Coding-Scheme",                 data_type: AvpType::Integer32 },
@@ -316,7 +321,7 @@ static AVP_TABLE: &[AvpDef] = &[
     AvpDef { code: 3010, vendor_id: TGPP, name: "Application-Port-Identifier",        data_type: AvpType::Unsigned32 },
     AvpDef { code: 3111, vendor_id: TGPP, name: "External-Identifier",                data_type: AvpType::UTF8String },
     // S6c (TS 29.336) and SGd (TS 29.338) — SMS over Diameter
-    AvpDef { code: 3300, vendor_id: TGPP, name: "SC-Address",                         data_type: AvpType::OctetString },
+    AvpDef { code: 3300, vendor_id: TGPP, name: "SC-Address",                         data_type: AvpType::ISDNAddressString },
     AvpDef { code: 3301, vendor_id: TGPP, name: "SM-RP-UI",                           data_type: AvpType::OctetString },
     AvpDef { code: 3308, vendor_id: TGPP, name: "SM-RP-MTI",                          data_type: AvpType::Enumerated },
     AvpDef { code: 3316, vendor_id: TGPP, name: "SM-Delivery-Outcome",                data_type: AvpType::Grouped },

--- a/src/diameter/s6c.rs
+++ b/src/diameter/s6c.rs
@@ -34,17 +34,6 @@ fn optional_u32(avps: &serde_json::Value, name: &str) -> Option<u32> {
     avps.get(name).and_then(|v| v.as_u64()).map(|n| n as u32)
 }
 
-/// Decode an OctetString AVP that holds an ISDN-AddressString
-/// (TS 29.002 §17.7.8) — strip the optional ToN/NPI prefix and
-/// TBCD-decode the remainder back to an E.164 digit string. Used for
-/// MSISDN (701), SC-Address (3300), SGSN-Number (1489), and
-/// MME-Number-for-MT-SMS (1645).
-fn octet_string_as_isdn_address(avps: &serde_json::Value, name: &str) -> Option<String> {
-    avps.get(name)
-        .and_then(|v| v.as_str())
-        .and_then(codec::hex::decode)
-        .map(|bytes| codec::decode_isdn_address_string(&bytes))
-}
 
 // ---------------------------------------------------------------------------
 // S6c answer builder — shared scaffolding for ALA / SRA / RSA answers
@@ -191,8 +180,8 @@ pub fn parse_sra(message: &codec::DiameterMessage) -> Option<SendRoutingInfoAnsw
         result_code,
         experimental_result_code,
         user_name: optional_str(avps, "User-Name"),
-        sgsn_number: octet_string_as_isdn_address(avps, "SGSN-Number"),
-        mme_number_for_mt_sms: octet_string_as_isdn_address(avps, "MME-Number-for-MT-SMS"),
+        sgsn_number: optional_str(avps, "SGSN-Number"),
+        mme_number_for_mt_sms: optional_str(avps, "MME-Number-for-MT-SMS"),
     })
 }
 
@@ -222,7 +211,7 @@ pub fn parse_alr(incoming: &IncomingRequest) -> Option<AlertServiceCentreRequest
         origin_host: required_str(avps, "Origin-Host")?,
         origin_realm: required_str(avps, "Origin-Realm")?,
         user_name: optional_str(avps, "User-Name"),
-        msisdn: octet_string_as_isdn_address(avps, "MSISDN"),
+        msisdn: optional_str(avps, "MSISDN"),
         smsmi_correlation_id_present: avps.get("SMSMI-Correlation-ID").is_some(),
     })
 }
@@ -391,27 +380,33 @@ mod tests {
 
         // MSISDN and SC-Address are ISDN-AddressString — ToN/NPI 0x91 +
         // TBCD digit pairs. Pre-fix siphon shipped raw ASCII, which any
-        // conformant HSS rejected as DIAMETER_USER_UNKNOWN.
-        let avps = &decoded.avps;
-        let msisdn_bytes = codec::hex::decode(avps.get("MSISDN").unwrap().as_str().unwrap()).unwrap();
-        assert_eq!(
-            msisdn_bytes,
-            // "31612345678": nibble-swap each pair (31)(61)(23)(45)(67)(8F)
-            // → 0x13 0x16 0x32 0x54 0x76 0xF8, with 0x91 ToN/NPI prefix.
-            vec![0x91, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8],
-            "MSISDN must be 0x91 ToN/NPI + TBCD(31612345678) — 7 octets, \
-             not 11 ASCII octets"
+        // conformant HSS rejected as DIAMETER_USER_UNKNOWN. Pin the exact
+        // octets on the wire (decode-path-independent, so a symmetric
+        // encode/decode bug can't hide them), then assert they round-trip
+        // back to the E.164 number and that the serde tree surfaces the
+        // decoded digits (ISDNAddressString type, not hex).
+        // "31612345678": nibble-swap each pair (31)(61)(23)(45)(67)(8F)
+        // → 0x13 0x16 0x32 0x54 0x76 0xF8, with 0x91 ToN/NPI prefix.
+        let msisdn_isdn = vec![0x91, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8];
+        assert!(
+            wire.windows(msisdn_isdn.len()).any(|w| w == msisdn_isdn.as_slice()),
+            "MSISDN must be 0x91 ToN/NPI + TBCD(31612345678) — 7 octets on \
+             the wire, not 11 ASCII octets"
         );
-        assert_eq!(codec::decode_isdn_address_string(&msisdn_bytes), "31612345678");
+        assert_eq!(codec::decode_isdn_address_string(&msisdn_isdn), "31612345678");
 
-        let sc_bytes = codec::hex::decode(avps.get("SC-Address").unwrap().as_str().unwrap()).unwrap();
-        assert_eq!(
-            sc_bytes,
-            // "31611111111": (31)(61)(11)(11)(11)(1F) → 0x13 0x16 0x11
-            // 0x11 0x11 0xF1, with 0x91 prefix.
-            vec![0x91, 0x13, 0x16, 0x11, 0x11, 0x11, 0xF1],
+        // "31611111111": (31)(61)(11)(11)(11)(1F) → 0x13 0x16 0x11
+        // 0x11 0x11 0xF1, with 0x91 prefix.
+        let sc_isdn = vec![0x91, 0x13, 0x16, 0x11, 0x11, 0x11, 0xF1];
+        assert!(
+            wire.windows(sc_isdn.len()).any(|w| w == sc_isdn.as_slice()),
+            "SC-Address must be 0x91 ToN/NPI + TBCD(31611111111) on the wire"
         );
-        assert_eq!(codec::decode_isdn_address_string(&sc_bytes), "31611111111");
+        assert_eq!(codec::decode_isdn_address_string(&sc_isdn), "31611111111");
+
+        let avps = &decoded.avps;
+        assert_eq!(avps.get("MSISDN").and_then(|v| v.as_str()), Some("31612345678"));
+        assert_eq!(avps.get("SC-Address").and_then(|v| v.as_str()), Some("31611111111"));
     }
 
     /// Regression test for the bug trace's MSISDN "3197010267609" — siphon
@@ -429,13 +424,16 @@ mod tests {
             1,
         );
         let decoded = codec::decode_diameter(&wire).unwrap();
-        let msisdn_bytes = codec::hex::decode(
-            decoded.avps.get("MSISDN").unwrap().as_str().unwrap(),
-        )
-        .unwrap();
+        let msisdn_isdn = vec![0x91, 0x13, 0x79, 0x10, 0x20, 0x76, 0x06, 0xF9];
+        assert!(
+            wire.windows(msisdn_isdn.len()).any(|w| w == msisdn_isdn.as_slice()),
+            "MSISDN 3197010267609 must be the exact 8-byte ISDN-AddressString \
+             on the wire, not the 13-byte ASCII the pre-fix encoder shipped"
+        );
+        assert_eq!(codec::decode_isdn_address_string(&msisdn_isdn), "3197010267609");
         assert_eq!(
-            msisdn_bytes,
-            vec![0x91, 0x13, 0x79, 0x10, 0x20, 0x76, 0x06, 0xF9],
+            decoded.avps.get("MSISDN").and_then(|v| v.as_str()),
+            Some("3197010267609"),
         );
     }
 

--- a/src/diameter/sgd.rs
+++ b/src/diameter/sgd.rs
@@ -43,14 +43,6 @@ fn octet_string_as_utf8(avps: &serde_json::Value, name: &str) -> Option<String> 
         })
 }
 
-/// Decode an ISDN-AddressString OctetString AVP (TS 29.002 §17.7.8) —
-/// strip the optional ToN/NPI prefix and TBCD-decode the remainder.
-fn octet_string_as_isdn_address(avps: &serde_json::Value, name: &str) -> Option<String> {
-    avps.get(name)
-        .and_then(|v| v.as_str())
-        .and_then(codec::hex::decode)
-        .map(|bytes| codec::decode_isdn_address_string(&bytes))
-}
 
 /// Decode an OctetString AVP into raw bytes (no UTF-8 assumption — for
 /// SM-RP-UI which carries TPDUs).
@@ -237,7 +229,7 @@ pub fn parse_ofr(incoming: &IncomingRequest) -> Option<MoForwardShortMessageRequ
         // the UTF-8 fallback; the ISDN-AddressString variant of this AVP
         // is not the one used on standard SGd.
         sms_gmsc_address: octet_string_as_utf8(avps, "SMS-GMSC-Address"),
-        sc_address: octet_string_as_isdn_address(avps, "SC-Address"),
+        sc_address: optional_str(avps, "SC-Address"),
         sm_rp_ui: octet_string_as_bytes(avps, "SM-RP-UI"),
     })
 }
@@ -351,15 +343,20 @@ mod tests {
             1,
         );
         let decoded = codec::decode_diameter(&wire).unwrap();
-        let sc_bytes = codec::hex::decode(
-            decoded.avps.get("SC-Address").unwrap().as_str().unwrap(),
-        )
-        .unwrap();
+        // "31611111111": (31)(61)(11)(11)(11)(1F) → nibble-swapped
+        // 0x13 0x16 0x11 0x11 0x11 0xF1, with 0x91 ToN/NPI prefix. Pin the
+        // exact octets on the wire (decode-path-independent), then the
+        // round-trip and the decoded serde value (ISDNAddressString type).
+        let sc_isdn = vec![0x91, 0x13, 0x16, 0x11, 0x11, 0x11, 0xF1];
+        assert!(
+            wire.windows(sc_isdn.len()).any(|w| w == sc_isdn.as_slice()),
+            "SC-Address must be 0x91 ToN/NPI + TBCD(31611111111) on the wire, \
+             not raw ASCII"
+        );
+        assert_eq!(codec::decode_isdn_address_string(&sc_isdn), "31611111111");
         assert_eq!(
-            sc_bytes,
-            // "31611111111": (31)(61)(11)(11)(11)(1F) → nibble-swapped
-            // 0x13 0x16 0x11 0x11 0x11 0xF1, with 0x91 ToN/NPI prefix.
-            vec![0x91, 0x13, 0x16, 0x11, 0x11, 0x11, 0xF1],
+            decoded.avps.get("SC-Address").and_then(|v| v.as_str()),
+            Some("31611111111"),
         );
     }
 

--- a/src/script/api/diameter.rs
+++ b/src/script/api/diameter.rs
@@ -55,7 +55,7 @@
 use std::sync::Arc;
 
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyBytes, PyDict};
 use tracing::warn;
 
 use crate::diameter::codec::{
@@ -742,6 +742,68 @@ impl PyDiameter {
     ///     The number of peers currently registered in the manager.
     fn peer_count(&self) -> usize {
         self.manager.peer_count()
+    }
+
+    /// Decode an ISDN-AddressString (3GPP TS 29.002 §17.7.8) to its E.164
+    /// digit string.
+    ///
+    /// Accepts the raw AVP bytes (``0x91`` ToN/NPI + TBCD digits) **or** an
+    /// already-decoded ``str`` — the latter is returned unchanged, so it is
+    /// safe to call on the result of ``req.get_avp("MSISDN")`` whether that
+    /// AVP is dictionary-typed (already a ``str``) or an unknown/raw AVP
+    /// (``bytes``). The ToN/NPI byte is optional: peers that ship bare TBCD
+    /// are tolerated.
+    ///
+    /// Args:
+    ///     value: ``bytes`` (raw ISDN-AddressString) or ``str`` (digits).
+    ///
+    /// Returns:
+    ///     The E.164 digit string (no leading ``+``).
+    ///
+    /// Example:
+    ///     >>> diameter.decode_isdn_address(req.get_avp("MSISDN"))
+    ///     '31612345678'
+    fn decode_isdn_address(&self, value: &Bound<'_, PyAny>) -> PyResult<String> {
+        // Already-decoded str (e.g. a dictionary-typed MSISDN read) →
+        // idempotent passthrough.
+        if let Ok(text) = value.extract::<String>() {
+            return Ok(text);
+        }
+        let bytes: Vec<u8> = value.extract().map_err(|_| {
+            pyo3::exceptions::PyTypeError::new_err("decode_isdn_address expects bytes or str")
+        })?;
+        Ok(crate::diameter::codec::decode_isdn_address_string(&bytes))
+    }
+
+    /// Encode an E.164 digit string as an ISDN-AddressString (TS 29.002
+    /// §17.7.8) — one ToN/NPI octet followed by the TBCD digit string.
+    ///
+    /// Use when building a raw OctetString AVP by hand (``set_avp`` /
+    /// ``send_request`` for an unknown code). Dictionary-typed AVPs
+    /// (MSISDN / SC-Address / SGSN-Number / MME-Number-for-MT-SMS) already
+    /// encode digit strings automatically — you do not need this for those.
+    /// A leading ``+`` is stripped.
+    ///
+    /// Args:
+    ///     digits: The E.164 number as a digit string.
+    ///     ton_npi: ToN/NPI byte (default ``0x91`` = international E.164).
+    ///
+    /// Returns:
+    ///     The encoded ISDN-AddressString ``bytes``.
+    ///
+    /// Example:
+    ///     >>> diameter.encode_isdn_address("31612345678")
+    ///     b'\\x91\\x13\\x16\\x32\\x54\\x76\\xf8'
+    #[pyo3(signature = (digits, ton_npi=None))]
+    fn encode_isdn_address<'py>(
+        &self,
+        py: Python<'py>,
+        digits: &str,
+        ton_npi: Option<u8>,
+    ) -> Bound<'py, PyBytes> {
+        let ton_npi = ton_npi.unwrap_or(crate::diameter::codec::TON_NPI_INTERNATIONAL_E164);
+        let bytes = crate::diameter::codec::encode_isdn_address_string(digits, ton_npi);
+        PyBytes::new(py, &bytes)
     }
 
     /// Send a Cx User-Authorization-Request to the HSS.
@@ -2474,6 +2536,31 @@ fn encode_kwarg_avp(def: &AvpDef, value: &Bound<'_, PyAny>) -> PyResult<Vec<u8>>
                 encode_avp_octet(def.code, &bytes)
             })
         }
+        AvpType::ISDNAddressString => {
+            // A str is an E.164 digit string → TBCD-encode with the
+            // international ToN/NPI byte (TS 29.002 §17.7.8). This is the fix
+            // for the MSISDN/SC-Address/SGSN-Number/MME-Number-for-MT-SMS
+            // encoding bug — the OctetString path used to ship raw ASCII.
+            // Bytes are taken as already-encoded ISDN-AddressString octets.
+            let bytes = if let Ok(digits) = value.extract::<String>() {
+                crate::diameter::codec::encode_isdn_address_string(
+                    &digits,
+                    crate::diameter::codec::TON_NPI_INTERNATIONAL_E164,
+                )
+            } else if let Ok(raw) = value.extract::<Vec<u8>>() {
+                raw
+            } else {
+                return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                    "{} expects str (E.164 digits) or bytes",
+                    def.name
+                )));
+            };
+            Ok(if is_vendor {
+                encode_avp_octet_3gpp(def.code, &bytes)
+            } else {
+                encode_avp_octet(def.code, &bytes)
+            })
+        }
         AvpType::Unsigned32 | AvpType::Enumerated => {
             let n: u32 = value.extract().map_err(|error| {
                 pyo3::exceptions::PyTypeError::new_err(format!(
@@ -3045,6 +3132,89 @@ mod tests {
         assert_eq!(avp_name_to_snake("SC-Address"), "sc_address");
         assert_eq!(avp_name_to_snake("SM-RP-UI"), "sm_rp_ui");
         assert_eq!(avp_name_to_snake("SMSMI-Correlation-ID"), "smsmi_correlation_id");
+    }
+
+    #[test]
+    fn encode_kwarg_avp_isdn_address_produces_tbcd_not_ascii() {
+        // The send_request(msisdn="…") path must TBCD-encode the digits, not
+        // ship raw ASCII (the pre-fix OctetString bug). MSISDN is now typed
+        // ISDNAddressString, so the kwarg encoder produces 0x91 + TBCD.
+        pyo3::Python::initialize();
+        let avp_def = crate::diameter::dictionary::lookup_avp_by_python_name("msisdn")
+            .expect("msisdn must resolve");
+        pyo3::Python::attach(|python| {
+            let value = "31612345678".into_pyobject(python).unwrap();
+            let encoded = encode_kwarg_avp(avp_def, value.as_any()).unwrap();
+            // The exact ISDN-AddressString octets must appear in the AVP.
+            let isdn = [0x91u8, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8];
+            assert!(
+                encoded.windows(isdn.len()).any(|w| w == isdn),
+                "MSISDN kwarg must encode as 0x91 ToN/NPI + TBCD, not 11 ASCII \
+                 octets; got {encoded:02x?}"
+            );
+            // And it must NOT contain the ASCII byte string "31612345678".
+            assert!(
+                !encoded.windows(11).any(|w| w == b"31612345678"),
+                "MSISDN must not be raw ASCII on the wire"
+            );
+        });
+    }
+
+    #[test]
+    fn decode_isdn_address_handles_bytes_str_and_bare_tbcd() {
+        pyo3::Python::initialize();
+        let py_diameter = PyDiameter::new(Arc::new(DiameterManager::new()));
+        pyo3::Python::attach(|python| {
+            // Raw ISDN-AddressString bytes (0x91 ToN/NPI + TBCD) → E.164 str.
+            let raw = pyo3::types::PyBytes::new(
+                python,
+                &[0x91, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8],
+            );
+            assert_eq!(
+                py_diameter.decode_isdn_address(raw.as_any()).unwrap(),
+                "31612345678",
+            );
+
+            // Bare TBCD (no ToN/NPI byte, bit 7 clear) is tolerated.
+            let bare = pyo3::types::PyBytes::new(python, &[0x13, 0x16, 0x32, 0x54, 0x76, 0xF8]);
+            assert_eq!(
+                py_diameter.decode_isdn_address(bare.as_any()).unwrap(),
+                "31612345678",
+            );
+
+            // An already-decoded str is returned unchanged (idempotent) — so
+            // decode_isdn_address(get_avp("MSISDN")) is safe either way.
+            let already = "31612345678".into_pyobject(python).unwrap();
+            assert_eq!(
+                py_diameter.decode_isdn_address(already.as_any()).unwrap(),
+                "31612345678",
+            );
+
+            // Wrong type → TypeError.
+            let bad = 42i64.into_pyobject(python).unwrap();
+            assert!(py_diameter.decode_isdn_address(bad.as_any()).is_err());
+        });
+    }
+
+    #[test]
+    fn encode_isdn_address_emits_ton_npi_and_roundtrips() {
+        pyo3::Python::initialize();
+        let py_diameter = PyDiameter::new(Arc::new(DiameterManager::new()));
+        pyo3::Python::attach(|python| {
+            let encoded = py_diameter.encode_isdn_address(python, "31612345678", None);
+            assert_eq!(
+                encoded.as_bytes(),
+                &[0x91, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8],
+            );
+            // Round-trips back through the decoder.
+            assert_eq!(
+                py_diameter.decode_isdn_address(encoded.as_any()).unwrap(),
+                "31612345678",
+            );
+            // A leading '+' is stripped (international form is the ToN/NPI byte).
+            let plus = py_diameter.encode_isdn_address(python, "+31612345678", None);
+            assert_eq!(plus.as_bytes(), &[0x91, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8]);
+        });
     }
 
 }

--- a/src/script/api/diameter_server.rs
+++ b/src/script/api/diameter_server.rs
@@ -50,6 +50,13 @@ fn avp_to_py<'py>(py: Python<'py>, code: u32, vendor: u32, avp: &Avp) -> PyResul
             Some(AvpType::UTF8String) | Some(AvpType::DiameterIdentity) => {
                 Ok(String::from_utf8_lossy(bytes).into_owned().into_pyobject(py)?.into_any())
             }
+            // ISDN-AddressString (MSISDN / SC-Address / SGSN-Number /
+            // MME-Number-for-MT-SMS) → decoded E.164 digit string, not raw
+            // TBCD bytes (TS 29.002 §17.7.8).
+            Some(AvpType::ISDNAddressString) => {
+                let digits = crate::diameter::codec::decode_isdn_address_string(bytes);
+                Ok(digits.into_pyobject(py)?.into_any())
+            }
             Some(AvpType::Unsigned32) | Some(AvpType::Enumerated) => {
                 let value = avp.as_u32().unwrap_or(0);
                 Ok(value.into_pyobject(py)?.into_any())
@@ -98,6 +105,21 @@ fn py_to_avp_raw(code: u32, vendor: u32, value: &Bound<'_, PyAny>) -> PyResult<V
         Some(AvpType::Unsigned64) => {
             let number: u64 = value.extract()?;
             Ok(number.to_be_bytes().to_vec())
+        }
+        Some(AvpType::ISDNAddressString) => {
+            // A str is an E.164 digit string → TBCD-encode with the
+            // international ToN/NPI byte (TS 29.002 §17.7.8); bytes are taken
+            // as already-encoded ISDN-AddressString wire octets (verbatim
+            // round-trip, e.g. relaying a value read off another message).
+            if let Ok(digits) = value.extract::<String>() {
+                Ok(crate::diameter::codec::encode_isdn_address_string(
+                    &digits,
+                    crate::diameter::codec::TON_NPI_INTERNATIONAL_E164,
+                ))
+            } else {
+                let bytes: Vec<u8> = value.extract()?;
+                Ok(bytes)
+            }
         }
         _ => {
             // OctetString / Address / unknown: accept bytes or str.
@@ -769,6 +791,69 @@ mod tests {
                 1
             );
             assert!(request.dest_host().unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn isdn_address_avp_encodes_tbcd_and_reads_back_e164() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let request = py_request();
+
+            // set_avp by name with a plain E.164 digit string (the natural
+            // Python value) — MSISDN resolves to (701, 3GPP) by name.
+            let msisdn = "31612345678".into_pyobject(py).unwrap().into_any();
+            request
+                .set_avp(&"MSISDN".into_pyobject(py).unwrap().into_any(), &msisdn, 0)
+                .unwrap();
+
+            // get_avp returns the DECODED digit string (str), not raw bytes.
+            let read = request
+                .get_avp(py, &"MSISDN".into_pyobject(py).unwrap().into_any(), 0)
+                .unwrap()
+                .unwrap();
+            let digits: String = read.extract().unwrap();
+            assert_eq!(digits, "31612345678");
+
+            // On the wire it is ISDN-AddressString — 0x91 ToN/NPI + TBCD
+            // nibble-swapped pairs (7 octets), NOT 11 ASCII octets. Exercise
+            // the answer path too (same build_avp / py_to_avp_raw).
+            let answer = request.answer(2001, None).unwrap();
+            answer
+                .set_avp(&"MSISDN".into_pyobject(py).unwrap().into_any(), &msisdn, 0)
+                .unwrap();
+            let wire = answer.to_wire().unwrap();
+            let msg = DiameterMsg::from_wire(&wire).unwrap();
+            let avp = msg
+                .find(dictionary::avp::MSISDN, dictionary::VENDOR_3GPP)
+                .expect("MSISDN present on the answer");
+            assert_eq!(
+                avp.raw_bytes(),
+                Some(&[0x91u8, 0x13, 0x16, 0x32, 0x54, 0x76, 0xF8][..]),
+            );
+        });
+    }
+
+    #[test]
+    fn isdn_address_avp_accepts_raw_bytes_verbatim() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let request = py_request();
+
+            // A bytes value is taken as already-encoded ISDN-AddressString
+            // wire octets (e.g. relaying a value lifted off another message).
+            // Here: raw TBCD with no ToN/NPI byte — the lenient decoder still
+            // recovers the digits on read-back.
+            let raw = PyBytes::new(py, &[0x13u8, 0x16, 0x32, 0x54, 0x76, 0xF8]).into_any();
+            request
+                .set_avp(&"MSISDN".into_pyobject(py).unwrap().into_any(), &raw, 0)
+                .unwrap();
+            let read = request
+                .get_avp(py, &"MSISDN".into_pyobject(py).unwrap().into_any(), 0)
+                .unwrap()
+                .unwrap();
+            let digits: String = read.extract().unwrap();
+            assert_eq!(digits, "31612345678");
         });
     }
 


### PR DESCRIPTION
## What

Introduces a proper `AvpType::ISDNAddressString` (3GPP TS 29.002 §17.7.8) and retags **MSISDN** (701), **SC-Address** (3300), **SGSN-Number** (1489) and **MME-Number-for-MT-SMS** (1645) from raw `OctetString`. It is wired consistently through **all four** AVP value paths so scripts read decoded E.164 strings and write digit strings that encode to correct TBCD on the wire.

## Why

The generic Diameter server mode (`7cef158`) replaced the old typed `@diameter.on_alr` handler — which gave a decoded `req.msisdn` — with `req.get_avp("MSISDN")`, which returned raw `0x91`+TBCD bytes. siphon already owned the decoder (`decode_isdn_address_string`) but never exposed it, so the ip-sm-gw `S6c:ALR` handler couldn't be ported (it's pinned below `7cef158`).

There was also a latent **write**-side defect: with these AVPs typed `OctetString`, the generic `diameter.send_request(msisdn="31612345678", …)` path encoded the digits as **ASCII instead of TBCD** — wrong on the wire, and rejected by conformant HSSes. The typed `s6c_srr`/`sgd_tfr` builders were already correct; this fixes the generic path too.

## Changes

| Path | Before | After |
|------|--------|-------|
| `req.get_avp("MSISDN")` (server read) | `b'\x91…'` bytes | `"31612345678"` (decoded str) |
| `set_avp` / `send_request(msisdn=…)` (write) | raw ASCII | `0x91` ToN/NPI + TBCD |
| serde/typed S6c·SGd parse | hex string | decoded digits (helpers simplified) |

New script helpers for raw/unknown AVPs and hand-built messages:
- `diameter.decode_isdn_address(value)` — accepts `bytes` **or** an already-decoded `str` (idempotent), so it's safe on `get_avp(...)` regardless of the AVP's dictionary type.
- `diameter.encode_isdn_address(digits, ton_npi=0x91)`.

Mirrored in the `siphon-sip` SDK mock (helpers + ISDN-aware `MockDiameterRequest.get_avp`) with a faithful Python TBCD codec.

## Tests

- New Rust unit tests: server read/write round-trip + exact TBCD wire octets; generic `send_request` kwarg encodes TBCD-not-ASCII; helper decode (bytes / bare-TBCD / str-passthrough / type-error) and encode round-trip.
- Encoder round-trip tests in `s6c.rs`/`sgd.rs` now pin the exact on-the-wire octets via a **decode-independent** substring check (stronger than the old hex assertion — a symmetric encode/decode bug can't hide it).
- New SDK tests for both helpers and `get_avp` decoding.
- `cargo test`: 2992 passed / 0 failed. `clippy --all-targets --all-features -D warnings`: clean. SDK `pytest`: 290 passed.

## Notes

- SMS-GMSC-Address (3332) stays `Address` (different encoding) — not retagged.
- This is the siphon-side unblock; bumping ip-sm-gw to `7cef158` + applying the ready-to-apply ALR handler lives in the consuming repo.