### PR TITLE
feat: memory-sane defaults — memory-aware sync-pool ceiling + install_allocator!()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`siphon::install_allocator!()` — one-line jemalloc + page-decay setup.** A
+  `#[global_allocator]` and jemalloc's `_rjem_malloc_conf` config symbol only
+  take effect in the final binary crate (the language honors `#[global_allocator]`
+  only in the binary root, and jemalloc's weak `_rjem_malloc_conf = NULL` default
+  means a library-provided definition isn't reliably linked), so both must be
+  emitted in `main.rs`. The new macro does exactly that in one line:
+  `siphon::install_allocator!();` installs jemalloc as the global allocator plus
+  siphon's page-decay tuning
+  (`background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0`), with siphon
+  owning the `tikv-jemallocator` version (re-exported, so there's no
+  `links = "jemalloc"` version skew and no separate dependency to add). Pass a
+  literal to override the decay config
+  (`siphon::install_allocator!("dirty_decay_ms:0")`). A read-only boot probe
+  (`siphon::metrics::jemalloc_is_active`) now logs a loud WARN at startup if
+  jemalloc isn't the active allocator — so the system allocator running
+  unexpectedly (RSS bloat, `siphon_memory_*` gauges reading jemalloc's idle
+  footprint) shows up in logs rather than a memory post-mortem. See
+  `examples/embed_with_allocator.rs`. siphon's own binary is unchanged.
 - **ISDN-AddressString AVPs decode to E.164 in scripts** — MSISDN (701),
   SC-Address (3300), SGSN-Number (1489) and MME-Number-for-MT-SMS (1645) are
   now dictionary-typed `ISDNAddressString` (3GPP TS 29.002 §17.7.8) instead of
@@ -84,6 +102,22 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the existing perf/mem and criterion regression gates.
 
 ### Changed
+- **Synchronous Python executor pool ceiling is now memory-aware by default.**
+  The pool's default `max`/`core` worker counts were derived only from the host
+  CPU count (`core = max(8, 2×CPUs)`, `max = max(32, 4×core)`), which scaled the
+  pool's memory ceiling with the *box's* core count rather than the NF's memory
+  budget. Combined with a per-worker heap that is ~8 MB on free-threaded CPython
+  3.14t (not the ~2 MB the comment assumed), an un-cpu-limited NF on a 16-core
+  host defaulted to `core=32/max=128` ≈ 1 GB of pool heap, so memory-constrained
+  IMS NFs hit their cgroup limit under churn. The default ceiling is now the
+  **minimum** of that CPU-derived cap and a memory budget (~30 % of the
+  container's cgroup memory limit — v2 `memory.max`, v1 `memory.limit_in_bytes`,
+  falling back to host RAM — divided by the ~10 MB conservative per-worker heap),
+  and `core` is capped the same way so the pool no longer *starts* at 32 workers
+  on a big box. On a 512 MB NF the ceiling resolves to ~15 (was 32/128); on
+  256 MB to ~7. The resolved `core`/`max` and which bound won (`cpu`/`memory`/
+  `override`) are logged at startup. The `script.sync_pool_size` /
+  `script.sync_pool_max` overrides still take precedence when set.
 - **SCTP is now an opt-in build feature, off by default.** SIP-over-SCTP
   (RFC 4168) and Diameter-over-SCTP link the `libsctp` system library, which
   only exists on Linux. Moving them behind the `sctp` Cargo feature lets the

--- a/examples/embed_with_allocator.rs
+++ b/examples/embed_with_allocator.rs
@@ -1,0 +1,34 @@
+//! Example: install jemalloc + siphon's page-decay tuning in one line.
+//!
+//! `siphon::install_allocator!()` expands — here, in this binary crate — to a
+//! jemalloc `#[global_allocator]` plus the baked `_rjem_malloc_conf` page-decay
+//! tuning. Both are binary-crate-only constructs (see the macro docs for the two
+//! linker reasons), so the macro emits them here. No `tikv-jemallocator`
+//! dependency is needed — siphon re-exports it, keeping a single
+//! `links = "jemalloc"` version in the graph.
+//!
+//! Run with:
+//!   cargo run --example embed_with_allocator
+//!
+//! Expected output: a line confirming jemalloc is the active global allocator.
+//! Verify the config symbol made it into the binary with:
+//!   nm target/debug/examples/embed_with_allocator | grep _rjem_malloc_conf
+
+// Override the decay config with, e.g.:
+//   siphon::install_allocator!("background_thread:true,dirty_decay_ms:0");
+siphon::install_allocator!();
+
+fn main() {
+    // Probe jemalloc the same way siphon's boot guard does. In a binary that
+    // forgot the macro this returns false and `verify_global_allocator()` WARNs.
+    let active = siphon::metrics::jemalloc_is_active();
+    println!("jemalloc active as global allocator: {active}");
+
+    assert!(
+        active,
+        "install_allocator!() should have made jemalloc the global allocator — \
+         allocations are not routing through it"
+    );
+
+    println!("OK — siphon::install_allocator!() installed jemalloc + decay config");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -437,9 +437,12 @@ pub struct ScriptConfig {
     /// OS thread with a persistent Python attach — see `script::py_executor`
     /// for why this is needed (the free-threaded-CPython mimalloc heap leak
     /// on the elastic `spawn_blocking` pool).  Defaults to 2× the number of
-    /// available CPUs (clamped to at least 2): the hot inbound path runs here,
-    /// and 2× restores the burst headroom the elastic pool gave at the
-    /// throughput ceiling.  Lower it on memory-constrained, low-traffic NFs.
+    /// available CPUs (floored at 8), but **capped by the container memory
+    /// budget** so an un-cpu-limited NF on a many-core box doesn't *start* at 32
+    /// always-on workers (each carries ~8 MB of persistent free-threaded-CPython
+    /// heap).  The hot inbound path runs here, and 2× restores the burst headroom
+    /// the elastic pool gave at the throughput ceiling.  Lower it on
+    /// memory-constrained, low-traffic NFs.
     #[serde(default)]
     pub sync_pool_size: Option<usize>,
     /// Hard ceiling on synchronous Python executor worker threads. The pool is
@@ -448,10 +451,13 @@ pub struct ScriptConfig {
     /// restores the burst headroom blocking-I/O handlers need (a handful of
     /// concurrent blocking REGISTERs no longer wedge the engine) without the
     /// free-threaded-CPython heap leak that reaping caused. Each grown worker
-    /// costs ~2 MB of persistent Python heap, so the pool's memory ceiling is
-    /// roughly `sync_pool_max × 2 MB` — lower it on memory-constrained NFs.
-    /// Defaults to `max(32, 4 × sync_pool_size)`; clamped to at least
-    /// `sync_pool_size`.
+    /// costs ~8 MB of persistent free-threaded-CPython heap (measured on 3.14t;
+    /// the earlier ~2 MB estimate was ~4× low), so the pool's memory ceiling is
+    /// roughly `sync_pool_max × 8 MB`. The default is **memory-aware**: the
+    /// MINIMUM of the CPU-derived `max(32, 4 × sync_pool_size)` and a memory
+    /// budget (~30 % of the container's cgroup memory limit ÷ per-worker heap),
+    /// clamped to at least `sync_pool_size`. On a 512 MB NF that resolves to ~15
+    /// (not 32); set this explicitly to override the budget either way.
     #[serde(default)]
     pub sync_pool_max: Option<usize>,
     /// Seconds the synchronous Python executor pool may show *zero forward

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,66 @@ pub mod srs;
 pub mod subscribe_state;
 
 pub use server::SiphonServer;
+
+// Re-export the jemalloc allocator crate so the macro can name
+// `$crate::tikv_jemallocator::Jemalloc` without a separate dependency.
+// `tikv-jemalloc-sys` is a `links = "jemalloc"` crate, so only ONE version may
+// exist in the dependency graph — using siphon's avoids any version skew or a
+// "two jemalloc" link error. Gated to non-MSVC to match the dependency itself.
+#[cfg(not(target_env = "msvc"))]
+#[doc(hidden)]
+pub use tikv_jemallocator;
+
+/// Install jemalloc as the global allocator **and** bake siphon's page-decay
+/// tuning into the calling binary, in one line. Invoke once at the top of
+/// `main.rs`:
+///
+/// ```ignore
+/// siphon::install_allocator!();                      // default decay config
+/// siphon::install_allocator!("dirty_decay_ms:0");    // custom jemalloc conf
+/// ```
+///
+/// # Why this is a macro
+///
+/// Both pieces only take effect when emitted in the **final binary crate**, so
+/// the macro expands them *in your binary*:
+///
+/// 1. `#[global_allocator]` is honored by the language only in the root of the
+///    final binary; a `static` with that attribute inside a dependency is
+///    ignored.
+/// 2. The `_rjem_malloc_conf` config symbol must be a *strong* definition in the
+///    binary. jemalloc ships a **weak** `_rjem_malloc_conf = NULL` default that
+///    already satisfies its own reference, so the linker has no undefined symbol
+///    to resolve and won't pull a definition out of a `.rlib` (`#[used]` keeps
+///    the symbol in its object but doesn't force the object into the link).
+///    Emitting it in the binary is the only reliable way.
+///
+/// The default conf — `background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0`
+/// — proactively returns freed pages to the OS, which is the win under
+/// free-threaded-CPython worker-pool churn. Pass a literal to override it on a
+/// memory-tight deployment. Invoking the macro twice is a compile error
+/// (duplicate `#[global_allocator]`). On MSVC (where jemalloc isn't a dependency)
+/// the macro expands to nothing, leaving the system allocator.
+#[macro_export]
+macro_rules! install_allocator {
+    () => {
+        $crate::install_allocator!(
+            "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0"
+        );
+    };
+    ($conf:literal) => {
+        #[cfg(not(target_env = "msvc"))]
+        #[global_allocator]
+        static __SIPHON_GLOBAL_ALLOC: $crate::tikv_jemallocator::Jemalloc =
+            $crate::tikv_jemallocator::Jemalloc;
+
+        // jemalloc reads this symbol at init. `tikv-jemalloc-sys` builds with the
+        // `_rjem_` symbol prefix, so the config name is `_rjem_malloc_conf`.
+        // `concat!(.., "\0")` NUL-terminates it for the C reader, and
+        // `str::as_bytes` is const so it's a valid `static` initializer.
+        #[cfg(not(target_env = "msvc"))]
+        #[allow(non_upper_case_globals)]
+        #[unsafe(export_name = "_rjem_malloc_conf")]
+        pub static __SIPHON_MALLOC_CONF: &[u8] = concat!($conf, "\0").as_bytes();
+    };
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -639,6 +639,74 @@ pub fn update_memory_stats() {
 #[cfg(target_env = "msvc")]
 pub fn update_memory_stats() {}
 
+/// Probe whether jemalloc is the live global allocator.
+///
+/// Allocates ~1 MiB and checks jemalloc's `allocated` stat moved: if jemalloc is
+/// *not* the global allocator the probe routes through the system allocator and
+/// jemalloc's internal counter doesn't budge. Read-only — never changes the
+/// allocator's runtime configuration.
+///
+/// Note: under `cargo test` this returns `false`, because the lib/integration
+/// test binaries set no `#[global_allocator]` and so run on the system allocator
+/// (the same reason the jemalloc gauges read ~0 in tests). It returns `true`
+/// only in a binary that emitted `siphon::install_allocator!()` (or its own
+/// jemalloc `#[global_allocator]`), e.g. the `siphon` binary.
+#[cfg(not(target_env = "msvc"))]
+pub fn jemalloc_is_active() -> bool {
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    const PROBE_BYTES: usize = 1 << 20; // 1 MiB
+    const MIN_DELTA: usize = 1 << 19; // 512 KiB — half the probe, tolerant of rounding/noise
+
+    // If the epoch can't be advanced we can't read jemalloc stats at all, which
+    // itself means jemalloc isn't the operative allocator.
+    if epoch::advance().is_err() {
+        return false;
+    }
+    let before = stats::allocated::read().unwrap_or(0);
+    // `with_capacity` allocates the backing buffer immediately; `black_box`
+    // stops the optimiser from eliding an otherwise-unused allocation.
+    let probe = std::hint::black_box(Vec::<u8>::with_capacity(PROBE_BYTES));
+    let _ = epoch::advance();
+    let after = stats::allocated::read().unwrap_or(0);
+    drop(probe);
+
+    after.saturating_sub(before) >= MIN_DELTA
+}
+
+/// On MSVC jemalloc is never a dependency, so it is never the allocator.
+#[cfg(target_env = "msvc")]
+pub fn jemalloc_is_active() -> bool {
+    false
+}
+
+/// Verify jemalloc is the live global allocator and warn loudly at boot if not.
+///
+/// A binary that forgot `siphon::install_allocator!()` runs siphon's Rust
+/// working set on the **system** allocator — RSS bloat (per-thread glibc
+/// arenas) and meaningless `siphon_memory_*` gauges, which then read jemalloc's
+/// idle internal footprint instead of the real working set. Catch it in the log
+/// at startup rather than in a memory post-mortem. Safe to call unconditionally:
+/// the probe is read-only.
+#[cfg(not(target_env = "msvc"))]
+pub fn verify_global_allocator() {
+    if jemalloc_is_active() {
+        tracing::debug!(target: "siphon", "jemalloc confirmed as the global allocator");
+    } else {
+        tracing::warn!(
+            target: "siphon",
+            "jemalloc is NOT the active global allocator — running on the system \
+             allocator. Add `siphon::install_allocator!();` to this binary's main.rs. \
+             Expect RSS bloat and meaningless siphon_memory_* gauges."
+        );
+    }
+}
+
+/// No-op on MSVC, where jemalloc isn't a dependency and the system allocator is
+/// expected — a warning there would be misleading.
+#[cfg(target_env = "msvc")]
+pub fn verify_global_allocator() {}
+
 /// Refresh the Python-side allocation gauge from `sys.getallocatedblocks()`.
 ///
 /// Python objects live in CPython's own allocator (mimalloc on free-threaded
@@ -689,6 +757,23 @@ pub fn update_glibc_stats() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The probe must not panic, and — because the `cargo test` binaries set no
+    /// `#[global_allocator]` and so run on the system allocator (the documented
+    /// reason the jemalloc gauges read ~0 in tests) — it must report jemalloc as
+    /// inactive here. `verify_global_allocator()` would WARN in this same case,
+    /// which is exactly its job for a binary that forgot `install_allocator!()`.
+    #[test]
+    fn jemalloc_inactive_under_cargo_test() {
+        assert!(
+            !jemalloc_is_active(),
+            "cargo-test binaries run on the system allocator, so jemalloc must \
+             probe as inactive; if this flips, a #[global_allocator] leaked into \
+             the test build"
+        );
+        // Smoke: the boot guard path must not panic either.
+        verify_global_allocator();
+    }
 
     #[test]
     fn metrics_init_and_access() {

--- a/src/script/py_executor.rs
+++ b/src/script/py_executor.rs
@@ -90,6 +90,201 @@ impl Default for ExecutorConfig {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Memory-aware pool sizing
+// ---------------------------------------------------------------------------
+
+/// Persistent per-worker Python heap on free-threaded CPython 3.14t, in MB.
+///
+/// Each elastic worker holds a persistent `PyGILState_Ensure` attach for its
+/// whole life (the never-reap design that fixes the mimalloc-heap leak), so it
+/// carries its own free-threaded mimalloc heap that grows as the worker runs
+/// handlers and then stays resident. Measured at **~8 MB** per warm worker on a
+/// free-threaded 3.14t IMS deployment — `scscf` (32 workers) − `pcscf`
+/// (8 workers) = 24 workers for +198 MB RSS ≈ 8.25 MB/worker. The original
+/// "~2 MB" estimate predated free-threading and was ~4× low. Rounded up to 10
+/// here so the derived budget is conservative (never under-counts the heap).
+const PER_WORKER_HEAP_MB: u64 = 10;
+
+/// Fraction of the container's memory limit the pool's *peak* heap
+/// (`max_threads × PER_WORKER_HEAP_MB`) is allowed to occupy by default. Keeps
+/// the pool from defaulting past ~30 % of the NF's RAM no matter how many CPUs
+/// the host has — the per-worker heap budget, not the host core count, sets the
+/// ceiling.
+const POOL_BUDGET_FRACTION: f64 = 0.30;
+
+/// Absolute floor for the CPU-derived thread ceiling (legacy default shape:
+/// `max(MIN_MAX_THREADS, 4 × core)`), before the memory budget caps it down.
+const MIN_MAX_THREADS: usize = 32;
+
+/// Always-on core-worker floor. A small container (`cpus: 0.5`) reports
+/// `available_parallelism() == 1`, which `2×` alone would make a 2-thread
+/// baseline — too small for the hot inbound path.
+const MIN_CORE_THREADS: usize = 8;
+
+/// cgroup v1 reports "no limit" as a page-aligned value near `i64::MAX`
+/// (`PAGE_COUNTER_MAX × PAGE_SIZE`, ≈ 9.22e18). A real memory limit — even a
+/// multi-terabyte one — is many orders of magnitude smaller, so treat anything
+/// at or above this threshold as unlimited.
+const CGROUP_V1_UNLIMITED: u64 = 0x7000_0000_0000_0000;
+
+/// Which budget determined the resolved `max_threads`, surfaced in the startup
+/// log so an operator can see why the ceiling landed where it did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SizingBound {
+    /// The CPU-derived ceiling (`max(MIN_MAX_THREADS, 4 × core)`) was binding.
+    Cpu,
+    /// The container memory budget (`POOL_BUDGET_FRACTION` of the limit) was binding.
+    Memory,
+    /// An explicit `script.sync_pool_max` override was set.
+    Override,
+}
+
+impl SizingBound {
+    /// Lower-case label for structured logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SizingBound::Cpu => "cpu",
+            SizingBound::Memory => "memory",
+            SizingBound::Override => "override",
+        }
+    }
+}
+
+/// Resolved `core` / `max` worker counts plus the bound that set the ceiling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PoolSizing {
+    pub core_threads: usize,
+    pub max_threads: usize,
+    pub bound: SizingBound,
+}
+
+/// Resolve the elastic pool's `core` / `max` worker counts from the CPU count
+/// and the container memory limit, honouring explicit overrides.
+///
+/// The ceiling is the **minimum** of a CPU-derived cap (`max(32, 4 × core)`)
+/// and a memory budget (`POOL_BUDGET_FRACTION` of the limit ÷ per-worker heap),
+/// so the pool can't default past ~30 % of the NF's RAM however many CPUs the
+/// host happens to have. `core` is likewise capped by the memory budget so an
+/// un-cpu-limited NF on a many-core box doesn't *start* at 32 always-on workers.
+/// Explicit `sync_pool_size` / `sync_pool_max` always win. `mem_limit_bytes` is
+/// `None` when no limit is readable (non-Linux / no `/proc`), in which case the
+/// CPU-derived ceiling stands unchanged (prior behaviour).
+pub fn resolve_sizing(
+    cpus: usize,
+    mem_limit_bytes: Option<u64>,
+    sync_pool_size: Option<usize>,
+    sync_pool_max: Option<usize>,
+) -> PoolSizing {
+    // How many per-worker heaps fit in the pool's memory budget. `None` keeps
+    // the CPU-derived shape (no limit known).
+    let per_worker_bytes = PER_WORKER_HEAP_MB * 1024 * 1024;
+    let mem_cap = mem_limit_bytes.map(|limit| {
+        let budget = (limit as f64) * POOL_BUDGET_FRACTION;
+        ((budget / per_worker_bytes as f64) as usize).max(1)
+    });
+
+    // Core: 2× CPUs floored at 8, but never above what the memory budget affords.
+    let cpu_core = cpus.saturating_mul(2).max(MIN_CORE_THREADS);
+    let core_threads = sync_pool_size
+        .unwrap_or(match mem_cap {
+            Some(cap) => cpu_core.min(cap),
+            None => cpu_core,
+        })
+        .max(1);
+
+    // Max: CPU-derived ceiling capped by the memory budget; an explicit
+    // override wins, clamped to at least `core` (existing contract).
+    let cpu_cap = core_threads.saturating_mul(4).max(MIN_MAX_THREADS);
+    let (max_threads, bound) = match sync_pool_max {
+        Some(explicit) => (explicit.max(core_threads), SizingBound::Override),
+        None => match mem_cap {
+            Some(cap) => {
+                let mem_max = cap.max(core_threads);
+                if mem_max < cpu_cap {
+                    (mem_max, SizingBound::Memory)
+                } else {
+                    (cpu_cap, SizingBound::Cpu)
+                }
+            }
+            None => (cpu_cap, SizingBound::Cpu),
+        },
+    };
+
+    PoolSizing {
+        core_threads,
+        max_threads,
+        bound,
+    }
+}
+
+/// Resolve the effective memory limit (bytes) for pool budgeting: the
+/// container's cgroup limit when one is set (cgroup v2 `memory.max`, then v1
+/// `memory.limit_in_bytes`), else host RAM (`/proc/meminfo` `MemTotal`). The
+/// cgroup limit is clamped to host RAM — a limit above physical RAM isn't a
+/// real budget. Returns `None` only when nothing is readable (non-Linux /
+/// no `/proc`), so callers fall back to the CPU-derived ceiling.
+pub fn read_memory_limit_bytes() -> Option<u64> {
+    let host_ram = read_host_ram_bytes();
+    let cgroup = read_cgroup_mem_limit();
+    match (cgroup, host_ram) {
+        (Some(cgroup_limit), Some(ram)) => Some(cgroup_limit.min(ram)),
+        (Some(cgroup_limit), None) => Some(cgroup_limit),
+        (None, Some(ram)) => Some(ram),
+        (None, None) => None,
+    }
+}
+
+/// Read the cgroup memory limit (v2 first, then v1). `None` when no limit is set
+/// (the `max` / unlimited sentinels) or the files are absent.
+fn read_cgroup_mem_limit() -> Option<u64> {
+    if let Some(limit) = std::fs::read_to_string("/sys/fs/cgroup/memory.max")
+        .ok()
+        .and_then(|content| parse_cgroup_v2_max(&content))
+    {
+        return Some(limit);
+    }
+    std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+        .ok()
+        .and_then(|content| parse_cgroup_v1_limit(&content))
+}
+
+/// Read host physical RAM from `/proc/meminfo` (`MemTotal`, reported in kB).
+fn read_host_ram_bytes() -> Option<u64> {
+    std::fs::read_to_string("/proc/meminfo")
+        .ok()
+        .and_then(|content| parse_meminfo_total(&content))
+}
+
+/// Parse cgroup v2 `memory.max`: a decimal byte count, or `max` (no limit).
+fn parse_cgroup_v2_max(content: &str) -> Option<u64> {
+    let trimmed = content.trim();
+    if trimmed == "max" {
+        return None;
+    }
+    trimmed.parse::<u64>().ok().filter(|&value| value > 0)
+}
+
+/// Parse cgroup v1 `memory.limit_in_bytes`: a decimal byte count. Treat the
+/// near-`i64::MAX` "unlimited" sentinel (see [`CGROUP_V1_UNLIMITED`]) as no limit.
+fn parse_cgroup_v1_limit(content: &str) -> Option<u64> {
+    content
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|&value| value > 0 && value < CGROUP_V1_UNLIMITED)
+}
+
+/// Parse `MemTotal:  N kB` from `/proc/meminfo`, returning bytes.
+fn parse_meminfo_total(content: &str) -> Option<u64> {
+    content
+        .lines()
+        .find_map(|line| line.strip_prefix("MemTotal:"))
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|kb| kb.parse::<u64>().ok())
+        .map(|kb| kb.saturating_mul(1024))
+}
+
 /// Live, lock-free counters shared between the worker threads (which mutate
 /// them), `submit` (which reads `idle`/`total` to decide whether to grow), and
 /// the watchdog thread. `inflight`/`completed` are the watchdog's forward-progress
@@ -927,6 +1122,111 @@ mod tests {
         assert_eq!(grow_deficit(100, 0, 6, 8), 2);
         assert_eq!(grow_deficit(100, 0, 8, 8), 0);
         assert_eq!(grow_deficit(100, 0, 9, 8), 0);
+    }
+
+    const MB: u64 = 1024 * 1024;
+
+    /// With no readable memory limit (`None`), the ceiling is the legacy
+    /// CPU-derived shape — unchanged behaviour on non-Linux / no-`/proc` hosts.
+    #[test]
+    fn resolve_sizing_without_mem_limit_uses_cpu_ceiling() {
+        let sizing = resolve_sizing(8, None, None, None);
+        // core = max(8, 2×8) = 16; max = max(32, 4×16) = 64.
+        assert_eq!(sizing.core_threads, 16);
+        assert_eq!(sizing.max_threads, 64);
+        assert_eq!(sizing.bound, SizingBound::Cpu);
+    }
+
+    /// Acceptance §4.1 — a 512 MB-cgroup NF resolves `max` to ~12–16 (not 32),
+    /// and the memory budget is the binding bound.
+    #[test]
+    fn resolve_sizing_512mb_caps_max_to_memory_budget() {
+        let sizing = resolve_sizing(2, Some(512 * MB), None, None);
+        // mem budget = 512×0.30 / 10 MB ≈ 15.
+        assert_eq!(sizing.core_threads, 8); // min(max(8, 2×2)=8, 15)
+        assert_eq!(sizing.max_threads, 15);
+        assert_eq!(sizing.bound, SizingBound::Memory);
+        assert!((12..=16).contains(&sizing.max_threads));
+    }
+
+    /// A 256 MB NF budgets even fewer workers (~7).
+    #[test]
+    fn resolve_sizing_256mb_caps_lower() {
+        let sizing = resolve_sizing(2, Some(256 * MB), None, None);
+        // mem budget = 256×0.30 / 10 MB ≈ 7.
+        assert_eq!(sizing.max_threads, 7);
+        assert_eq!(sizing.bound, SizingBound::Memory);
+    }
+
+    /// Acceptance §4.2 — an un-cpu-limited NF on a 16-core box no longer defaults
+    /// to core=32/max=128; both are bounded by the memory budget. `core` is
+    /// capped too, so the pool doesn't *start* at 32 always-on workers.
+    #[test]
+    fn resolve_sizing_big_cpu_box_bounded_by_memory() {
+        let sizing = resolve_sizing(16, Some(512 * MB), None, None);
+        assert_eq!(sizing.core_threads, 15); // min(max(8, 2×16)=32, 15)
+        assert_eq!(sizing.max_threads, 15);
+        assert_eq!(sizing.bound, SizingBound::Memory);
+    }
+
+    /// A generous memory budget leaves the CPU-derived ceiling in charge.
+    #[test]
+    fn resolve_sizing_high_mem_leaves_cpu_bound() {
+        // 8 CPUs, 8 GB: mem budget = 8192×0.30 / 10 ≈ 245 ≫ cpu cap (64).
+        let sizing = resolve_sizing(8, Some(8192 * MB), None, None);
+        assert_eq!(sizing.core_threads, 16);
+        assert_eq!(sizing.max_threads, 64);
+        assert_eq!(sizing.bound, SizingBound::Cpu);
+    }
+
+    /// Acceptance §4.5 — explicit overrides win over the memory budget.
+    #[test]
+    fn resolve_sizing_explicit_overrides_win() {
+        let sizing = resolve_sizing(2, Some(256 * MB), Some(20), Some(40));
+        assert_eq!(sizing.core_threads, 20);
+        assert_eq!(sizing.max_threads, 40);
+        assert_eq!(sizing.bound, SizingBound::Override);
+    }
+
+    /// `max` is always clamped to at least `core` (existing contract), even when
+    /// an override would set it lower.
+    #[test]
+    fn resolve_sizing_max_clamped_to_core() {
+        let sizing = resolve_sizing(2, None, Some(12), Some(4));
+        assert_eq!(sizing.core_threads, 12);
+        assert_eq!(sizing.max_threads, 12);
+        assert_eq!(sizing.bound, SizingBound::Override);
+    }
+
+    /// A pathologically tiny budget still yields a usable (≥1) pool.
+    #[test]
+    fn resolve_sizing_tiny_budget_floors_at_one() {
+        let sizing = resolve_sizing(1, Some(8 * MB), None, None);
+        assert!(sizing.core_threads >= 1);
+        assert!(sizing.max_threads >= sizing.core_threads);
+    }
+
+    #[test]
+    fn parse_cgroup_v2_max_handles_max_and_number() {
+        assert_eq!(parse_cgroup_v2_max("max\n"), None);
+        assert_eq!(parse_cgroup_v2_max("536870912\n"), Some(536_870_912));
+        assert_eq!(parse_cgroup_v2_max("0\n"), None);
+        assert_eq!(parse_cgroup_v2_max("garbage"), None);
+    }
+
+    #[test]
+    fn parse_cgroup_v1_limit_handles_sentinel() {
+        // The kernel "unlimited" sentinel (near i64::MAX) is not a real limit.
+        assert_eq!(parse_cgroup_v1_limit("9223372036854771712\n"), None);
+        assert_eq!(parse_cgroup_v1_limit("268435456"), Some(268_435_456));
+        assert_eq!(parse_cgroup_v1_limit("0"), None);
+    }
+
+    #[test]
+    fn parse_meminfo_total_parses_kb_to_bytes() {
+        let meminfo = "MemTotal:       16384000 kB\nMemFree:         8000000 kB\n";
+        assert_eq!(parse_meminfo_total(meminfo), Some(16_384_000 * 1024));
+        assert_eq!(parse_meminfo_total("MemFree: 100 kB\n"), None);
     }
 
     /// The bounded queue sheds once full instead of growing without bound: with

--- a/src/server.rs
+++ b/src/server.rs
@@ -310,6 +310,13 @@ impl SiphonServer {
             init_logging(&config.log)
         };
 
+        // --- Verify jemalloc is actually the global allocator ---
+        // A binary that forgot `siphon::install_allocator!()` runs siphon's Rust
+        // working set on the system allocator (RSS bloat + meaningless
+        // siphon_memory_* gauges). Catch it in the boot log, not a post-mortem.
+        // Read-only probe — never changes allocator config.
+        crate::metrics::verify_global_allocator();
+
         // --- Allocator tuning (glibc arena cap + periodic trim) ---
         // Applied as early as possible so the arena cap takes effect before the
         // Python/script workload starts creating glibc arenas. The
@@ -414,21 +421,37 @@ impl SiphonServer {
         // free-threaded-CPython attach from leaking (the reason the pool stopped
         // using `spawn_blocking`).
         //
-        // core default = max(8, 2×CPUs): the always-on baseline. The floor of 8
-        // matters on small containers — a `cpus: 0.5` box reports
-        // `available_parallelism() == 1`, which 2× alone would make a 2-thread
-        // baseline. max default = max(32, 4×core): the burst ceiling. Each grown
-        // worker costs ~2 MB of persistent Python heap, so peak memory is
-        // ~max_threads × 2 MB — lower `script.sync_pool_max` on memory-
-        // constrained NFs (and prefer `auth.http.cache_ttl_secs`, which keeps
-        // the storm from ever needing to grow).
+        // The default ceiling is MEMORY-AWARE, not just CPU-derived. Each grown
+        // worker carries its own persistent free-threaded-CPython mimalloc heap
+        // measured at ~8 MB (not the ~2 MB the original estimate assumed), and a
+        // purely CPU-derived ceiling (`max(32, 4×core)`) scaled the pool's memory
+        // ceiling with the *host* core count — unrelated to the NF's memory
+        // budget — so an un-cpu-limited NF on a 16-core box defaulted to
+        // core=32/max=128 ≈ 1 GB of pool heap. `resolve_sizing` instead takes the
+        // MINIMUM of that CPU cap and a memory budget (~30 % of the container's
+        // cgroup limit ÷ per-worker heap), and caps `core` the same way so the
+        // pool also doesn't *start* at 32 workers on a big box. On a 512 MB NF the
+        // ceiling resolves to ~15 (was 32/128); the `script.sync_pool_size` /
+        // `script.sync_pool_max` overrides still win. `auth.http.cache_ttl_secs`
+        // remains the right lever to keep an auth storm from ever needing to grow.
         let cpus = std::thread::available_parallelism().map_or(1, |n| n.get());
-        let core_threads = config.script.sync_pool_size.unwrap_or((cpus * 2).max(8));
-        let max_threads = config
-            .script
-            .sync_pool_max
-            .unwrap_or((core_threads * 4).max(32))
-            .max(core_threads);
+        let mem_limit = crate::script::py_executor::read_memory_limit_bytes();
+        let sizing = crate::script::py_executor::resolve_sizing(
+            cpus,
+            mem_limit,
+            config.script.sync_pool_size,
+            config.script.sync_pool_max,
+        );
+        info!(
+            cpus,
+            mem_limit_mb = mem_limit.map(|bytes| bytes / 1024 / 1024),
+            core_threads = sizing.core_threads,
+            max_threads = sizing.max_threads,
+            bound = sizing.bound.as_str(),
+            "resolved synchronous Python executor pool sizing"
+        );
+        let core_threads = sizing.core_threads;
+        let max_threads = sizing.max_threads;
         // Bound the queue (load-shed under overload instead of unbounded growth)
         // and arm the liveness watchdog (abort + supervisor-restart only if the
         // pool reaches the cap and still wedges). `handler_stall_abort_secs == 0`


### PR DESCRIPTION
Two independent memory-sanity changes, landing together.

## 1. Memory-aware synchronous-pool ceiling

The sync Python executor pool's default `core`/`max` were derived only from the
host CPU count (`core = max(8, 2×CPUs)`, `max = max(32, 4×core)`). That scaled
the pool's **memory** ceiling with the box's core count rather than the
process's memory budget — and each persistently-attached worker carries a
free-threaded-CPython mimalloc heap measured at **~8 MB**, not the ~2 MB the old
comment assumed. So an un-cpu-limited process on a 16-core host defaulted to
`core=32/max=128` ≈ **1 GB** of pool heap, blowing past tight cgroup limits
under churn.

The default ceiling is now the **minimum** of the CPU-derived cap and a memory
budget — ~30 % of the container memory limit (cgroup v2 `memory.max`, v1
`memory.limit_in_bytes`, falling back to `/proc/meminfo` `MemTotal`) ÷ a
conservative ~10 MB per-worker heap. `core` is capped the same way so the pool
no longer *starts* at 32 workers on a big box.

| limit | resolves to (max) |
|------:|------------------:|
| 512 MB | ~15 (was 32/128) |
| 256 MB | ~7 |
| high-RAM box | CPU cap wins → **no-op** |

The resolved `core`/`max` and the binding bound (`cpu`/`memory`/`override`) are
logged at startup. `script.sync_pool_size` / `script.sync_pool_max` overrides
still take precedence.

`resolve_sizing()` and the cgroup/meminfo parsers are pure and unit-tested
(12 cases: 512/256 MB budgets, big-CPU box, no-limit CPU fallback, overrides,
tiny-budget floor, and the parse sentinels).

## 2. `siphon::install_allocator!()`

A `#[global_allocator]` and jemalloc's `_rjem_malloc_conf` config symbol only
take effect in the final binary crate (the language honors `#[global_allocator]`
only in the binary root; jemalloc's weak `_rjem_malloc_conf = NULL` default
means a library-provided definition isn't reliably linked). The new macro emits
both in `main.rs` in one line:

```rust
siphon::install_allocator!();                      // default decay config
siphon::install_allocator!("dirty_decay_ms:0");    // override
```

It installs jemalloc + the page-decay tuning
(`background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0`), with siphon
owning the `tikv-jemallocator` version (re-exported, single `links = "jemalloc"`
— no version skew, no separate dependency). Gated to non-MSVC, where it expands
to nothing.

A read-only boot probe (`metrics::jemalloc_is_active` /
`verify_global_allocator`) logs a loud WARN at startup if jemalloc isn't the
active allocator — so the system allocator running unexpectedly (RSS bloat,
`siphon_memory_*` gauges reading jemalloc's idle footprint) shows up in logs
rather than a memory post-mortem.

`examples/embed_with_allocator.rs` exercises the macro end to end — the defined
`_rjem_malloc_conf` symbol is verified with `nm`, and the runtime probe confirms
jemalloc is the live allocator.

## Scope notes

- **siphon's own binary is unchanged** — its existing `#[global_allocator]` is
  left as-is (no decay-config change), so the macro adds no behavioural change to
  the shipping binary.
- **Perf-neutral by construction.** The memory cap only *lowers* the ceiling when
  RAM is tight; on a high-RAM benchmark box the CPU cap still wins, so the sizing
  default is a no-op there. The only added runtime work is a one-time read-only
  ~1 MiB probe at boot (outside any hot path). The full 16-row SIPp + mem-leak
  baseline still wants a run on the reference machine per project policy before
  merge.

## Tests

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `PYO3_PYTHON=python3 cargo test` — green (2653 lib + integration suites + doc-tests, 0 failures)
- `nm` confirms a defined `_rjem_malloc_conf`; example runs and confirms jemalloc

## Acceptance mapping (specs)

Pool sizing §4.1–§4.5: 512 MB → ~15 ✓, big-CPU box memory-bound ✓, overrides win ✓.
Allocator §6.1 build+link+symbol ✓, §6.2 WARN on missing ✓, §6.3 double-invoke is
a compile error (duplicate `#[global_allocator]`) ✓, §6.4 conf override arm ✓,
§6.5 siphon binary unchanged ✓. Pool-sizing §3.4 (shed idle grown workers) is left
as a follow-up.

Please review before merging — not merging this myself.