### PR TITLE
fix(transaction): RFC 4320 §4.2 timing for the non-INVITE 100 Trying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
     connect with `ErrorKind::Unsupported` (no silent fallback to TCP).
   - CI builds and tests both configurations (default and `--features sctp`).
 
+### Fixed
+- **Premature `100 Trying` on non-INVITE transactions over UDP (RFC 4320 §4.2).**
+  The non-INVITE auto-100 (MESSAGE/SUBSCRIBE/OPTIONS/BYE) fired after the short
+  INVITE-style delay (~200ms), violating RFC 4320 §4.2, which forbids a 100 to a
+  non-INVITE over an unreliable transport before the UAC's Timer E is reset to T2
+  (≈3.5s with default timers). The most visible symptom was a `100 Trying` for an
+  in-dialog BYE that the peer answers in milliseconds. The auto-100 delay over
+  UDP is now derived from T1/T2 (Timer E → T2); over a reliable transport, where
+  RFC 4320 permits a 100 at any time, the configured
+  `transaction.auto_emit_100_trying_delay_ms` still applies. INVITE 100 Trying
+  behavior is unchanged.
+
 ### Performance
 - `SipHeaders` now stores one `IndexMap<String, (String, Vec<String>)>` (lowercase
   key → original-cased name + values) instead of two parallel maps. This removes a

--- a/src/config.rs
+++ b/src/config.rs
@@ -1436,12 +1436,17 @@ pub struct TransactionConfig {
     #[serde(default = "default_tx_invite_timeout")]
     pub invite_timeout_secs: u32,
     /// Auto-emit `100 Trying` on slow non-INVITE server transactions to
-    /// suppress UAC retransmits (RFC 3261 §17.1.2). Mirror of §17.2.1 for
-    /// INVITE applied to MESSAGE/SUBSCRIBE/OPTIONS relays. Default: true.
+    /// suppress UAC retransmits (MESSAGE/SUBSCRIBE/OPTIONS/BYE relays).
+    /// Default: true. Timing is governed by RFC 4320 §4.2 — see
+    /// `auto_emit_100_trying_delay_ms`.
     #[serde(default = "default_auto_emit_100_trying")]
     pub auto_emit_100_trying: bool,
-    /// Delay before the auto-100 Trying fires. Default: 200ms (mirrors
-    /// RFC 3261 §17.2.1's 200 ms IST timer).
+    /// Delay before the non-INVITE auto-100 fires **over a reliable transport**
+    /// (TCP/TLS), where RFC 4320 §4.2 permits a 100 at any time. Default: 200ms.
+    /// Over UDP this value is ignored: RFC 4320 §4.2 forbids a 100 to a
+    /// non-INVITE before the UAC's Timer E is reset to T2 (≈3.5s with default
+    /// timers), so the delay there is derived from T1/T2, not this field. This
+    /// is why an in-dialog BYE answered in milliseconds never draws a 100.
     #[serde(default = "default_auto_emit_100_trying_delay_ms")]
     pub auto_emit_100_trying_delay_ms: u64,
 }

--- a/src/transaction/state.rs
+++ b/src/transaction/state.rs
@@ -169,7 +169,15 @@ impl Nist {
     ) -> (Self, Vec<Action>) {
         let mut actions = Vec::new();
         if timers.auto_100_trying {
-            actions.push(Action::StartTimer(TimerName::Trying100, timers.auto_100_delay));
+            // RFC 4320 §4.2: a 100 Trying for a non-INVITE MUST NOT be sent over
+            // an unreliable transport before the UAC's Timer E is reset to T2
+            // (≈3.5s with default timers), and MUST be sent by then if still
+            // unanswered; over a reliable transport it MAY be sent at any time.
+            // So the delay is transport-derived, NOT the short INVITE-style
+            // `auto_100_delay` — which fired ~200ms in and produced a premature
+            // 100 for e.g. an in-dialog BYE the peer answers in milliseconds.
+            let delay = timers.nist_auto_100_delay(transport == Transport::Reliable);
+            actions.push(Action::StartTimer(TimerName::Trying100, delay));
         }
         let nist = Self {
             state: NistState::Trying,
@@ -223,9 +231,12 @@ impl Nist {
                 actions
             }
             (NistState::Trying, NistEvent::Trying100Fired) => {
-                // TU was silent past `auto_100_delay` — synthesize the
-                // 100 Trying ourselves to suppress upstream UAC retransmits
-                // (RFC 3261 §17.1.2). Mirror of §17.2.1 for INVITE.
+                // TU was silent past the NIST auto-100 delay — synthesize the
+                // 100 Trying ourselves to suppress upstream UAC retransmits. The
+                // delay is bounded by RFC 4320 §4.2 (over UDP, not before the
+                // UAC's Timer E reaches T2; see `TimerConfig::nist_auto_100_delay`),
+                // so by the time this fires the UAC has ramped its retransmit
+                // interval to T2 and a 100 is warranted.
                 let trying = crate::sip::builder::build_response_skeleton(
                     &self.original_request,
                     100,
@@ -1070,8 +1081,22 @@ mod tests {
 
     #[test]
     fn nist_auto_100_initial_actions_include_timer() {
+        // RFC 4320 §4.2: over UDP the auto-100 is delayed until Timer E reaches
+        // T2 (3.5s with default timers) — NOT the short configured auto_100_delay.
         let (nist, actions) = nist_auto_100(Transport::Udp);
         assert_eq!(nist.state, NistState::Trying);
+        let started = actions.iter().find_map(|a| match a {
+            Action::StartTimer(TimerName::Trying100, d) => Some(*d),
+            _ => None,
+        });
+        assert_eq!(started, Some(std::time::Duration::from_millis(3500)));
+    }
+
+    #[test]
+    fn nist_auto_100_reliable_uses_configured_delay() {
+        // RFC 4320 §4.2: over a reliable transport a 100 MAY be sent at any
+        // time, so the configured auto_100_delay (50ms here) applies.
+        let (_nist, actions) = nist_auto_100(Transport::Reliable);
         let started = actions.iter().find_map(|a| match a {
             Action::StartTimer(TimerName::Trying100, d) => Some(*d),
             _ => None,

--- a/src/transaction/timer.rs
+++ b/src/transaction/timer.rs
@@ -131,6 +131,46 @@ impl TimerConfig {
     pub fn next_retransmit(&self, current: Duration) -> Duration {
         std::cmp::min(current * 2, self.t2)
     }
+
+    /// Elapsed time until a non-INVITE client transaction's Timer E is first
+    /// reset to T2 (RFC 3261 §17.1.2.2): the sum of the retransmit intervals
+    /// (T1, 2·T1, 4·T1, …) that precede the first interval clamped to T2. With
+    /// the default T1=500ms, T2=4s this is 3.5s.
+    ///
+    /// This is the RFC 4320 §4.2 lower bound for emitting a `100 Trying` to a
+    /// non-INVITE request over an unreliable transport: an element MUST NOT
+    /// send the 100 before this point, and MUST send it once reached if still
+    /// unanswered.
+    pub fn timer_e_reaches_t2(&self) -> Duration {
+        // Degenerate configs: never loop forever, fall back to T2.
+        if self.t1.is_zero() || self.t1 >= self.t2 {
+            return self.t2;
+        }
+        let mut elapsed = Duration::ZERO;
+        let mut interval = self.t1;
+        while interval < self.t2 {
+            elapsed += interval;
+            interval *= 2;
+        }
+        elapsed
+    }
+
+    /// Delay before a non-INVITE server transaction (NIST) auto-emits
+    /// `100 Trying`, per RFC 4320 §4.2.
+    ///
+    /// Over a reliable transport a 100 MAY be sent at any time, so the
+    /// configured [`Self::auto_100_delay`] applies. Over an unreliable transport
+    /// it MUST NOT be sent before the UAC's Timer E is reset to T2, so the delay
+    /// is [`Self::timer_e_reaches_t2`] — NOT the short INVITE-style
+    /// `auto_100_delay`, which would fire ~200ms in and violate RFC 4320 (e.g. a
+    /// premature 100 for an in-dialog BYE the peer answers in milliseconds).
+    pub fn nist_auto_100_delay(&self, reliable: bool) -> Duration {
+        if reliable {
+            self.auto_100_delay
+        } else {
+            self.timer_e_reaches_t2()
+        }
+    }
 }
 
 impl Default for TimerConfig {
@@ -247,5 +287,47 @@ mod tests {
         assert_eq!(config.timer_k_tcp(), Duration::ZERO);
         assert_eq!(config.timer_i_tcp(), Duration::ZERO);
         assert_eq!(config.timer_j_tcp(), Duration::ZERO);
+    }
+
+    #[test]
+    fn timer_e_reaches_t2_default() {
+        // T1=500, T2=4000 → intervals 500 + 1000 + 2000 = 3500ms before the
+        // first interval clamps to T2.
+        let config = TimerConfig::default();
+        assert_eq!(config.timer_e_reaches_t2(), Duration::from_millis(3500));
+    }
+
+    #[test]
+    fn timer_e_reaches_t2_custom() {
+        // T1=100, T2=800 → 100 + 200 + 400 = 700ms (next would be 800 = T2).
+        let config = TimerConfig::new(
+            Duration::from_millis(100),
+            Duration::from_millis(800),
+            Duration::from_secs(5),
+        );
+        assert_eq!(config.timer_e_reaches_t2(), Duration::from_millis(700));
+    }
+
+    #[test]
+    fn timer_e_reaches_t2_degenerate_t1_ge_t2() {
+        // T1 >= T2 can't ramp — fall back to T2 rather than loop forever.
+        let config = TimerConfig::new(
+            Duration::from_secs(4),
+            Duration::from_secs(4),
+            Duration::from_secs(5),
+        );
+        assert_eq!(config.timer_e_reaches_t2(), Duration::from_secs(4));
+    }
+
+    #[test]
+    fn nist_auto_100_delay_by_transport() {
+        let config = TimerConfig::default();
+        // Unreliable (UDP): RFC 4320 §4.2 lower bound (Timer E → T2).
+        assert_eq!(
+            config.nist_auto_100_delay(false),
+            config.timer_e_reaches_t2()
+        );
+        // Reliable: the configured auto_100_delay (any time allowed).
+        assert_eq!(config.nist_auto_100_delay(true), config.auto_100_delay);
     }
 }


### PR DESCRIPTION
## Summary

The non-INVITE server transaction (NIST) auto-emitted `100 Trying` after the short **INVITE-style** delay (`transaction.auto_emit_100_trying_delay_ms`, default ~200ms) — reusing the timing meant for the INVITE server transaction.

**RFC 4320 §4.2** forbids sending a `100` to a non-INVITE over an *unreliable* transport **before** the UAC's Timer E is reset to T2 (≈3.5s with default T1/T2), and requires it by then if still unanswered; over a *reliable* transport a 100 MAY be sent at any time.

The most visible symptom: a `100 Trying` for an **in-dialog BYE** that the peer answers in milliseconds — surprising, non-conformant, and enough to abort rigid UAC scenarios that don't expect a provisional on the BYE.

## Fix

The NIST auto-100 delay is now **transport-derived**:
- **UDP / unreliable** → `TimerConfig::timer_e_reaches_t2()` — the sum of the Timer E retransmit intervals (T1, 2·T1, …) before the first clamp to T2 (3.5s with defaults). This is the RFC 4320 §4.2 lower bound.
- **TCP/TLS / reliable** → the configured `auto_emit_100_trying_delay_ms` (RFC 4320 permits a 100 at any time there).

Because a BYE is answered long before Timer E ramps to T2, its auto-100 timer is cancelled before it can fire. The **INVITE** `100 Trying` path (TU/dispatcher-driven, not the NIST) is unchanged.

## Scope

- `auto_emit_100_trying` stays **on by default** — it's now correctly timed, and RFC 4320 actually *requires* the 100 by the Timer-E→T2 point if still unanswered.
- No scripting-API or config-shape change; `auto_emit_100_trying_delay_ms` keeps its meaning for reliable transports (its doc is updated to note UDP is governed by RFC 4320).

## Tests

- `timer_e_reaches_t2` — default (3.5s), custom timers, and the degenerate `t1 >= t2` guard.
- `nist_auto_100_delay` by transport.
- NIST initial-timer tests now assert the UDP delay is Timer-E→T2 (3.5s) while reliable keeps the configured delay.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo test`: all green (lib 2641, integration 269).

CHANGELOG `[Unreleased] → Fixed` updated.