### PR TITLE
fix(deps): bump quick-xml 0.37 → 0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-07-02
+
+### Security
+- **Bump `quick-xml` 0.37 → 0.41** to address RUSTSEC-2026-0194 (quadratic
+  runtime when checking a start tag for duplicate attribute names) and
+  RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in `NsReader`,
+  a memory-exhaustion DoS). siphon parses XML on the presence (PIDF/reginfo),
+  iFC, SIPREC-metadata, and Sh paths — some of it from remote peers — so the
+  parser hardening matters. No API or behavioural change (the reginfo / iFC /
+  SIPREC parsers keep identical decode + entity-unescape semantics).
+
 ## [1.1.0] — 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,9 +2398,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ tower = { version = "0.5.3", features = ["util"] }
 rasn = "0.22"
 rasn-derive = "0.22"
 chrono = { version = "0.4", default-features = false }
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 
 # iFC evaluation engine — regex for SPT header content matching
 regex = "1"

--- a/src/ifc/mod.rs
+++ b/src/ifc/mod.rs
@@ -13,6 +13,22 @@ use dashmap::DashMap;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use regex::Regex;
+
+/// quick-xml 0.41 (RUSTSEC-2026-0194/0195 fix) removed `BytesText::unescape()`;
+/// restore its "decode encoding + resolve XML entities" behaviour.
+trait BytesTextExt {
+    fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String>;
+}
+impl BytesTextExt for quick_xml::events::BytesText<'_> {
+    fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String> {
+        let decoded = self.decode().map_err(|error| error.to_string())?;
+        Ok(std::borrow::Cow::Owned(
+            quick_xml::escape::unescape(&decoded)
+                .map_err(|error| error.to_string())?
+                .into_owned(),
+        ))
+    }
+}
 use tokio::sync::mpsc;
 use tracing::warn;
 

--- a/src/registrar/reginfo.rs
+++ b/src/registrar/reginfo.rs
@@ -309,6 +309,22 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
+    // quick-xml 0.41 (RUSTSEC-2026-0194/0195 fix) removed `BytesText::unescape()`;
+    // restore its "decode encoding + resolve XML entities" behaviour.
+    trait BytesTextExt {
+        fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String>;
+    }
+    impl BytesTextExt for quick_xml::events::BytesText<'_> {
+        fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String> {
+            let decoded = self.decode().map_err(|error| error.to_string())?;
+            Ok(std::borrow::Cow::Owned(
+                quick_xml::escape::unescape(&decoded)
+                    .map_err(|error| error.to_string())?
+                    .into_owned(),
+            ))
+        }
+    }
+
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(true);
 
@@ -565,7 +581,7 @@ fn attr_optional_str(
         let attr = attr.map_err(|error| ReginfoParseError::Xml(error.to_string()))?;
         if attr.key.local_name().as_ref() == name.as_bytes() {
             let value = attr
-                .unescape_value()
+                .normalized_value(quick_xml::XmlVersion::Explicit1_0)
                 .map_err(|error| ReginfoParseError::Xml(error.to_string()))?;
             return Ok(Some(value.into_owned()));
         }

--- a/src/siprec/metadata.rs
+++ b/src/siprec/metadata.rs
@@ -10,6 +10,22 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use thiserror::Error;
 
+/// quick-xml 0.41 (RUSTSEC-2026-0194/0195 fix) removed `BytesText::unescape()`;
+/// restore its "decode encoding + resolve XML entities" behaviour.
+trait BytesTextExt {
+    fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String>;
+}
+impl BytesTextExt for quick_xml::events::BytesText<'_> {
+    fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String> {
+        let decoded = self.decode().map_err(|error| error.to_string())?;
+        Ok(std::borrow::Cow::Owned(
+            quick_xml::escape::unescape(&decoded)
+                .map_err(|error| error.to_string())?
+                .into_owned(),
+        ))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
@@ -271,7 +287,10 @@ fn get_attribute(element: &BytesStart, attribute_name: &str) -> Option<String> {
     for attribute in element.attributes().flatten() {
         let key = std::str::from_utf8(attribute.key.as_ref()).unwrap_or("");
         if key == attribute_name {
-            return attribute.unescape_value().ok().map(|value| value.to_string());
+            return attribute
+                .normalized_value(quick_xml::XmlVersion::Explicit1_0)
+                .ok()
+                .map(|value| value.to_string());
         }
     }
     None


### PR DESCRIPTION
## Security fix
Two `quick-xml` advisories were published **2026-07-02** (the same day v1.1.0 shipped) flagging DoS-class parser issues:
- **RUSTSEC-2026-0194** — quadratic runtime checking a start tag for duplicate attribute names
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS)

`quick-xml` is a **direct** dependency; siphon parses XML on the presence (PIDF/reginfo), iFC, SIPREC-metadata and Sh paths — some of it from remote peers — so this is worth patching. The advisory mandates **`>= 0.41.0`** (no 0.37.x backport).

## Changes
- `Cargo.toml` / `Cargo.lock`: `quick-xml` 0.37 → **0.41.0**.
- 0.41 API migration in the 3 reader-side parsers (`ifc`, `siprec/metadata`, `registrar/reginfo`):
  - `BytesText::unescape()` was removed → restored via a tiny `decode() + escape::unescape()` compat trait, so **no call-site logic changed** and decode+entity-unescape semantics are identical.
  - `Attribute::unescape_value()` deprecated → `normalized_value(XmlVersion::Explicit1_0)`.
  - (`li/x1` uses `se`/`de` only — unaffected.)

## Verification
- `cargo build` / `cargo clippy --all-targets --all-features -D warnings` — clean.
- `cargo test` — **2654 lib tests + all integration suites pass, 0 failures** (the reginfo/iFC/SIPREC XML tests confirm parsing is unchanged).
- Clears the `cargo-deny` advisory gate that went red on `main` after the advisories dropped.

Ready for a **v1.1.1** patch.