### PR TITLE
docs(changelog): promote [Unreleased] to [1.1.0] (release prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-07-02
+
 ### Added
 - **Supply-chain documentation + `SECURITY.md`.** A new **Supply chain & SBOM**
   docs page documents the per-release SBOM (SPDX 2.3 + CycloneDX 1.4, attached to


### PR DESCRIPTION
Stages the **v1.1.0** release notes (promotes `[Unreleased]` → `## [1.1.0]`). **Release-notes only — no code, no tag, no version bump.** This is the CHANGELOG heading `cut-release.sh` requires, so cutting the release becomes a single command.

## To cut v1.1.0 (when ready)
```
# on main, in sync with origin/main:
scripts/cut-release.sh 1.1.0
```
That bumps `Cargo.toml`, runs the gates, commits, tags `v1.1.0`, and pushes → crates.io + PyPI + GHCR + GitHub Release.

## Why v1.1.0 (minor)
All 24 changes since v1.0.0 are backward-compatible per the scripting-API / config / CLI contract (new features, one bug fix, one no-op config-key removal that still parses, SCTP moved behind an opt-in build feature with config unchanged).

## Pre-release validation (run on the reference machine)
| Gate | Result |
|---|---|
| `cargo test` (unit/integration/RFC4475/proptest) | ✅ 3012 passed |
| clippy `--all-targets --all-features -D warnings` | ✅ clean |
| SDK pytest | ✅ 348 passed |
| 16-row SIPp throughput baseline | ✅ **0 failures / 0 retransmits** every row |
| Memory-leak regression (proxy + b2bua) | ✅ both clean |
| SIP-parser fuzz | ✅ no crashes |
| criterion per-op regression gate | ✅ within threshold¹ |
| CI functional (OPTIONS + REGISTER) | ✅ green |

¹ `bencode/encode_offer` tripped the 10% gate on criterion's short default window (+11–16%), but a stable 10s measurement gives **220.9 ns (+3.7%** vs the 213 ns baseline) with zero code/dep changes to that path — measurement noise on the suite's smallest allocation bench. Baseline left untouched.

## ⚠️ One caveat before cutting
The **manual** `--auto100` functional scenario (NIST auto-100 Trying; **not run in CI** — CI functional is OPTIONS+REGISTER only) did **not** pass locally. Traced it: the auto100 REGISTER succeeds but the UAS receives **0 MESSAGEs**; the test siphon logs `advertised_address` unset (Via/Contact = 127.0.0.1 in the Docker net); the local Docker network state was also churned during the run. The plain-MESSAGE relay scenario passes and every automated + CI gate is green, so this reads as **test-env/scenario fragility, not a code regression** — but I could not get a clean local pass and did not force it (no scenario edits shipped). **Please confirm auto100 (a quick live check) before cutting.**