### PR TITLE
refactor(nat): drop inert force_rport / fix_register config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
     connect with `ErrorKind::Unsupported` (no silent fallback to TCP).
   - CI builds and tests both configurations (default and `--features sctp`).
 
+### Removed
+- **Dropped the no-op `nat.force_rport` and `nat.fix_register` config keys.** Both
+  were accepted but never consumed by the runtime. Their intended behaviour is
+  already covered: responses are always routed symmetrically to the request's
+  source address (RFC 6314, so rport is effectively unconditional), and every
+  `registrar.save()` records the observed source (`Contact.received` /
+  `Contact.flow`) for NAT/MT routing. REGISTER-side fixups remain available as the
+  explicit script methods `request.fix_nated_register()` / `fix_nated_contact()`.
+  Removal is backward-compatible — existing `siphon.yaml` files carrying either
+  key still parse (the keys are ignored, exactly as before). `nat.fix_contact`,
+  `nat.keepalive`, and `nat.crlf_keepalive` are unchanged.
+
 ### Fixed
 - **Premature `100 Trying` on non-INVITE transactions over UDP (RFC 4320 §4.2).**
   The non-INVITE auto-100 (MESSAGE/SUBSCRIBE/OPTIONS/BYE) fired after the short

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -119,10 +119,10 @@ This document tracks the maturity of every SIPhon feature across three readiness
 
 | Feature | Readiness | Config | Notes |
 |---------|-----------|--------|-------|
-| Force rport (RFC 3581) | **Production** | `nat.force_rport: true` | |
-| Fix Contact (observed source) | **Production** | `nat.fix_contact: true` | |
-| Fix REGISTER Contact | **Production** | `nat.fix_register: true` | |
-| Fix NATed Contact (script) | **Production** | `request.fix_nated_contact()` | |
+| Symmetric response routing (rport, RFC 3581/6314) | **Production** | always on | Responses always go to the request source; no `force_rport` knob needed |
+| Fix Contact (observed source) | **Production** | `nat.fix_contact: true` | Rewrites the Contact on responses |
+| REGISTER source capture | **Production** | automatic in `registrar.save()` | Stored as `Contact.received` / `Contact.flow` for MT routing |
+| Fix NATed Contact / REGISTER (script) | **Production** | `request.fix_nated_contact()` / `fix_nated_register()` | Explicit REGISTER-side fixups |
 | NAT keepalive (OPTIONS ping) | Implemented | `nat.keepalive` | Configurable interval + failure threshold |
 | CRLF keepalive (RFC 5626 §4.4.1) | Implemented | `nat.crlf_keepalive` | TCP/TLS/pool connection keep-alive; outbound probe + inbound peer-ping/pong responder |
 | Stale contact eviction on restart | **Production** | Core | Evicts connection-oriented contacts + on_change notify |

--- a/examples/ims_pcscf.yaml
+++ b/examples/ims_pcscf.yaml
@@ -83,9 +83,7 @@ ipsec:
 # NAT traversal
 # ---------------------------------------------------------------------------
 nat:
-  force_rport: true
   fix_contact: true
-  fix_register: true
 
 # ---------------------------------------------------------------------------
 # Media — RTPEngine for media anchoring

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -361,9 +361,11 @@ auth:
 # NAT traversal
 # ---------------------------------------------------------------------------
 # nat:
-#   force_rport: true       # always rewrite Via/Contact port from observed source
-#   fix_contact: true       # rewrite Contact URI host:port with observed source
-#   fix_register: true      # rewrite Contact on REGISTER with observed source
+#   fix_contact: true       # rewrite Contact URI host:port on responses with the
+#                           # observed source address (responses already route
+#                           # symmetrically to source, RFC 6314 — no force_rport
+#                           # knob; for REGISTER use request.fix_nated_contact()
+#                           # / fix_nated_register() in your script).
 #   keepalive:
 #     enabled: true
 #     interval_secs: 30     # send OPTIONS to each registered contact

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,7 +88,7 @@ pub struct Config {
     /// Rate limiting, scanner UA blocking, trusted source CIDRs.
     pub security: Option<SecurityConfig>,
 
-    /// NAT traversal: force_rport, Contact rewriting, keepalive OPTIONS.
+    /// NAT traversal: response Contact rewriting + keepalives (OPTIONS + CRLF).
     pub nat: Option<NatConfig>,
 
     /// SIP call tracing via HEP (Homer/captAgent).
@@ -1255,15 +1255,18 @@ fn default_strong_signal_weight() -> u32 {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct NatConfig {
-    /// Always rewrite received port in Via/Contact from source port.
-    #[serde(default)]
-    pub force_rport: bool,
-    /// Rewrite Contact URI host:port with observed source address.
+    /// Rewrite the Contact URI host:port on *responses* with the observed
+    /// source address of the entity that sent the response (applied before
+    /// `@proxy.on_reply` handlers run).
+    ///
+    /// Note: there is no `force_rport` / `fix_register` equivalent here.
+    /// Responses are always routed symmetrically to the request's source
+    /// (RFC 6314), so rport is effectively unconditional, and every
+    /// `registrar.save()` already records the observed source for NAT
+    /// routing — the REGISTER-side fixups are exposed as the explicit script
+    /// methods `request.fix_nated_register()` / `fix_nated_contact()`.
     #[serde(default)]
     pub fix_contact: bool,
-    /// Rewrite Contact on REGISTER with observed source address.
-    #[serde(default)]
-    pub fix_register: bool,
     /// Send periodic OPTIONS keep-alives to maintain NAT pinholes.
     pub keepalive: Option<NatKeepaliveConfig>,
     /// RFC 5626 §4.4.1 CRLF keep-alive for persistent connections (TCP/TLS).
@@ -3235,9 +3238,7 @@ domain:
 script:
   path: "scripts/proxy_default.py"
 nat:
-  force_rport: true
   fix_contact: true
-  fix_register: true
   keepalive:
     enabled: true
     interval_secs: 30
@@ -3245,12 +3246,34 @@ nat:
 "#;
         let config = Config::from_str(yaml).unwrap();
         let nat = config.nat.unwrap();
-        assert!(nat.force_rport);
         assert!(nat.fix_contact);
-        assert!(nat.fix_register);
         let ka = nat.keepalive.unwrap();
         assert!(ka.enabled);
         assert_eq!(ka.interval_secs, 30);
+    }
+
+    #[test]
+    fn nat_config_ignores_removed_legacy_keys() {
+        // The no-op `force_rport` / `fix_register` keys were removed; a config
+        // that still carries them must keep parsing (serde ignores unknown
+        // fields) so existing siphon.yaml files don't break on upgrade.
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+nat:
+  force_rport: true
+  fix_contact: true
+  fix_register: true
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        let nat = config.nat.unwrap();
+        assert!(nat.fix_contact);
     }
 
     #[test]


### PR DESCRIPTION
## What

Remove the `nat.force_rport` and `nat.fix_register` config keys. Both were accepted in `siphon.yaml` but **never read** by the runtime (only `nat.fix_contact` was wired), so setting them did nothing.

## Why they aren't needed

Their intended behaviour is already covered without a knob:

- **Symmetric response routing is unconditional.** Every response is sent back to the source IP:port the request arrived from (RFC 6314), so `force_rport` had nothing to enable.
- **Source capture is automatic.** Every `registrar.save()` records the observed source (`Contact.received` / `Contact.flow`) for NAT / mobile-terminating routing — not gated on a knob.
- **REGISTER-side fixups stay available** as the explicit script methods `request.fix_nated_register()` / `fix_nated_contact()`.

Auto-rewriting REGISTER Contact URIs (what `fix_register` implied) is also RFC-fraught for multi-contact / third-party registration, so wiring it was the wrong move — the modern source-capture + flow path supersedes it.

## Backward compatibility

Non-breaking. Config has no `deny_unknown_fields`, so existing `siphon.yaml` files that still carry either key keep parsing (the keys are ignored, exactly as they behaved before). A new regression test (`nat_config_ignores_removed_legacy_keys`) locks this in.

## Changes

- `src/config.rs` — remove the two fields from `NatConfig`; document the real behaviour on `fix_contact`; update the parse test + add the legacy-keys regression test.
- `siphon.yaml`, `examples/ims_pcscf.yaml` — drop the dead keys.
- `docs/feature-readiness-matrix.md` — rows now reflect reality (symmetric routing always-on; automatic REGISTER source capture; script-method fixups).
- `CHANGELOG.md` — `## [Unreleased] → Removed` entry.

`nat.fix_contact`, `nat.keepalive`, `nat.crlf_keepalive` are unchanged.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 2654 lib + all integration tests pass, 0 failures
- No datapath change, so the SIPp/perf baseline is unaffected (these keys were never on any hot path).