### PR TITLE
docs: publish documentation to GitHub Pages (mkdocs-material)

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,56 @@
+name: docs
+
+# Builds the mkdocs-material site from docs/ and publishes it to GitHub Pages.
+# On pull requests it only builds (with --strict, so broken links/nav fail the
+# check); on push to main it builds and deploys.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/pages.yaml
+  pull_request:
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/pages.yaml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install mkdocs-material
+      - name: Build site (strict)
+        run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    # Deploy only from main; PRs just validate the build above.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ CLAUDE.md
 
 # Private test fixtures
 sipp/ipsec/
+
+# mkdocs build output
+/site/

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,10 +29,10 @@ browse the `docs/` folder.)
 ## Runnable deployments
 
 Reference deployment artifacts — a front-LB + 2-backend demo with a failover-proof
-script, plus Kubernetes manifests — live in **[../deploy/](../deploy/)**.
+script, plus Kubernetes manifests — live in **[../deploy/](https://github.com/siphon-project/siphon-sip/tree/main/deploy/)**.
 
 ## Also
 
-- The main **[README](../README.md)** — overview, install, scripting API, performance.
-- **[siphon.yaml](../siphon.yaml)** — the annotated reference configuration.
-- **[sdk/](../sdk/)** — the `siphon-sip` mock library for testing scripts.
+- The main **[README](https://github.com/siphon-project/siphon-sip/blob/main/README.md)** — overview, install, scripting API, performance.
+- **[siphon.yaml](https://github.com/siphon-project/siphon-sip/blob/main/siphon.yaml)** — the annotated reference configuration.
+- **[sdk/](https://github.com/siphon-project/siphon-sip/tree/main/sdk/)** — the `siphon-sip` mock library for testing scripts.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,19 +8,19 @@ The golden rule from that document, restated: **one node does the work; you add
 nodes for redundancy, and you get redundancy with a front LB + DNS SRV, not a
 cluster.**
 
-- [Scenario 1 — single node](#scenario-1--single-node)
-- [Scenario 2 — redundant pair / N nodes (front LB + DNS SRV)](#scenario-2--redundant-pair--n-nodes)
-- [Scenario 3 — IMS core](#scenario-3--ims-core)
+- [Scenario 1: single node](#scenario-1-single-node)
+- [Scenario 2: redundant pair, N nodes (front LB + DNS SRV)](#scenario-2-redundant-pair-n-nodes)
+- [Scenario 3: IMS core](#scenario-3-ims-core)
 - [Operations runbook](#operations-runbook)
 - [Kubernetes (kept deliberately light)](#kubernetes-kept-deliberately-light)
 
 A runnable, self-contained version of Scenario 2 lives in
-[`deploy/ha-demo/`](../deploy/ha-demo/); the Kubernetes manifests are in
-[`deploy/k8s/`](../deploy/k8s/).
+[`deploy/ha-demo/`](https://github.com/siphon-project/siphon-sip/tree/main/deploy/ha-demo/); the Kubernetes manifests are in
+[`deploy/k8s/`](https://github.com/siphon-project/siphon-sip/tree/main/deploy/k8s/).
 
 ---
 
-## Scenario 1 — single node
+## Scenario 1: single node
 
 The default, and the right answer for most deployments. One process, optionally a
 Redis backend so a restart comes back whole.
@@ -57,7 +57,7 @@ same config, kept ready; promote it by moving traffic (DNS/VIP) when you need to
 
 ---
 
-## Scenario 2 — redundant pair / N nodes
+## Scenario 2: redundant pair, N nodes
 
 Survive a node failure and do zero-downtime upgrades. Three ingredients, none of
 which require the nodes to share live call state:
@@ -87,7 +87,7 @@ works in both directions.
 ### The front LB (SIPhon fronting SIPhon)
 
 You can use any SIP-aware load balancer you already trust. The self-contained way —
-and what [`deploy/ha-demo/`](../deploy/ha-demo/) demonstrates — is a thin SIPhon
+and what [`deploy/ha-demo/`](https://github.com/siphon-project/siphon-sip/tree/main/deploy/ha-demo/) demonstrates — is a thin SIPhon
 proxy whose only job is to spread traffic over a `gateway` group of backends:
 
 ```yaml
@@ -169,7 +169,7 @@ gives you active/standby rather than active/active.
 
 ---
 
-## Scenario 3 — IMS core
+## Scenario 3: IMS core
 
 In IMS, **SIPhon does not need to share location state at all**, because the
 **HSS is the location authority**:
@@ -184,7 +184,7 @@ In IMS, **SIPhon does not need to share location state at all**, because the
 
 So an IMS core scales to many nodes per role using exactly the mechanisms above plus
 the HSS — no `clusterer`/DMQ equivalent required. See the
-[`examples/ims_*`](../examples/) configs for per-role starting points.
+[`examples/ims_*`](https://github.com/siphon-project/siphon-sip/tree/main/examples/) configs for per-role starting points.
 
 ---
 
@@ -270,7 +270,7 @@ re-registration. There is no SIPhon-specific snapshot format to manage.
 ## Kubernetes (kept deliberately light)
 
 People expect to see K8s, so here's a clean shape to copy — **not** a platform.
-Manifests are in [`deploy/k8s/`](../deploy/k8s/). The load-bearing details:
+Manifests are in [`deploy/k8s/`](https://github.com/siphon-project/siphon-sip/tree/main/deploy/k8s/). The load-bearing details:
 
 - **`StatefulSet`** (not Deployment) so each pod has a stable identity. Wire
   `server.instance_id` from the pod name via the downward API:

--- a/docs/handler-execution-model.md
+++ b/docs/handler-execution-model.md
@@ -3,8 +3,8 @@
 This documents how SIPhon runs Python script handlers, what may block, and the
 elasticity / backpressure / liveness guarantees. It is the user-facing companion
 to the source doc-comments in
-[`src/script/py_executor.rs`](../src/script/py_executor.rs) and
-[`src/script/async_pool.rs`](../src/script/async_pool.rs).
+[`src/script/py_executor.rs`](https://github.com/siphon-project/siphon-sip/blob/main/src/script/py_executor.rs) and
+[`src/script/async_pool.rs`](https://github.com/siphon-project/siphon-sip/blob/main/src/script/async_pool.rs).
 
 ## The two handler pools
 

--- a/docs/migrating-from-kamailio-opensips.md
+++ b/docs/migrating-from-kamailio-opensips.md
@@ -132,7 +132,7 @@ explicit **state-replication subsystems** and SIPhon deliberately did not.
 
 If your scale genuinely requires N-way live usrloc replication with zero affinity,
 that's a deliberate design discussion — see the "when would you miss one" section of
-[scaling-and-redundancy.md](scaling-and-redundancy.md#why-siphon-has-no-clusterer--dmq-and-when-youd-miss-one).
+[scaling-and-redundancy.md](scaling-and-redundancy.md#why-siphon-ships-no-clusterer-or-dmq).
 
 ---
 

--- a/docs/scaling-and-redundancy.md
+++ b/docs/scaling-and-redundancy.md
@@ -9,7 +9,7 @@ why SIPhon deliberately does **not** ship a clustering/replication engine.
 
 - **One node is a lot.** A single SIPhon process handles tens of thousands of calls
   per second — the documented baseline runs to roughly **28–30k cps** on one
-  commodity box (see the [README baseline](../README.md#current-baseline)). Most
+  commodity box (see the [README baseline](https://github.com/siphon-project/siphon-sip/blob/main/README.md#current-baseline)). Most
   deployments never outgrow a single active node.
 - **You run more than one node for _redundancy_, not throughput.** And you get
   redundancy the boring, proven SIP way: a **front-facing load balancer + DNS SRV
@@ -143,7 +143,7 @@ Concrete configs for all of this are in [deployment.md](deployment.md).
 
 ---
 
-## Why SIPhon has no `clusterer` / DMQ (and when you'd miss one)
+## Why SIPhon ships no clusterer or DMQ
 
 If you come from Kamailio or OpenSIPS you'll notice SIPhon has nothing like their
 state-replication subsystems. That's a deliberate design choice, not a gap waiting

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,69 @@
+site_name: SIPhon
+site_description: High-performance SIP proxy, B2BUA, and IMS platform in Rust with free-threaded Python scripting
+site_url: https://siphon-sip.org/
+repo_url: https://github.com/siphon-project/siphon-sip
+repo_name: siphon-project/siphon-sip
+edit_uri: edit/main/docs/
+copyright: MIT-licensed. SIPhon is built on the shoulders of Kamailio and OpenSIPS.
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - navigation.tracking
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: README.md
+  - Running in production:
+      - Scaling, clustering & redundancy: scaling-and-redundancy.md
+      - Deployment & operations: deployment.md
+      - Migrating from Kamailio / OpenSIPS: migrating-from-kamailio-opensips.md
+  - Internals:
+      - Handler execution model: handler-execution-model.md
+      - Feature readiness matrix: feature-readiness-matrix.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+plugins:
+  - search


### PR DESCRIPTION
Turns `docs/` into a documentation **website** (mkdocs-material) so people land on the docs directly, served via GitHub Pages.

## What

- **`mkdocs.yml`** — Material theme (light/dark, search, code-copy), nav grouped into *Running in production* / *Internals*, repo + edit links. `docs/README.md` is the home page.
- **`.github/workflows/pages.yaml`** — builds the site on every PR with `--strict` (broken links/nav fail the check) and **builds + deploys to Pages on push to `main`**.
- **docs** — cross-tree links (`../deploy`, `../README.md`, `../siphon.yaml`, …) rewritten to absolute GitHub URLs so they resolve on the published site; four heading slugs made stable (em-dash/slash → colon/comma) so in-page anchors work on **both** GitHub and mkdocs.
- `site/` gitignored.

Validated locally: `mkdocs build --strict` is clean (home + all 6 pages render, nav correct). The Pages workflow's build job also runs on this PR.

## To go live (one-time, your side)
1. **Settings → Pages → Source: GitHub Actions** (or I can enable it via API).
2. The site deploys to the default Pages URL on the next push to `main`.
3. For **siphon-sip.org**: add a DNS record to the Pages target + set the custom domain (adds a CNAME). I can wire the CNAME once DNS is pointed.