### PR TITLE
feat(sdk): mock smpp + http extension namespaces for testing and authoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **SDK mocks for the extension namespaces (`smpp`, `http`).** The `siphon-sip`
+  Python SDK now mocks the namespaces injected by the opt-in extensions, so
+  `from siphon import smpp` / `from siphon import http` resolve under pytest and
+  carry full type hints + docstrings for script authoring. Two new harnesses —
+  `siphon_sdk.smpp_testing.SmppTestHarness` and
+  `siphon_sdk.http_testing.HttpTestHarness` — dispatch mock binds / PDUs and
+  HTTP requests into a script's handlers and capture the results, mirroring
+  `SipTestHarness`. This lets SMPP/HTTP scripts be unit-tested with a single
+  `pip install siphon-sip`, no running SMSC or listener required. The mocks
+  track the extension runtimes (siphon-smpp, siphon-http), which each ship a CI
+  check that fails if their namespace surface drifts from these mocks. The docs
+  **Extensions** page and nav now link the per-extension documentation sites.
 - **HTTP extension wired into `siphon-bin` (`--features http`).** The second
   opt-in extension module alongside SMPP: when `extensions.http` in `siphon.yaml`
   points at an `http.yaml`, `siphon-bin` registers the scriptable `http`
@@ -19,7 +31,7 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   provisioning callback) should enable this feature and use `http.Client` rather
   than a synchronous Python client that blocks its driver loop for the whole
   round-trip. A new `full` aggregate feature (`--features full`) enables every
-  extension module at once. The HTTP module is pinned to **siphon-http v1.0.0**;
+  extension module at once. The HTTP module is pinned to **siphon-http v1.0.1**;
   with the feature off, an `extensions.http` block still parses and is skipped
   with a loud warning (same contract as SMPP and the `sctp` feature). Documented
   under **Extensions** in the docs site.
@@ -35,7 +47,7 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `siphon-bin` (e.g. `cargo build -p siphon-bin --release --features smpp`, or
   the `siphon-bin/Dockerfile` image). Documented under **Extensions** in the
   docs site. The `ext/` layer is structured so further modules (HTTP, …) plug in
-  behind their own features. The SMPP module is pinned to **siphon-smpp v1.2.0**,
+  behind their own features. The SMPP module is pinned to **siphon-smpp v1.2.1**,
   which adds a per-ESME-session inbound ingress rate cap (`server.max_msg_per_sec`
   with a `pace` / `reject` over-rate action).
 - **`siphon::install_allocator!()` — one-line jemalloc + page-decay setup.** A

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,7 +1,7 @@
-# Extensions (SMPP, …)
+# Extensions (SMPP, HTTP)
 
-SIPhon's core speaks SIP. Protocol functionality **beyond SIP** — SMPP today,
-HTTP route serving planned — is provided by **opt-in extension modules**. They
+SIPhon's core speaks SIP. Protocol functionality **beyond SIP** — SMPP and HTTP
+today — is provided by **opt-in extension modules**. They
 are not part of the default binary: you enable a module at build time and
 configure it through the `extensions:` block in `siphon.yaml`. Each module adds
 a scriptable Python namespace your routing scripts can use, alongside the
@@ -79,13 +79,116 @@ code.
 
 The full `smpp` namespace (PDU types, bind handling, outbound `submit`/`deliver`,
 delivery receipts), the complete `smpp.yaml` schema, and deployment examples live
-in the **siphon-smpp** repository:
+in the **siphon-smpp** docs and repository:
 
-➡️ <https://github.com/siphon-project/siphon-smpp>
+- 📖 Documentation: <https://smpp.siphon-sip.org/>
+- 💻 Source: <https://github.com/siphon-project/siphon-smpp>
 
-## Available and planned modules
+## HTTP (route serving + outbound client)
 
-| Module | Feature | Status | Namespace |
-| --- | --- | --- | --- |
-| SMPP 3.4 | `smpp` | Available | `smpp` |
-| HTTP route serving | `http` | Planned | `http` |
+The HTTP extension lets routing scripts **serve** inbound HTTP (`@http.route`)
+and **call out** (`http.Client`) from the same asyncio loop they use for SIP —
+useful for webhooks, health/readiness endpoints, small REST surfaces, and
+provisioning callbacks. The server is axum + rustls (HTTP/1.1 and HTTP/2, TLS and
+mutual TLS); the client is pooled reqwest.
+
+!!! tip "Enable it for the client alone — even if you never serve a route"
+    If a script makes **outbound** HTTP calls on the hot path (a REST lookup per
+    INVITE, a provisioning callback, an auth token refresh), enable the `http`
+    feature and use `http.Client` rather than reaching for a pure-Python library
+    (`requests` / `httpx` / `urllib`). With `http.Client` the entire round-trip
+    runs **in Rust** on siphon's Tokio runtime — connection pooling, TLS, and
+    HTTP/1.1 + HTTP/2 framing — and each call is a real awaitable that **hands the
+    asyncio driver loop back** while the request is in flight, so the driver keeps
+    dispatching other handlers. A **synchronous** Python client instead does the
+    protocol work in the interpreter and **blocks its driver loop for the whole
+    round-trip**, stalling every other handler that shares it. Same pooled client
+    across calls, no per-call setup:
+
+    ```python
+    from siphon import http, proxy
+
+    api = http.Client("api")           # named, pooled — construct once, reuse
+
+    @proxy.on_request("INVITE")
+    async def screen(request):
+        verdict = await api.get(f"/screen/{request.from_uri.user}")
+        if verdict.status != 200:
+            request.reply(403, "Blocked")
+            return
+        request.relay()
+    ```
+
+    You do **not** need to declare an `http.servers` listener to use the client —
+    an `http.yaml` with only a `clients:` block is enough.
+
+### 1. Build with the feature
+
+```bash
+cargo build -p siphon-bin --release --features http
+```
+
+### 2. Point siphon at the HTTP config
+
+```yaml
+# siphon.yaml
+extensions:
+  http: /etc/siphon/http.yaml
+```
+
+### 3. Serve routes in your script
+
+```python
+from siphon import http
+
+@http.route("/healthz")
+def healthz(req):
+    return http.Response(status=200, body=b"ok")
+
+@http.route("/users/{id}", methods=["GET"])
+async def get_user(req):
+    async with http.Client("api") as client:
+        upstream = await client.get(f"/v1/users/{req.path_params['id']}")
+    return http.Response(status=upstream.status, body=upstream.body)
+```
+
+### Further reading
+
+The full `http` namespace (`Request`/`Response`/`Client`, middleware, startup
+hooks, path/query params, TLS/mTLS), the `http.yaml` schema, and examples live in
+the **siphon-http** docs and repository:
+
+- 📖 Documentation: <https://http.siphon-sip.org/>
+- 💻 Source: <https://github.com/siphon-project/siphon-http>
+
+## Testing extension scripts
+
+The [`siphon-sip` SDK](https://pypi.org/project/siphon-sip/) (`pip install
+siphon-sip`) ships mocks and pytest harnesses for the extension namespaces
+alongside the SIP ones, so you can unit-test SMPP and HTTP scripts without a
+running SMSC or listener — and get type hints / docstrings while authoring:
+
+```python
+from siphon_sdk.smpp_testing import SmppTestHarness
+from siphon_sdk.http_testing import HttpTestHarness
+
+def test_submit_sm():
+    h = SmppTestHarness()
+    h.load_script("scripts/gateway.py")
+    assert h.bind("esme1", password="s3cret")
+    reply = h.submit_sm(source_addr="15550100", destination_addr="15550101",
+                        short_message=b"hi")
+    assert reply.ok
+
+def test_healthz():
+    h = HttpTestHarness()
+    h.load_script("scripts/api.py")
+    assert h.request("GET", "/healthz").body == b"ok"
+```
+
+## Available modules
+
+| Module | Feature | Status | Namespace | Docs |
+| --- | --- | --- | --- | --- |
+| SMPP 3.4 | `smpp` | Available | `smpp` | [smpp.siphon-sip.org](https://smpp.siphon-sip.org/) |
+| HTTP / HTTPS | `http` | Available | `http` | [http.siphon-sip.org](https://http.siphon-sip.org/) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,10 @@ nav:
       - Scaling, clustering & redundancy: scaling-and-redundancy.md
       - Deployment & operations: deployment.md
       - Migrating from Kamailio / OpenSIPS: migrating-from-kamailio-opensips.md
-  - Extensions (SMPP, …): extensions.md
+  - Extensions:
+      - Overview: extensions.md
+      - SMPP addon docs ↗: https://smpp.siphon-sip.org/
+      - HTTP addon docs ↗: https://http.siphon-sip.org/
   - Commercial support: support.md
   - Internals:
       - Handler execution model: handler-execution-model.md

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -87,6 +87,36 @@ result = harness.send_bye(initiator_side="a")
 assert result.was_terminated
 ```
 
+## Testing extension scripts (SMPP, HTTP)
+
+The opt-in [siphon extensions](https://siphon-sip.org/extensions/) inject extra
+namespaces (`smpp`, `http`) at runtime. The SDK mocks them too, with dedicated
+harnesses, so extension scripts are testable from the same `pip install
+siphon-sip` — no running SMSC or HTTP listener required:
+
+```python
+from siphon_sdk.smpp_testing import SmppTestHarness
+
+harness = SmppTestHarness()
+harness.load_script("scripts/gateway.py")
+assert harness.bind("esme1", password="s3cret")
+reply = harness.submit_sm(source_addr="15550100", destination_addr="15550101",
+                          short_message=b"hi")
+assert reply.ok
+```
+
+```python
+from siphon_sdk.http_testing import HttpTestHarness
+from siphon_sdk.http import MockResponse
+
+harness = HttpTestHarness()
+harness.add_response(MockResponse(status=200, body=b'{"ok":true}'))
+harness.load_script("scripts/api.py")
+
+resp = harness.request("GET", "/users/42")
+assert resp.status == 200
+```
+
 ## Inline scripts
 
 Test scripts without separate files:

--- a/sdk/siphon_sdk/__init__.py
+++ b/sdk/siphon_sdk/__init__.py
@@ -30,5 +30,7 @@ __version__ = "0.1.0"
 
 from siphon_sdk.mock_module import install
 from siphon_sdk.testing import SipTestHarness
+from siphon_sdk.smpp_testing import SmppTestHarness
+from siphon_sdk.http_testing import HttpTestHarness
 
-__all__ = ["install", "SipTestHarness"]
+__all__ = ["install", "SipTestHarness", "SmppTestHarness", "HttpTestHarness"]

--- a/sdk/siphon_sdk/http.py
+++ b/sdk/siphon_sdk/http.py
@@ -1,0 +1,302 @@
+"""
+siphon.http — mock of the HTTP server+client namespace (siphon-http extension).
+
+At runtime the ``http`` namespace is injected by the **siphon-http** extension
+(a ``siphon-bin`` build with the ``http`` feature), not by siphon-sip itself.
+This module mirrors that namespace so HTTP scripts can be:
+
+1. **Unit tested** with pytest without binding a real listener — see
+   :class:`siphon_sdk.http_testing.HttpTestHarness`.
+2. **Authored with LLM/IDE assistance** — the decorators and the
+   ``Request`` / ``Response`` / ``Client`` pyclasses carry the same signatures
+   and docstrings as the runtime.
+
+The runtime namespace is defined by ``python/http.py`` (decorators) plus the
+Rust ``Request`` / ``Response`` / ``Client`` pyclasses (``src/request.rs`` /
+``response.rs`` / ``client.rs``) in the siphon-http repository. Keep this mock
+in step — the siphon-http CI parity check fails if a name here drifts.
+
+Quick start::
+
+    from siphon import http
+
+    @http.route("/users/{id}", methods=["GET"])
+    async def get_user(req):
+        uid = req.path_params["id"]
+        return http.Response(status=200, body=f"user {uid}")
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any, Callable, Optional, Union
+
+
+class HttpStatusError(Exception):
+    """Raised by :meth:`MockResponse.raise_for_status` for a >= 400 status —
+    the mock analogue of ``reqwest``'s error-for-status."""
+
+
+def _as_bytes(value: Union[str, bytes, bytearray, None]) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return bytes(value)
+
+
+def _lower_headers(headers: Optional[dict[str, str]]) -> dict[str, str]:
+    """Lowercase header keys (the runtime exposes a lowercase-keyed dict)."""
+    return {str(k).lower(): str(v) for k, v in (headers or {}).items()}
+
+
+# ---------------------------------------------------------------------------
+# Pyclasses (mirror src/request.rs / response.rs / client.rs)
+# ---------------------------------------------------------------------------
+
+class MockRequest:
+    """An inbound HTTP request — the only arg passed to ``@http.route`` and
+    ``@http.middleware`` handlers.
+
+    Attributes:
+        method:       ``"GET"`` / ``"PUT"`` / …
+        path:         request path
+        path_params:  ``dict[str, str]`` extracted from the matched route
+        query_params: ``dict[str, str]``
+        headers:      lowercase-keyed ``dict[str, str]``
+        client:       remote socket address, ``"ip:port"``
+    """
+
+    def __init__(self, *, method: str = "GET", path: str = "/",
+                 path_params: Optional[dict[str, str]] = None,
+                 query_params: Optional[dict[str, str]] = None,
+                 headers: Optional[dict[str, str]] = None,
+                 client: str = "127.0.0.1:0",
+                 body: Union[str, bytes, None] = b"") -> None:
+        self.method = method.upper()
+        self.path = path
+        self.path_params = path_params or {}
+        self.query_params = query_params or {}
+        self.headers = _lower_headers(headers)
+        self.client = client
+        self._body = _as_bytes(body)
+
+    def body(self) -> bytes:
+        """The buffered request body as bytes."""
+        return self._body
+
+    def header(self, name: str) -> Optional[str]:
+        """Case-insensitive header lookup; ``None`` if absent."""
+        return self.headers.get(name.lower())
+
+    def __repr__(self) -> str:
+        return f"Request(method={self.method}, path={self.path!r})"
+
+
+class MockResponse:
+    """An outbound HTTP response (route return value) or the result of an
+    outbound :class:`MockClient` call.
+
+    Construct with ``http.Response(status=200, headers={...}, body=b"...")``;
+    ``body`` accepts bytes or str (UTF-8 encoded).
+    """
+
+    def __init__(self, status: int = 200,
+                 headers: Optional[dict[str, str]] = None,
+                 body: Union[str, bytes, None] = None) -> None:
+        self.status = status
+        self.headers = _lower_headers(headers)
+        self._body = _as_bytes(body)
+
+    @property
+    def body(self) -> bytes:
+        """The response body as bytes."""
+        return self._body
+
+    def header(self, name: str) -> Optional[str]:
+        """Case-insensitive header lookup; ``None`` if absent."""
+        return self.headers.get(name.lower())
+
+    def raise_for_status(self) -> "MockResponse":
+        """Raise :class:`HttpStatusError` if ``status`` is >= 400, else return
+        self (so ``resp.raise_for_status()`` can be chained)."""
+        if self.status >= 400:
+            raise HttpStatusError(f"HTTP status {self.status}")
+        return self
+
+    def __repr__(self) -> str:
+        return f"Response(status={self.status}, body_len={len(self._body)})"
+
+
+class MockClient:
+    """An outbound HTTP client. In tests it **records** each request on the
+    namespace's :attr:`MockHttp.sent_requests` and returns a canned
+    :class:`MockResponse` (queue → per-path → default; configure via
+    ``http`` harness helpers). Supports ``async with``.
+
+    Two construction modes, mirroring the runtime::
+
+        http.Client("api")                       # named (config clients.api)
+        http.Client(base_url="https://api.example.com")
+    """
+
+    def __init__(self, name: Optional[str] = None, *, base_url: Optional[str] = None,
+                 verify: Optional[str] = None,
+                 cert: Optional[tuple[str, str]] = None,
+                 timeout_ms: Optional[int] = None,
+                 http2_prior_knowledge: bool = False) -> None:
+        self.name = name
+        self.base_url = base_url
+        self.verify = verify
+        self.cert = cert
+        self.timeout_ms = timeout_ms
+        self.http2_prior_knowledge = http2_prior_knowledge
+
+    async def get(self, path: str, *, headers: Optional[dict] = None) -> MockResponse:
+        return self._request("GET", path, None, headers)
+
+    async def put(self, path: str, *, body: Any = None,
+                  headers: Optional[dict] = None) -> MockResponse:
+        return self._request("PUT", path, body, headers)
+
+    async def post(self, path: str, *, body: Any = None,
+                   headers: Optional[dict] = None) -> MockResponse:
+        return self._request("POST", path, body, headers)
+
+    async def patch(self, path: str, *, body: Any = None,
+                    headers: Optional[dict] = None) -> MockResponse:
+        return self._request("PATCH", path, body, headers)
+
+    async def delete(self, path: str, *, headers: Optional[dict] = None) -> MockResponse:
+        return self._request("DELETE", path, None, headers)
+
+    async def __aenter__(self) -> "MockClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+    def _request(self, method: str, path: str, body: Any,
+                 headers: Optional[dict]) -> MockResponse:
+        ns = _active_http()
+        url = f"{self.base_url.rstrip('/')}{path}" if self.base_url else path
+        ns.sent_requests.append({
+            "method": method, "path": path, "url": url,
+            "name": self.name, "base_url": self.base_url,
+            "headers": dict(headers or {}), "body": _as_bytes(body),
+        })
+        return ns._next_response(path)
+
+
+# ---------------------------------------------------------------------------
+# The http namespace
+# ---------------------------------------------------------------------------
+
+def _registry() -> Any:
+    """Resolve the mock ``_siphon_registry`` (deferred import, like the runtime
+    ``python/http.py``)."""
+    import _siphon_registry as registry
+    return registry
+
+
+# Module-global handle to the active namespace, so a script-constructed
+# ``http.Client(...)`` can record onto / read canned responses from it. There
+# is exactly one MockHttp singleton per process (created in mock_module).
+_ACTIVE: Optional["MockHttp"] = None
+
+
+def _active_http() -> "MockHttp":
+    if _ACTIVE is None:  # pragma: no cover - install() always creates one
+        raise RuntimeError("mock http namespace not installed")
+    return _ACTIVE
+
+
+class MockHttp:
+    """Mock ``http`` namespace — the ``route`` / ``middleware`` / ``on_startup``
+    decorators plus the ``Request`` / ``Response`` / ``Client`` pyclasses.
+
+    Outbound :class:`MockClient` calls are recorded on :attr:`sent_requests`
+    and answered from a configurable response source (queue → per-path →
+    default), so route logic that calls out can be tested in isolation.
+    """
+
+    # Pyclasses attached to the namespace (``http.Response(...)`` etc.).
+    Request = MockRequest
+    Response = MockResponse
+    Client = MockClient
+
+    def __init__(self) -> None:
+        #: Recorded outbound client requests — list of dicts.
+        self.sent_requests: list[dict[str, Any]] = []
+        self._response_queue: deque[MockResponse] = deque()
+        self._path_responses: dict[str, MockResponse] = {}
+        self._default_response: Optional[MockResponse] = None
+        global _ACTIVE
+        _ACTIVE = self
+
+    # -- test helpers -------------------------------------------------------
+
+    def clear(self) -> None:
+        """Reset recorded requests + canned responses (called by
+        ``mock_module.reset()``)."""
+        self.sent_requests.clear()
+        self._response_queue.clear()
+        self._path_responses.clear()
+        self._default_response = None
+
+    def add_response(self, response: MockResponse) -> None:
+        """Enqueue a :class:`MockResponse` returned by the next outbound
+        client call (FIFO)."""
+        self._response_queue.append(response)
+
+    def set_response(self, path: str, response: MockResponse) -> None:
+        """Set the :class:`MockResponse` returned for outbound calls to
+        ``path`` (used after the FIFO queue is drained)."""
+        self._path_responses[path] = response
+
+    def set_default_response(self, response: MockResponse) -> None:
+        """Set the fallback :class:`MockResponse` for outbound calls with no
+        queued/per-path match (default is ``200`` empty)."""
+        self._default_response = response
+
+    def _next_response(self, path: str) -> MockResponse:
+        if self._response_queue:
+            return self._response_queue.popleft()
+        if path in self._path_responses:
+            return self._path_responses[path]
+        if self._default_response is not None:
+            return self._default_response
+        return MockResponse(200, body=b"")
+
+    # -- decorators ---------------------------------------------------------
+
+    def route(self, path: str, methods: Optional[list[str]] = None) -> Callable:
+        """Register a route handler. ``path`` is a matchit-style pattern
+        (``/users/{id}``, ``/static/{*rest}``); ``methods`` defaults to
+        ``["GET"]``. The handler receives a :class:`MockRequest` and must
+        return a :class:`MockResponse` (anything else is a 500)."""
+        methods = [m.upper() for m in (methods or ["GET"])]
+
+        def decorator(fn: Callable) -> Callable:
+            _registry().register("http.route", None, fn,
+                                 asyncio.iscoroutinefunction(fn),
+                                 {"path": path, "methods": methods})
+            return fn
+        return decorator
+
+    def middleware(self, fn: Callable) -> Callable:
+        """Register a request-guard middleware. Middlewares run in registration
+        order before the matched route handler, each receiving the
+        :class:`MockRequest`; return a :class:`MockResponse` to short-circuit,
+        or ``None`` to continue."""
+        _registry().register("http.middleware", None, fn,
+                             asyncio.iscoroutinefunction(fn), {})
+        return fn
+
+    def on_startup(self, fn: Callable) -> Callable:
+        """Register a startup hook — runs once, to completion, after the script
+        loads and before any listener accepts."""
+        _registry().register("http.startup", None, fn,
+                             asyncio.iscoroutinefunction(fn), {})
+        return fn

--- a/sdk/siphon_sdk/http_testing.py
+++ b/sdk/siphon_sdk/http_testing.py
@@ -1,0 +1,199 @@
+"""
+Test harness for HTTP scripts (siphon-http extension).
+
+Mirrors :class:`siphon_sdk.testing.SipTestHarness` for the ``http`` namespace:
+install the mock module, load a script (registering ``@http.route`` /
+``@http.middleware`` / ``@http.on_startup``), then dispatch mock requests
+through the middleware chain into the matched route and assert on the response.
+
+Example::
+
+    from siphon_sdk.http_testing import HttpTestHarness
+
+    harness = HttpTestHarness()
+    harness.load_source('''
+    from siphon import http
+
+    @http.route("/users/{id}")
+    def get_user(req):
+        return http.Response(status=200, body=f"user {req.path_params['id']}")
+    ''')
+
+    resp = harness.request("GET", "/users/42")
+    assert resp.status == 200
+    assert resp.body == b"user 42"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import parse_qsl
+
+from siphon_sdk import mock_module
+from siphon_sdk.http import MockHttp, MockRequest, MockResponse
+
+
+def _match_route(pattern: str, path: str) -> Optional[dict[str, str]]:
+    """Match a concrete ``path`` against a matchit-style ``pattern``.
+
+    Supports ``{name}`` (one segment) and ``{*rest}`` (catch-all, must be the
+    last segment). Returns the extracted path-params dict, or ``None`` when the
+    pattern doesn't match.
+    """
+    pat_parts = pattern.strip("/").split("/") if pattern.strip("/") else []
+    path_parts = path.strip("/").split("/") if path.strip("/") else []
+
+    params: dict[str, str] = {}
+    for i, seg in enumerate(pat_parts):
+        if seg.startswith("{*") and seg.endswith("}"):
+            params[seg[2:-1]] = "/".join(path_parts[i:])
+            return params
+        if i >= len(path_parts):
+            return None
+        if seg.startswith("{") and seg.endswith("}"):
+            params[seg[1:-1]] = path_parts[i]
+        elif seg != path_parts[i]:
+            return None
+    if len(path_parts) != len(pat_parts):
+        return None
+    return params
+
+
+class HttpTestHarness:
+    """High-level test harness for HTTP scripts.
+
+    Installs the mock ``siphon`` module, loads scripts, and dispatches mock
+    HTTP requests through the registered middleware chain and route handlers.
+    """
+
+    def __init__(self, config: Optional[dict[str, Any]] = None) -> None:
+        mock_module.reset()
+        self._module = mock_module.install()
+        self._loop = asyncio.new_event_loop()
+        self._config = config or {}
+
+    # -- accessors ----------------------------------------------------------
+
+    @property
+    def http(self) -> MockHttp:
+        """The mock ``http`` namespace (e.g. ``harness.http.add_response(...)``)."""
+        return mock_module.get_http()
+
+    @property
+    def sent_requests(self) -> list[dict[str, Any]]:
+        """Recorded outbound ``http.Client`` requests."""
+        return mock_module.get_http().sent_requests
+
+    @property
+    def log(self) -> Any:
+        return mock_module.get_log()
+
+    @property
+    def cache(self) -> Any:
+        return mock_module.get_cache()
+
+    def reset(self) -> None:
+        mock_module.reset()
+
+    def close(self) -> None:
+        self._loop.close()
+
+    # -- outbound client canning (delegate to the namespace) ----------------
+
+    def add_response(self, response: MockResponse) -> None:
+        """Enqueue a response for the next outbound ``http.Client`` call."""
+        mock_module.get_http().add_response(response)
+
+    def set_response(self, path: str, response: MockResponse) -> None:
+        """Set the response returned for outbound calls to ``path``."""
+        mock_module.get_http().set_response(path, response)
+
+    # -- script loading -----------------------------------------------------
+
+    def load_script(self, path: str) -> None:
+        script_path = Path(path).resolve()
+        if not script_path.exists():
+            raise FileNotFoundError(f"Script not found: {script_path}")
+        script_dir = str(script_path.parent)
+        if script_dir not in sys.path:
+            sys.path.insert(0, script_dir)
+        source = script_path.read_text()
+        code = compile(source, str(script_path), "exec")
+        exec(code, {"__name__": "__siphon_script__", "__file__": str(script_path)})
+
+    def load_source(self, source: str, name: str = "<test>") -> None:
+        code = compile(source, name, "exec")
+        exec(code, {"__name__": "__siphon_script__", "__file__": name})
+
+    # -- dispatch -----------------------------------------------------------
+
+    def _run(self, coro_or_value: Any) -> Any:
+        if asyncio.iscoroutine(coro_or_value):
+            return self._loop.run_until_complete(coro_or_value)
+        return coro_or_value
+
+    def run_startup(self) -> None:
+        """Run all ``@http.on_startup`` hooks to completion."""
+        for _f, fn, _a, _m in mock_module.get_registry().handlers.get("http.startup", []):
+            self._run(fn())
+
+    def request(self, method: str = "GET", path: str = "/", *,
+                headers: Optional[dict[str, str]] = None,
+                query_params: Optional[dict[str, str]] = None,
+                path_params: Optional[dict[str, str]] = None,
+                body: Any = None,
+                client: str = "127.0.0.1:0") -> MockResponse:
+        """Dispatch a mock HTTP request: run the middleware chain, then the
+        first matching route handler; return the :class:`MockResponse`.
+
+        Semantics mirror the runtime:
+
+        * a middleware returning a :class:`MockResponse` short-circuits;
+        * an unmatched path returns ``404``;
+        * a route handler returning a non-``Response`` returns ``500``.
+        """
+        method = method.upper()
+        # Split a query string off the path if present.
+        query: dict[str, str] = dict(query_params or {})
+        if "?" in path:
+            path, _, qs = path.partition("?")
+            query.update(dict(parse_qsl(qs)))
+
+        registry = mock_module.get_registry()
+
+        # Resolve the route first so matched path-params are on the Request the
+        # middleware chain sees.
+        matched_fn = None
+        matched_params: dict[str, str] = {}
+        for _f, fn, _a, meta in registry.handlers.get("http.route", []):
+            if method not in meta.get("methods", []):
+                continue
+            params = _match_route(meta.get("path", ""), path)
+            if params is not None:
+                matched_fn = fn
+                matched_params = params
+                break
+
+        request = MockRequest(
+            method=method, path=path,
+            path_params=path_params if path_params is not None else matched_params,
+            query_params=query, headers=headers, client=client, body=body,
+        )
+
+        # Middleware chain — first Response short-circuits.
+        for _f, fn, _a, _m in registry.handlers.get("http.middleware", []):
+            result = self._run(fn(request))
+            if isinstance(result, MockResponse):
+                return result
+
+        if matched_fn is None:
+            return MockResponse(status=404, body=b"Not Found")
+
+        result = self._run(matched_fn(request))
+        if not isinstance(result, MockResponse):
+            # Runtime: a handler that doesn't return a Response is a 500.
+            return MockResponse(status=500, body=b"Internal Server Error")
+        return result

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Optional, Union
 
 from siphon_sdk.types import Contact, SipUri
 from siphon_sdk.request import _parse_uri
+from siphon_sdk.smpp import MockSmpp
+from siphon_sdk.http import MockHttp
 
 
 # ---------------------------------------------------------------------------
@@ -5782,6 +5784,18 @@ def _ue_flow_status(media: _MiniSdpMedia) -> Optional[str]:
 _qos = MockQos()
 
 
+# The ``smpp`` namespace is injected at runtime by the siphon-smpp extension
+# (a ``siphon-bin --features smpp`` build), not by siphon-sip itself. The mock
+# is provided here so SMPP scripts can be tested/authored alongside the SIP
+# ones with a single ``pip install siphon-sip``.
+_smpp = MockSmpp()
+
+# The ``http`` namespace is injected at runtime by the siphon-http extension
+# (a ``siphon-bin`` build with the ``http`` feature). Mocked here so HTTP
+# scripts can be tested/authored with a single ``pip install siphon-sip``.
+_http = MockHttp()
+
+
 def install() -> ModuleType:
     """Install the mock ``siphon`` module into ``sys.modules``.
 
@@ -5818,6 +5832,11 @@ def install() -> ModuleType:
     mod.stir = _stir  # type: ignore[attr-defined]
     mod.sdp = _sdp  # type: ignore[attr-defined]
     mod.qos = _qos  # type: ignore[attr-defined]
+    # smpp namespace — provided by the siphon-smpp extension at runtime;
+    # mocked here so `from siphon import smpp` works under pytest.
+    mod.smpp = _smpp  # type: ignore[attr-defined]
+    # http namespace — provided by the siphon-http extension at runtime.
+    mod.http = _http  # type: ignore[attr-defined]
 
     # IPsec types — exposed at top level so scripts can do
     # `from siphon import Transform, SecurityOffer, …` (matching the
@@ -5862,6 +5881,8 @@ def reset() -> None:
     _isc.clear()
     _ipsec.clear()
     _stir.clear()
+    _smpp.clear()
+    _http.clear()
     _auth._allow = False
     _auth._credentials.clear()
     _proxy._utils._rate_limit_allow = True
@@ -5873,6 +5894,16 @@ def reset() -> None:
 def get_registry() -> _HandlerRegistry:
     """Access the handler registry (test helper)."""
     return _registry
+
+
+def get_smpp() -> MockSmpp:
+    """Access the mock smpp namespace singleton (test helper)."""
+    return _smpp
+
+
+def get_http() -> MockHttp:
+    """Access the mock http namespace singleton (test helper)."""
+    return _http
 
 
 def get_proxy() -> MockProxy:

--- a/sdk/siphon_sdk/smpp.py
+++ b/sdk/siphon_sdk/smpp.py
@@ -1,0 +1,643 @@
+"""
+siphon.smpp — mock of the SMPP 3.4 namespace (siphon-smpp extension).
+
+At runtime the ``smpp`` namespace is injected by the **siphon-smpp**
+extension (compiled into a ``siphon-bin`` build with ``--features smpp``),
+not by siphon-sip itself. This module mirrors that namespace so SMPP
+scripts can be:
+
+1. **Unit tested** with pytest without a running SMSC — see
+   :class:`siphon_sdk.smpp_testing.SmppTestHarness`.
+2. **Authored with LLM/IDE assistance** — every decorator, send helper and
+   pyclass carries the same docstrings and signatures as the runtime.
+
+The runtime namespace is defined by ``python/smpp.py`` (decorators + config
+readouts), ``src/pyclasses.rs`` (``Pdu`` / ``Bind`` / …) and ``src/sends.rs``
+(the ``*_via`` / ``*_to`` send helpers) in the siphon-smpp repository. Keep
+this mock in step with those — the siphon-smpp CI parity check fails the
+build if a name here drifts from the runtime.
+
+Quick start::
+
+    from siphon import smpp, log
+
+    @smpp.on_bind
+    def authorise(bind):
+        if bind.password != "s3cret":
+            return bind.reject("ESME_RINVPASWD", "bad password")
+        return bind.accept()
+
+    @smpp.on_pdu("submit_sm")
+    async def on_submit(pdu, session):
+        log.info(f"MO from {pdu.source_addr} -> {pdu.destination_addr}")
+        return pdu.reply(message_id="msg-1")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any, Callable, Optional, Union
+
+
+# ---------------------------------------------------------------------------
+# SMPP command statuses (mirror src/pyclasses.rs::parse_smpp_status)
+# ---------------------------------------------------------------------------
+
+#: Every SMPP command-status name the runtime accepts. Passing anything else
+#: to ``pdu.reply(command_status=…)`` / ``bind.reject(status=…)`` raises
+#: ``ValueError`` — exactly as the Rust ``parse_smpp_status`` raises a
+#: ``PyValueError`` — so a typo surfaces in tests instead of silently
+#: falling through to ``ESME_ROK``.
+SMPP_STATUSES: frozenset[str] = frozenset({
+    "ESME_ROK", "ESME_RINVMSGLEN", "ESME_RINVCMDLEN", "ESME_RINVCMDID",
+    "ESME_RINVBNDSTS", "ESME_RALYBND", "ESME_RINVPRTFLG", "ESME_RINVREGDLVFLG",
+    "ESME_RSYSERR", "ESME_RINVSRCADR", "ESME_RINVDSTADR", "ESME_RINVMSGID",
+    "ESME_RBINDFAIL", "ESME_RINVPASWD", "ESME_RINVSYSID", "ESME_RCANCELFAIL",
+    "ESME_RREPLACEFAIL", "ESME_RMSGQFUL", "ESME_RINVSERTYP", "ESME_RINVNUMDESTS",
+    "ESME_RINVDLNAME", "ESME_RINVDESTFLAG", "ESME_RINVSUBREP", "ESME_RINVESMCLASS",
+    "ESME_RCNTSUBDL", "ESME_RSUBMITFAIL", "ESME_RINVSRCTON", "ESME_RINVSRCNPI",
+    "ESME_RINVDSTTON", "ESME_RINVDSTNPI", "ESME_RINVSYSTYP", "ESME_RINVREPFLAG",
+    "ESME_RINVNUMMSGS", "ESME_RTHROTTLED", "ESME_RINVSCHED", "ESME_RINVEXPIRY",
+    "ESME_RINVDFTMSGID", "ESME_RX_T_APPN", "ESME_RX_P_APPN", "ESME_RX_R_APPN",
+    "ESME_RQUERYFAIL",
+})
+
+
+def _validate_status(status: str) -> str:
+    """Reject an unknown SMPP status name (mirrors the Rust behaviour)."""
+    if status not in SMPP_STATUSES:
+        raise ValueError(f"unknown SMPP status: {status!r}")
+    return status
+
+
+def _as_bytes(value: Union[str, bytes, bytearray, None]) -> bytes:
+    """Coerce a script-supplied ``short_message`` to bytes.
+
+    The runtime send helpers take ``bytes``; a ``str`` is encoded as UTF-8
+    for ergonomics in tests.
+    """
+    if value is None:
+        return b""
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return bytes(value)
+
+
+# ---------------------------------------------------------------------------
+# Delivery-receipt parser (mirror src/pyclasses.rs::Receipt::parse)
+# ---------------------------------------------------------------------------
+
+# Canonical receipt keys, longest-first so ``submit date`` is matched before
+# a bare ``date``. Output name is the snake_case form exposed to Python.
+_RECEIPT_KEYS: tuple[tuple[str, str], ...] = (
+    ("submit date", "submit_date"),
+    ("done date", "done_date"),
+    ("dlvrd", "dlvrd"),
+    ("stat", "stat"),
+    ("text", "text"),
+    ("sub", "sub"),
+    ("err", "err"),
+    ("id", "id"),
+)
+
+
+def _parse_receipt(sm: bytes) -> Optional[dict[str, str]]:
+    """Best-effort parse of the de-facto SMSC delivery-receipt body.
+
+    Returns a dict with the keys that were present (``id``, ``sub``,
+    ``dlvrd``, ``submit_date``, ``done_date``, ``stat``, ``err``, ``text``)
+    plus ``raw`` (the undecoded body), or ``None`` when the body has no
+    ``key:value`` structure. The format is not standardised across SMSCs,
+    so always keep ``raw`` as the source of truth.
+    """
+    raw = sm.decode("utf-8", errors="replace")
+    hay = raw.lower()
+
+    hits: list[tuple[int, int, str]] = []
+    for key, field in _RECEIPT_KEYS:
+        needle = f"{key}:"
+        pos = hay.find(needle)
+        if pos == -1:
+            continue
+        # Skip if this position is already claimed by a longer key
+        # (e.g. the ``date:`` inside ``submit date:``).
+        if any(pos >= p and pos < p + length for p, length, _ in hits):
+            continue
+        hits.append((pos, len(needle), field))
+
+    if not hits:
+        return None
+    hits.sort(key=lambda h: h[0])
+
+    out: dict[str, str] = {}
+    for i, (pos, key_len, field) in enumerate(hits):
+        val_start = pos + key_len
+        val_end = hits[i + 1][0] if i + 1 < len(hits) else len(raw)
+        out[field] = raw[val_start:val_end].strip()
+    out["raw"] = raw
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pyclasses (mirror src/pyclasses.rs + src/sends.rs response types)
+# ---------------------------------------------------------------------------
+
+class MockPduReply:
+    """What an ``@smpp.on_pdu`` handler returns — the outcome of
+    ``pdu.reply(...)`` / ``pdu.reply_query(...)``.
+
+    You rarely construct this directly; use ``pdu.reply(...)``. ``ok`` is a
+    convenience for tests.
+    """
+
+    def __init__(self, *, command_status: str = "ESME_ROK",
+                 message_id: Optional[str] = None,
+                 message_state: Optional[int] = None,
+                 final_date: str = "", error_code: int = 0) -> None:
+        self.command_status = _validate_status(command_status)
+        self.message_id = message_id
+        self.message_state = message_state
+        self.final_date = final_date
+        self.error_code = error_code
+
+    @property
+    def ok(self) -> bool:
+        """True when ``command_status == "ESME_ROK"``."""
+        return self.command_status == "ESME_ROK"
+
+    def __repr__(self) -> str:
+        return (f"PduReply(command_status={self.command_status!r}, "
+                f"message_id={self.message_id!r})")
+
+
+class MockPdu:
+    """The PDU passed into an ``@smpp.on_pdu`` handler.
+
+    Common surface for ``submit_sm`` / ``deliver_sm`` / ``data_sm`` /
+    ``cancel_sm`` / ``query_sm`` / ``replace_sm`` / ``submit_sm_multi``.
+    Field names mirror SMPP 3.4 §5.2; not every field is meaningful for
+    every command (e.g. ``message_id`` is set only for cancel/query/replace,
+    ``destinations`` only for ``submit_sm_multi``).
+    """
+
+    def __init__(
+        self,
+        *,
+        command: str = "submit_sm",
+        message_id: str = "",
+        service_type: str = "",
+        source_addr_ton: int = 1,
+        source_addr_npi: int = 1,
+        source_addr: str = "",
+        dest_addr_ton: int = 1,
+        dest_addr_npi: int = 1,
+        destination_addr: str = "",
+        esm_class: int = 0,
+        protocol_id: int = 0,
+        priority_flag: int = 0,
+        registered_delivery: int = 0,
+        data_coding: int = 0,
+        sm_length: int = 0,
+        destinations: Optional[list[str]] = None,
+        short_message: Union[str, bytes, None] = b"",
+    ) -> None:
+        self.command = command
+        self.message_id = message_id
+        self.service_type = service_type
+        self.source_addr_ton = source_addr_ton
+        self.source_addr_npi = source_addr_npi
+        self.source_addr = source_addr
+        self.dest_addr_ton = dest_addr_ton
+        self.dest_addr_npi = dest_addr_npi
+        self.destination_addr = destination_addr
+        self.esm_class = esm_class
+        self.protocol_id = protocol_id
+        self.priority_flag = priority_flag
+        self.registered_delivery = registered_delivery
+        self.data_coding = data_coding
+        self.sm_length = sm_length
+        self.destinations = destinations or []
+        self.short_message = _as_bytes(short_message)
+
+    @property
+    def is_tpdu(self) -> bool:
+        """True when ``short_message`` carries a TPDU (UDHI bit, ``esm_class
+        & 0x40``). Decode the payload with an SMS-TPDU codec rather than as
+        a literal message."""
+        return bool(self.esm_class & 0x40)
+
+    @property
+    def is_dlr(self) -> bool:
+        """True when this ``deliver_sm`` is an SMSC **delivery receipt**
+        (``esm_class & 0x04``). Route these back to the ESME that originally
+        requested ``registered_delivery``; see :attr:`receipt`."""
+        return bool(self.esm_class & 0x04)
+
+    @property
+    def receipt(self) -> Optional[dict[str, str]]:
+        """Parsed delivery-receipt fields, or ``None`` when this PDU is not a
+        DLR / the body doesn't follow the de-facto receipt format. Keys:
+        ``id``, ``sub``, ``dlvrd``, ``submit_date``, ``done_date``, ``stat``,
+        ``err``, ``text`` (those present), plus ``raw``."""
+        if not self.is_dlr:
+            return None
+        return _parse_receipt(self.short_message)
+
+    def reply(self, *, command_status: str = "ESME_ROK",
+              message_id: Optional[str] = None) -> MockPduReply:
+        """Build a reply for the dispatcher. Default is ``ESME_ROK`` with no
+        message_id; pass ``command_status="ESME_RSUBMITFAIL"`` etc. to reject,
+        or ``message_id="…"`` on success (submit_sm path). Raises
+        ``ValueError`` on an unknown status name."""
+        return MockPduReply(command_status=command_status, message_id=message_id)
+
+    def reply_query(self, *, message_state: int,
+                    message_id: Optional[str] = None,
+                    final_date: str = "", error_code: int = 0) -> MockPduReply:
+        """Build a ``query_sm_resp``. ``message_state`` is the SMPP
+        message-state code (1=ENROUTE, 2=DELIVERED, 3=EXPIRED, 4=DELETED,
+        5=UNDELIVERABLE, 6=ACCEPTED, 7=UNKNOWN, 8=REJECTED). ``message_id``
+        defaults to the queried ``pdu.message_id``. To reject a query use
+        ``pdu.reply(command_status="ESME_RQUERYFAIL")`` instead."""
+        return MockPduReply(
+            command_status="ESME_ROK",
+            message_id=message_id if message_id is not None else self.message_id,
+            message_state=message_state,
+            final_date=final_date,
+            error_code=error_code,
+        )
+
+    def __repr__(self) -> str:
+        return (f"Pdu(command={self.command}, source_addr={self.source_addr}, "
+                f"destination_addr={self.destination_addr}, "
+                f"esm_class=0x{self.esm_class:02x}, dcs=0x{self.data_coding:02x}, "
+                f"len={self.sm_length})")
+
+
+class MockBindResult:
+    """Outcome of ``@smpp.on_bind`` — what ``bind.accept()`` /
+    ``bind.reject(...)`` return. Truthy when the bind is accepted."""
+
+    def __init__(self, *, accept: bool, status: str = "ESME_ROK",
+                 reason: str = "") -> None:
+        self.accept = accept
+        self.status = status
+        self.reason = reason
+
+    def __bool__(self) -> bool:
+        return self.accept
+
+    def __repr__(self) -> str:
+        if self.accept:
+            return "BindResult(accept)"
+        return f"BindResult(reject, status={self.status!r}, reason={self.reason!r})"
+
+
+class MockBind:
+    """Argument to ``@smpp.on_bind``. Authorise the bind by returning
+    ``bind.accept()`` or ``bind.reject("ESME_RINVPASWD", "why")`` (a bare
+    truthy/falsy return also works). With no ``@smpp.on_bind`` handler the
+    default is **reject** — binds are closed by default."""
+
+    def __init__(self, *, system_id: str = "", password: str = "",
+                 client_addr: str = "") -> None:
+        self.system_id = system_id
+        self.password = password
+        self.client_addr = client_addr
+
+    def accept(self) -> MockBindResult:
+        """Accept the bind. ``return bind.accept()``."""
+        return MockBindResult(accept=True, status="ESME_ROK", reason="")
+
+    def reject(self, status: str = "ESME_RBINDFAIL",
+               reason: str = "") -> MockBindResult:
+        """Reject the bind with an explicit SMPP status and operator-facing
+        reason (logged). Common statuses: ``ESME_RINVPASWD`` (bad password),
+        ``ESME_RINVSYSID`` (unknown system_id), ``ESME_RBINDFAIL`` (generic),
+        ``ESME_RTHROTTLED`` (rate-limited). Raises ``ValueError`` on an
+        unknown status name."""
+        return MockBindResult(accept=False, status=_validate_status(status),
+                              reason=reason)
+
+    def __repr__(self) -> str:
+        return f"Bind(system_id={self.system_id!r}, client_addr={self.client_addr!r})"
+
+
+class MockSession:
+    """Per-PDU context — which side delivered this PDU and which session.
+
+    ``kind`` is ``"esme"`` when an external client bound to our listener, or
+    ``"bind"`` when the PDU arrived via one of our outbound binds.
+    """
+
+    def __init__(self, *, kind: str = "esme", session_id: str = "",
+                 system_id: str = "", client_addr: str = "") -> None:
+        if kind not in ("esme", "bind"):
+            raise ValueError(f"session kind must be 'esme' or 'bind', got {kind!r}")
+        self.kind = kind
+        self.session_id = session_id
+        self.system_id = system_id
+        self.client_addr = client_addr
+
+    def __repr__(self) -> str:
+        return (f"Session(kind={self.kind}, system_id={self.system_id!r}, "
+                f"session_id={self.session_id!r}, client_addr={self.client_addr!r})")
+
+
+class MockAlertNotification:
+    """Payload for ``@smpp.on_pdu("alert_notification")`` — an SMSC telling us
+    (on an outbound bind) that a previously-unavailable MS is reachable again,
+    so queued MT can be flushed. ``source_addr`` is the MS, ``esme_addr`` the
+    ESME the alert targets, ``ms_availability_status`` the availability state
+    (0=available, 1=denied, 2=unavailable) when present."""
+
+    def __init__(self, *, source_addr: str = "", esme_addr: str = "",
+                 ms_availability_status: Optional[int] = None) -> None:
+        self.source_addr = source_addr
+        self.esme_addr = esme_addr
+        self.ms_availability_status = ms_availability_status
+
+    @property
+    def command(self) -> str:
+        return "alert_notification"
+
+    def __repr__(self) -> str:
+        return (f"AlertNotification(source_addr={self.source_addr!r}, "
+                f"esme_addr={self.esme_addr!r}, "
+                f"ms_availability_status={self.ms_availability_status!r})")
+
+
+class MockSmppResp:
+    """Response returned by the send helpers. ``command_status`` is the SMPP
+    status name (``ESME_ROK`` on success); ``message_id`` is the SMSC-assigned
+    id when the op returns one (``submit_sm`` / ``submit_sm_multi``), empty
+    otherwise."""
+
+    def __init__(self, *, command_status: str = "ESME_ROK",
+                 message_id: str = "") -> None:
+        self.command_status = command_status
+        self.message_id = message_id
+
+    @property
+    def ok(self) -> bool:
+        return self.command_status == "ESME_ROK"
+
+    def __repr__(self) -> str:
+        return (f"SmppResp(command_status={self.command_status!r}, "
+                f"message_id={self.message_id!r})")
+
+
+class MockQueryResp:
+    """Response returned by ``query_via`` — the result of a ``query_sm``.
+    ``message_state`` is the SMPP message-state code (1=ENROUTE … 8=REJECTED),
+    ``final_date`` the SMPP-format absolute time (empty if not final),
+    ``error_code`` the network error code."""
+
+    def __init__(self, *, command_status: str = "ESME_ROK", message_id: str = "",
+                 message_state: int = 1, final_date: str = "",
+                 error_code: int = 0) -> None:
+        self.command_status = command_status
+        self.message_id = message_id
+        self.message_state = message_state
+        self.final_date = final_date
+        self.error_code = error_code
+
+    @property
+    def ok(self) -> bool:
+        return self.command_status == "ESME_ROK"
+
+    def __repr__(self) -> str:
+        return (f"QueryResp(command_status={self.command_status!r}, "
+                f"message_id={self.message_id!r}, message_state={self.message_state}, "
+                f"final_date={self.final_date!r}, error_code={self.error_code})")
+
+
+# Default config shape mirrors src/install.rs::build_config_dict.
+def _default_config() -> dict[str, Any]:
+    return {
+        "server": {
+            "bind_address": "0.0.0.0",
+            "port": 2775,
+            "session_init_timer_ms": 30000,
+            "enquire_link_timer_ms": 30000,
+            "inactivity_timer_ms": 0,
+            "response_timer_ms": 30000,
+            "max_msg_per_sec": 0,
+            "throttle_action": "pace",
+        },
+        "binds": [],
+        "routing": {"default_chain": [], "rules": []},
+    }
+
+
+# ---------------------------------------------------------------------------
+# The smpp namespace
+# ---------------------------------------------------------------------------
+
+def _registry() -> Any:
+    """Resolve the mock ``_siphon_registry`` installed by ``mock_module.install()``.
+
+    Deferred (imported at decorator-call time) so this module has no import
+    dependency on ``mock_module`` — exactly how the runtime ``python/smpp.py``
+    defers ``import _siphon_registry``.
+    """
+    import _siphon_registry as registry
+    return registry
+
+
+class MockSmpp:
+    """Mock ``smpp`` namespace — decorators, config readouts, send helpers and
+    pyclasses, matching the siphon-smpp runtime namespace.
+
+    Outbound sends (``submit_via`` / ``data_via`` / …) and inbound sends
+    (``deliver_to`` / ``data_to`` / ``alert_to``) are recorded on
+    :attr:`sent` for test assertions instead of hitting a real SMSC.
+    """
+
+    # Pyclasses attached to the namespace (``siphon.smpp.Pdu`` etc.).
+    Pdu = MockPdu
+    PduReply = MockPduReply
+    Bind = MockBind
+    BindResult = MockBindResult
+    Session = MockSession
+    AlertNotification = MockAlertNotification
+    SmppResp = MockSmppResp
+    QueryResp = MockQueryResp
+
+    def __init__(self) -> None:
+        #: Recorded outbound/inbound sends — a list of ``(op, kwargs)`` tuples.
+        self.sent: list[tuple[str, dict[str, Any]]] = []
+        #: Config dict (shape mirrors ``src/install.rs::build_config_dict``).
+        self._config: dict[str, Any] = _default_config()
+        #: Optional canned ``query_via`` result (else ENROUTE).
+        self._query_result: Optional[MockQueryResp] = None
+
+    # -- test helpers -------------------------------------------------------
+
+    def clear(self) -> None:
+        """Reset recorded sends and config (called by ``mock_module.reset()``)."""
+        self.sent.clear()
+        self._config = _default_config()
+        self._query_result = None
+
+    def set_config(self, config: dict[str, Any]) -> None:
+        """Replace the mock ``_config`` (drives ``config()`` / ``binds()`` /
+        ``bind_address()`` / ``routing_rules()``)."""
+        self._config = config
+
+    def set_query_result(self, resp: MockQueryResp) -> None:
+        """Set the :class:`MockQueryResp` the next ``query_via`` returns."""
+        self._query_result = resp
+
+    # -- decorators ---------------------------------------------------------
+
+    def on_bind(self, fn: Callable) -> Callable:
+        """Authorise an SMPP bind. Handler receives a :class:`MockBind` and
+        returns ``bind.accept()`` / ``bind.reject(status, reason)`` (or a bare
+        truthy/falsy). With no handler, binds are rejected by default."""
+        _registry().register("smpp.on_bind", None, fn,
+                             asyncio.iscoroutinefunction(fn), None)
+        return fn
+
+    def on_pdu(self, command: str) -> Callable:
+        """Register a handler for a specific SMPP command:
+        ``"submit_sm"``, ``"submit_sm_multi"``, ``"deliver_sm"`` (check
+        ``pdu.is_dlr`` for delivery receipts), ``"data_sm"``, ``"cancel_sm"``,
+        ``"query_sm"`` (reply via ``pdu.reply_query(...)``), ``"replace_sm"``,
+        ``"alert_notification"`` (first arg is an :class:`MockAlertNotification`).
+
+        Handler signature ``(pdu, session)``; return ``pdu.reply(...)`` /
+        ``pdu.reply_query(...)`` / ``None`` (same as ``pdu.reply()``)."""
+        def decorator(fn: Callable) -> Callable:
+            _registry().register("smpp.on_pdu", None, fn,
+                                 asyncio.iscoroutinefunction(fn),
+                                 {"command": command})
+            return fn
+        return decorator
+
+    def on_session(self, event: str) -> Callable:
+        """Lifecycle hook; ``event`` is ``"bound"`` or ``"unbound"``. Handler
+        signature ``(session)``; fires when an inbound ESME binds/unbinds
+        (``session.kind == "esme"``) and when an outbound bind comes up/goes
+        down (``session.kind == "bind"``). Return value ignored."""
+        def decorator(fn: Callable) -> Callable:
+            _registry().register("smpp.on_session", event, fn,
+                                 asyncio.iscoroutinefunction(fn),
+                                 {"event": event})
+            return fn
+        return decorator
+
+    # -- config readouts ----------------------------------------------------
+
+    def bind_address(self) -> str:
+        """Listening address, e.g. ``"0.0.0.0:2775"`` — useful for /healthz."""
+        server = self._config["server"]
+        return f"{server['bind_address']}:{server['port']}"
+
+    def config(self) -> dict[str, Any]:
+        """Read-only view of the addon config as a dict."""
+        return dict(self._config)
+
+    def binds(self) -> list[dict[str, Any]]:
+        """List of outbound bind descriptors (``name``, ``host``, ``port``,
+        ``system_id``, ``bind_type``, …)."""
+        return list(self._config.get("binds", []))
+
+    def routing_rules(self) -> tuple[list[str], list[dict[str, Any]]]:
+        """Returns ``(default_chain, rules)`` as ``(list[str], list[dict])``."""
+        routing = self._config.get("routing", {})
+        return routing.get("default_chain", []), routing.get("rules", [])
+
+    # -- outbound send helpers (target a bind by name) ----------------------
+
+    async def submit_via(self, *, bind: str, source_addr: str,
+                         destination_addr: str, short_message: Union[str, bytes],
+                         **fields: Any) -> MockSmppResp:
+        """Submit a ``submit_sm`` via the named outbound bind. Resolves to a
+        :class:`MockSmppResp` carrying the SMSC message_id."""
+        return self._record_submit("submit_via", dict(
+            bind=bind, source_addr=source_addr, destination_addr=destination_addr,
+            short_message=_as_bytes(short_message), **fields))
+
+    async def submit_multi_via(self, *, bind: str, source_addr: str,
+                              destinations: list[str],
+                              short_message: Union[str, bytes],
+                              **fields: Any) -> MockSmppResp:
+        """Submit one message to many destinations (``submit_sm_multi``) via the
+        named outbound bind. Resolves to a :class:`MockSmppResp`."""
+        return self._record_submit("submit_multi_via", dict(
+            bind=bind, source_addr=source_addr, destinations=destinations,
+            short_message=_as_bytes(short_message), **fields))
+
+    async def data_via(self, *, bind: str, source_addr: str,
+                       destination_addr: str, **fields: Any) -> MockSmppResp:
+        """Send a ``data_sm`` via the named outbound bind."""
+        self.sent.append(("data_via", dict(
+            bind=bind, source_addr=source_addr,
+            destination_addr=destination_addr, **fields)))
+        return MockSmppResp()
+
+    async def cancel_via(self, *, bind: str, message_id: str,
+                         **fields: Any) -> MockSmppResp:
+        """Cancel a previously-submitted message via the named outbound bind."""
+        self.sent.append(("cancel_via", dict(
+            bind=bind, message_id=message_id, **fields)))
+        return MockSmppResp()
+
+    async def query_via(self, *, bind: str, message_id: str,
+                        **fields: Any) -> MockQueryResp:
+        """Query the state of a previously-submitted message via the named
+        outbound bind. Resolves to a :class:`MockQueryResp` (defaults to
+        ENROUTE; override with :meth:`set_query_result`)."""
+        self.sent.append(("query_via", dict(
+            bind=bind, message_id=message_id, **fields)))
+        if self._query_result is not None:
+            return self._query_result
+        return MockQueryResp(message_id=message_id, message_state=1)
+
+    async def replace_via(self, *, bind: str, message_id: str,
+                          **fields: Any) -> MockSmppResp:
+        """Replace a previously-submitted message via the named outbound bind."""
+        record = dict(bind=bind, message_id=message_id, **fields)
+        if "short_message" in record:
+            record["short_message"] = _as_bytes(record["short_message"])
+        self.sent.append(("replace_via", record))
+        return MockSmppResp()
+
+    # -- inbound send helpers (target a bound ESME by session_id) -----------
+
+    async def deliver_to(self, *, session_id: str, source_addr: str,
+                         destination_addr: str, short_message: Union[str, bytes],
+                         **fields: Any) -> MockSmppResp:
+        """Deliver a ``deliver_sm`` to a bound ESME (by ``session_id``) — the
+        SMSC→ESME half: MT/MO content and delivery receipts route back through
+        here (set ``esm_class=0x04`` + a receipt body for a DLR)."""
+        self.sent.append(("deliver_to", dict(
+            session_id=session_id, source_addr=source_addr,
+            destination_addr=destination_addr,
+            short_message=_as_bytes(short_message), **fields)))
+        return MockSmppResp()
+
+    async def data_to(self, *, session_id: str, source_addr: str,
+                      destination_addr: str, **fields: Any) -> MockSmppResp:
+        """Send a ``data_sm`` to a bound ESME (by ``session_id``)."""
+        self.sent.append(("data_to", dict(
+            session_id=session_id, source_addr=source_addr,
+            destination_addr=destination_addr, **fields)))
+        return MockSmppResp()
+
+    async def alert_to(self, *, session_id: str, source_addr: str,
+                       esme_addr: str, **fields: Any) -> MockSmppResp:
+        """Send an ``alert_notification`` to a bound ESME — tell it a
+        previously-unavailable MS is reachable again so it can flush queued MT."""
+        self.sent.append(("alert_to", dict(
+            session_id=session_id, source_addr=source_addr,
+            esme_addr=esme_addr, **fields)))
+        return MockSmppResp()
+
+    # -- internals ----------------------------------------------------------
+
+    def _record_submit(self, op: str, record: dict[str, Any]) -> MockSmppResp:
+        self.sent.append((op, record))
+        return MockSmppResp(message_id=uuid.uuid4().hex)

--- a/sdk/siphon_sdk/smpp_testing.py
+++ b/sdk/siphon_sdk/smpp_testing.py
@@ -1,0 +1,255 @@
+"""
+Test harness for SMPP scripts (siphon-smpp extension).
+
+Mirrors :class:`siphon_sdk.testing.SipTestHarness` for the ``smpp`` namespace:
+install the mock module, load a script (registering its ``@smpp.*``
+decorators), then drive binds / PDUs / lifecycle events into the registered
+handlers and assert on the returned replies and recorded outbound sends.
+
+Example::
+
+    from siphon_sdk.smpp_testing import SmppTestHarness
+
+    harness = SmppTestHarness()
+    harness.load_source('''
+    from siphon import smpp
+
+    @smpp.on_bind
+    def authorise(bind):
+        return bind.accept() if bind.password == "s3cret" else bind.reject("ESME_RINVPASWD")
+
+    @smpp.on_pdu("submit_sm")
+    def on_submit(pdu, session):
+        return pdu.reply(message_id="msg-1")
+    ''')
+
+    assert harness.bind("esme1", password="s3cret")
+    reply = harness.submit_sm(source_addr="15550100", destination_addr="15550101",
+                              short_message=b"hi")
+    assert reply.ok and reply.message_id == "msg-1"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from siphon_sdk import mock_module
+from siphon_sdk.smpp import (
+    MockAlertNotification,
+    MockBind,
+    MockBindResult,
+    MockPdu,
+    MockPduReply,
+    MockSession,
+    MockSmpp,
+)
+
+
+class SmppTestHarness:
+    """High-level test harness for SMPP scripts.
+
+    Installs the mock ``siphon`` module, loads scripts, and dispatches mock
+    binds / PDUs / session events to the handlers registered via
+    ``@smpp.on_bind`` / ``@smpp.on_pdu(...)`` / ``@smpp.on_session(...)``.
+    """
+
+    def __init__(self, config: Optional[dict[str, Any]] = None) -> None:
+        """Create a harness.
+
+        Args:
+            config: Optional ``smpp`` config dict (shape mirrors
+                ``src/install.rs::build_config_dict`` — ``server`` / ``binds``
+                / ``routing``). Drives ``smpp.config()`` / ``smpp.binds()`` /
+                ``smpp.bind_address()`` / ``smpp.routing_rules()``.
+        """
+        mock_module.reset()
+        self._module = mock_module.install()
+        self._loop = asyncio.new_event_loop()
+        if config is not None:
+            mock_module.get_smpp().set_config(config)
+
+    # -- accessors ----------------------------------------------------------
+
+    @property
+    def smpp(self) -> MockSmpp:
+        """The mock ``smpp`` namespace (e.g. ``harness.smpp.set_query_result(...)``)."""
+        return mock_module.get_smpp()
+
+    @property
+    def sent(self) -> list[tuple[str, dict[str, Any]]]:
+        """Recorded outbound/inbound sends — ``(op, kwargs)`` tuples."""
+        return mock_module.get_smpp().sent
+
+    @property
+    def log(self) -> Any:
+        """Captured log messages (``harness.log.messages``)."""
+        return mock_module.get_log()
+
+    @property
+    def cache(self) -> Any:
+        """The mock cache (pre-populate with ``harness.cache.set_data(...)``)."""
+        return mock_module.get_cache()
+
+    def reset(self) -> None:
+        """Reset all mock state between tests."""
+        mock_module.reset()
+
+    def close(self) -> None:
+        """Close the harness event loop."""
+        self._loop.close()
+
+    # -- script loading -----------------------------------------------------
+
+    def load_script(self, path: str) -> None:
+        """Load and execute an SMPP script file, registering its handlers."""
+        script_path = Path(path).resolve()
+        if not script_path.exists():
+            raise FileNotFoundError(f"Script not found: {script_path}")
+        script_dir = str(script_path.parent)
+        if script_dir not in sys.path:
+            sys.path.insert(0, script_dir)
+        source = script_path.read_text()
+        code = compile(source, str(script_path), "exec")
+        exec(code, {"__name__": "__siphon_script__", "__file__": str(script_path)})
+
+    def load_source(self, source: str, name: str = "<test>") -> None:
+        """Load an SMPP script from a string (inline test scripts)."""
+        code = compile(source, name, "exec")
+        exec(code, {"__name__": "__siphon_script__", "__file__": name})
+
+    # -- dispatch -----------------------------------------------------------
+
+    def _run(self, coro_or_value: Any) -> Any:
+        if asyncio.iscoroutine(coro_or_value):
+            return self._loop.run_until_complete(coro_or_value)
+        return coro_or_value
+
+    def bind(self, system_id: str, *, password: str = "",
+             client_addr: str = "203.0.113.5:5000"
+             ) -> Union[MockBindResult, bool]:
+        """Dispatch a ``bind_transceiver`` to the ``@smpp.on_bind`` handler.
+
+        Returns the handler's result (a :class:`MockBindResult`, or a bare
+        truthy/falsy). With no handler, returns a reject
+        :class:`MockBindResult` — binds are closed by default.
+        """
+        bind_obj = MockBind(system_id=system_id, password=password,
+                            client_addr=client_addr)
+        handlers = mock_module.get_registry().handlers.get("smpp.on_bind", [])
+        if not handlers:
+            return MockBindResult(accept=False, status="ESME_RBINDFAIL",
+                                  reason="no @smpp.on_bind handler")
+        _filter, fn, _is_async, _meta = handlers[-1]
+        return self._run(fn(bind_obj))
+
+    def _dispatch_pdu(self, command: str, pdu: MockPdu,
+                      session: MockSession) -> Optional[MockPduReply]:
+        result: Optional[MockPduReply] = None
+        ran = False
+        for _filter, fn, _is_async, meta in \
+                mock_module.get_registry().handlers.get("smpp.on_pdu", []):
+            if not meta or meta.get("command") != command:
+                continue
+            ran = True
+            result = self._run(fn(pdu, session))
+        if not ran:
+            return None
+        # None from a handler == a default ESME_ROK reply (runtime semantics).
+        return result if result is not None else MockPduReply()
+
+    def _session(self, kind: str, session_id: str, system_id: str,
+                 client_addr: str) -> MockSession:
+        return MockSession(kind=kind, session_id=session_id,
+                           system_id=system_id, client_addr=client_addr)
+
+    def submit_sm(self, *, session_id: str = "esme-1", system_id: str = "esme1",
+                  client_addr: str = "203.0.113.5:5000",
+                  **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch an inbound ``submit_sm`` to ``@smpp.on_pdu("submit_sm")``."""
+        pdu = MockPdu(command="submit_sm", **fields)
+        return self._dispatch_pdu("submit_sm", pdu,
+                                  self._session("esme", session_id, system_id, client_addr))
+
+    def submit_sm_multi(self, *, session_id: str = "esme-1", system_id: str = "esme1",
+                        client_addr: str = "203.0.113.5:5000",
+                        **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch an inbound ``submit_sm_multi`` (destinations in ``fields``)."""
+        pdu = MockPdu(command="submit_sm_multi", **fields)
+        return self._dispatch_pdu("submit_sm_multi", pdu,
+                                  self._session("esme", session_id, system_id, client_addr))
+
+    def deliver_sm(self, *, session_id: str = "bind-1", system_id: str = "carrier",
+                   client_addr: str = "198.51.100.7:2775",
+                   **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch an outbound-bind ``deliver_sm`` (MT/MO/DLR) to
+        ``@smpp.on_pdu("deliver_sm")``. Set ``esm_class=0x04`` + a receipt body
+        for a DLR (``pdu.is_dlr`` / ``pdu.receipt``)."""
+        pdu = MockPdu(command="deliver_sm", **fields)
+        return self._dispatch_pdu("deliver_sm", pdu,
+                                  self._session("bind", session_id, system_id, client_addr))
+
+    def data_sm(self, *, kind: str = "esme", session_id: str = "esme-1",
+                system_id: str = "esme1", client_addr: str = "203.0.113.5:5000",
+                **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch a ``data_sm`` to ``@smpp.on_pdu("data_sm")``."""
+        pdu = MockPdu(command="data_sm", **fields)
+        return self._dispatch_pdu("data_sm", pdu,
+                                  self._session(kind, session_id, system_id, client_addr))
+
+    def cancel_sm(self, *, message_id: str, session_id: str = "esme-1",
+                  system_id: str = "esme1", client_addr: str = "203.0.113.5:5000",
+                  **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch an inbound ``cancel_sm`` to ``@smpp.on_pdu("cancel_sm")``."""
+        pdu = MockPdu(command="cancel_sm", message_id=message_id, **fields)
+        return self._dispatch_pdu("cancel_sm", pdu,
+                                  self._session("esme", session_id, system_id, client_addr))
+
+    def query_sm(self, *, message_id: str, session_id: str = "esme-1",
+                 system_id: str = "esme1", client_addr: str = "203.0.113.5:5000",
+                 **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch an inbound ``query_sm`` to ``@smpp.on_pdu("query_sm")``
+        (reply via ``pdu.reply_query(...)``)."""
+        pdu = MockPdu(command="query_sm", message_id=message_id, **fields)
+        return self._dispatch_pdu("query_sm", pdu,
+                                  self._session("esme", session_id, system_id, client_addr))
+
+    def replace_sm(self, *, message_id: str, session_id: str = "esme-1",
+                   system_id: str = "esme1", client_addr: str = "203.0.113.5:5000",
+                   **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch an inbound ``replace_sm`` to ``@smpp.on_pdu("replace_sm")``."""
+        pdu = MockPdu(command="replace_sm", message_id=message_id, **fields)
+        return self._dispatch_pdu("replace_sm", pdu,
+                                  self._session("esme", session_id, system_id, client_addr))
+
+    def alert_notification(self, *, session_id: str = "bind-1",
+                           system_id: str = "carrier",
+                           client_addr: str = "198.51.100.7:2775",
+                           **fields: Any) -> Optional[MockPduReply]:
+        """Dispatch an ``alert_notification`` to
+        ``@smpp.on_pdu("alert_notification")``. The handler's first arg is a
+        :class:`MockAlertNotification`."""
+        alert = MockAlertNotification(**fields)
+        session = self._session("bind", session_id, system_id, client_addr)
+        result: Optional[MockPduReply] = None
+        for _filter, fn, _is_async, meta in \
+                mock_module.get_registry().handlers.get("smpp.on_pdu", []):
+            if not meta or meta.get("command") != "alert_notification":
+                continue
+            result = self._run(fn(alert, session))
+        return result
+
+    def session_event(self, event: str, *, kind: str = "esme",
+                      session_id: str = "esme-1", system_id: str = "esme1",
+                      client_addr: str = "203.0.113.5:5000") -> None:
+        """Fire a ``@smpp.on_session(event)`` lifecycle hook (``event`` is
+        ``"bound"`` or ``"unbound"``)."""
+        session = self._session(kind, session_id, system_id, client_addr)
+        for method_filter, fn, _is_async, meta in \
+                mock_module.get_registry().handlers.get("smpp.on_session", []):
+            hook_event = (meta or {}).get("event", method_filter)
+            if hook_event != event:
+                continue
+            self._run(fn(session))

--- a/sdk/tests/test_http_mock.py
+++ b/sdk/tests/test_http_mock.py
@@ -1,0 +1,265 @@
+"""Tests for the mock ``http`` namespace + :class:`HttpTestHarness`.
+
+The ``http`` namespace is injected at runtime by the siphon-http extension;
+these tests exercise the siphon-sip mock of it (route/middleware/startup
+decorators, Request/Response/Client) so HTTP scripts can be unit-tested
+without binding a real listener.
+"""
+
+import pytest
+
+from siphon_sdk.mock_module import install, reset, get_registry
+from siphon_sdk.http import MockRequest, MockResponse, HttpStatusError
+from siphon_sdk.http_testing import HttpTestHarness, _match_route
+
+
+@pytest.fixture(autouse=True)
+def _install():
+    install()
+    reset()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Decorator registration
+# ---------------------------------------------------------------------------
+
+class TestDecorators:
+    def test_route_records_path_and_methods(self):
+        from siphon import http
+
+        @http.route("/users/{id}", methods=["get", "post"])
+        def handler(req):
+            return http.Response()
+
+        handlers = get_registry().handlers.get("http.route", [])
+        assert len(handlers) == 1
+        _filter, fn, _is_async, metadata = handlers[0]
+        assert fn is handler
+        assert metadata["path"] == "/users/{id}"
+        # methods are upper-cased (mirrors python/http.py)
+        assert metadata["methods"] == ["GET", "POST"]
+
+    def test_route_defaults_to_get(self):
+        from siphon import http
+
+        @http.route("/health")
+        def health(req):
+            return http.Response()
+
+        _f, _fn, _a, meta = get_registry().handlers["http.route"][0]
+        assert meta["methods"] == ["GET"]
+
+    def test_middleware_and_startup_register(self):
+        from siphon import http
+
+        @http.middleware
+        def guard(req):
+            return None
+
+        @http.on_startup
+        async def warm():
+            pass
+
+        assert len(get_registry().handlers.get("http.middleware", [])) == 1
+        startup = get_registry().handlers.get("http.startup", [])
+        assert len(startup) == 1
+        assert startup[0][2]  # is_async
+
+
+# ---------------------------------------------------------------------------
+# Pyclasses
+# ---------------------------------------------------------------------------
+
+class TestRequest:
+    def test_header_case_insensitive(self):
+        req = MockRequest(headers={"Content-Type": "application/json"})
+        assert req.header("content-type") == "application/json"
+        assert req.header("CONTENT-TYPE") == "application/json"
+        assert req.header("missing") is None
+
+    def test_body_bytes(self):
+        assert MockRequest(body="hi").body() == b"hi"
+        assert MockRequest(body=b"raw").body() == b"raw"
+
+    def test_method_uppercased(self):
+        assert MockRequest(method="get").method == "GET"
+
+
+class TestResponse:
+    def test_body_coerced_to_bytes(self):
+        assert MockResponse(body="ok").body == b"ok"
+        assert MockResponse(body=b"raw").body == b"raw"
+
+    def test_raise_for_status(self):
+        MockResponse(200).raise_for_status()   # no raise
+        MockResponse(204).raise_for_status()
+        with pytest.raises(HttpStatusError, match="404"):
+            MockResponse(404).raise_for_status()
+        with pytest.raises(HttpStatusError, match="503"):
+            MockResponse(503).raise_for_status()
+
+    def test_raise_for_status_returns_self(self):
+        resp = MockResponse(200, body=b"x")
+        assert resp.raise_for_status() is resp
+
+
+class TestRouteMatcher:
+    def test_static_match(self):
+        assert _match_route("/health", "/health") == {}
+        assert _match_route("/health", "/other") is None
+
+    def test_named_param(self):
+        assert _match_route("/users/{id}", "/users/42") == {"id": "42"}
+        assert _match_route("/users/{id}", "/users/42/extra") is None
+
+    def test_catch_all(self):
+        assert _match_route("/static/{*rest}", "/static/a/b/c") == {"rest": "a/b/c"}
+
+    def test_multi_segment(self):
+        assert _match_route("/a/{x}/b/{y}", "/a/1/b/2") == {"x": "1", "y": "2"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via HttpTestHarness
+# ---------------------------------------------------------------------------
+
+class TestHarness:
+    def test_route_dispatch_and_path_params(self):
+        harness = HttpTestHarness()
+        harness.load_source("""
+from siphon import http
+
+@http.route("/users/{id}")
+def get_user(req):
+    return http.Response(status=200, body=f"user {req.path_params['id']}")
+""")
+        resp = harness.request("GET", "/users/42")
+        assert resp.status == 200
+        assert resp.body == b"user 42"
+
+    def test_method_filter_and_404(self):
+        harness = HttpTestHarness()
+        harness.load_source("""
+from siphon import http
+
+@http.route("/things", methods=["POST"])
+def create(req):
+    return http.Response(status=201)
+""")
+        assert harness.request("POST", "/things").status == 201
+        # GET on a POST-only route → no match → 404
+        assert harness.request("GET", "/things").status == 404
+        # unknown path → 404
+        assert harness.request("GET", "/nope").status == 404
+
+    def test_query_params_parsed_from_path(self):
+        harness = HttpTestHarness()
+        harness.load_source("""
+from siphon import http
+
+@http.route("/search")
+def search(req):
+    return http.Response(status=200, body=req.query_params.get("q", ""))
+""")
+        resp = harness.request("GET", "/search?q=hello&lang=en")
+        assert resp.body == b"hello"
+
+    def test_middleware_short_circuits(self):
+        harness = HttpTestHarness()
+        harness.load_source("""
+from siphon import http
+
+@http.middleware
+def auth(req):
+    if req.header("authorization") is None:
+        return http.Response(status=401, body=b"unauthorized")
+    return None
+
+@http.route("/secure")
+def secure(req):
+    return http.Response(status=200, body=b"secret")
+""")
+        assert harness.request("GET", "/secure").status == 401
+        ok = harness.request("GET", "/secure", headers={"Authorization": "Bearer x"})
+        assert ok.status == 200 and ok.body == b"secret"
+
+    def test_handler_returning_non_response_is_500(self):
+        harness = HttpTestHarness()
+        harness.load_source("""
+from siphon import http
+
+@http.route("/broken")
+def broken(req):
+    return "oops"   # not a Response
+""")
+        assert harness.request("GET", "/broken").status == 500
+
+    def test_outbound_client_recorded_and_canned(self):
+        harness = HttpTestHarness()
+        harness.add_response(MockResponse(status=200, body=b'{"ok":true}'))
+        harness.load_source("""
+from siphon import http
+
+@http.route("/proxy")
+async def proxy(req):
+    async with http.Client("api") as c:
+        upstream = await c.get("/v1/thing")
+    return http.Response(status=upstream.status, body=upstream.body)
+""")
+        resp = harness.request("GET", "/proxy")
+        assert resp.status == 200
+        assert resp.body == b'{"ok":true}'
+        assert len(harness.sent_requests) == 1
+        sent = harness.sent_requests[0]
+        assert sent["method"] == "GET"
+        assert sent["path"] == "/v1/thing"
+        assert sent["name"] == "api"
+
+    def test_outbound_client_per_path_response(self):
+        harness = HttpTestHarness()
+        harness.set_response("/v1/thing", MockResponse(status=418))
+        harness.load_source("""
+from siphon import http
+
+@http.route("/proxy")
+async def proxy(req):
+    async with http.Client(base_url="https://api.example.com") as c:
+        upstream = await c.post("/v1/thing", body=b"x")
+    return http.Response(status=upstream.status)
+""")
+        assert harness.request("GET", "/proxy").status == 418
+        assert harness.sent_requests[0]["url"] == "https://api.example.com/v1/thing"
+
+    def test_startup_hook_runs(self):
+        harness = HttpTestHarness()
+        harness.load_source("""
+from siphon import http, log
+
+@http.on_startup
+async def warm():
+    log.info("warmed")
+""")
+        harness.run_startup()
+        assert any("warmed" in msg for _lvl, msg in harness.log.messages)
+
+    def test_coexists_with_sip_and_smpp(self):
+        harness = HttpTestHarness()
+        harness.load_source("""
+from siphon import proxy, smpp, http
+
+@proxy.on_request
+def sip(request):
+    request.relay()
+
+@smpp.on_pdu("submit_sm")
+def sms(pdu, session):
+    return pdu.reply()
+
+@http.route("/health")
+def health(req):
+    return http.Response(status=200, body=b"ok")
+""")
+        assert harness.request("GET", "/health").body == b"ok"
+        assert len(get_registry().handlers.get("proxy.on_request", [])) == 1
+        assert len(get_registry().handlers.get("smpp.on_pdu", [])) == 1

--- a/sdk/tests/test_smpp_mock.py
+++ b/sdk/tests/test_smpp_mock.py
@@ -1,0 +1,390 @@
+"""Tests for the mock ``smpp`` namespace + :class:`SmppTestHarness`.
+
+The ``smpp`` namespace is injected at runtime by the siphon-smpp extension;
+these tests exercise the siphon-sip mock of it (decorators, pyclasses, send
+helpers) so SMPP scripts can be unit-tested without a running SMSC.
+"""
+
+import pytest
+
+from siphon_sdk.mock_module import install, reset, get_registry
+from siphon_sdk.smpp import (
+    MockBind, MockBindResult, MockPdu, MockQueryResp, SMPP_STATUSES, _parse_receipt,
+)
+from siphon_sdk.smpp_testing import SmppTestHarness
+
+
+@pytest.fixture(autouse=True)
+def _install():
+    """Install + reset the mock module before every test (function and method)."""
+    install()
+    reset()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Decorator registration
+# ---------------------------------------------------------------------------
+
+class TestDecorators:
+    def test_on_bind_registers(self):
+        from siphon import smpp
+
+        @smpp.on_bind
+        def authorise(bind):
+            return bind.accept()
+
+        handlers = get_registry().handlers.get("smpp.on_bind", [])
+        assert len(handlers) == 1
+        method_filter, fn, is_async, metadata = handlers[0]
+        assert fn is authorise
+        assert not is_async
+        assert method_filter is None
+
+    def test_on_pdu_records_command_metadata(self):
+        from siphon import smpp
+
+        @smpp.on_pdu("submit_sm")
+        def on_submit(pdu, session):
+            return pdu.reply()
+
+        handlers = get_registry().handlers.get("smpp.on_pdu", [])
+        assert len(handlers) == 1
+        _filter, fn, _is_async, metadata = handlers[0]
+        assert fn is on_submit
+        assert metadata == {"command": "submit_sm"}
+
+    def test_on_session_records_event_metadata(self):
+        from siphon import smpp
+
+        @smpp.on_session("bound")
+        def on_bound(session):
+            pass
+
+        handlers = get_registry().handlers.get("smpp.on_session", [])
+        _filter, _fn, _is_async, metadata = handlers[0]
+        assert _filter == "bound"
+        assert metadata == {"event": "bound"}
+
+    def test_async_handler_detected(self):
+        from siphon import smpp
+
+        @smpp.on_pdu("deliver_sm")
+        async def on_deliver(pdu, session):
+            return pdu.reply()
+
+        _filter, fn, is_async, _meta = \
+            get_registry().handlers["smpp.on_pdu"][0]
+        assert is_async
+
+    def test_coexists_with_proxy_handlers(self):
+        from siphon import proxy, smpp
+
+        @proxy.on_request
+        def route(request):
+            pass
+
+        @smpp.on_pdu("submit_sm")
+        def on_submit(pdu, session):
+            pass
+
+        assert len(get_registry().get("proxy.on_request")) == 1
+        assert len(get_registry().handlers.get("smpp.on_pdu", [])) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pyclasses
+# ---------------------------------------------------------------------------
+
+class TestPdu:
+    def test_reply_defaults_to_ok(self):
+        pdu = MockPdu(command="submit_sm")
+        reply = pdu.reply()
+        assert reply.command_status == "ESME_ROK"
+        assert reply.ok
+        assert reply.message_id is None
+
+    def test_reply_with_message_id(self):
+        reply = MockPdu().reply(message_id="msg-42")
+        assert reply.message_id == "msg-42"
+        assert reply.ok
+
+    def test_reply_reject_status(self):
+        reply = MockPdu().reply(command_status="ESME_RSUBMITFAIL")
+        assert reply.command_status == "ESME_RSUBMITFAIL"
+        assert not reply.ok
+
+    def test_reply_unknown_status_raises(self):
+        with pytest.raises(ValueError, match="unknown SMPP status"):
+            MockPdu().reply(command_status="ESME_BOGUS")
+
+    def test_reply_query_defaults_message_id_to_queried(self):
+        pdu = MockPdu(command="query_sm", message_id="qid-7")
+        reply = pdu.reply_query(message_state=2, final_date="2401011200")
+        assert reply.message_state == 2
+        assert reply.message_id == "qid-7"   # defaults to queried id
+        assert reply.final_date == "2401011200"
+
+    def test_reply_query_explicit_message_id(self):
+        pdu = MockPdu(command="query_sm", message_id="qid-7")
+        reply = pdu.reply_query(message_state=7, message_id="other", error_code=9)
+        assert reply.message_id == "other"
+        assert reply.error_code == 9
+
+    def test_is_tpdu_reflects_udhi_bit(self):
+        assert MockPdu(esm_class=0x40).is_tpdu
+        assert MockPdu(esm_class=0xC0).is_tpdu
+        assert not MockPdu(esm_class=0x00).is_tpdu
+        assert not MockPdu(esm_class=0x01).is_tpdu
+
+    def test_is_dlr_reflects_receipt_bit(self):
+        assert MockPdu(esm_class=0x04).is_dlr
+        assert MockPdu(esm_class=0x44).is_dlr
+        assert not MockPdu(esm_class=0x00).is_dlr
+        assert not MockPdu(esm_class=0x40).is_dlr
+
+    def test_receipt_only_for_dlr(self):
+        # receipt-shaped body but not flagged as a DLR → None
+        pdu = MockPdu(esm_class=0x00, short_message=b"id:1 stat:DELIVRD")
+        assert pdu.receipt is None
+        # flagged DLR → parsed dict
+        dlr = MockPdu(esm_class=0x04, short_message=b"id:1 stat:DELIVRD err:000")
+        assert dlr.receipt["id"] == "1"
+        assert dlr.receipt["stat"] == "DELIVRD"
+
+    def test_short_message_coerced_to_bytes(self):
+        assert MockPdu(short_message="hello").short_message == b"hello"
+        assert MockPdu(short_message=b"raw").short_message == b"raw"
+
+
+class TestBind:
+    def test_accept(self):
+        result = MockBind(system_id="esme1").accept()
+        assert result.accept
+        assert bool(result)
+        assert result.status == "ESME_ROK"
+
+    def test_reject_with_status_and_reason(self):
+        result = MockBind().reject("ESME_RINVPASWD", "bad password")
+        assert not result.accept
+        assert not bool(result)
+        assert result.status == "ESME_RINVPASWD"
+        assert result.reason == "bad password"
+
+    def test_reject_default_status(self):
+        result = MockBind().reject()
+        assert result.status == "ESME_RBINDFAIL"
+        assert result.reason == ""
+
+    def test_reject_unknown_status_raises(self):
+        with pytest.raises(ValueError, match="unknown SMPP status"):
+            MockBind().reject("ESME_BOGUS")
+
+
+class TestResponses:
+    def test_smpp_resp_ok(self):
+        from siphon_sdk.smpp import MockSmppResp
+        assert MockSmppResp(command_status="ESME_ROK").ok
+        assert not MockSmppResp(command_status="ESME_RSUBMITFAIL").ok
+
+    def test_query_resp_fields(self):
+        resp = MockQueryResp(message_id="m1", message_state=2, final_date="x", error_code=3)
+        assert resp.ok
+        assert resp.message_state == 2
+        assert resp.error_code == 3
+
+    def test_alert_notification_command(self):
+        from siphon_sdk.smpp import MockAlertNotification
+        alert = MockAlertNotification(source_addr="15550100", esme_addr="esme1")
+        assert alert.command == "alert_notification"
+
+
+class TestReceiptParser:
+    def test_canonical_form(self):
+        body = (b"id:0a1b2c3d sub:001 dlvrd:001 submit date:2401011200 "
+                b"done date:2401011201 stat:DELIVRD err:000 text:Hello world")
+        r = _parse_receipt(body)
+        assert r["id"] == "0a1b2c3d"
+        assert r["submit_date"] == "2401011200"
+        assert r["done_date"] == "2401011201"
+        assert r["stat"] == "DELIVRD"
+        assert r["err"] == "000"
+        assert r["text"] == "Hello world"
+
+    def test_minimal(self):
+        r = _parse_receipt(b"id:XYZ stat:EXPIRED")
+        assert r["id"] == "XYZ"
+        assert r["stat"] == "EXPIRED"
+        assert "sub" not in r
+
+    def test_non_receipt_is_none(self):
+        assert _parse_receipt(b"hey are we still on for lunch?") is None
+
+
+def test_status_set_matches_expected_size():
+    # Guard the mirror of parse_smpp_status — 41 statuses (SMPP 3.4 + query).
+    assert "ESME_ROK" in SMPP_STATUSES
+    assert "ESME_RQUERYFAIL" in SMPP_STATUSES
+    assert len(SMPP_STATUSES) == 41
+
+
+# ---------------------------------------------------------------------------
+# Send helpers (recorded on smpp.sent)
+# ---------------------------------------------------------------------------
+
+class TestSendHelpers:
+    def test_submit_via_records_and_returns_message_id(self):
+        harness = SmppTestHarness()
+        harness.load_source("""
+from siphon import smpp
+
+@smpp.on_pdu("submit_sm")
+async def route(pdu, session):
+    resp = await smpp.submit_via(bind="carrier", source_addr=pdu.source_addr,
+                                 destination_addr=pdu.destination_addr,
+                                 short_message=pdu.short_message)
+    return pdu.reply(message_id=resp.message_id)
+""")
+        reply = harness.submit_sm(source_addr="15550100",
+                                  destination_addr="15550101", short_message=b"hi")
+        assert reply.ok and reply.message_id
+        op, kwargs = harness.sent[0]
+        assert op == "submit_via"
+        assert kwargs["bind"] == "carrier"
+        assert kwargs["destination_addr"] == "15550101"
+
+    def test_query_via_result_is_configurable(self):
+        harness = SmppTestHarness()
+        harness.smpp.set_query_result(MockQueryResp(message_id="m1", message_state=2))
+        harness.load_source("""
+from siphon import smpp
+
+@smpp.on_pdu("query_sm")
+async def route(pdu, session):
+    resp = await smpp.query_via(bind="carrier", message_id=pdu.message_id)
+    return pdu.reply_query(message_state=resp.message_state)
+""")
+        reply = harness.query_sm(message_id="m1")
+        assert reply.message_state == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via SmppTestHarness
+# ---------------------------------------------------------------------------
+
+class TestHarness:
+    def _gateway(self, harness):
+        harness.load_source("""
+from siphon import smpp, log
+
+@smpp.on_bind
+def authorise(bind):
+    if bind.password != "s3cret":
+        return bind.reject("ESME_RINVPASWD", "bad password")
+    return bind.accept()
+
+@smpp.on_pdu("submit_sm")
+def on_submit(pdu, session):
+    if not pdu.destination_addr:
+        return pdu.reply(command_status="ESME_RINVDSTADR")
+    return pdu.reply(message_id="msg-1")
+
+@smpp.on_pdu("deliver_sm")
+async def on_deliver(pdu, session):
+    if pdu.is_dlr:
+        await smpp.deliver_to(session_id="esme-1", source_addr=pdu.source_addr,
+                              destination_addr=pdu.destination_addr,
+                              short_message=pdu.short_message, esm_class=0x04)
+    return pdu.reply()
+
+@smpp.on_session("bound")
+def on_bound(session):
+    log.info(f"bound: {session.system_id}")
+""")
+
+    def test_bind_accept_and_reject(self):
+        harness = SmppTestHarness()
+        self._gateway(harness)
+        assert harness.bind("esme1", password="s3cret")
+        rejected = harness.bind("esme1", password="wrong")
+        assert not rejected
+        assert rejected.status == "ESME_RINVPASWD"
+
+    def test_bind_default_reject_without_handler(self):
+        harness = SmppTestHarness()
+        harness.load_source("from siphon import smpp\n")
+        result = harness.bind("esme1")
+        assert isinstance(result, MockBindResult)
+        assert not result
+
+    def test_submit_sm_success_and_reject(self):
+        harness = SmppTestHarness()
+        self._gateway(harness)
+        ok = harness.submit_sm(source_addr="15550100",
+                               destination_addr="15550101", short_message=b"hi")
+        assert ok.ok and ok.message_id == "msg-1"
+        bad = harness.submit_sm(source_addr="15550100",
+                                destination_addr="", short_message=b"hi")
+        assert bad.command_status == "ESME_RINVDSTADR"
+
+    def test_deliver_dlr_routes_back_to_esme(self):
+        harness = SmppTestHarness()
+        self._gateway(harness)
+        reply = harness.deliver_sm(
+            source_addr="15550101", destination_addr="15550100",
+            esm_class=0x04, short_message=b"id:msg-1 stat:DELIVRD err:000")
+        assert reply.ok
+        op, kwargs = harness.sent[0]
+        assert op == "deliver_to"
+        assert kwargs["session_id"] == "esme-1"
+
+    def test_no_handler_returns_none(self):
+        harness = SmppTestHarness()
+        harness.load_source("from siphon import smpp\n")
+        assert harness.submit_sm(source_addr="1", destination_addr="2",
+                                 short_message=b"x") is None
+
+    def test_session_event_fires(self):
+        harness = SmppTestHarness()
+        self._gateway(harness)
+        harness.session_event("bound", system_id="esme1")
+        assert any("bound: esme1" in msg for _lvl, msg in harness.log.messages)
+
+    def test_query_sm_reply_query(self):
+        harness = SmppTestHarness()
+        harness.load_source("""
+from siphon import smpp
+
+@smpp.on_pdu("query_sm")
+def on_query(pdu, session):
+    return pdu.reply_query(message_state=2, final_date="2401011200")
+""")
+        reply = harness.query_sm(message_id="msg-1")
+        assert reply.message_state == 2
+        assert reply.message_id == "msg-1"
+
+
+class TestConfigReadouts:
+    def test_config_readouts(self):
+        harness = SmppTestHarness(config={
+            "server": {"bind_address": "10.0.0.1", "port": 2775},
+            "binds": [{"name": "carrier", "host": "smsc.example", "port": 2775,
+                       "system_id": "sysid", "bind_type": "transceiver"}],
+            "routing": {"default_chain": ["carrier"], "rules": []},
+        })
+        harness.load_source("""
+from siphon import smpp, log
+
+@smpp.on_pdu("submit_sm")
+def on_submit(pdu, session):
+    log.info(smpp.bind_address())
+    log.info(str(len(smpp.binds())))
+    default_chain, rules = smpp.routing_rules()
+    log.info(",".join(default_chain))
+    return pdu.reply()
+""")
+        harness.submit_sm(source_addr="1", destination_addr="2", short_message=b"x")
+        msgs = [msg for _lvl, msg in harness.log.messages]
+        assert "10.0.0.1:2775" in msgs
+        assert "1" in msgs
+        assert "carrier" in msgs

--- a/siphon-bin/Cargo.lock
+++ b/siphon-bin/Cargo.lock
@@ -2985,8 +2985,8 @@ dependencies = [
 
 [[package]]
 name = "siphon-http"
-version = "1.0.0"
-source = "git+https://github.com/siphon-project/siphon-http?tag=v1.0.0#569ac5a3f9913ab67a5752c1aa05902d12c7bab1"
+version = "1.0.1"
+source = "git+https://github.com/siphon-project/siphon-http?tag=v1.0.1#9f5e03a7045ddf4b15b942866e191738ccb3b011"
 dependencies = [
  "async-trait",
  "axum",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "siphon-sip"
 version = "1.0.0"
-source = "git+https://github.com/siphon-project/siphon-sip?branch=main#15c69aa3342ee6267cd8fbfb31addce53d3a362d"
+source = "git+https://github.com/siphon-project/siphon-sip?branch=main#0746fa7d21d4dc967f697845b3b7570ad6d3abd2"
 dependencies = [
  "aes",
  "arc-swap",
@@ -3071,8 +3071,8 @@ dependencies = [
 
 [[package]]
 name = "siphon-smpp"
-version = "1.2.0"
-source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.2.0#7321095008f8e9a197922ab3ba08f5da539e5f72"
+version = "1.2.1"
+source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.2.1#59eb5d7cf31516308cd004b3700066e9394ebe9d"
 dependencies = [
  "async-trait",
  "pyo3",

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -32,14 +32,14 @@ full = ["smpp", "http"]    # convenience aggregate: every extension module
 # Single-source rule: every crate here that depends on siphon-sip MUST use a
 # byte-identical git URL + ref, or cargo keys two separate `siphon-sip` sources
 # (it does NOT follow GitHub's repo-rename redirect) and the builder closures
-# fail to type-match. siphon-smpp v1.2.0 pins
+# fail to type-match. siphon-smpp v1.2.1 pins
 # `siphon-sip = { git = ".../siphon-sip", branch = "main" }`, so siphon-sip stays
 # on `branch = "main"` here too; the committed Cargo.lock pins the exact SHA for
 # reproducible builds (advance with `cargo update`). Extension crates themselves
 # are pinned to their released tags for stable, intentional bumps.
 siphon-sip = { git = "https://github.com/siphon-project/siphon-sip", branch = "main" }
-siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.2.0", optional = true }
-siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.0", optional = true }
+siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.2.1", optional = true }
+siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.1", optional = true }
 
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"


### PR DESCRIPTION
## What

The `siphon-sip` SDK previously mocked only the core SIP `siphon` module. The opt-in **siphon-smpp** and **siphon-http** extensions each inject their own scriptable namespace at runtime (`smpp`, `http`), but those had **no SDK coverage** — so extension scripts couldn't be unit-tested and got no type hints / docstrings while authoring.

This adds mocks + pytest harnesses for both, so an SMPP or HTTP script is testable and authorable from a single `pip install siphon-sip`, with no running SMSC or HTTP listener.

## Contents

- **`siphon_sdk/smpp.py`** — mock `smpp` namespace: `@smpp.on_bind` / `@smpp.on_pdu` / `@smpp.on_session` decorators, `submit_via`/`deliver_to`/… send helpers (recorded for assertions), config readouts, and the `Pdu` / `Bind` / `Session` / `AlertNotification` / `SmppResp` / `QueryResp` pyclasses (incl. delivery-receipt parsing + SMPP status validation), seeded from the runtime's docstrings.
- **`siphon_sdk/http.py`** — mock `http` namespace: `@http.route` / `@http.middleware` / `@http.on_startup` decorators and the `Request` / `Response` / `Client` pyclasses (outbound client calls recorded + answered from canned responses).
- **`SmppTestHarness`** (`smpp_testing.py`) and **`HttpTestHarness`** (`http_testing.py`) — dispatch mock binds/PDUs and HTTP requests (with a matchit-style route matcher + middleware chain) into a script's handlers and capture results, mirroring `SipTestHarness`.
- Wired into `mock_module.install()` / `reset()` with `get_smpp()` / `get_http()` accessors; exported from `siphon_sdk`.
- **Docs**: Extensions page documents the HTTP extension + a "Testing extension scripts" section; mkdocs nav links the per-extension docs sites (smpp.siphon-sip.org, http.siphon-sip.org).
- CHANGELOG `[Unreleased]` entry; SDK README section.

## Keeping it honest

These mocks live in the core SDK but track two other repos' runtimes. **siphon-smpp** and **siphon-http** each get a companion PR adding a CI parity check that fails if their namespace surface drifts from these mocks.

## Tests

58 new SDK tests (`test_smpp_mock.py`, `test_http_mock.py`). Full SDK suite green:

```
348 passed
```