### PR TITLE
docs: supply-chain & SBOM page + SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **Supply-chain documentation + `SECURITY.md`.** A new **Supply chain & SBOM**
+  docs page documents the per-release SBOM (SPDX 2.3 + CycloneDX 1.4, attached to
+  each GitHub Release), how to consume it with Grype / Trivy / Dependency-Track,
+  how to reproduce it with `cargo sbom`, and the scheduled `cargo-deny` advisory /
+  license / source audit. A root `SECURITY.md` adds a private vulnerability-
+  reporting policy (GitHub private reporting, coordinated disclosure) — previously
+  absent. No behavioural change; documents supply-chain artifacts that already
+  ship at release.
 - **SDK mocks for the extension namespaces (`smpp`, `http`).** The `siphon-sip`
   Python SDK now mocks the namespaces injected by the opt-in extensions, so
   `from siphon import smpp` / `from siphon import http` resolve under pytest and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately through either channel:
+
+- **Preferred:** GitHub [private vulnerability reporting](https://github.com/siphon-project/siphon-sip/security/advisories/new)
+  — the **"Report a vulnerability"** button on the repository's **Security** tab.
+- **Alternative:** reach the maintainer through
+  [Real Time Telecom B.V.](https://realtime-telecom.nl).
+
+Please include enough detail to reproduce: affected version or commit, a
+description of the issue and its impact, and a proof of concept or steps to
+trigger it where possible.
+
+## What to expect
+
+- **Acknowledgement** of your report within a few business days.
+- An assessment and, for confirmed issues, a **coordinated-disclosure timeline**.
+- Credit in the release notes and advisory when a fix ships, unless you prefer to
+  remain anonymous.
+
+Please give us reasonable time to investigate and release a fix before any public
+disclosure.
+
+## Supported versions
+
+SIPhon is pre-1.0 and versioned in lockstep across the `siphon-sip` crate and the
+`siphon-sip` Python SDK (driven by the git tag). Security fixes ship in the
+**latest release**; there are no long-term-support branches yet. Run the latest
+tagged version to stay current on fixes.
+
+## Supply chain
+
+Every tagged release ships an SBOM (SPDX + CycloneDX), and dependency advisories
+are audited on a schedule with `cargo-deny`. See
+[Supply chain & SBOM](https://siphon-sip.org/supply-chain/) for how to consume the
+SBOM and reproduce the audit.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,9 @@ common roles — each with the config, a real script, and how to test it:
   redundant pair / N nodes, IMS), the ops runbook (graceful drain, health/readiness
   probes, metrics & alerting, capacity planning, backup/DR), and a light Kubernetes
   shape.
+- **[Supply chain & SBOM](supply-chain.md)** — what every release publishes (SPDX +
+  CycloneDX SBOM), how to feed it to your own scanners, how dependency advisories are
+  audited, and how to report a vulnerability.
 - **[Migrating from Kamailio / OpenSIPS](migrating-from-kamailio-opensips.md)** — a
   concept map for porting routes and modules, and how to translate `clusterer` /
   `dmq_usrloc` topologies to SIPhon's model.

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -1,0 +1,155 @@
+# Supply chain & SBOM
+
+If you run SIPhon in critical infrastructure, your security and procurement teams
+will ask two questions: *what is in this binary?* and *how do you know it's not
+vulnerable?* This page answers both. It covers what SIPhon publishes with every
+release, how to consume it in your own scanning pipeline, and how vulnerabilities
+are tracked and reported.
+
+This is the operator/procurement view. For **runtime** hardening of a live proxy —
+rate limiting, scanner blocking, TLS, auth — see
+[Hardening & security](cookbook/security.md).
+
+- [Software Bill of Materials (SBOM)](#software-bill-of-materials-sbom)
+- [Consuming the SBOM](#consuming-the-sbom)
+- [Generating an SBOM yourself](#generating-an-sbom-yourself)
+- [Dependency vulnerability monitoring](#dependency-vulnerability-monitoring)
+- [Reporting a vulnerability](#reporting-a-vulnerability)
+- [Known gaps](#known-gaps)
+
+---
+
+## Software Bill of Materials (SBOM)
+
+Every tagged release from **v1.0.0** onward ships a full SBOM in **two industry
+formats**, generated from the exact dependency graph that built the release
+artifacts and attached to the [GitHub Release](https://github.com/siphon-project/siphon-sip/releases):
+
+| Format | Spec version | Asset name |
+| --- | --- | --- |
+| **SPDX** | SPDX 2.3 (JSON) | `siphon-sip-vX.Y.Z.spdx.json` |
+| **CycloneDX** | CycloneDX 1.4 (JSON) | `siphon-sip-vX.Y.Z.cdx.json` |
+
+Both are produced by [`cargo-sbom`](https://github.com/psastras/sbom-rs) in CI as
+part of the release workflow, so they reflect the resolved `Cargo.lock` for that
+tag — every crate, its version, and its license. Two formats because scanners and
+compliance tools differ in what they ingest: SPDX is the ISO/IEC 5962 standard and
+what most license-compliance tooling expects; CycloneDX is what most
+vulnerability scanners (Grype, Trivy, Dependency-Track) consume natively.
+
+!!! note "What the SBOM covers"
+    The SBOM enumerates the **Rust dependency graph** of the `siphon-sip` crate.
+    SIPhon also links a few C libraries (libsctp, jemalloc, netlink) and embeds
+    CPython via PyO3 — those system/interpreter components are outside the Cargo
+    graph and are not enumerated per-package by `cargo-sbom`. Pin and scan them
+    through your base image / OS package manager as usual.
+
+---
+
+## Consuming the SBOM
+
+Download the format your tooling prefers from the release assets, then feed it in.
+A few common flows:
+
+**Scan for known vulnerabilities with [Grype](https://github.com/anchore/grype):**
+
+```bash
+grype sbom:./siphon-sip-v1.0.0.cdx.json
+```
+
+**Scan with [Trivy](https://github.com/aquasecurity/trivy):**
+
+```bash
+trivy sbom ./siphon-sip-v1.0.0.cdx.json
+```
+
+**Continuous monitoring with [Dependency-Track](https://dependencytrack.org/):**
+upload the CycloneDX document to a project via the API or UI, and it re-evaluates
+the component list against new advisories over time — no re-scan of the binary
+needed.
+
+**License compliance:** feed the SPDX document to your compliance tool of choice
+(FOSSA, ORT, or a simple `jq` over the `licenseConcluded` fields). SIPhon and its
+dependencies are OSI-permissive by policy (see below).
+
+---
+
+## Generating an SBOM yourself
+
+The release SBOM is not magic — you can reproduce it from any checkout, which is
+useful for a fork, an unreleased commit, or verifying the published document:
+
+```bash
+cargo install cargo-sbom
+
+cargo sbom --output-format spdx_json_2_3      > siphon-sip.spdx.json
+cargo sbom --output-format cyclone_dx_json_1_4 > siphon-sip.cdx.json
+```
+
+Because the output is derived from `Cargo.lock`, a checkout of the same tag
+produces an equivalent component list to the published asset.
+
+---
+
+## Dependency vulnerability monitoring
+
+An SBOM is a snapshot; advisories are continuous. A crate that was clean at
+release time can have an advisory filed against it a week later without a single
+line of code changing. SIPhon handles that with a scheduled
+[`cargo-deny`](https://embarkstudios.github.io/cargo-deny/) audit rather than a
+one-time gate:
+
+- **RustSec advisories** are checked **weekly** (Mondays) and on any change to the
+  dependency set (`Cargo.toml` / `Cargo.lock` / `deny.toml`) in
+  [`.github/workflows/audit.yml`](https://github.com/siphon-project/siphon-sip/blob/main/.github/workflows/audit.yml).
+  A new advisory surfaces here within a week even if no code changed — which is
+  exactly why it's a schedule, not a per-PR check.
+- **A yanked crate fails the audit** (`yanked = "deny"`).
+- **License policy is enforced** — dependencies must resolve to an OSI-permissive
+  license from an explicit allow-list (MIT, Apache-2.0, BSD, ISC, MPL-2.0, …).
+- **Source policy is enforced** — crates must come from crates.io; unknown
+  registries and unknown git sources are denied.
+
+The full policy lives in
+[`deny.toml`](https://github.com/siphon-project/siphon-sip/blob/main/deny.toml).
+You can run the same checks against your own checkout:
+
+```bash
+cargo install cargo-deny
+cargo deny check              # advisories + licenses + sources + bans
+```
+
+---
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public GitHub issue
+for a suspected vulnerability. See
+[`SECURITY.md`](https://github.com/siphon-project/siphon-sip/blob/main/SECURITY.md)
+for the disclosure process. In short: use GitHub's
+[private vulnerability reporting](https://github.com/siphon-project/siphon-sip/security/advisories/new)
+on the repository's **Security** tab, or reach the maintainer through
+[Real Time Telecom](https://realtime-telecom.nl). You'll get an acknowledgement and
+a coordinated-disclosure timeline.
+
+---
+
+## Known gaps
+
+Stated honestly, because a supply-chain page that overclaims is worse than none:
+
+- **No container-image SBOM/provenance yet.** The published SBOM describes the
+  Rust crate graph, not the Docker image layers. Image-level SBOM and SLSA build
+  provenance (via `docker buildx --sbom=true --provenance=true`) are not yet
+  wired. Until they are, scan the published image with your registry scanner and
+  treat the crate SBOM as the authoritative component list for the SIPhon binary
+  itself.
+- **No cryptographic signing of release artifacts yet.** Artifacts are published
+  through GitHub Releases and OIDC Trusted Publishing to crates.io / PyPI (no
+  long-lived tokens), but the tarballs/SBOMs are not yet Sigstore-signed. Verify
+  by matching the SBOM to a `cargo sbom` of the corresponding tag.
+
+## See also
+
+- [Hardening & security](cookbook/security.md) — runtime hardening of a live proxy.
+- [Deployment & operations](deployment.md) — the production runbook these artifacts slot into.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Transports & networking: transports.md
       - Scaling, clustering & redundancy: scaling-and-redundancy.md
       - Deployment & operations: deployment.md
+      - Supply chain & SBOM: supply-chain.md
       - Migrating from Kamailio / OpenSIPS: migrating-from-kamailio-opensips.md
   - Extensions:
       - Overview: extensions.md


### PR DESCRIPTION
## What

Adds operator/procurement-facing documentation for SIPhon's supply-chain artifacts, plus a repository security policy.

- **New docs page — `docs/supply-chain.md` ("Supply chain & SBOM")**, wired into the *Running in production* nav and the docs home page. Covers:
  - The SBOM published with every release — **SPDX 2.3 + CycloneDX 1.4**, generated by `cargo-sbom` in the release workflow and attached to each GitHub Release (`siphon-sip-vX.Y.Z.spdx.json` / `.cdx.json`).
  - How to consume it — Grype, Trivy, Dependency-Track, SPDX license compliance.
  - How to reproduce it locally with `cargo sbom`.
  - Dependency vulnerability monitoring — the scheduled `cargo-deny` advisory / license / source audit (`audit.yml` + `deny.toml`), and how to run it locally.
  - Honest **known gaps**: no container-image SBOM/provenance and no artifact signing yet.
- **New `SECURITY.md`** at the repo root (previously absent) — private vulnerability-reporting policy via GitHub private reporting + maintainer contact, with a coordinated-disclosure expectation and supported-versions note.
- CHANGELOG `[Unreleased]` entry.

## Why

The SBOM and `cargo-deny` audit already run at release time, but nothing told operators or security teams they exist, where to find them, or how to consume them — a real gap for critical-infra buyers (CRA / NIS2 procurement checklists). This turns existing CI artifacts into documented, verifiable supply-chain transparency, and gives security researchers a clear private disclosure channel.

## Notes

- Docs-only + a policy file — no code or behavioural change.
- `mkdocs build --strict` passes locally (nav + all internal links/anchors resolve).
- The page states SBOMs ship "from v1.0.0 onward" since no release is cut yet — accurate the moment the first tagged release lands.