### PR TITLE
feat(siphon-bin): wire http extension (--features http)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **HTTP extension wired into `siphon-bin` (`--features http`).** The second
+  opt-in extension module alongside SMPP: when `extensions.http` in `siphon.yaml`
+  points at an `http.yaml`, `siphon-bin` registers the scriptable `http`
+  namespace and the HTTP runtime, so scripts can serve inbound HTTP
+  (`@http.route`, `@http.middleware`, `@http.on_startup`) and make outbound calls
+  (`http.Client`) from the same asyncio loop they use for SIP. `http.Client` is a
+  **pooled, Rust-backed (reqwest) client whose calls run entirely on siphon's
+  Tokio runtime and yield the asyncio driver loop while in flight** — so a script
+  that only needs outbound HTTP on the hot path (a REST lookup per INVITE, a
+  provisioning callback) should enable this feature and use `http.Client` rather
+  than a synchronous Python client that blocks its driver loop for the whole
+  round-trip. A new `full` aggregate feature (`--features full`) enables every
+  extension module at once. The HTTP module is pinned to **siphon-http v1.0.0**;
+  with the feature off, an `extensions.http` block still parses and is skipped
+  with a loud warning (same contract as SMPP and the `sctp` feature). Documented
+  under **Extensions** in the docs site.
 - **Opt-in extension binary (`siphon-bin`)** — a new standalone package that
   builds a drop-in `siphon` binary composing optional extension modules behind
   cargo features (all off by default). The first module is **SMPP 3.4**

--- a/siphon-bin/Cargo.lock
+++ b/siphon-bin/Cargo.lock
@@ -178,6 +178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -221,6 +222,39 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -827,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1038,25 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1182,6 +1245,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2490,6 +2554,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2607,6 +2672,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2903,8 +2977,38 @@ name = "siphon-bin"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "siphon-http",
  "siphon-sip",
  "siphon-smpp",
+ "tracing",
+]
+
+[[package]]
+name = "siphon-http"
+version = "1.0.0"
+source = "git+https://github.com/siphon-project/siphon-http?tag=v1.0.0#569ac5a3f9913ab67a5752c1aa05902d12c7bab1"
+dependencies = [
+ "async-trait",
+ "axum",
+ "axum-server",
+ "bytes",
+ "http",
+ "http-body-util",
+ "hyper",
+ "matchit",
+ "pyo3",
+ "pyo3-async-runtimes",
+ "reqwest",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_yaml",
+ "siphon-sip",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
  "tracing",
 ]
 
@@ -3465,10 +3569,13 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -25,8 +25,8 @@ default = []
 # disabled, an `extensions.<name>` block in siphon.yaml still parses and is
 # skipped with a loud warning (mirrors the siphon `sctp` feature contract).
 smpp = ["dep:siphon-smpp"] # SMPP 3.4 — inbound/outbound binds, scriptable `smpp` namespace
-# http = ["dep:siphon-http"]   # ← drop-in slot: uncomment when siphon-http lands
-# full = ["smpp"]              # convenience aggregate: grows to ["smpp", "http", …]
+http = ["dep:siphon-http"] # HTTP/HTTPS — inbound routes + Rust-backed `http.Client`, scriptable `http` namespace
+full = ["smpp", "http"]    # convenience aggregate: every extension module
 
 [dependencies]
 # Single-source rule: every crate here that depends on siphon-sip MUST use a
@@ -39,7 +39,7 @@ smpp = ["dep:siphon-smpp"] # SMPP 3.4 — inbound/outbound binds, scriptable `sm
 # are pinned to their released tags for stable, intentional bumps.
 siphon-sip = { git = "https://github.com/siphon-project/siphon-sip", branch = "main" }
 siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.2.0", optional = true }
-# siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "vX.Y.Z", optional = true }
+siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.0", optional = true }
 
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/siphon-bin/Dockerfile
+++ b/siphon-bin/Dockerfile
@@ -1,16 +1,19 @@
-# SIPhon container image WITH opt-in extension modules (SMPP).
+# SIPhon container image WITH opt-in extension modules (SMPP, HTTP).
 #
 # This builds the `siphon-bin` package — a drop-in `siphon` binary that composes
-# optional extension crates behind cargo features — with `--features smpp`. It is
-# SEPARATE from the root Dockerfile (which builds the plain siphon-sip binary):
-# siphon-bin git-deps the published siphon-sip lib + siphon-smpp, so the build
-# context is just this package directory (no root tree needed).
+# optional extension crates behind cargo features — with `--features smpp` by
+# default. It is SEPARATE from the root Dockerfile (which builds the plain
+# siphon-sip binary): siphon-bin git-deps the published siphon-sip lib + the
+# extension crates, so the build context is just this package directory (no root
+# tree needed).
 #
 # Build (context = this directory):
 #   docker build -f siphon-bin/Dockerfile -t siphon-smpp siphon-bin/
 #
-# Override the enabled modules with the FEATURES build-arg, e.g.
-#   docker build -f siphon-bin/Dockerfile --build-arg FEATURES=smpp -t siphon-smpp siphon-bin/
+# Override the enabled modules with the FEATURES build-arg, e.g. HTTP only, or
+# every module at once via the `full` aggregate:
+#   docker build -f siphon-bin/Dockerfile --build-arg FEATURES=http -t siphon-http siphon-bin/
+#   docker build -f siphon-bin/Dockerfile --build-arg FEATURES=full -t siphon-ext  siphon-bin/
 #
 # The image bakes NO default script/config (the SMPP handler lives in your
 # script, e.g. siphon-smpp's examples/echo.py). Mount siphon.yaml + smpp.yaml +

--- a/siphon-bin/src/ext/http.rs
+++ b/siphon-bin/src/ext/http.rs
@@ -1,0 +1,40 @@
+//! HTTP/HTTPS extension wiring (compiled only with `--features http`).
+//!
+//! Resolves the HTTP sub-config referenced by `extensions.http` in siphon.yaml,
+//! then registers the scriptable `http` namespace and the HTTP runtime task onto
+//! the builder. Structurally identical to `ext/smpp.rs` — the SMPP module is the
+//! template every path-configured extension follows.
+
+use siphon::config::Config;
+use siphon::SiphonServer;
+use siphon_http::HttpConfig;
+
+/// Register the `http` namespace + runtime task if `extensions.http` resolves to
+/// a loadable config file. Any problem (missing path, inline form, load error)
+/// is logged and HTTP is left disabled rather than aborting startup.
+pub fn register(builder: SiphonServer, config: &Config) -> SiphonServer {
+    let Some(path) = config.extension_path("http") else {
+        if config.extension_config("http").is_some() {
+            tracing::error!(
+                target: "siphon",
+                "extensions.http must reference a path to an http.yaml \
+                 (inline form not yet supported); HTTP disabled"
+            );
+        }
+        return builder;
+    };
+
+    match HttpConfig::from_file(path) {
+        Ok(cfg) => builder
+            .register_namespace_with("http", siphon_http::namespace(cfg.clone()))
+            .register_task(siphon_http::task(cfg)),
+        Err(error) => {
+            tracing::error!(
+                target: "siphon",
+                path = %path.display(),
+                "http extension config failed to load: {error}; HTTP disabled"
+            );
+            builder
+        }
+    }
+}

--- a/siphon-bin/src/ext/mod.rs
+++ b/siphon-bin/src/ext/mod.rs
@@ -6,12 +6,12 @@
 //! `extensions.<name>` block, a loud warning is emitted and the module is
 //! skipped — the same contract as siphon's `sctp` feature.
 //!
-//! ## Adding a module (e.g. when `siphon-http` lands)
+//! ## Adding a module (the `smpp` / `http` modules are the templates)
 //!
 //! 1. Add the optional dep + feature to `Cargo.toml`
-//!    (`http = ["dep:siphon-http"]`).
-//! 2. Add `src/ext/http.rs` (a near-copy of [`smpp`]).
-//! 3. Wire three lines below: the `register_http` call inside [`register_all`],
+//!    (e.g. `foo = ["dep:siphon-foo"]`).
+//! 2. Add `src/ext/foo.rs` (a near-copy of [`smpp`] / [`http`]).
+//! 3. Wire three lines below: the `register_foo` call inside [`register_all`],
 //!    plus the feature-on `pub use` and the feature-off shim.
 
 use siphon::config::Config;
@@ -22,7 +22,7 @@ use siphon::SiphonServer;
 /// module's feature-off shim below).
 pub fn register_all(mut builder: SiphonServer, config: &Config) -> SiphonServer {
     builder = register_smpp(builder, config);
-    // builder = register_http(builder, config);   // ← add when siphon-http lands
+    builder = register_http(builder, config);
     builder
 }
 
@@ -34,6 +34,17 @@ pub use smpp::register as register_smpp;
 #[cfg(not(feature = "smpp"))]
 pub fn register_smpp(builder: SiphonServer, config: &Config) -> SiphonServer {
     warn_unwired(config, "smpp", "smpp");
+    builder
+}
+
+#[cfg(feature = "http")]
+mod http;
+#[cfg(feature = "http")]
+pub use http::register as register_http;
+
+#[cfg(not(feature = "http"))]
+pub fn register_http(builder: SiphonServer, config: &Config) -> SiphonServer {
+    warn_unwired(config, "http", "http");
     builder
 }
 


### PR DESCRIPTION
## What

Wires the **HTTP extension** into `siphon-bin` — the second opt-in extension module alongside SMPP. Follows the exact pattern established when SMPP was wired (#20): a near-copy of `ext/smpp.rs`, gated behind its own cargo feature.

When `extensions.http` in `siphon.yaml` points at an `http.yaml`, `siphon-bin` registers the scriptable `http` namespace and the HTTP runtime task, so scripts can:

- **serve** inbound HTTP — `@http.route`, `@http.middleware`, `@http.on_startup`
- **call out** — `http.Client` (pooled, Rust-backed reqwest)

from the same asyncio loop they use for SIP.

## Why the client matters (even without serving routes)

`http.Client` runs the entire round-trip — connection pooling, TLS, HTTP/1.1 + HTTP/2 framing — **in Rust on the Tokio runtime**, and each call is a real awaitable that hands the asyncio driver loop back while the request is in flight. A synchronous Python client (`requests`/`httpx`) instead does the protocol work in the interpreter and blocks its driver loop for the whole round-trip. So a script that only needs outbound HTTP on the hot path (a REST lookup per INVITE, a provisioning callback) should enable this feature and use `http.Client`. The **Extensions** docs page gets a tip callout making this explicit.

## Changes

- `siphon-bin/src/ext/http.rs` — new; resolves `extensions.http` → `http.yaml`, registers namespace + task. Any load error logs and leaves HTTP disabled rather than aborting startup.
- `siphon-bin/src/ext/mod.rs` — `register_http` wired into `register_all`, with the feature-on `pub use` and a feature-off shim that warns loudly if `extensions.http` is configured but the binary was built without `--features http` (same contract as SMPP / the `sctp` transport feature).
- `siphon-bin/Cargo.toml` — `http = ["dep:siphon-http"]`, a `full = ["smpp", "http"]` aggregate, and `siphon-http` pinned to **v1.0.0** using the byte-identical `siphon-sip` git URL (single-source rule).
- `siphon-bin/Cargo.lock` — adds `siphon-http` v1.0.0; `siphon-sip` / `siphon-smpp` pins unchanged.
- `siphon-bin/Dockerfile` — comments note HTTP is buildable via the `FEATURES` build-arg (`FEATURES=http` / `FEATURES=full`).
- `CHANGELOG.md` — `[Unreleased]` entry.

## Verification

- `cargo build` green for `--features "smpp http"`, `--features full`, and default (shim path).
- `cargo clippy --all-targets -- -D warnings` clean for all-features and default.

The plain `siphon` binary from `cargo install siphon-sip` is unaffected — `siphon-bin` is a separate, excluded workspace.
