### PR TITLE
docs: add Cookbook — scenario recipes (registrar, proxy, LB, SBC, media, security, monitoring)

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build site (strict)
         run: mkdocs build --strict
       - name: Pin the custom domain
-        run: echo "docs.siphon-sip.org" > site/CNAME
+        run: echo "siphon-sip.org" > site/CNAME
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -36,6 +36,8 @@ jobs:
       - run: pip install mkdocs-material
       - name: Build site (strict)
         run: mkdocs build --strict
+      - name: Pin the custom domain
+        run: echo "docs.siphon-sip.org" > site/CNAME
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,46 @@
-# SIPhon documentation
+# SIPhon
 
-Operator and developer documentation for SIPhon. (GitHub renders this page when you
-browse the `docs/` folder.)
+**A high-performance SIP proxy, B2BUA, and IMS platform — a Kamailio/OpenSIPS-class
+protocol engine, scripted in Python instead of a config DSL.**
+
+SIPhon is written in Rust — the transports, the RFC 3261 transaction and dialog state
+machines, the registrar — and scripted in free-threaded Python, which decides policy.
+You get the parts that are genuinely hard to get right as a fast, memory-safe core,
+and you drive them with real code:
+
+- **Python, not a config language** — real functions, imports, a debugger, and
+  `pytest` (with a mock SDK) instead of `$avp` expansions and `failure_route` chains.
+- **One YAML file** for config — documented inline, no `modparam`.
+- **Hot-reload** — edit a script, save, done. No restart.
+- **The B2BUA is first-class** — two independent dialogs, topology hiding, media
+  anchoring, header policies, forking — in ~50 lines of readable Python.
+- **Fast** — tens of thousands of calls per second per node (~28–30k cps on commodity
+  hardware), so you usually add nodes for *redundancy*, not throughput.
+
+```python
+from siphon import b2bua, gateway
+
+@b2bua.on_invite
+def on_invite(call):
+    call.media.anchor(engine="rtpengine")      # hide the media path
+    call.remove_headers_matching("^X-")         # strip internal headers
+    call.dial(gateway.select("carriers").uri)   # bridge to a trunk
+```
+
+That's a topology-hiding SBC with media anchoring. More like it in the Cookbook.
+
+## New here? Start with the Cookbook
+
+The **[Cookbook](cookbook/index.md)** has complete, working starting points for the
+common roles — each with the config, a real script, and how to test it:
+
+[Registrar](cookbook/registrar.md) ·
+[Stateful proxy](cookbook/proxy.md) ·
+[Load balancer](cookbook/load-balancer.md) ·
+[SBC (B2BUA)](cookbook/sbc.md) ·
+[Media & RTP profiles](cookbook/media-rtp.md) ·
+[Hardening & security](cookbook/security.md) ·
+[Monitoring](cookbook/monitoring.md)
 
 ## Running it in production
 
@@ -29,10 +68,10 @@ browse the `docs/` folder.)
 ## Runnable deployments
 
 Reference deployment artifacts — a front-LB + 2-backend demo with a failover-proof
-script, plus Kubernetes manifests — live in **[../deploy/](https://github.com/siphon-project/siphon-sip/tree/main/deploy/)**.
+script, plus Kubernetes manifests — live in **[deploy/](https://github.com/siphon-project/siphon-sip/tree/main/deploy/)**.
 
 ## Also
 
-- The main **[README](https://github.com/siphon-project/siphon-sip/blob/main/README.md)** — overview, install, scripting API, performance.
+- The main **[README](https://github.com/siphon-project/siphon-sip/blob/main/README.md)** — overview, install, full scripting API, performance baseline.
 - **[siphon.yaml](https://github.com/siphon-project/siphon-sip/blob/main/siphon.yaml)** — the annotated reference configuration.
 - **[sdk/](https://github.com/siphon-project/siphon-sip/tree/main/sdk/)** — the `siphon-sip` mock library for testing scripts.

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -1,0 +1,50 @@
+# Cookbook
+
+Build real things, fast. Each recipe is a complete, working starting point —
+the YAML config, the Python script, and how to test it — for a common SIP role.
+They're deliberately small (usually under 60 lines of Python) so you can read the
+whole thing and adapt it.
+
+Every recipe is grounded in a real script in the repo (linked at the bottom of each
+page); none of the APIs here are invented.
+
+## The recipes
+
+| Recipe | What you build | Key ideas |
+|---|---|---|
+| [Registrar](registrar.md) | A SIP registrar with digest auth | `auth.require_digest`, `registrar.save`/`lookup`, NAT fixups |
+| [Stateful proxy](proxy.md) | A residential/edge proxy | `request.fork`, `loose_route`, `record_route`, sanity checks |
+| [Load balancer](load-balancer.md) | A front LB over a backend pool | `gateway.select`, health probing, subscriber affinity |
+| [SBC (B2BUA)](sbc.md) | A topology-hiding SBC with media | `@b2bua.*`, `call.dial`/`fork`, **header policies**, RTPEngine |
+| [Media & RTP profiles](media-rtp.md) | SRTP↔RTP, WebRTC, transcoding, hold | `rtpengine.offer`/`answer`, profiles, the `sdp` namespace |
+| [Hardening & security](security.md) | A locked-down edge | rate-limit, scanner/auth bans, TLS/mTLS, STIR/SHAKEN, IPsec |
+| [Monitoring & observability](monitoring.md) | Metrics, CDRs, tracing, probes | custom Prometheus metrics, `/admin/*`, CDR, HEP/Homer |
+
+## How to run any recipe
+
+Each recipe is a `siphon.yaml` + a Python script. Point the config at the script and
+run siphon:
+
+```yaml
+# siphon.yaml
+script:
+  path: "/etc/siphon/myscript.py"
+```
+
+```bash
+siphon --config /etc/siphon/siphon.yaml
+```
+
+Scripts **hot-reload** — edit and save, no restart (except `listen:` changes). Test
+your script logic without a running server using the
+[`siphon-sip` mock SDK](https://github.com/siphon-project/siphon-sip/tree/main/sdk).
+
+## Mixing roles
+
+A single script can be several of these at once — the dispatcher routes INVITEs to
+your `@b2bua.on_invite` handler and everything else to `@proxy.on_request`. So a
+"proxy for REGISTER/OPTIONS + SBC for calls" is one script, one process (see the
+[SBC recipe](sbc.md) and the README's hybrid-mode section).
+
+For running more than one node, see [Scaling & redundancy](../scaling-and-redundancy.md)
+and [Deployment & operations](../deployment.md).

--- a/docs/cookbook/load-balancer.md
+++ b/docs/cookbook/load-balancer.md
@@ -1,0 +1,105 @@
+# Load balancer
+
+A front-facing proxy that spreads new transactions across a pool of backends, with
+health probing and (optionally) subscriber affinity. SIPhon's `gateway` namespace is
+the equivalent of OpenSIPS `dispatcher` / Kamailio `dispatcher`.
+
+## Config
+
+Define a named group of destinations with a balancing algorithm and health probe:
+
+```yaml
+# siphon.yaml
+script:
+  path: "/etc/siphon/lb.py"
+
+gateway:
+  groups:
+    - name: "backends"
+      algorithm: hash         # weighted (default) | round_robin | hash
+      probe:
+        enabled: true
+        interval_secs: 5
+        failure_threshold: 3
+      destinations:
+        - uri: "sip:backend1.example.com:5060"
+          address: "10.0.0.1:5060"
+          weight: 2
+          attrs: { region: "us-east" }
+        - uri: "sip:backend2.example.com:5060"
+          address: "10.0.0.2:5060"
+```
+
+- **`weighted`** — weighted round-robin (the default).
+- **`round_robin`** — even rotation, ignores weight.
+- **`hash`** — consistent hash on a `key` you provide → sticky routing.
+
+## Script
+
+```python
+from siphon import proxy, gateway, log
+
+@proxy.on_request
+def route(request):
+    # In-dialog requests follow the established route set, not the LB.
+    if request.in_dialog:
+        if request.loose_route():
+            request.relay()
+        else:
+            request.reply(404, "Not Here")
+        return
+
+    # Pick a healthy backend. key= gives subscriber affinity: the same AoR
+    # always hashes to the same backend (needed if that backend holds the
+    # subscriber's registrar binding).
+    destination = gateway.select("backends", key=str(request.to_uri))
+    if not destination:
+        log.error("no healthy backend in 'backends' group")
+        request.reply(503, "Service Unavailable")
+        return
+
+    log.info(f"LB {request.method} {request.to_uri} -> {destination.uri}")
+    request.record_route()
+    request.relay(destination.uri)
+```
+
+### Selecting backends
+
+```python
+gw = gateway.select("backends")                          # next per algorithm
+gw = gateway.select("backends", key=request.call_id)     # sticky on Call-ID
+gw = gateway.select("backends", attrs={"region": "us-east"})  # filter by attribute
+
+gw.uri        # "sip:backend1.example.com:5060"
+gw.healthy    # bool
+bool(gw)      # True if healthy
+```
+
+Health is probed per node (`probe.enabled`), and you can override it from a script
+(`gateway.mark_down` / `mark_up`) or build groups dynamically
+(`gateway.add_group` / `remove_group`).
+
+## Why affinity matters
+
+Registrar lookups are node-local (see
+[Scaling & redundancy](../scaling-and-redundancy.md)), so a subscriber can only be
+reached for a terminating call on the node that holds their binding. Hashing both the
+REGISTER and the terminating INVITE for an AoR (`key=str(request.to_uri)`) sends both
+to the same backend — any-node delivery with no shared live state. For pure outbound
+(PSTN breakout) where there's no registrar lookup, drop the key and use
+`algorithm: weighted`.
+
+## Runnable example
+
+A complete front-LB + two-backend + Redis demo (with a failover proof) lives in
+[`deploy/ha-demo/`](https://github.com/siphon-project/siphon-sip/tree/main/deploy/ha-demo):
+
+```bash
+SIPHON_BIN=target/release/siphon deploy/ha-demo/validate.sh
+```
+
+## See also
+
+- Real example: [`examples/proxy_gateway.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/proxy_gateway.py), [`deploy/ha-demo/lb.py`](https://github.com/siphon-project/siphon-sip/blob/main/deploy/ha-demo/lb.py).
+- [Deployment & operations](../deployment.md) — front-LB + DNS SRV topologies, K8s.
+- [SBC (B2BUA)](sbc.md) — load-balance *and* hide topology / anchor media.

--- a/docs/cookbook/media-rtp.md
+++ b/docs/cookbook/media-rtp.md
@@ -1,0 +1,137 @@
+# Media & RTP profiles
+
+SIPhon anchors and transforms media through [RTPEngine](https://github.com/sipwise/rtpengine)
+using its NG control protocol. A **profile** is a named bundle of RTPEngine flags —
+SRTP↔RTP interworking, WebRTC, ICE handling, transcoding direction — that you select
+per call with one argument.
+
+## Config
+
+```yaml
+# siphon.yaml
+media:
+  rtpengine:
+    address: "127.0.0.1:22222"     # NG control protocol (UDP)
+    timeout_ms: 1000
+  sdp_name: "SIPhon"               # masks the endpoint identity in o=/s=
+  health_check_interval_secs: 5    # exported as siphon_rtpengine_instances_up
+```
+
+Multiple engines load-balance with weighted round-robin:
+
+```yaml
+media:
+  rtpengine:
+    instances:
+      - { address: "10.0.0.1:22222", weight: 2 }
+      - { address: "10.0.0.2:22222", weight: 1 }
+```
+
+## The offer / answer / delete lifecycle
+
+Anchor the offer when the INVITE arrives, the answer when the 2xx comes back, and
+release on teardown. RTPEngine rewrites the SDP so media flows through it.
+
+On a **proxy**:
+
+```python
+from siphon import proxy, registrar, rtpengine
+
+@proxy.on_request
+async def route(request):
+    if request.in_dialog:
+        if request.method == "BYE":
+            await rtpengine.delete(request)
+        elif request.method == "INVITE" and request.body:
+            await rtpengine.offer(request, profile="srtp_to_rtp")  # re-INVITE
+        request.loose_route() and request.relay()
+        return
+
+    contacts = registrar.lookup(request.ruri)
+    if request.method == "INVITE" and request.body:
+        await rtpengine.offer(request, profile="srtp_to_rtp")
+    request.record_route()
+    request.fork([c.uri for c in contacts])
+
+@proxy.on_reply
+async def reply_route(request, reply):
+    if 200 <= reply.status_code < 300 and reply.has_body("application/sdp"):
+        await rtpengine.answer(reply, profile="srtp_to_rtp")
+    reply.relay()
+
+@proxy.on_cancel
+async def cancel_route(request):
+    await rtpengine.delete(request)   # release media for an abandoned call
+```
+
+On a **B2BUA** it's the same three calls in `@b2bua.on_invite` / `on_answer` /
+`on_bye` (+ `on_failure` / `on_cancel`); pass `call=` to `answer()` so it reuses the
+A-leg Call-ID that matched the offer (see [the SBC recipe](sbc.md)).
+
+!!! warning "Always release"
+    `offer` without a matching `delete` leaks an RTPEngine session until its
+    inactivity timeout. Handle every teardown path — `on_bye`, `on_failure`,
+    `on_cancel` (proxy: `@proxy.on_cancel`) — or media lingers.
+
+## Built-in profiles
+
+| Profile | Interworking |
+|---|---|
+| `rtp_passthrough` | Plain RTP both sides — anchoring only (the default) |
+| `srtp_to_rtp` | SRTP UE ↔ RTP core (VoLTE/secure access ↔ trunk) |
+| `ws_to_rtp` | WebSocket UE (RTP/AVPF + ICE) ↔ RTP core |
+| `wss_to_rtp` | Secure WebSocket (DTLS-SRTP/AVPF + ICE) ↔ RTP core |
+
+`ws_to_rtp` / `wss_to_rtp` are what make a **WebRTC** gateway work — terminate the
+browser's DTLS-SRTP + ICE on one side, plain RTP toward your core on the other.
+
+## Custom profiles
+
+Define your own under `media.profiles` — any RTPEngine flag, per direction:
+
+```yaml
+media:
+  profiles:
+    srtp_to_srtp:
+      offer:
+        transport_protocol: "RTP/SAVP"
+        ice: "remove"
+        replace: ["origin"]
+        direction: ["external", "internal"]
+      answer:
+        transport_protocol: "RTP/SAVP"
+        ice: "remove"
+        replace: ["origin"]
+        direction: ["internal", "external"]
+```
+
+```python
+await rtpengine.offer(request, profile="srtp_to_srtp")
+```
+
+## Shape the SDP yourself
+
+For codec filtering, hold, or attribute tweaks without RTPEngine, use the `sdp`
+namespace:
+
+```python
+from siphon import sdp
+
+s = sdp.parse(request)
+for m in s.media:
+    if m.media_type == "audio":
+        s.filter_codecs(["PCMU", "PCMA"])   # keep only G.711
+        # m.port = 0                          # ... or put audio on hold
+s.apply(request)
+```
+
+## More media control
+
+The `rtpengine` namespace also drives announcements and tones (`play_media`,
+`play_dtmf`), gating (`silence_media` / `block_media`), DTMF events (`@rtpengine.on_dtmf`),
+and conference/MPTY subscriptions — useful for IVR, MMTel announcements, and recording.
+
+## See also
+
+- Real examples: [`examples/proxy_rtpengine.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/proxy_rtpengine.py), [`examples/b2bua_rtpengine.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/b2bua_rtpengine.py).
+- [SBC (B2BUA)](sbc.md) — media anchoring in a topology-hiding SBC.

--- a/docs/cookbook/monitoring.md
+++ b/docs/cookbook/monitoring.md
@@ -1,0 +1,112 @@
+# Monitoring & observability
+
+You can see what SIPhon is doing four ways: Prometheus metrics (built-in + your own),
+the admin API, Call Detail Records, and full SIP tracing to Homer. None of them block
+the call path.
+
+## Prometheus metrics
+
+Enable the endpoint:
+
+```yaml
+metrics:
+  prometheus:
+    listen: "0.0.0.0:9090"
+    path: "/metrics"
+```
+
+SIPhon exports built-in gauges/counters; the ones worth alerting on:
+
+| Signal | Alert when | Why |
+|---|---|---|
+| `siphon_memory_allocated_bytes` | `rate(...[30m]) > 0` at flat call rate | A real memory leak |
+| `siphon_pyexec_jobs_shed_total` | sustained `rate() > 0` | Handler pool saturated → SIP retransmits |
+| `siphon_pyexec_pool_size` vs `_pool_max` | pinned equal + all busy for minutes | Pool fully grown and saturated |
+| `siphon_proxy_dialog_sessions` | grows under flat completed-call load | Dialog state not draining |
+| `siphon_rtpengine_instances_up` | drops below your engine count | An RTPEngine is unhealthy |
+
+See [Handler execution model](../handler-execution-model.md) for the pool internals.
+
+### Your own metrics
+
+The `metrics` namespace adds counters, gauges, and histograms that appear on the same
+`/metrics` endpoint:
+
+```python
+from siphon import metrics
+
+calls = metrics.counter("calls_total", "Calls processed", labels=["direction", "result"])
+active = metrics.gauge("calls_active", "Active calls", labels=["direction"])
+setup  = metrics.histogram("call_setup_seconds", "INVITE→200 latency",
+                           buckets=[0.1, 0.25, 0.5, 1, 2.5, 5])
+
+calls.labels(direction="outbound", result="ok").inc()
+active.labels(direction="outbound").inc()      # ... .dec() when it ends
+setup.observe(0.342)
+```
+
+## Admin API — health, readiness, registrations
+
+A separate HTTP port for probes and runtime inspection:
+
+```yaml
+admin:
+  listen: "0.0.0.0:9091"
+```
+
+| Endpoint | Use |
+|---|---|
+| `GET /admin/health` | liveness — `200` while the process is alive (survives drain) |
+| `GET /admin/ready` | readiness — `200`, or **`503` while draining** (SIGTERM) |
+| `GET /admin/stats` | uptime + active registration count |
+| `GET /admin/registrations[/{aor}]` | inspect bindings |
+| `DELETE /admin/registrations/{aor}` | force-unregister |
+
+Point Kubernetes liveness at `/admin/health` and readiness at `/admin/ready` so a
+draining pod leaves rotation cleanly — see [Deployment & operations](../deployment.md).
+
+## Call Detail Records
+
+```yaml
+cdr:
+  enabled: true
+  backend: http              # file | http | syslog
+  http:
+    url: "https://collector.example.com/v1/cdr"
+    auth_header: "Bearer tok123"
+```
+
+CDRs are written asynchronously (a bounded channel, never blocks a call) with the
+call's timing, parties, transport, disconnect initiator, and response code. Add your
+own fields from a script:
+
+```python
+from siphon import cdr
+cdr.write(request, extra={"billing_id": "B-12345", "account": "ACC-789"})
+```
+
+## Full SIP tracing → Homer
+
+Stream every SIP message to a [Homer](https://github.com/sipcapture/homer) /
+heplify-server collector over HEP — invaluable for debugging call flows:
+
+```yaml
+tracing:
+  hep:
+    endpoint: "127.0.0.1:9060"
+    version: 3
+    transport: udp           # udp | tcp | tls
+    agent_id: "siphon-sbc"   # per-role name so nodes appear separately in Homer
+```
+
+## Putting it together
+
+A solid baseline: scrape `/metrics` with Prometheus + alert on the table above; probe
+`/admin/health` + `/admin/ready` from your orchestrator; ship CDRs to your billing
+collector; and point HEP at Homer for call-flow forensics. For the production alert
+set and capacity guidance, see [Deployment & operations](../deployment.md#metrics-and-alerting).
+
+## See also
+
+- Real example: [`examples/timer_example.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/timer_example.py) (periodic health pushes), [`siphon.yaml`](https://github.com/siphon-project/siphon-sip/blob/main/siphon.yaml).
+- [Deployment & operations](../deployment.md) — the ops runbook.

--- a/docs/cookbook/proxy.md
+++ b/docs/cookbook/proxy.md
@@ -1,0 +1,102 @@
+# Stateful proxy
+
+A proxy routes requests without taking part in the media or owning the dialog. This
+recipe is a residential/edge proxy: it challenges REGISTER, routes calls to
+registered contacts, loose-routes in-dialog traffic, and drops garbage before it
+costs you anything.
+
+## Script
+
+```python
+from siphon import proxy, registrar, auth, log
+
+DOMAIN = "example.com"
+
+@proxy.on_request
+def route(request):
+    # 1. Drop malformed / torture traffic before any work (RFC 4475).
+    #    Scoped to out-of-dialog requests; dropped silently so we don't
+    #    fingerprint the server to scanners.
+    if not request.in_dialog and not proxy.sanity_check(request):
+        return
+
+    # 2. Local OPTIONS keepalive.
+    if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+        return
+
+    # 3. In-dialog requests follow the dialog's route set.
+    if request.in_dialog:
+        if request.loose_route():
+            request.relay()
+        else:
+            request.reply(404, "Not Here")
+        return
+
+    # 4. REGISTER.
+    if request.method == "REGISTER":
+        if not auth.require_digest(request, realm=DOMAIN):
+            return
+        registrar.save(request)
+        return
+
+    # 5. Out-of-dialog INVITE/MESSAGE/…: location lookup + fork.
+    if not request.ruri.user:
+        request.reply(484, "Address Incomplete")
+        return
+    contacts = registrar.lookup(request.ruri)
+    if not contacts:
+        request.reply(404, "Not Found")
+        return
+    request.record_route()
+    request.fork(contacts)
+```
+
+## The routing primitives
+
+| Call | What it does |
+|---|---|
+| `request.relay()` / `request.relay("sip:next@host")` | Forward to the next hop (or an explicit target). Like Kamailio `t_relay()`. |
+| `request.fork(targets, strategy="parallel"\|"sequential")` | Fork to many targets; first 2xx wins (parallel) or try in order (sequential). |
+| `request.record_route()` | Insert this proxy into the dialog's route set so in-dialog requests come back. |
+| `request.loose_route()` | Consume the top `Route` and route the request onward (RFC 3261 §16.12). |
+| `request.reply(code, reason)` | Send a response from the proxy. |
+
+The transaction layer handles CANCEL matching, Max-Forwards, retransmissions and
+ACK-for-non-2xx automatically — you don't write routes for those.
+
+## Aggregating fork results
+
+For a parallel fork, SIPhon aggregates the branches per RFC 3261 §16.7 (first 2xx
+wins, best error otherwise). To act when *all* branches fail:
+
+```python
+@proxy.on_failure
+def failure_route(request, reply):
+    # e.g. send to voicemail, or relay the best error upstream
+    reply.relay()
+```
+
+And to touch responses on the way back (rewrite headers, strip internal info):
+
+```python
+@proxy.on_reply
+def reply_route(request, reply):
+    reply.remove_header("X-Internal-Trace")
+    reply.relay()
+```
+
+## Test it
+
+```bash
+# register a contact, then place a call to it
+python3 deploy/ha-demo/sipcli.py register 127.0.0.1 5060 bob 127.0.0.1 5080
+python3 deploy/ha-demo/sipcli.py invite   127.0.0.1 5060 bob     # -> 1xx (routed)
+```
+
+## See also
+
+- Real example: [`scripts/proxy_default.py`](https://github.com/siphon-project/siphon-sip/blob/main/scripts/proxy_default.py), [`examples/proxy_gateway.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/proxy_gateway.py).
+- [Load balancer](load-balancer.md) — route to a backend pool instead of registered contacts.
+- [Media & RTP](media-rtp.md) — anchor media on a proxy with RTPEngine.
+- Coming from Kamailio/OpenSIPS? See the [migration guide](../migrating-from-kamailio-opensips.md).

--- a/docs/cookbook/registrar.md
+++ b/docs/cookbook/registrar.md
@@ -1,0 +1,115 @@
+# Registrar
+
+A SIP registrar accepts `REGISTER`, authenticates the subscriber, and stores their
+`Contact` so calls can be routed to them later. This recipe is a registrar that also
+proxies calls to the registered contacts.
+
+## Config
+
+```yaml
+# siphon.yaml
+listen:
+  udp: ["0.0.0.0:5060"]
+  tcp: ["0.0.0.0:5060"]
+domain:
+  local: ["example.com"]
+script:
+  path: "/etc/siphon/registrar.py"
+
+registrar:
+  backend: redis            # memory | redis | postgres | python
+  redis:
+    url: "redis://127.0.0.1:6379"
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "example.com"
+  backend: static           # static | http | database | diameter_cx
+  # static credentials for a quick start (use http/database in production):
+  # credentials:
+  #   alice: "secret"
+```
+
+`backend: redis` makes the registrar survive a restart — see
+[Scaling & redundancy](../scaling-and-redundancy.md) for exactly what that does
+(durability + a boot snapshot, not live cross-node sync).
+
+## Script
+
+```python
+from siphon import proxy, registrar, auth, log
+
+DOMAIN = "example.com"
+
+@proxy.on_request
+def route(request):
+    # In-dialog requests follow the established route set.
+    if request.in_dialog:
+        if request.loose_route():
+            request.relay()
+        else:
+            request.reply(404, "Not Here")
+        return
+
+    # REGISTER: challenge, then store the contact. registrar.save() also sends
+    # the 200 OK with the granted Expires.
+    if request.method == "REGISTER":
+        if not auth.require_digest(request, realm=DOMAIN):
+            return                      # 401 challenge already sent
+        request.fix_nated_register()    # rewrite Contact with the observed source
+        registrar.save(request)
+        return
+
+    # Anything else (INVITE, MESSAGE, …): look up the AoR and route to it.
+    contacts = registrar.lookup(request.ruri)
+    if not contacts:
+        request.reply(404, "Not Found")
+        return
+    request.record_route()
+    request.fork(contacts)              # ring all bindings; first 2xx wins
+```
+
+A few things worth knowing:
+
+- **`registrar.save(request)` sends the 200 OK for you** (with the granted Expires,
+  clamped by `max_expires`). You don't reply yourself.
+- **`request.fork(contacts)`** passes the `Contact` objects (not just `.uri`). For a
+  binding this node accepted, that routes over the captured inbound flow — the only
+  way to reach a WebSocket UE (RFC 5626 §5.3 connection reuse). Non-local contacts
+  fall back to URI routing.
+- **`request.fix_nated_register()`** rewrites the Contact with the source the packet
+  actually came from, so NAT'd clients are reachable. Pair it with `nat:` config.
+
+## React to registration changes
+
+```python
+@registrar.on_change
+def on_reg_change(aor, event_type, contacts):
+    # event_type: "registered" | "refreshed" | "deregistered" | "expired"
+    log.info(f"{aor} {event_type}: {len(contacts)} contact(s)")
+```
+
+Use this to push presence, notify an external system, or emit charging events.
+
+## Test it
+
+Register and look up with any SIP client, or with the in-repo
+[`sipcli.py`](https://github.com/siphon-project/siphon-sip/blob/main/deploy/ha-demo/sipcli.py):
+
+```bash
+python3 deploy/ha-demo/sipcli.py register 127.0.0.1 5060 alice 127.0.0.1 5080
+# -> 200
+```
+
+If you enabled the admin API (`admin.listen`), confirm the binding over HTTP:
+
+```bash
+curl http://127.0.0.1:9091/admin/registrations/sip:alice@example.com
+```
+
+## See also
+
+- Real example: [`examples/registrar_proxy.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/registrar_proxy.py) (adds external-API contact notifications) and [`scripts/proxy_default.py`](https://github.com/siphon-project/siphon-sip/blob/main/scripts/proxy_default.py).
+- [Stateful proxy](proxy.md) — routing and forking in more depth.
+- [Hardening & security](security.md) — auth backends, rate limiting, bans.

--- a/docs/cookbook/sbc.md
+++ b/docs/cookbook/sbc.md
@@ -1,0 +1,150 @@
+# SBC (B2BUA)
+
+A Session Border Controller sits between two networks as a back-to-back user agent:
+two fully independent dialogs, topology hiding, media anchoring, and control over
+exactly which headers cross the trust boundary. In SIPhon the B2BUA is first-class —
+no entity IDs, no bridge calls, just `@b2bua.*` handlers and a `call` object.
+
+## The call lifecycle
+
+```python
+from siphon import b2bua, gateway, log
+
+@b2bua.on_invite
+def on_invite(call):
+    call.media.anchor(engine="rtpengine")     # hide media topology
+    call.remove_headers_matching("^X-")        # strip internal headers
+    gw = gateway.select("carriers")            # pick a trunk
+    call.dial(gw.uri, timeout=30)              # dial the B-leg
+
+@b2bua.on_early_media
+def on_early_media(call, reply):
+    log.info(f"[{call.id}] early media {reply.status_code}")
+
+@b2bua.on_answer
+def on_answer(call, reply):
+    log.info(f"[{call.id}] answered")
+
+@b2bua.on_failure
+def on_failure(call, code, reason):
+    call.reject(code, reason)                  # propagate to the A-leg
+
+@b2bua.on_bye
+def on_bye(call, initiator):
+    call.media.release()
+    log.info(f"[{call.id}] ended by {initiator.side}")
+
+@b2bua.on_cancel
+def on_cancel(call):                            # caller abandoned before answer
+    log.info(f"[{call.id}] cancelled")
+```
+
+Each B-leg gets its own Call-ID and From-tag by default, so the two dialogs are fully
+decoupled — **topology hiding out of the box**. Other call methods: `call.fork(targets)`
+(ring several B-legs), `call.reject(code, reason)`, `call.terminate()`,
+`call.set_header` / `remove_header`, and B-leg userpart rewrites
+(`call.set_ruri_user` / `set_from_user` / `set_to_user`).
+
+## Header policies — control what crosses the boundary
+
+The whole point of an SBC is deciding which headers leak between two networks. SIPhon
+handles this with **named, versioned header policies** instead of hand-rolled
+strip/copy logic on every call.
+
+```python
+call.dial(
+    "sip:5112@ims.example.com",
+    header_policy="ims-trust-domain-boundary@2026",
+    copy=["X-Operator-Tag"],                       # also let this one through
+    strip=["History-Info"],                        # also drop this one
+    translate=[("Diversion", "rfc7044")],          # rewrite Diversion → History-Info
+)
+```
+
+### Built-in presets
+
+Pin the version (`@2026`) so a SIPhon upgrade can't silently change which headers
+cross the boundary.
+
+| Preset | Use at | Behaviour |
+|---|---|---|
+| `transparent-b2bua@2026` | general SBC (default) | today's strip set; behaviour-equivalent to pre-policy SIPhon |
+| `ims-intra-trust-domain@2026` | S-CSCF ↔ AS | passes `P-*` headers + end-to-end PRACK / preconditions |
+| `ims-trust-domain-boundary@2026` | P-CSCF / IBCF / BGCF edge | strict trust-boundary hygiene |
+| `sip-trunk-edge@2026` | plain SIP trunk | strips `P-*` / `X-*` |
+
+Set a default for all calls in `siphon.yaml` and override per call as needed:
+
+```yaml
+b2bua:
+  default_header_policy: "ims-trust-domain-boundary@2026"
+```
+
+### Per-call deltas
+
+On top of the preset, `copy` / `strip` / `translate` apply per call — for emergency
+calls, aggregator quirks, etc. that the YAML preset can't express. `translate` ops in
+v1 are `rfc7044` and `diversion-to-history-info`.
+
+### Precedence (highest wins)
+
+1. Script `call.set_header()` / `call.remove_header()` — always wins
+2. `copy=` / `strip=` / `translate=` per-call deltas
+3. The named preset's overrides
+4. The named preset's default copy/strip set
+5. **Framework-auto headers** — `Via`, `Call-ID`, `CSeq`, `Max-Forwards`,
+   `Content-Length`, `From`, `To`, `Contact`, `Record-Route`, `Route`,
+   `Proxy-Authorization`, `Proxy-Authenticate`. Never policy-able.
+
+!!! note "One intentional change from pre-policy SIPhon"
+    Every preset strips `Proxy-Authenticate` on B→A responses. RFC 3261 §22.3 makes
+    it hop-by-hop, so passing it through would point the A-leg's
+    `Proxy-Authorization` at the wrong realm. Opt back in with
+    `copy=["Proxy-Authenticate"]` if you really want the old transparent behaviour.
+
+## Add media anchoring
+
+`call.media.anchor(engine="rtpengine")` hides the media path too. For SRTP↔RTP
+interworking, WebRTC, transcoding, hold, or announcements, drive RTPEngine directly —
+see [Media & RTP profiles](media-rtp.md):
+
+```python
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    await rtpengine.offer(call, profile="srtp_to_rtp")   # SRTP UE ↔ RTP trunk
+    call.dial(str(call.ruri))
+
+@b2bua.on_answer
+async def on_answer(call, reply):
+    await rtpengine.answer(reply, profile="srtp_to_rtp", call=call)
+
+@b2bua.on_bye
+async def on_bye(call, initiator):
+    await rtpengine.delete(call)
+```
+
+## Hybrid: proxy + SBC in one script
+
+INVITEs go to `@b2bua.on_invite`; REGISTER/OPTIONS/etc. go to `@proxy.on_request` —
+in the same script, same process. So you can B2BUA calls (topology hiding + media)
+while lightly proxying registrations:
+
+```python
+@proxy.on_request("REGISTER")
+def on_register(request):
+    if auth.require_digest(request, realm=DOMAIN):
+        registrar.save(request)
+
+@b2bua.on_invite
+def on_invite(call):
+    call.media.anchor(engine="rtpengine")
+    call.dial(gateway.select("carriers").uri)
+```
+
+## See also
+
+- Real examples: [`scripts/b2bua_default.py`](https://github.com/siphon-project/siphon-sip/blob/main/scripts/b2bua_default.py), [`examples/b2bua_gateway.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/b2bua_gateway.py), [`examples/b2bua_rtpengine.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/b2bua_rtpengine.py).
+- [Media & RTP profiles](media-rtp.md) — the RTPEngine profiles in depth.
+- [Hardening & security](security.md) — STIR/SHAKEN at the edge, TLS, IPsec.

--- a/docs/cookbook/security.md
+++ b/docs/cookbook/security.md
@@ -1,0 +1,138 @@
+# Hardening & security
+
+A SIP port on the public internet gets scanned within minutes. This recipe collects
+the layers SIPhon gives you — most are config, a few are one-liners in a script.
+
+## 1. Drop abuse before it costs you (config)
+
+The `security:` block runs **before any SIP parsing or scripting**, so banned/garbage
+traffic never reaches your handlers:
+
+```yaml
+security:
+  rate_limit:
+    window_secs: 10
+    max_requests: 30            # per source IP per window
+    ban_duration_secs: 3600
+
+  scanner_block:
+    user_agents: ["sipvicious", "friendly-scanner", "VaxSip", "sipcli"]
+
+  trusted_cidrs: ["10.0.0.0/8"] # own infra: never rate-limited, never banned
+
+  failed_auth_ban:              # auto-ban at accept (UDP/TCP/TLS/WS/SCTP)
+    threshold: 10               # weighted failures in window_secs → ban
+    window_secs: 600
+    ban_duration_secs: 3600
+    strong_signal_weight: 3     # weight of a high-confidence abuse signal
+
+  apiban:                       # optional: APIBAN community blocklist
+    api_key: "your-api-key"
+    interval_secs: 300
+```
+
+`failed_auth_ban` weights signals by confidence: a wrong-password digest, a forged
+nonce, or non-SIP garbage on a TLS stream counts heavily; a single 401 challenge
+counts as 1; a successful auth resets the counter. Banned IPs are dropped at
+`recv()`, before parsing. Put your load balancers and health checks in
+`trusted_cidrs`.
+
+In a script, you can also rate-limit a specific flow:
+
+```python
+if not proxy.rate_limit(request, window_secs=1, max_requests=5):
+    return    # silently drop — don't fingerprint the server
+```
+
+## 2. Drop malformed traffic (script)
+
+`proxy.sanity_check()` runs the RFC 4475 semantic checks (mandatory headers, CSeq,
+Content-Length). Drop failures **silently** so scanners learn nothing:
+
+```python
+@proxy.on_request
+def route(request):
+    if not request.in_dialog and not proxy.sanity_check(request):
+        return                  # silent drop
+    ...
+```
+
+!!! note "Silent drop is intentional"
+    Returning from a handler without `reply()`/`relay()`/`reject()` sends no response.
+    For rate-limit and scanner blocking that's the point — a `403` would confirm the
+    server exists. Don't "helpfully" reply.
+
+## 3. Encrypt the signalling (config)
+
+```yaml
+listen:
+  tls: ["0.0.0.0:5061"]
+tls:
+  certificate: "/etc/siphon/tls/cert.pem"
+  private_key:  "/etc/siphon/tls/key.pem"
+  method: "TLSv1_3"
+  # mTLS — require and verify client certs (SIP trunks with mutual auth):
+  verify_client: true
+  client_ca: "/etc/siphon/tls/client-ca.pem"
+```
+
+`verify_client: true` requires a client cert chaining to `client_ca` (fails closed at
+startup if `client_ca` is missing). It applies to `listen.tls` **and** `listen.wss`.
+
+## 4. Authenticate subscribers (script + config)
+
+```python
+if not auth.require_digest(request, realm="example.com"):
+    return                      # 401/407 challenge already sent
+user = request.auth_user        # the authenticated username afterwards
+```
+
+The `auth.backend` can be `static`, `http` (REST credential lookup), `database`, or
+`diameter_cx` (IMS HSS). For REGISTER-time account-takeover protection, set
+`registrar.enforce_auth_aor_match: true` so a subscriber can't bind a Contact under
+someone else's AoR.
+
+## 5. Verify caller ID — STIR/SHAKEN (script)
+
+Sign on egress, verify on ingress at a trunk edge:
+
+```python
+from siphon import proxy, stir, log
+
+@proxy.on_request("INVITE")
+def on_invite(request):
+    if request.source_ip_in(["203.0.113.0/24"]):           # inbound from a peer
+        result = stir.verify(request)
+        if result.verstat == "TN-Validation-Failed":
+            request.reply(438, "Invalid Identity Header")  # RFC 8224 §6.2.2
+            return
+        stir.apply_verstat(request, result)                 # convey downstream
+    else:                                                    # outbound
+        origid = stir.sign(request, attestation="A")
+    request.record_route()
+    request.relay()
+```
+
+Needs a `stir:` block with `signing` + `verification` configured.
+
+## 6. IMS access security — IPsec (Gm)
+
+For a P-CSCF, SIPhon does full 3GPP TS 33.203 sec-agree: parse `Security-Client`,
+run AKA, install kernel IPsec SAs, and route MT requests back over the flow. It's a
+substantial flow — see [`examples/ims_pcscf.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/ims_pcscf.py)
+and the `ipsec:` config block. The SA lifetime tracks the registration lifetime
+automatically.
+
+## Checklist
+
+- [ ] `security.failed_auth_ban` + `scanner_block` on, infra in `trusted_cidrs`
+- [ ] `proxy.sanity_check()` on out-of-dialog requests, silent-drop failures
+- [ ] TLS (and mTLS for trunks); subscriber-facing access over TLS/WSS
+- [ ] Digest auth on REGISTER (+ `enforce_auth_aor_match`)
+- [ ] STIR/SHAKEN at PSTN edges; IPsec at IMS Gm
+- [ ] Alert on the security metrics (see [Monitoring](monitoring.md))
+
+## See also
+
+- Real example: [`examples/stir_shaken.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/stir_shaken.py), [`examples/ims_pcscf.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/ims_pcscf.py).
+- Reference config: [`siphon.yaml`](https://github.com/siphon-project/siphon-sip/blob/main/siphon.yaml).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -230,7 +230,7 @@ or force-unregister bindings), and `/metrics`. If you'd rather not enable it, a
 ping to the SIP port works for readiness (the default proxy scripts answer local
 `OPTIONS` with `200`).
 
-### Metrics & alerting
+### Metrics and alerting
 
 Scrape `/metrics`. The handful that matter operationally:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: SIPhon
 site_description: High-performance SIP proxy, B2BUA, and IMS platform in Rust with free-threaded Python scripting
-site_url: https://siphon-sip.org/
+site_url: https://docs.siphon-sip.org/
 repo_url: https://github.com/siphon-project/siphon-sip
 repo_name: siphon-project/siphon-sip
 edit_uri: edit/main/docs/
@@ -40,6 +40,15 @@ theme:
 
 nav:
   - Home: README.md
+  - Cookbook:
+      - Overview: cookbook/index.md
+      - Registrar: cookbook/registrar.md
+      - Stateful proxy: cookbook/proxy.md
+      - Load balancer: cookbook/load-balancer.md
+      - SBC (B2BUA): cookbook/sbc.md
+      - Media & RTP profiles: cookbook/media-rtp.md
+      - Hardening & security: cookbook/security.md
+      - Monitoring & observability: cookbook/monitoring.md
   - Running in production:
       - Scaling, clustering & redundancy: scaling-and-redundancy.md
       - Deployment & operations: deployment.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: SIPhon
 site_description: High-performance SIP proxy, B2BUA, and IMS platform in Rust with free-threaded Python scripting
-site_url: https://docs.siphon-sip.org/
+site_url: https://siphon-sip.org/
 repo_url: https://github.com/siphon-project/siphon-sip
 repo_name: siphon-project/siphon-sip
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Adds a **Cookbook** section to the docs site (https://docs.siphon-sip.org/) — complete, working starting points for the common SIP roles, so people can immediately see how to build real things with SIPhon.

Each recipe has the YAML config, a real Python script, and how to test it. All grounded in the repo's actual example scripts — no invented APIs.

## Recipes
- **Registrar** — digest auth, `registrar.save`/`lookup`, NAT fixups
- **Stateful proxy** — `fork`/`loose_route`/`record_route`, sanity checks, failure/reply routes
- **Load balancer** — `gateway.select`, health probing, subscriber affinity
- **SBC (B2BUA)** — the `@b2bua.*` lifecycle + an in-depth **header policies** section (presets, `copy`/`strip`/`translate`, precedence) + media anchoring
- **Media & RTP profiles** — `rtpengine.offer`/`answer`/`delete`, built-in + custom profiles, the `sdp` namespace
- **Hardening & security** — rate-limit/scanner/auth bans, TLS/mTLS, STIR/SHAKEN, IPsec
- **Monitoring** — custom Prometheus metrics, the admin API, CDR, HEP/Homer

## Also
- Wires the Cookbook into the mkdocs nav.
- Points `site_url` at the live custom domain and pins the CNAME in the Pages build (so the custom domain survives every deploy).
- Slug-stabilises one `deployment.md` heading so its anchor works on both GitHub and the site.

Validated locally with `mkdocs build --strict` (clean). The Pages `build` job also runs on this PR.