### PR TITLE
test(sipp): fix non-INVITE auto-100 scenario — self-register the UAS

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -110,8 +110,7 @@ fi
 
 # ── Step 6b: NIST auto-100 Trying + UAS To-tag tests (optional) ─────────────
 if [[ "$RUN_AUTO100" == true ]]; then
-  echo "=== SIPp NIST auto-100 test (slow MESSAGE UAS forces proxy auto-100) ==="
-  run_sipp docker compose -f "$COMPOSE_FILE" --profile auto100 run --rm sipp-message-auto100-register
+  echo "=== SIPp NIST auto-100 test (self-registering slow MESSAGE UAS forces proxy auto-100) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile auto100 up --abort-on-container-exit sipp-message-auto100-uas sipp-message-auto100-uac
 
   echo "=== SIPp UAS To-tag test (script-built 404 must carry tag=) ==="

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -279,8 +279,10 @@ services:
   # The proxy's NIST auto-100 timer (default 200 ms) must fire and produce a
   # 100 Trying upstream; the UAC's scenario requires the 100 before the 200.
 
-  # Register alice with Contact pointing to 172.20.0.36:5060 (slow UAS)
-  sipp-message-auto100-register:
+  # Slow MESSAGE UAS at 172.20.0.36:5060 — self-registers (Contact = its own
+  # address, so the proxy's MT routing lands back here), then pauses past the
+  # ~3.5s RFC 4320 §4.2 auto-100 point before the 200 OK.
+  sipp-message-auto100-uas:
     image: ctaloi/sipp:latest
     depends_on:
       siphon:
@@ -289,46 +291,18 @@ services:
       - .:/sipp/scenarios:ro
     networks:
       sipnet:
-        ipv4_address: 172.20.0.38
-    entrypoint:
-      - sipp
-      - "172.20.0.10:5060"
-      - -sf
-      - /sipp/scenarios/register_alice_contact.xml
-      - -inf
-      - /sipp/scenarios/message_auto100_contact.csv
-      - -s
-      - alice
-      - -ap
-      - secret
-      - -m
-      - "1"
-      - -timeout
-      - "10"
-    profiles:
-      - auto100
-
-  # Slow MESSAGE UAS at 172.20.0.36:5060 — pauses 500 ms before 200 OK
-  sipp-message-auto100-uas:
-    image: ctaloi/sipp:latest
-    depends_on:
-      sipp-message-auto100-register:
-        condition: service_completed_successfully
-    volumes:
-      - .:/sipp/scenarios:ro
-    networks:
-      sipnet:
         ipv4_address: 172.20.0.36
+    # Register self (from this container's own IP, so the proxy records THIS
+    # address for MT routing), then run the pure server scenario.
     entrypoint:
-      - sipp
-      - -sf
-      - /sipp/scenarios/message_auto100_uas.xml
-      - -p
-      - "5060"
-      - -m
-      - "1"
-      - -timeout
-      - "30"
+      - sh
+      - -c
+      - >-
+        sipp 172.20.0.10:5060
+        -sf /sipp/scenarios/register_alice_contact.xml
+        -inf /sipp/scenarios/message_auto100_contact.csv
+        -s alice -ap secret -m 1 -timeout 10
+        && sipp -sf /sipp/scenarios/message_auto100_uas.xml -p 5060 -m 1 -timeout 30
     profiles:
       - auto100
 

--- a/sipp/message_auto100.xml
+++ b/sipp/message_auto100.xml
@@ -2,19 +2,27 @@
 <!DOCTYPE scenario SYSTEM "sipp.dtd">
 
 <!--
-  MESSAGE UAC that expects siphon's NIST auto-100 Trying timer to fire.
+  MESSAGE UAC that expects siphon's non-INVITE auto-100 Trying timer to fire.
 
-  Sends a MESSAGE and asserts the proxy emits 100 Trying *before* the
-  upstream UAS's final 200 OK. Pairs with message_auto100_uas.xml which
-  delays its 200 OK by 500 ms; the proxy's auto-100 timer (200 ms) must
-  produce the provisional so retrans="500" never fires on the UAC.
+  Asserts the proxy emits 100 Trying *before* the upstream (slow) UAS's final
+  200 OK. Pairs with message_auto100_uas.xml, which self-registers and then
+  delays its 200 OK to 4.5s.
 
-  retrans="500" is left in place so a missing 100 Trying surfaces as a
-  retransmit count > 0 in sipp's stats — a regression signal.
+  Per RFC 4320 §4.2 the proxy delays a non-INVITE 100 over UDP until the UAC's
+  Timer E is reset to T2 (~3.5s with default T1=500ms/T2=4s). So the MESSAGE
+  legitimately retransmits (retrans="500") a few times before the ~3.5s
+  auto-100 — expected RFC 4320 behaviour, not a regression. The assertion is
+  the ORDERING: the 100 arrives before the 200.
 
-  Run: sipp -sf message_auto100.xml -s user <proxy>:<port>
+  An initial pause lets the UAS finish self-registering before the MESSAGE is
+  sent, so the proxy has a binding to relay to.
+
+  Run: sipp -sf message_auto100.xml -s alice <proxy>:<port>
 -->
 <scenario name="MESSAGE (auto-100 Trying)">
+
+  <!-- Let the self-registering UAS install its binding first. -->
+  <pause milliseconds="3000" />
 
   <send retrans="500">
     <![CDATA[

--- a/sipp/message_auto100_uas.xml
+++ b/sipp/message_auto100_uas.xml
@@ -2,12 +2,15 @@
 <!DOCTYPE scenario SYSTEM "sipp.dtd">
 
 <!--
-  MESSAGE UAS that deliberately stalls before sending 200 OK.
+  Slow MESSAGE UAS (server half) for the non-INVITE auto-100 test.
 
-  Pairs with message_auto100.xml to exercise siphon's NIST auto-100 Trying
-  timer: with the UAS final response delayed 500 ms, the proxy's 200 ms
-  auto-100 timer must fire and emit a 100 Trying upstream so the UAC sees
-  a provisional before the final and does not retransmit the MESSAGE.
+  The container first self-registers alice with a Contact for its OWN address
+  (see the entrypoint in docker-compose.yaml), so the proxy's MT routing lands
+  back here. This scenario is then the pure server: it receives the relayed
+  MESSAGE and stalls past the ~3.5s RFC 4320 §4.2 non-INVITE auto-100 point
+  (default T1=500ms / T2=4s → Timer E reaches T2 at ~3.5s; see
+  TimerConfig::nist_auto_100_delay) before answering 200 OK, so the proxy's
+  auto-100 Trying fires upstream first.
 
   Run: sipp -sf message_auto100_uas.xml -p 5060
 -->
@@ -15,14 +18,16 @@
 
   <recv request="MESSAGE" />
 
-  <pause milliseconds="500" />
+  <!-- Stall past the ~3.5s RFC 4320 §4.2 auto-100 point so the proxy emits
+       the 100 Trying before this final 200 OK. -->
+  <pause milliseconds="4500" />
 
   <send>
     <![CDATA[
 SIP/2.0 200 OK
 [last_Via:]
 [last_From:]
-[last_To:];tag=[pid]SIPpTag00[call_number]
+[last_To:];tag=[pid]SIPpTag01[call_number]
 [last_Call-ID:]
 [last_CSeq:]
 Content-Length: 0


### PR DESCRIPTION
## Problem
The manual `--auto100` functional scenario (NIST non-INVITE 100 Trying) failed: the UAC got the 100 but never the 200, timing out (exit 97).

## Root cause (not a siphon bug)
The test registered `alice` from a **separate ephemeral helper** container (172.20.0.38) carrying a Contact for a **different** address (172.20.0.36, the UAS), then the helper exited (`-m 1`). siphon correctly records the observed source for MT routing (NAT / RFC 5626 §5.3, per the #22 behaviour), so relayed MESSAGEs went to the dead helper source and **never reached the UAS** — the UAS received **0 MESSAGEs**. A real UA never does this; it registers from where it listens.

The lenient plain-`MESSAGE` test has the **same** underlying behaviour (its UAS also receives 0), but tolerates it (UAC exits 255) so it "passes" — which is why this only surfaced on auto100 (which strictly asserts the 100→200 flow) and never in CI (CI functional = OPTIONS + REGISTER only).

## Fix
Make the UAS **register itself** (source == Contact == UAS address) via a *register-then-serve* entrypoint, so the proxy's MT routing lands on the live UAS. Also:
- Delay the UAS 200 past the ~3.5s **RFC 4320 §4.2** non-INVITE auto-100 point (the timing #19 introduced) so the auto-100 fires first.
- Pause the UAC briefly so the binding installs before the MESSAGE.
- Drop the now-unneeded separate register container (compose + `run-tests.sh`).

## Verified end-to-end
`scripts/run-tests.sh --skip-rust --auto100`:
- **UAC**: MESSAGE sent (3 retransmits before the ~3.5s auto-100 — expected RFC 4320), **100 received, then 200 received**, `Successful call 1`, **exit 0**.
- **UAS**: received the MESSAGE, sent 200, `Successful call 1`.
- The 100 arrives **before** the 200 (the test's assertion). `=== All tests passed ===`.

Test-only change (SIPp scenarios + compose + `run-tests.sh`); no code or CHANGELOG impact.