### PR TITLE
feat(security): drop banned sources in-kernel via nftables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -365,3 +365,40 @@ jobs:
           path: |
             siphon-ipsec.log
             *.log
+
+  # ── nftables kernel-firewall live test (self-hosted) ───────────────────
+  # The nf_tables netlink marshalling is validated end-to-end against a real
+  # kernel — the only coverage for the chain/rule/expression builders that a
+  # byte-layout test can't fully prove (it caught the big-endian-integer,
+  # NFTA_SET_KEY_TYPE, and multi-ack bugs during development). Needs
+  # CAP_NET_ADMIN, which GitHub-hosted runners don't grant, so it shares the
+  # self-hosted `ipsec` runner on trusted triggers only (trunk push + manual
+  # dispatch, never fork PRs). The test runs inside a throwaway user+net
+  # namespace (`unshare -rn`): the fresh netns gives it an isolated nft ruleset
+  # so it touches nothing on the host and cleans up when the namespace exits,
+  # and the user-namespace root map supplies CAP_NET_ADMIN without real
+  # privilege. Host prerequisites on the runner: the `nft` binary and
+  # unprivileged user namespaces enabled (user.max_user_namespaces > 0).
+  nftables-firewall:
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    runs-on: [self-hosted, linux, x64, ipsec]
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Python 3.14 (free-threaded)
+        uses: deadsnakes/action@v3.2.0
+        with:
+          python-version: "3.14-dev"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Build the test binary WITH network, OUTSIDE the namespace, so the
+      # network-isolated `unshare -n` run below never needs to fetch or compile.
+      - name: Build the firewall live test
+        run: PYO3_PYTHON=python3.14 cargo test --lib --no-run firewall::nftables
+
+      - name: nftables live-kernel roundtrip (isolated user+net namespace)
+        run: unshare -rn env PYO3_PYTHON=python3.14 cargo test --lib firewall::nftables::tests::live_kernel_roundtrip -- --ignored --nocapture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   to the userspace ACL with a warning when it's missing. Zero-touch by default:
   SIPhon owns the whole ruleset (table, sets, base chain, and the `saddr @banned
   drop` rules), so `firewall: {}` is all that's needed; set `manage_rule: false` to
-  have SIPhon maintain only the sets and reference them from your own ruleset. Also
-  expands the security cookbook with the ban-scoring model and adds a Kernel firewall
-  page covering `CAP_NET_ADMIN` per runtime, container behaviour, and the
+  have SIPhon maintain only the sets and reference them from your own ruleset. Two
+  new counters make the runtime failure modes observable:
+  `siphon_firewall_command_failures_total` (a ban did not reach the kernel — alert
+  on it) and `siphon_firewall_commands_dropped_total` (a ban storm outran the
+  netlink actor's queue; the userspace ACL still enforces every ban). Also expands
+  the security cookbook with the ban-scoring model and adds a Kernel firewall page
+  covering `CAP_NET_ADMIN` per runtime, container behaviour, and the
   nftables-vs-XDP tradeoff.
 
 ## [1.1.1] — 2026-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   SIPhon programs the set directly over netlink (no `nft` shell-out, no daemon, no
   new dependencies), and the kernel auto-expires each ban via a per-element timeout
   matching the in-memory TTL. Opt-in, Linux-only, needs `CAP_NET_ADMIN`; falls back
-  to the userspace ACL with a warning when it's missing. SIPhon owns the sets; you
-  add one drop rule referencing them (self-contained rule management is a follow-up).
-  Also expands the security cookbook with the ban-scoring model and adds a Kernel
-  firewall page covering `CAP_NET_ADMIN` per runtime, container behaviour, and the
+  to the userspace ACL with a warning when it's missing. Zero-touch by default:
+  SIPhon owns the whole ruleset (table, sets, base chain, and the `saddr @banned
+  drop` rules), so `firewall: {}` is all that's needed; set `manage_rule: false` to
+  have SIPhon maintain only the sets and reference them from your own ruleset. Also
+  expands the security cookbook with the ban-scoring model and adds a Kernel firewall
+  page covering `CAP_NET_ADMIN` per runtime, container behaviour, and the
   nftables-vs-XDP tradeoff.
 
 ## [1.1.1] — 2026-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the security cookbook with the ban-scoring model and adds a Kernel firewall page
   covering `CAP_NET_ADMIN` per runtime, container behaviour, and the
   nftables-vs-XDP tradeoff.
+- **Admin API ban management** — `GET /admin/bans` lists the sources currently
+  auto-banned by `failed_auth_ban` (with remaining TTL), and
+  `DELETE /admin/bans/{ip}` lifts a ban early for an operator clearing a false
+  positive. The unban clears the userspace ban and, when the kernel firewall is
+  enabled, removes the matching nf_tables element in lockstep so the in-kernel
+  drop is lifted too.
 
 ## [1.1.1] — 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **Kernel firewall (`security.firewall`).** Mirror SIPhon's bans — the
+  confidence-weighted `failed_auth_ban` store and the APIBAN blocklist — into a
+  kernel nf_tables set, so abusive sources are dropped in the kernel before they
+  reach SIPhon's socket instead of only in the userspace ACL. Self-contained:
+  SIPhon programs the set directly over netlink (no `nft` shell-out, no daemon, no
+  new dependencies), and the kernel auto-expires each ban via a per-element timeout
+  matching the in-memory TTL. Opt-in, Linux-only, needs `CAP_NET_ADMIN`; falls back
+  to the userspace ACL with a warning when it's missing. SIPhon owns the sets; you
+  add one drop rule referencing them (self-contained rule management is a follow-up).
+  Also expands the security cookbook with the ban-scoring model and adds a Kernel
+  firewall page covering `CAP_NET_ADMIN` per runtime, container behaviour, and the
+  nftables-vs-XDP tradeoff.
+
 ## [1.1.1] — 2026-07-02
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,6 +3105,7 @@ dependencies = [
  "http",
  "indexmap",
  "ipnet",
+ "libc",
  "md5",
  "netlink-sys",
  "nom 8.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,10 @@ tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 # on other kernels; consumers gate the netlink backend on cfg(target_os).
 [target.'cfg(target_os = "linux")'.dependencies]
 netlink-sys = "0.8"
+# Already a hard dependency of netlink-sys (zero new crates) — declared
+# directly for the `SO_RCVTIMEO` setsockopt on the nf_tables ack socket, which
+# netlink-sys does not expose.
+libc = "0.2"
 
 [dev-dependencies]
 proptest = "1"

--- a/docs/cookbook/security.md
+++ b/docs/cookbook/security.md
@@ -31,11 +31,36 @@ security:
     interval_secs: 300
 ```
 
-`failed_auth_ban` weights signals by confidence: a wrong-password digest, a forged
-nonce, or non-SIP garbage on a TLS stream counts heavily; a single 401 challenge
-counts as 1; a successful auth resets the counter. Banned IPs are dropped at
-`recv()`, before parsing. Put your load balancers and health checks in
-`trusted_cidrs`.
+### How the scoring works
+
+`failed_auth_ban` is a **confidence-weighted** counter, not a flat fail2ban tally.
+Every abuse signal from a source IP adds to a per-IP score within `window_secs`;
+crossing `threshold` bans the IP for `ban_duration_secs`. Signals are weighted by
+how hard they are to fake:
+
+| Signal | Score |
+|--------|-------|
+| 401/407 challenge with no follow-up success | 1 |
+| INVITE server-transaction timeout (never ACKed) | 1 |
+| Wrong password, or a forged/stale/replayed digest nonce | `strong_signal_weight` (default 3) |
+| Non-SIP bytes on a TCP/TLS stream | `strong_signal_weight` |
+| Failed TLS/WSS/WS handshake | `strong_signal_weight` |
+| Scanner User-Agent (`scanner_block`) | `strong_signal_weight` |
+
+Signals arriving over TCP (handshake, malformed bytes) score high because the source
+IP is validated by the three-way handshake — it can't be spoofed, and a legitimate
+client never trips them. A **successful authentication resets the score to zero**,
+so a subscriber who mistypes a password twice then logs in is never banned, while an
+IP spraying garbage is banned ~3× faster than one just rattling doorknobs.
+
+Bans are enforced at `recv()`/`accept()` — before any SIP parsing — and expire on
+their own. `trusted_cidrs` are exempt from scoring entirely, so put your load
+balancers and health checks there.
+
+!!! tip "Drop bans in the kernel"
+    With [`security.firewall`](../kernel-firewall.md), every ban is also pushed to a
+    kernel nf_tables set, so abusive sources are dropped **before they reach
+    SIPhon** — real defense against volume, not just userspace politeness.
 
 In a script, you can also rate-limit a specific flow:
 

--- a/docs/kernel-firewall.md
+++ b/docs/kernel-firewall.md
@@ -1,0 +1,143 @@
+# Kernel firewall (nf_tables)
+
+By default SIPhon drops banned sources in **userspace**: the transport ACL rejects
+them at `recv()`/`accept()`, before any SIP parsing. That protects your handlers,
+but the packet still travels NIC → kernel → SIPhon before being dropped, so it does
+nothing against volume.
+
+`security.firewall` mirrors SIPhon's bans into a **kernel nf_tables set** so the
+kernel drops the traffic before it reaches SIPhon's socket. It's self-contained
+(no `nft` shell-out, no daemon, no log scraping) — SIPhon programs the set directly
+over netlink and the kernel auto-expires each ban via a per-element timeout.
+
+## What gets dropped
+
+The same sources SIPhon already bans, now enforced in the kernel:
+
+- **Auto-ban** — the confidence-weighted [`failed_auth_ban`](cookbook/security.md#how-the-scoring-works)
+  store. Each ban is pushed to the kernel with the **same TTL** as the in-memory
+  ban, so both expire in lockstep.
+- **APIBAN** — every IP from the [APIBAN](https://apiban.org) community blocklist,
+  added permanently (the blocklist carries no per-IP lifetime).
+
+`trusted_cidrs` are never banned, so they're never in the set.
+
+## Enable it
+
+```yaml
+security:
+  failed_auth_ban:            # (or apiban:) — the source of bans
+    threshold: 10
+    window_secs: 600
+    ban_duration_secs: 3600
+
+  firewall:
+    table: "siphon"           # nf_tables table SIPhon owns (family inet)
+    set_v4: "banned4"         # IPv4 ban set
+    set_v6: "banned6"         # IPv6 ban set
+```
+
+All three names default to the values shown, so `firewall: {}` is enough. On
+startup SIPhon creates the `inet siphon` table and the two timeout sets
+(idempotent — safe across restarts).
+
+## Grant `CAP_NET_ADMIN`
+
+Programming nf_tables needs `CAP_NET_ADMIN` (the same capability the IMS P-CSCF
+IPsec path uses). Without it SIPhon logs a warning and falls back to the userspace
+ACL — the feature is never fatal, it just doesn't reach the kernel.
+
+=== "systemd"
+
+    ```ini
+    [Service]
+    AmbientCapabilities=CAP_NET_ADMIN
+    ```
+
+=== "Docker"
+
+    ```bash
+    docker run --cap-add=NET_ADMIN siphon-sip ...
+    ```
+
+=== "Kubernetes"
+
+    ```yaml
+    securityContext:
+      capabilities:
+        add: ["NET_ADMIN"]
+    ```
+
+## Activate the drop rule
+
+SIPhon owns and maintains the **sets**; you reference them from one drop rule.
+Add it once (a shipped `.nft` snippet or your existing ruleset works too):
+
+```nft
+table inet siphon {
+    chain input {
+        type filter hook input priority filter; policy accept;
+        ip  saddr @banned4 drop
+        ip6 saddr @banned6 drop
+    }
+}
+```
+
+```bash
+nft -f /etc/siphon/firewall.nft
+```
+
+The sets already exist (SIPhon created them), so this only adds the chain + rules.
+Once loaded, banned sources are dropped in-kernel; SIPhon keeps the set contents
+current.
+
+!!! note "Self-contained rule management is coming"
+    A future release will let SIPhon own the chain + rule too (`manage_rule: true`),
+    so no manual `nft` step is needed. Today SIPhon manages the sets and you wire
+    the one rule.
+
+## Containers: use nftables, not XDP
+
+Most SIPhon binaries run in containers, and this is the right tool there. nftables
+runs in the **pod's network namespace**; `CAP_NET_ADMIN` is grantable per-pod
+without host privilege, and it works on any CNI, `veth`, or cloud vNIC.
+
+XDP is *not* the tool here. From inside a pod you can't attach XDP to the host NIC
+(that's the node/CNI's job), `veth` and cloud vNICs fall back to generic-mode XDP
+(no faster than nftables), it needs `CAP_BPF`/bpffs, and it collides with CNIs that
+already own XDP (Cilium). Line-rate volumetric scrubbing belongs at the **edge /
+host / CNI**, not in the SIPhon container. (SIPhon's XDP story is on the *media*
+plane, where packet rates justify it.)
+
+One honest limit: from inside a container, neither nftables nor XDP drops at the
+host NIC — the packet has already crossed host → CNI → `veth`. nftables still drops
+it **before SIPhon's userspace**, which is the win here; true volumetric defense is
+an edge/upstream concern.
+
+## Verify & troubleshoot
+
+Confirm the sets and their live contents:
+
+```bash
+nft list ruleset
+# table inet siphon {
+#   set banned4 { type ipv4_addr; flags timeout; elements = { 203.0.113.5 timeout 1h expires 59m } }
+#   ...
+# }
+```
+
+- **Nothing in the sets?** Check that `failed_auth_ban` and/or `apiban` are
+  configured — the firewall only mirrors bans those produce. Trigger a few failed
+  auths and watch the set fill.
+- **`kernel firewall (nf_tables) unavailable` in the logs?** SIPhon couldn't
+  program the sets — almost always a missing `CAP_NET_ADMIN`. It's running on the
+  userspace ACL until you grant it.
+- **Bans not dropping?** The sets are current but you haven't added the drop rule
+  (see above), or the rule references the wrong set names.
+
+## See also
+
+- [How the scoring works](cookbook/security.md#how-the-scoring-works) — what earns
+  a ban and how fast.
+- [Monitoring](cookbook/monitoring.md) — the `siphon_banned_ips` gauge tracks the
+  active ban count.

--- a/docs/kernel-firewall.md
+++ b/docs/kernel-firewall.md
@@ -31,15 +31,17 @@ security:
     window_secs: 600
     ban_duration_secs: 3600
 
-  firewall:
-    table: "siphon"           # nf_tables table SIPhon owns (family inet)
-    set_v4: "banned4"         # IPv4 ban set
-    set_v6: "banned6"         # IPv6 ban set
+  firewall: {}                # that's it — every field below defaults
+    # table:  "siphon"        # nf_tables table SIPhon owns (family inet)
+    # chain:  "input"         # base chain SIPhon adds the drop rules to
+    # set_v4: "banned4"       # IPv4 ban set
+    # set_v6: "banned6"       # IPv6 ban set
+    # manage_rule: true       # SIPhon owns the chain + drop rules too (see below)
 ```
 
-All three names default to the values shown, so `firewall: {}` is enough. On
-startup SIPhon creates the `inet siphon` table and the two timeout sets
-(idempotent — safe across restarts).
+`firewall: {}` is enough. On startup SIPhon creates the `inet siphon` table, the
+two timeout sets, a base chain, and the drop rules that reference them — all
+idempotent and safe across restarts. Nothing else to configure.
 
 ## Grant `CAP_NET_ADMIN`
 
@@ -68,10 +70,29 @@ ACL — the feature is never fatal, it just doesn't reach the kernel.
         add: ["NET_ADMIN"]
     ```
 
-## Activate the drop rule
+## Zero-touch by default
 
-SIPhon owns and maintains the **sets**; you reference them from one drop rule.
-Add it once (a shipped `.nft` snippet or your existing ruleset works too):
+With `manage_rule: true` (the default) SIPhon owns the whole ruleset — table,
+sets, base chain, and the two drop rules — so enabling `firewall` is all you do.
+On startup it installs, in the `inet siphon` table:
+
+```nft
+chain input {
+    type filter hook input priority filter; policy accept;
+    ip  saddr @banned4 drop
+    ip6 saddr @banned6 drop
+}
+```
+
+Banned sources are dropped in-kernel from the first ban; SIPhon keeps the set
+contents current with per-element timeouts. On restart it leaves the existing
+table in place (so the rules are never duplicated).
+
+### Bring your own rule (`manage_rule: false`)
+
+If you already manage nftables and want to place the drop yourself, set
+`manage_rule: false`. SIPhon then maintains only the **sets**, and you reference
+them from your own ruleset:
 
 ```nft
 table inet siphon {
@@ -86,15 +107,6 @@ table inet siphon {
 ```bash
 nft -f /etc/siphon/firewall.nft
 ```
-
-The sets already exist (SIPhon created them), so this only adds the chain + rules.
-Once loaded, banned sources are dropped in-kernel; SIPhon keeps the set contents
-current.
-
-!!! note "Self-contained rule management is coming"
-    A future release will let SIPhon own the chain + rule too (`manage_rule: true`),
-    so no manual `nft` step is needed. Today SIPhon manages the sets and you wire
-    the one rule.
 
 ## Containers: use nftables, not XDP
 
@@ -132,8 +144,9 @@ nft list ruleset
 - **`kernel firewall (nf_tables) unavailable` in the logs?** SIPhon couldn't
   program the sets — almost always a missing `CAP_NET_ADMIN`. It's running on the
   userspace ACL until you grant it.
-- **Bans not dropping?** The sets are current but you haven't added the drop rule
-  (see above), or the rule references the wrong set names.
+- **Bans not dropping?** Confirm the `chain input` + `@banned4/@banned6 drop` rules
+  are present in `nft list ruleset`. With the default `manage_rule: true` SIPhon
+  installs them; with `manage_rule: false` you add them yourself (see above).
 
 ## See also
 

--- a/docs/kernel-firewall.md
+++ b/docs/kernel-firewall.md
@@ -171,6 +171,22 @@ Two counters on `/metrics` cover the runtime failure modes:
 | `siphon_firewall_command_failures_total` | any sustained `rate() > 0` | Bans are **not** reaching the kernel (ruleset deleted out from under SIPhon, capability lost). Userspace ACL is the only enforcement left. |
 | `siphon_firewall_commands_dropped_total` | sustained `rate() > 0` | A ban storm is outrunning the netlink actor's queue; kernel enforcement lags the ban rate (userspace ACL still enforces every ban). |
 
+### Lifting a false-positive ban
+
+If a legitimate source gets auto-banned, lift it through the [admin API](deployment.md)
+rather than editing `nft` by hand — that keeps the userspace ban and the kernel
+set in sync:
+
+```bash
+curl http://127.0.0.1:9091/admin/bans                        # list active bans
+curl -X DELETE http://127.0.0.1:9091/admin/bans/203.0.113.5  # lift one
+```
+
+`DELETE /admin/bans/{ip}` clears the userspace ban and, when the kernel firewall
+is enabled, removes the matching nf_tables element in the same step. (A ban left
+alone expires on its own; both the userspace store and the kernel element use the
+same TTL.)
+
 ## See also
 
 - [How the scoring works](cookbook/security.md#how-the-scoring-works) — what earns

--- a/docs/kernel-firewall.md
+++ b/docs/kernel-firewall.md
@@ -85,8 +85,11 @@ chain input {
 ```
 
 Banned sources are dropped in-kernel from the first ban; SIPhon keeps the set
-contents current with per-element timeouts. On restart it leaves the existing
-table in place (so the rules are never duplicated).
+contents current with per-element timeouts. The whole setup is **one atomic
+nf_tables transaction**: every object is declared idempotently, and the chain's
+rules are flushed and re-appended inside the same transaction — so a first run,
+a clean restart, and a restart after a crash all converge to exactly this
+ruleset, with no duplicated rules and no instant where the drop rule is absent.
 
 ### Bring your own rule (`manage_rule: false`)
 
@@ -106,6 +109,19 @@ table inet siphon {
 
 ```bash
 nft -f /etc/siphon/firewall.nft
+```
+
+### Renaming or disabling: clean up the old objects yourself
+
+SIPhon only ever **creates** its objects — it never deletes a table or chain it
+finds, because it can't know the objects aren't yours. So if you rename `table`
+/ `chain` in the config, flip `manage_rule` off, or remove `firewall:` entirely,
+the previously created table (and its drop rules) stays in the kernel and keeps
+dropping whatever is still in its sets — including permanent APIBAN entries that
+never expire. Remove it explicitly:
+
+```bash
+nft delete table inet siphon
 ```
 
 ## Containers: use nftables, not XDP
@@ -147,6 +163,13 @@ nft list ruleset
 - **Bans not dropping?** Confirm the `chain input` + `@banned4/@banned6 drop` rules
   are present in `nft list ruleset`. With the default `manage_rule: true` SIPhon
   installs them; with `manage_rule: false` you add them yourself (see above).
+
+Two counters on `/metrics` cover the runtime failure modes:
+
+| Metric | Alert when | Meaning |
+|---|---|---|
+| `siphon_firewall_command_failures_total` | any sustained `rate() > 0` | Bans are **not** reaching the kernel (ruleset deleted out from under SIPhon, capability lost). Userspace ACL is the only enforcement left. |
+| `siphon_firewall_commands_dropped_total` | sustained `rate() > 0` | A ban storm is outrunning the netlink actor's queue; kernel enforcement lags the ban rate (userspace ACL still enforces every ban). |
 
 ## See also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Monitoring & observability: cookbook/monitoring.md
   - Running in production:
       - Transports & networking: transports.md
+      - Kernel firewall (nf_tables): kernel-firewall.md
       - Scaling, clustering & redundancy: scaling-and-redundancy.md
       - Deployment & operations: deployment.md
       - Supply chain & SBOM: supply-chain.md

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -356,6 +356,20 @@ auth:
 #   apiban:                     # APIBAN community blocklist (apiban.org)
 #     api_key: "your-api-key"   # get a free key at apiban.org
 #     interval_secs: 300        # poll interval (default: 300 = 5 min)
+#
+#   firewall: {}                # kernel firewall: mirror bans (failed_auth_ban +
+#                               # apiban) into a kernel nf_tables set so banned
+#                               # sources are dropped before siphon's socket.
+#                               # Linux-only, needs CAP_NET_ADMIN; falls back to
+#                               # the userspace ACL (with a warning) without it.
+#                               # `{}` is enough — every field defaults:
+#     # table: "siphon"         # nf_tables table siphon owns (family inet)
+#     # chain: "input"          # base chain the drop rules live in
+#     # set_v4: "banned4"       # IPv4 ban set (per-element timeouts)
+#     # set_v6: "banned6"       # IPv6 ban set
+#     # manage_rule: true       # siphon owns chain + drop rules too; false =
+#                               # siphon maintains only the sets and you
+#                               # reference them from your own ruleset
 
 # ---------------------------------------------------------------------------
 # NAT traversal

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -529,6 +529,8 @@ auth:
 #   GET    /admin/registrations       list all AoRs + their contacts
 #   GET    /admin/registrations/{aor} one AoR's contacts
 #   DELETE /admin/registrations/{aor} force-unregister an AoR
+#   GET    /admin/bans                list active auto-bans + remaining TTL
+#   DELETE /admin/bans/{ip}           lift an auto-ban (also clears the kernel set)
 #   GET    /metrics                   Prometheus scrape (same body as the metrics port)
 # admin:
 #   listen: "0.0.0.0:9091"

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -5,8 +5,9 @@
 //! - Runtime inspection (registrations, dialogs, transactions, connections)
 //! - Health/readiness probes (`GET /admin/health`)
 //! - Force-unregister (`DELETE /admin/registrations/:aor`)
+//! - List / lift auto-bans (`GET /admin/bans`, `DELETE /admin/bans/:ip`)
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -61,6 +62,8 @@ fn router(state: AdminState) -> Router {
         .route("/admin/registrations", get(registrations_handler))
         .route("/admin/registrations/{aor}", get(registration_detail_handler))
         .route("/admin/registrations/{aor}", delete(registration_delete_handler))
+        .route("/admin/bans", get(bans_handler))
+        .route("/admin/bans/{ip}", delete(ban_delete_handler))
         .with_state(state)
 }
 
@@ -199,6 +202,56 @@ async fn registration_delete_handler(
         "status": "removed",
         "aor": aor,
     })))
+}
+
+/// `GET /admin/bans` — list the sources currently auto-banned by
+/// `failed_auth_ban`, each with its remaining ban time in seconds. Empty when
+/// the feature is not configured.
+async fn bans_handler() -> impl IntoResponse {
+    let entries: Vec<serde_json::Value> = crate::security::auto_ban()
+        .map(|store| store.banned_sources())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(address, remaining)| {
+            serde_json::json!({
+                "ip": address.to_string(),
+                "expires_remaining": remaining,
+            })
+        })
+        .collect();
+    Json(entries)
+}
+
+/// `DELETE /admin/bans/:ip` — lift an auto-ban early (operator clearing a false
+/// positive). Removes the userspace ban and, when the kernel firewall is wired,
+/// the matching nf_tables element too, so the in-kernel drop is lifted in
+/// lockstep. 404 when the source is not banned or `failed_auth_ban` is off,
+/// 400 when `:ip` is not a valid address.
+async fn ban_delete_handler(Path(ip): Path<String>) -> impl IntoResponse {
+    let address: IpAddr = match ip.parse() {
+        Ok(address) => address,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "invalid IP address", "ip": ip })),
+            );
+        }
+    };
+
+    match crate::security::auto_ban() {
+        Some(store) if store.unban(address) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "unbanned", "ip": address.to_string() })),
+        ),
+        Some(_) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "not banned", "ip": address.to_string() })),
+        ),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "auto-ban not enabled", "ip": address.to_string() })),
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -382,5 +435,44 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    // The auto-ban store is a process-global `OnceLock` that another test in the
+    // lib binary installs, so these assert only what holds regardless of whether
+    // a store is installed (list is always a JSON array; a bad IP is always 400).
+    // The unban / list-contents logic is covered by store-level tests in
+    // `crate::security` where a local store can be constructed deterministically.
+    #[tokio::test]
+    async fn bans_list_returns_json_array() {
+        let app = test_app();
+
+        let response = app
+            .oneshot(Request::get("/admin/bans").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.is_array());
+    }
+
+    #[tokio::test]
+    async fn ban_delete_invalid_ip_returns_400() {
+        let app = test_app();
+
+        let response = app
+            .oneshot(
+                Request::delete("/admin/bans/not-an-ip")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "invalid IP address");
     }
 }

--- a/src/apiban/mod.rs
+++ b/src/apiban/mod.rs
@@ -38,6 +38,9 @@ pub struct ApiBanClient {
     interval: Duration,
     banned: Arc<DashSet<IpAddr>>,
     client: reqwest::Client,
+    /// Optional kernel-firewall handle — fetched IPs are also pushed to the
+    /// nf_tables set (permanently; the blocklist carries no per-IP TTL).
+    firewall: Option<crate::firewall::KernelFirewall>,
 }
 
 impl ApiBanClient {
@@ -53,12 +56,20 @@ impl ApiBanClient {
             interval: Duration::from_secs(config.interval_secs),
             banned: Arc::new(DashSet::new()),
             client,
+            firewall: None,
         })
     }
 
     /// Returns the shared banned IP set for ACL integration.
     pub fn banned(&self) -> Arc<DashSet<IpAddr>> {
         Arc::clone(&self.banned)
+    }
+
+    /// Attach a kernel-firewall handle so fetched IPs are also programmed into
+    /// the nf_tables set, on top of the userspace ACL set.
+    pub fn with_firewall(mut self, firewall: Option<crate::firewall::KernelFirewall>) -> Self {
+        self.firewall = firewall;
+        self
     }
 
     /// Spawn the background polling task. Returns a `JoinHandle` for the poll loop.
@@ -144,6 +155,9 @@ impl ApiBanClient {
                     Ok(ip_address) => {
                         if self.banned.insert(ip_address) {
                             total_added += 1;
+                            if let Some(firewall) = &self.firewall {
+                                firewall.ban_permanent(ip_address);
+                            }
                         }
                     }
                     Err(_) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1202,10 +1202,21 @@ pub struct FirewallConfig {
     /// Set holding banned IPv6 sources. Default: `banned6`.
     #[serde(default = "default_firewall_set_v6")]
     pub set_v6: String,
+    /// Base chain siphon adds the drop rules to. Default: `input`.
+    #[serde(default = "default_firewall_chain")]
+    pub chain: String,
+    /// When true (the default), siphon also owns the chain + drop rules, so no
+    /// manual `nft` step is needed — enabling `firewall` is enough. Set false to
+    /// have siphon manage only the sets and reference them from your own ruleset.
+    #[serde(default = "bool_true")]
+    pub manage_rule: bool,
 }
 
 fn default_firewall_table() -> String {
     "siphon".to_string()
+}
+fn default_firewall_chain() -> String {
+    "input".to_string()
 }
 fn default_firewall_set_v4() -> String {
     "banned4".to_string()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1185,6 +1185,33 @@ pub struct SecurityConfig {
     pub failed_auth_ban: Option<FailedAuthBanConfig>,
     /// APIBAN community blocklist integration.
     pub apiban: Option<ApiBanConfig>,
+    /// Kernel firewall: drop banned sources in the kernel via nf_tables so
+    /// abusive traffic never reaches siphon's socket (Linux only, needs
+    /// `CAP_NET_ADMIN`). Falls back to the userspace ACL when unavailable.
+    pub firewall: Option<FirewallConfig>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct FirewallConfig {
+    /// nf_tables table name siphon owns (family `inet`). Default: `siphon`.
+    #[serde(default = "default_firewall_table")]
+    pub table: String,
+    /// Set holding banned IPv4 sources. Default: `banned4`.
+    #[serde(default = "default_firewall_set_v4")]
+    pub set_v4: String,
+    /// Set holding banned IPv6 sources. Default: `banned6`.
+    #[serde(default = "default_firewall_set_v6")]
+    pub set_v6: String,
+}
+
+fn default_firewall_table() -> String {
+    "siphon".to_string()
+}
+fn default_firewall_set_v4() -> String {
+    "banned4".to_string()
+}
+fn default_firewall_set_v6() -> String {
+    "banned6".to_string()
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1437,6 +1437,8 @@ fn default_metrics_path() -> String {
 ///   `GET /admin/registrations`       list all AoRs + contacts
 ///   `GET /admin/registrations/{aor}` one AoR's contacts
 ///   `DELETE /admin/registrations/{aor}` force-unregister an AoR
+///   `GET /admin/bans`                list active auto-bans + remaining TTL
+///   `DELETE /admin/bans/{ip}`        lift an auto-ban (also clears the kernel set)
 ///   `GET /metrics`                   Prometheus scrape (same body as the metrics port)
 #[derive(Debug, Deserialize, Clone)]
 pub struct AdminConfig {

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -69,7 +69,14 @@ impl KernelFirewall {
 /// typically a missing `CAP_NET_ADMIN`.
 #[cfg(target_os = "linux")]
 pub async fn start(config: &crate::config::FirewallConfig) -> std::io::Result<KernelFirewall> {
-    nftables::ensure_sets(&config.table, &config.set_v4, &config.set_v6).await?;
+    nftables::ensure_firewall(
+        &config.table,
+        &config.chain,
+        &config.set_v4,
+        &config.set_v6,
+        config.manage_rule,
+    )
+    .await?;
 
     let (sender, mut receiver) = mpsc::channel::<Command>(1024);
     let table = config.table.clone();

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -35,9 +35,11 @@ enum Command {
 }
 
 /// Handle to the kernel-firewall actor. Cheap to clone; feeding a ban is a
-/// non-blocking `try_send` that drops silently if the actor's queue is full
-/// (the userspace ACL still enforces the ban, so a dropped kernel update only
-/// costs a little extra CPU until the next ban lands).
+/// non-blocking `try_send` that never blocks the ban/auth hot paths. When the
+/// actor's queue is full the command is dropped — counted on
+/// `siphon_firewall_commands_dropped_total` — and the userspace ACL still
+/// enforces the ban, so a dropped kernel update only costs a little extra CPU
+/// until the next ban lands.
 #[derive(Clone)]
 pub struct KernelFirewall {
     sender: mpsc::Sender<Command>,
@@ -47,19 +49,32 @@ impl KernelFirewall {
     /// Drop `ip` in the kernel for `ttl` (mirrors an auto-ban's TTL so the
     /// kernel expires it in lockstep with the userspace store).
     pub fn ban(&self, ip: IpAddr, ttl: Duration) {
-        let ttl_ms = ttl.as_millis().min(u64::MAX as u128) as u64;
-        let _ = self.sender.try_send(Command::Ban { ip, ttl_ms });
+        // Clamp to ≥ 1 ms: in the kernel set, 0 means PERMANENT — a sub-ms
+        // `ttl` must never silently flip a timed ban into a permanent one.
+        let ttl_ms = ttl.as_millis().clamp(1, u64::MAX as u128) as u64;
+        self.send_command(Command::Ban { ip, ttl_ms });
     }
 
     /// Drop `ip` permanently — for an apiban blocklist entry, which carries no
     /// per-IP lifetime.
     pub fn ban_permanent(&self, ip: IpAddr) {
-        let _ = self.sender.try_send(Command::Ban { ip, ttl_ms: 0 });
+        self.send_command(Command::Ban { ip, ttl_ms: 0 });
     }
 
     /// Lift a ban early (optional; timed elements self-expire).
     pub fn unban(&self, ip: IpAddr) {
-        let _ = self.sender.try_send(Command::Unban { ip });
+        self.send_command(Command::Unban { ip });
+    }
+
+    /// Non-blocking enqueue; a full (or closed) queue drops the command and
+    /// bumps `siphon_firewall_commands_dropped_total` so a ban storm outrunning
+    /// the netlink actor is visible instead of silent.
+    fn send_command(&self, command: Command) {
+        if self.sender.try_send(command).is_err() {
+            if let Some(metrics) = crate::metrics::try_metrics() {
+                metrics.firewall_commands_dropped_total.inc();
+            }
+        }
     }
 }
 
@@ -78,7 +93,13 @@ pub async fn start(config: &crate::config::FirewallConfig) -> std::io::Result<Ke
     )
     .await?;
 
-    let (sender, mut receiver) = mpsc::channel::<Command>(1024);
+    // Sized for the worst realistic burst: the APIBAN poller's first fetch
+    // pushes its whole blocklist (thousands of IPs) as fast as it parses
+    // pages, and a dropped permanent ban is not retried until a restart
+    // re-fetches the full list (the poller's dedupe set never re-pushes a
+    // known IP). Commands are tiny, so headroom is cheap; overflow is counted
+    // on `siphon_firewall_commands_dropped_total`.
+    let (sender, mut receiver) = mpsc::channel::<Command>(8192);
     let table = config.table.clone();
     let set_v4 = config.set_v4.clone();
     let set_v6 = config.set_v6.clone();
@@ -94,6 +115,11 @@ pub async fn start(config: &crate::config::FirewallConfig) -> std::io::Result<Ke
                 }
             };
             if let Err(error) = result {
+                // A failure here means the ban did NOT reach the kernel — the
+                // userspace ACL is the only enforcement left for this source.
+                if let Some(metrics) = crate::metrics::try_metrics() {
+                    metrics.firewall_command_failures_total.inc();
+                }
                 tracing::warn!(%error, "nftables: failed to apply firewall command");
             }
         }

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -1,0 +1,107 @@
+//! Kernel firewall integration — drop banned source IPs in the kernel.
+//!
+//! Siphon already decides *who* to ban (the confidence-weighted
+//! [`crate::security::AutoBanStore`] + the [`crate::apiban`] blocklist) but only
+//! enforces it in userspace via the transport ACL, so every abusive packet
+//! still travels NIC → kernel → siphon before being dropped. This module
+//! mirrors those bans into a kernel nf_tables set with per-element timeouts, so
+//! the kernel drops the traffic before it reaches siphon's socket — real
+//! defense against volume, self-contained (no `nft` shell-out, no daemon), and
+//! the kernel auto-expires bans so there is no unban bookkeeping.
+//!
+//! Linux-only (nf_tables + netlink). The whole feature is opt-in via
+//! `security.firewall` and requires `CAP_NET_ADMIN`; when unavailable siphon
+//! logs a warning and the userspace ACL keeps working.
+//!
+//! A single actor task owns the netlink work; the [`KernelFirewall`] handle
+//! feeds it bans with a non-blocking `try_send`, so the ban / auth hot paths
+//! never block on a syscall.
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+#[cfg(target_os = "linux")]
+pub mod nftables;
+
+/// A command for the firewall actor.
+#[derive(Debug)]
+enum Command {
+    /// Add `ip` to the kernel ban set. `ttl_ms == 0` means permanent.
+    Ban { ip: IpAddr, ttl_ms: u64 },
+    /// Remove `ip` (optional — timed elements self-expire in the kernel).
+    Unban { ip: IpAddr },
+}
+
+/// Handle to the kernel-firewall actor. Cheap to clone; feeding a ban is a
+/// non-blocking `try_send` that drops silently if the actor's queue is full
+/// (the userspace ACL still enforces the ban, so a dropped kernel update only
+/// costs a little extra CPU until the next ban lands).
+#[derive(Clone)]
+pub struct KernelFirewall {
+    sender: mpsc::Sender<Command>,
+}
+
+impl KernelFirewall {
+    /// Drop `ip` in the kernel for `ttl` (mirrors an auto-ban's TTL so the
+    /// kernel expires it in lockstep with the userspace store).
+    pub fn ban(&self, ip: IpAddr, ttl: Duration) {
+        let ttl_ms = ttl.as_millis().min(u64::MAX as u128) as u64;
+        let _ = self.sender.try_send(Command::Ban { ip, ttl_ms });
+    }
+
+    /// Drop `ip` permanently — for an apiban blocklist entry, which carries no
+    /// per-IP lifetime.
+    pub fn ban_permanent(&self, ip: IpAddr) {
+        let _ = self.sender.try_send(Command::Ban { ip, ttl_ms: 0 });
+    }
+
+    /// Lift a ban early (optional; timed elements self-expire).
+    pub fn unban(&self, ip: IpAddr) {
+        let _ = self.sender.try_send(Command::Unban { ip });
+    }
+}
+
+/// Build the kernel firewall: ensure the nf_tables sets exist, then spawn the
+/// actor that applies bans over netlink. Returns an error (so the caller can
+/// warn + fall back to the userspace ACL) when the sets can't be programmed —
+/// typically a missing `CAP_NET_ADMIN`.
+#[cfg(target_os = "linux")]
+pub async fn start(config: &crate::config::FirewallConfig) -> std::io::Result<KernelFirewall> {
+    nftables::ensure_sets(&config.table, &config.set_v4, &config.set_v6).await?;
+
+    let (sender, mut receiver) = mpsc::channel::<Command>(1024);
+    let table = config.table.clone();
+    let set_v4 = config.set_v4.clone();
+    let set_v6 = config.set_v6.clone();
+
+    tokio::spawn(async move {
+        while let Some(command) = receiver.recv().await {
+            let result = match command {
+                Command::Ban { ip, ttl_ms } => {
+                    nftables::add_banned(&table, &set_v4, &set_v6, ip, ttl_ms).await
+                }
+                Command::Unban { ip } => {
+                    nftables::remove_banned(&table, &set_v4, &set_v6, ip).await
+                }
+            };
+            if let Err(error) = result {
+                tracing::warn!(%error, "nftables: failed to apply firewall command");
+            }
+        }
+    });
+
+    tracing::info!(
+        table = %config.table,
+        "kernel firewall active (nf_tables) — banned sources dropped in-kernel"
+    );
+    Ok(KernelFirewall { sender })
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn start(_config: &crate::config::FirewallConfig) -> std::io::Result<KernelFirewall> {
+    Err(std::io::Error::other(
+        "firewall: the nf_tables backend is Linux-only",
+    ))
+}

--- a/src/firewall/nftables.rs
+++ b/src/firewall/nftables.rs
@@ -33,7 +33,6 @@ const NLMSG_ALIGNTO: usize = 4;
 
 const NLM_F_REQUEST: u16 = 0x001;
 const NLM_F_ACK: u16 = 0x004;
-const NLM_F_EXCL: u16 = 0x200;
 const NLM_F_CREATE: u16 = 0x400;
 const NLM_F_APPEND: u16 = 0x800;
 
@@ -97,6 +96,7 @@ const NFTA_LIST_ELEM: u16 = 1;
 
 const NFT_MSG_NEWCHAIN: u16 = 3;
 const NFT_MSG_NEWRULE: u16 = 6;
+const NFT_MSG_DELRULE: u16 = 8;
 
 const NFPROTO_IPV4: u8 = 2;
 const NFPROTO_IPV6: u8 = 10;
@@ -325,13 +325,25 @@ fn build_new_chain(table: &str, chain: &str, seq: u32) -> Vec<u8> {
     nlmsg(nft_type(NFT_MSG_NEWCHAIN), OBJECT_FLAGS, seq, &body)
 }
 
-/// Like `build_new_table` but with `NLM_F_EXCL`, so it fails with `EEXIST` when
-/// the table already exists. This lets the caller tell a first run (create the
-/// chain + rules) from a restart (they already exist) without deleting anything.
-fn build_new_table_exclusive(table: &str, seq: u32) -> Vec<u8> {
+/// Declare siphon's `inet` table. Idempotent (`NLM_F_CREATE`, no `NLM_F_EXCL`),
+/// so a restart re-declares the existing table as a no-op instead of erroring.
+fn build_new_table(table: &str, seq: u32) -> Vec<u8> {
     let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
     push_nla_str(&mut body, NFTA_TABLE_NAME, table);
-    nlmsg(nft_type(NFT_MSG_NEWTABLE), OBJECT_FLAGS | NLM_F_EXCL, seq, &body)
+    nlmsg(nft_type(NFT_MSG_NEWTABLE), OBJECT_FLAGS, seq, &body)
+}
+
+/// Flush every rule in `chain` (`NFT_MSG_DELRULE` with only the table + chain
+/// name and no rule handle deletes all of the chain's rules). Batched directly
+/// before re-appending the drop rules so a restart converges to exactly the
+/// current rule set instead of stacking a duplicate — and because the flush and
+/// the re-append commit in the *same* atomic transaction, the drop rule is never
+/// absent for even an instant.
+fn build_flush_chain(table: &str, chain: &str, seq: u32) -> Vec<u8> {
+    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
+    push_nla_str(&mut body, NFTA_RULE_TABLE, table);
+    push_nla_str(&mut body, NFTA_RULE_CHAIN, chain);
+    nlmsg(nft_type(NFT_MSG_DELRULE), NLM_F_REQUEST | NLM_F_ACK, seq, &body)
 }
 
 /// Append one expression: `NFTA_LIST_ELEM { NFTA_EXPR_NAME, NFTA_EXPR_DATA }`.
@@ -487,64 +499,22 @@ fn count_acks(buffer: &[u8]) -> io::Result<usize> {
     Ok(ok)
 }
 
-/// The errno of the first `NLMSG_ERROR` in a reply, or `None` if there is none.
-fn first_errno(buffer: &[u8]) -> Option<i32> {
-    let mut offset = 0;
-    while offset + NLMSG_HDR_LEN <= buffer.len() {
-        let len = u32::from_ne_bytes([
-            buffer[offset],
-            buffer[offset + 1],
-            buffer[offset + 2],
-            buffer[offset + 3],
-        ]) as usize;
-        let msg_type = u16::from_ne_bytes([buffer[offset + 4], buffer[offset + 5]]);
-        if len < NLMSG_HDR_LEN || offset + len > buffer.len() {
-            return None;
-        }
-        if msg_type == NLMSG_ERROR && len >= NLMSG_HDR_LEN + 4 {
-            return Some(i32::from_ne_bytes([
-                buffer[offset + NLMSG_HDR_LEN],
-                buffer[offset + NLMSG_HDR_LEN + 1],
-                buffer[offset + NLMSG_HDR_LEN + 2],
-                buffer[offset + NLMSG_HDR_LEN + 3],
-            ]));
-        }
-        offset += align_to(len, NLMSG_ALIGNTO);
-    }
-    None
-}
-
-/// Send a single-object batch and report whether the object was newly created
-/// (`Ok(true)`) or already existed (`Ok(false)`, from `EEXIST`).
-async fn send_create_exclusive(message: Vec<u8>) -> io::Result<bool> {
-    const EEXIST: i32 = 17;
-    let batch = wrap_batch(&[message]);
-    let expected = batch.len();
-    tokio::task::spawn_blocking(move || -> io::Result<bool> {
-        let socket = Socket::new(NETLINK_NETFILTER)?;
-        socket.connect(&SocketAddr::new(0, 0))?;
-        let sent = socket.send(&batch, 0)?;
-        if sent != expected {
-            return Err(io::Error::other(format!("nftables: short send ({sent}/{expected})")));
-        }
-        let mut response = vec![0u8; 8192];
-        let received = socket.recv(&mut &mut response[..], 0)?;
-        match first_errno(&response[..received]) {
-            Some(0) | None => Ok(true),
-            Some(errno) if -errno == EEXIST => Ok(false),
-            Some(errno) => Err(io::Error::from_raw_os_error(-errno)),
-        }
-    })
-    .await
-    .map_err(|join| io::Error::other(format!("nftables netlink task panic: {join}")))?
-}
-
 // --- public operations ------------------------------------------------------
 
 /// Ensure the `inet` table + both timeout sets exist, and — when `manage_rule`
-/// — the base chain + drop rules that reference them, all in one idempotent,
-/// atomic transaction. With `manage_rule` the operator needs no manual `nft`
-/// step at all; without it siphon owns only the sets and the operator adds the
+/// — the base chain + drop rules that reference them, all in ONE idempotent,
+/// atomic netlink transaction.
+///
+/// Every object is declared with `NLM_F_CREATE` (a no-op when it already
+/// exists), and the chain's rules are flushed and re-appended, so a first run,
+/// a clean restart, and a restart after a crash that interrupted a previous
+/// setup all converge to exactly the same ruleset — no half-configured state,
+/// no stacked-duplicate rules. Because it is a single `BATCH_BEGIN … BATCH_END`
+/// the kernel applies all of it or none of it, and the drop rule is never
+/// missing for even an instant across the flush/re-append.
+///
+/// With `manage_rule` the operator needs no manual `nft` step at all; without it
+/// siphon owns only the sets and the operator references them from their own
 /// rule.
 pub async fn ensure_firewall(
     table: &str,
@@ -553,35 +523,24 @@ pub async fn ensure_firewall(
     set_v6: &str,
     manage_rule: bool,
 ) -> io::Result<()> {
-    // Create the table exclusively so we can tell a first run (table newly
-    // created) from a restart (table already there). On a restart the chain +
-    // drop rules already exist, so we skip re-adding them and never duplicate.
-    let table_is_new = send_create_exclusive(build_new_table_exclusive(table, 1)).await?;
-
-    // Ensure both timeout sets exist (idempotent).
-    send(
-        wrap_batch(&[
-            build_new_set(table, set_v4, 1, SetFamily::V4, 1),
-            build_new_set(table, set_v6, 2, SetFamily::V6, 2),
-        ]),
-        2,
-    )
-    .await?;
-
-    if manage_rule && table_is_new {
-        // Fresh table: create the base chain, then the drop rules that look the
-        // source address up in the (now committed) sets by name.
-        send(wrap_batch(&[build_new_chain(table, chain, 1)]), 1).await?;
-        send(
-            wrap_batch(&[
-                build_drop_rule(table, chain, set_v4, SetFamily::V4, 1),
-                build_drop_rule(table, chain, set_v6, SetFamily::V6, 2),
-            ]),
-            2,
-        )
-        .await?;
+    // Object seqs run 1..=N within the batch (BATCH_END is N+1, set by
+    // `wrap_batch`). The kernel resolves the rules' set/chain references against
+    // the objects staged earlier in the same transaction, so table → sets →
+    // chain → rules in one batch is self-consistent.
+    let mut messages = vec![
+        build_new_table(table, 1),
+        build_new_set(table, set_v4, 1, SetFamily::V4, 2),
+        build_new_set(table, set_v6, 2, SetFamily::V6, 3),
+    ];
+    if manage_rule {
+        messages.push(build_new_chain(table, chain, 4));
+        // Flush before re-appending so a restart never stacks a duplicate rule.
+        messages.push(build_flush_chain(table, chain, 5));
+        messages.push(build_drop_rule(table, chain, set_v4, SetFamily::V4, 6));
+        messages.push(build_drop_rule(table, chain, set_v6, SetFamily::V6, 7));
     }
-    Ok(())
+    let object_count = messages.len();
+    send(wrap_batch(&messages), object_count).await
 }
 
 /// Add a banned source to the appropriate set with a per-element timeout
@@ -618,6 +577,44 @@ mod tests {
     }
     fn be32_at(buffer: &[u8], offset: usize) -> u32 {
         u32::from_be_bytes([buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3]])
+    }
+    fn be32(payload: &[u8]) -> u32 {
+        u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]])
+    }
+
+    /// Split a sequence of netlink attributes into `(type_without_nested_flag,
+    /// payload)` pairs. `payload` is the value after the 4-byte attr header,
+    /// length `nla_len - 4` (padding excluded). Works for both a top-level
+    /// object body (pass `&message[NLMSG_HDR_LEN + 4..]`, i.e. past nlmsghdr +
+    /// nfgenmsg) and a nested attribute's payload.
+    fn walk_attrs(buffer: &[u8]) -> Vec<(u16, &[u8])> {
+        let mut attrs = Vec::new();
+        let mut offset = 0;
+        while offset + 4 <= buffer.len() {
+            let nla_len = u16_at(buffer, offset) as usize;
+            let nla_type = u16_at(buffer, offset + 2) & !NLA_F_NESTED;
+            if nla_len < 4 || offset + nla_len > buffer.len() {
+                break;
+            }
+            attrs.push((nla_type, &buffer[offset + 4..offset + nla_len]));
+            offset += align_to(nla_len, NLA_ALIGNTO);
+        }
+        attrs
+    }
+
+    /// The payload of the first attribute of `attr_type`, or panic. `expect_msg`
+    /// names the attribute in the failure.
+    fn attr<'a>(attrs: &[(u16, &'a [u8])], attr_type: u16, expect_msg: &str) -> &'a [u8] {
+        attrs
+            .iter()
+            .find(|(ty, _)| *ty == attr_type)
+            .map(|(_, payload)| *payload)
+            .unwrap_or_else(|| panic!("missing attribute: {expect_msg}"))
+    }
+
+    /// The `NFTA_EXPR_DATA` payload of one expression `NFTA_LIST_ELEM`.
+    fn expr_data(expr_elem: &[u8]) -> &[u8] {
+        attr(&walk_attrs(expr_elem), NFTA_EXPR_DATA, "NFTA_EXPR_DATA")
     }
 
     #[test]
@@ -717,8 +714,123 @@ mod tests {
     }
 
     #[test]
+    fn new_chain_carries_hook_type_and_priority() {
+        let message = build_new_chain("siphon", "input", 4);
+        assert_eq!(u16_at(&message, 4), nft_type(NFT_MSG_NEWCHAIN));
+        let attrs = walk_attrs(&message[NLMSG_HDR_LEN + 4..]);
+        assert_eq!(attr(&attrs, NFTA_CHAIN_TABLE, "table"), b"siphon\0");
+        assert_eq!(attr(&attrs, NFTA_CHAIN_NAME, "name"), b"input\0");
+        // A base chain: type "filter", hook = input, priority 0 (NF_IP_PRI_FILTER).
+        assert_eq!(attr(&attrs, NFTA_CHAIN_TYPE, "type"), b"filter\0");
+        let hook = walk_attrs(attr(&attrs, NFTA_CHAIN_HOOK, "hook"));
+        assert_eq!(be32(attr(&hook, NFTA_HOOK_HOOKNUM, "hooknum")), NF_INET_LOCAL_IN);
+        assert_eq!(be32(attr(&hook, NFTA_HOOK_PRIORITY, "priority")), 0);
+    }
+
+    #[test]
+    fn drop_rule_expression_sequence_and_layout() {
+        // The v4 rule: `meta nfproto ipv4; ipv4 saddr @banned4; drop`.
+        let message = build_drop_rule("siphon", "input", "banned4", SetFamily::V4, 6);
+        assert_eq!(u16_at(&message, 4), nft_type(NFT_MSG_NEWRULE));
+        let attrs = walk_attrs(&message[NLMSG_HDR_LEN + 4..]);
+        assert_eq!(attr(&attrs, NFTA_RULE_TABLE, "table"), b"siphon\0");
+        assert_eq!(attr(&attrs, NFTA_RULE_CHAIN, "chain"), b"input\0");
+
+        // Expressions in order: meta, cmp, payload, lookup, immediate.
+        let exprs = walk_attrs(attr(&attrs, NFTA_RULE_EXPRESSIONS, "expressions"));
+        let names: Vec<&[u8]> = exprs
+            .iter()
+            .map(|(_, elem)| attr(&walk_attrs(elem), NFTA_EXPR_NAME, "expr name"))
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                b"meta\0".as_ref(),
+                b"cmp\0",
+                b"payload\0",
+                b"lookup\0",
+                b"immediate\0"
+            ]
+        );
+
+        // meta loads nfproto into reg1.
+        let meta = walk_attrs(expr_data(exprs[0].1));
+        assert_eq!(be32(attr(&meta, NFTA_META_KEY, "meta key")), NFT_META_NFPROTO);
+        assert_eq!(be32(attr(&meta, NFTA_META_DREG, "meta dreg")), NFT_REG_1);
+
+        // cmp reg1 == NFPROTO_IPV4 (a single byte) — the guard that keeps a v6
+        // packet from matching the v4 saddr offset/length in the shared `inet`
+        // chain.
+        let cmp = walk_attrs(expr_data(exprs[1].1));
+        assert_eq!(be32(attr(&cmp, NFTA_CMP_SREG, "cmp sreg")), NFT_REG_1);
+        assert_eq!(be32(attr(&cmp, NFTA_CMP_OP, "cmp op")), NFT_CMP_EQ);
+        let cmp_value = walk_attrs(attr(&cmp, NFTA_CMP_DATA, "cmp data"));
+        assert_eq!(attr(&cmp_value, NFTA_DATA_VALUE, "cmp value"), &[NFPROTO_IPV4]);
+
+        // payload loads the v4 source address: network base, offset 12, len 4.
+        let payload = walk_attrs(expr_data(exprs[2].1));
+        assert_eq!(be32(attr(&payload, NFTA_PAYLOAD_DREG, "dreg")), NFT_REG_1);
+        assert_eq!(
+            be32(attr(&payload, NFTA_PAYLOAD_BASE, "base")),
+            NFT_PAYLOAD_NETWORK_HEADER
+        );
+        assert_eq!(be32(attr(&payload, NFTA_PAYLOAD_OFFSET, "offset")), 12);
+        assert_eq!(be32(attr(&payload, NFTA_PAYLOAD_LEN, "len")), 4);
+
+        // lookup references the set by name.
+        let lookup = walk_attrs(expr_data(exprs[3].1));
+        assert_eq!(be32(attr(&lookup, NFTA_LOOKUP_SREG, "lookup sreg")), NFT_REG_1);
+        assert_eq!(attr(&lookup, NFTA_LOOKUP_SET, "lookup set"), b"banned4\0");
+
+        // immediate verdict = drop, into the verdict register.
+        let immediate = walk_attrs(expr_data(exprs[4].1));
+        assert_eq!(
+            be32(attr(&immediate, NFTA_IMMEDIATE_DREG, "imm dreg")),
+            NFT_REG_VERDICT
+        );
+        let imm_data = walk_attrs(attr(&immediate, NFTA_IMMEDIATE_DATA, "imm data"));
+        let verdict = walk_attrs(attr(&imm_data, NFTA_DATA_VERDICT, "verdict container"));
+        assert_eq!(be32(attr(&verdict, NFTA_VERDICT_CODE, "verdict code")), NF_DROP);
+    }
+
+    #[test]
+    fn drop_rule_v6_uses_ipv6_saddr_offset_and_len() {
+        // The v6 rule must load 16 bytes at offset 8 and guard on NFPROTO_IPV6.
+        let message = build_drop_rule("siphon", "input", "banned6", SetFamily::V6, 6);
+        let attrs = walk_attrs(&message[NLMSG_HDR_LEN + 4..]);
+        let exprs = walk_attrs(attr(&attrs, NFTA_RULE_EXPRESSIONS, "expressions"));
+
+        let cmp = walk_attrs(expr_data(exprs[1].1));
+        let cmp_value = walk_attrs(attr(&cmp, NFTA_CMP_DATA, "cmp data"));
+        assert_eq!(attr(&cmp_value, NFTA_DATA_VALUE, "cmp value"), &[NFPROTO_IPV6]);
+
+        let payload = walk_attrs(expr_data(exprs[2].1));
+        assert_eq!(be32(attr(&payload, NFTA_PAYLOAD_OFFSET, "offset")), 8);
+        assert_eq!(be32(attr(&payload, NFTA_PAYLOAD_LEN, "len")), 16);
+
+        let lookup = walk_attrs(expr_data(exprs[3].1));
+        assert_eq!(attr(&lookup, NFTA_LOOKUP_SET, "lookup set"), b"banned6\0");
+    }
+
+    #[test]
+    fn flush_chain_targets_table_and_chain_with_no_handle() {
+        // A flush is DELRULE carrying only table + chain (no rule handle), so the
+        // kernel drops every rule in the chain.
+        const NFTA_RULE_HANDLE: u16 = 3; // absent = flush all rules in the chain
+        let message = build_flush_chain("siphon", "input", 5);
+        assert_eq!(u16_at(&message, 4), nft_type(NFT_MSG_DELRULE));
+        let attrs = walk_attrs(&message[NLMSG_HDR_LEN + 4..]);
+        assert_eq!(attr(&attrs, NFTA_RULE_TABLE, "table"), b"siphon\0");
+        assert_eq!(attr(&attrs, NFTA_RULE_CHAIN, "chain"), b"input\0");
+        assert!(
+            !attrs.iter().any(|(ty, _)| *ty == NFTA_RULE_HANDLE),
+            "flush must carry no rule handle"
+        );
+    }
+
+    #[test]
     fn batch_wraps_begin_and_end() {
-        let inner = build_new_table_exclusive("siphon", 1);
+        let inner = build_new_table("siphon", 1);
         let batch = wrap_batch(std::slice::from_ref(&inner));
         assert_eq!(u16_at(&batch, 4), NFNL_MSG_BATCH_BEGIN);
         let after_begin = 20; // BATCH_BEGIN = 16 hdr + 4 nfgenmsg

--- a/src/firewall/nftables.rs
+++ b/src/firewall/nftables.rs
@@ -22,8 +22,14 @@
 
 use std::io;
 use std::net::IpAddr;
+use std::time::Duration;
 
 use netlink_sys::{protocols::NETLINK_NETFILTER, Socket, SocketAddr};
+
+/// Upper bound on waiting for a kernel ack (`SO_RCVTIMEO`). Netlink to the
+/// local kernel is reliable, so this never fires in practice — it exists so a
+/// lost ack can never park a `spawn_blocking` thread forever.
+const ACK_RECV_TIMEOUT: Duration = Duration::from_secs(5);
 
 // --- netlink framing (shared shape with src/ipsec/netlink.rs) --------------
 
@@ -279,9 +285,11 @@ fn build_new_set(table: &str, set: &str, set_id: u32, family: SetFamily, seq: u3
     nlmsg(nft_type(NFT_MSG_NEWSET), OBJECT_FLAGS, seq, &body)
 }
 
-/// Encode one set element: nested `NFTA_LIST_ELEM { KEY { DATA_VALUE=ip },
-/// TIMEOUT=ttl_ms }`. `ttl_ms == 0` means never expire.
-fn encode_element(address: &IpAddr, ttl_ms: u64) -> Vec<u8> {
+/// Encode one set element: nested `NFTA_LIST_ELEM { KEY { DATA_VALUE=ip }[,
+/// TIMEOUT=ttl_ms] }`. `ttl_ms` is only meaningful on an add: `Some(0)` means
+/// never expire; a delete passes `None` (it matches on the key alone, so the
+/// attribute is omitted).
+fn encode_element(address: &IpAddr, ttl_ms: Option<u64>) -> Vec<u8> {
     let key_value: Vec<u8> = match address {
         IpAddr::V4(v4) => v4.octets().to_vec(),
         IpAddr::V6(v6) => v6.octets().to_vec(),
@@ -292,14 +300,23 @@ fn encode_element(address: &IpAddr, ttl_ms: u64) -> Vec<u8> {
 
     let mut elem = Vec::new();
     push_nla_nested(&mut elem, NFTA_SET_ELEM_KEY, &data);
-    push_nla_be64(&mut elem, NFTA_SET_ELEM_TIMEOUT, ttl_ms);
+    if let Some(ttl_ms) = ttl_ms {
+        push_nla_be64(&mut elem, NFTA_SET_ELEM_TIMEOUT, ttl_ms);
+    }
 
     let mut list_elem = Vec::new();
     push_nla_nested(&mut list_elem, NFTA_LIST_ELEM, &elem);
     list_elem
 }
 
-fn build_setelem(msg: u16, table: &str, set: &str, address: &IpAddr, ttl_ms: u64, seq: u32) -> Vec<u8> {
+fn build_setelem(
+    msg: u16,
+    table: &str,
+    set: &str,
+    address: &IpAddr,
+    ttl_ms: Option<u64>,
+    seq: u32,
+) -> Vec<u8> {
     let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
     push_nla_str(&mut body, NFTA_SET_ELEM_LIST_TABLE, table);
     push_nla_str(&mut body, NFTA_SET_ELEM_LIST_SET, set);
@@ -432,15 +449,53 @@ fn wrap_batch(messages: &[Vec<u8>]) -> Vec<u8> {
     buffer
 }
 
+const EEXIST: i32 = 17;
+const ENOENT: i32 = 2;
+
+/// Bound the blocking `recv` with `SO_RCVTIMEO` so a lost ack surfaces as an
+/// error instead of parking the thread forever. `netlink-sys` exposes no
+/// timeout setter, so this goes through `libc::setsockopt` on the raw fd
+/// (`libc` is already in the tree as a hard dependency of `netlink-sys`).
+fn set_recv_timeout(socket: &Socket, timeout: Duration) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let timeval = libc::timeval {
+        tv_sec: timeout.as_secs() as libc::time_t,
+        tv_usec: libc::suseconds_t::from(timeout.subsec_micros()),
+    };
+    // SAFETY: plain setsockopt on a socket fd we own, passing a properly sized
+    // and initialized `timeval` — no aliasing, no retained pointers.
+    let result = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            (&raw const timeval).cast::<libc::c_void>(),
+            std::mem::size_of::<libc::timeval>() as libc::socklen_t,
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 /// Send a batch and read its `object_count` per-message acks. A successful
 /// batch yields one errno-0 `NLMSG_ERROR` per acked object message; a failure
 /// yields the offending message's errno and rolls the transaction back
 /// atomically. Blocking I/O is offloaded to `spawn_blocking` (bans are rare, a
-/// fresh socket per transaction is fine — matches the XFRM backend).
-async fn send(buffer: Vec<u8>, object_count: usize) -> io::Result<()> {
+/// fresh socket per transaction is fine — matches the XFRM backend); the recv
+/// is bounded by [`ACK_RECV_TIMEOUT`] so a missing ack cannot wedge the thread.
+///
+/// `benign_errno` is the ONE errno this operation may treat as idempotent
+/// success (see [`count_acks`]). Because a kernel-side benign errno still
+/// aborts the whole transaction, callers must never batch a benign-errno-able
+/// message together with messages whose effects they rely on — element
+/// add/remove are single-message batches for exactly this reason.
+async fn send(buffer: Vec<u8>, object_count: usize, benign_errno: Option<i32>) -> io::Result<()> {
     let expected = buffer.len();
     tokio::task::spawn_blocking(move || -> io::Result<()> {
         let socket = Socket::new(NETLINK_NETFILTER)?;
+        set_recv_timeout(&socket, ACK_RECV_TIMEOUT)?;
         socket.connect(&SocketAddr::new(0, 0))?;
         let sent = socket.send(&buffer, 0)?;
         if sent != expected {
@@ -449,8 +504,17 @@ async fn send(buffer: Vec<u8>, object_count: usize) -> io::Result<()> {
         let mut seen = 0usize;
         let mut response = vec![0u8; 8192];
         while seen < object_count {
-            let received = socket.recv(&mut &mut response[..], 0)?;
-            seen += count_acks(&response[..received])?;
+            let received = socket.recv(&mut &mut response[..], 0).map_err(|error| {
+                if matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut) {
+                    io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("nftables: timed out waiting for kernel ack ({seen}/{object_count} received)"),
+                    )
+                } else {
+                    error
+                }
+            })?;
+            seen += count_acks(&response[..received], benign_errno)?;
         }
         Ok(())
     })
@@ -459,12 +523,14 @@ async fn send(buffer: Vec<u8>, object_count: usize) -> io::Result<()> {
 }
 
 /// Count the errno-0 acks in a reply, returning `Err` on a real kernel error.
-/// `EEXIST` (add of an existing element) and `ENOENT` (delete of a missing
-/// element, e.g. one the kernel already expired) are benign idempotency cases
-/// and count as success.
-fn count_acks(buffer: &[u8]) -> io::Result<usize> {
-    const EEXIST: i32 = 17;
-    const ENOENT: i32 = 2;
+///
+/// `benign_errno` scopes idempotency to the operation at hand instead of
+/// blanket-accepting: an add may treat `EEXIST` (element already present) as
+/// success, a delete may treat `ENOENT` (element already expired) as success —
+/// but an add must NOT swallow `ENOENT`, because there it means the set/table
+/// is gone (e.g. an operator `nft flush ruleset`) and kernel enforcement has
+/// silently stopped. That case must surface so the actor can log it.
+fn count_acks(buffer: &[u8], benign_errno: Option<i32>) -> io::Result<usize> {
     let mut offset = 0;
     let mut ok = 0;
     while offset + NLMSG_HDR_LEN <= buffer.len() {
@@ -488,7 +554,7 @@ fn count_acks(buffer: &[u8]) -> io::Result<usize> {
                 buffer[offset + NLMSG_HDR_LEN + 2],
                 buffer[offset + NLMSG_HDR_LEN + 3],
             ]);
-            if errno == 0 || -errno == EEXIST || -errno == ENOENT {
+            if errno == 0 || Some(-errno) == benign_errno {
                 ok += 1;
             } else {
                 return Err(io::Error::from_raw_os_error(-errno));
@@ -540,28 +606,34 @@ pub async fn ensure_firewall(
         messages.push(build_drop_rule(table, chain, set_v6, SetFamily::V6, 7));
     }
     let object_count = messages.len();
-    send(wrap_batch(&messages), object_count).await
+    // No benign errno: every object is declared with `NLM_F_CREATE` (existing
+    // objects ack errno-0, never `EEXIST`), so ANY errno here is a real,
+    // batch-aborting failure that must reach the caller.
+    send(wrap_batch(&messages), object_count, None).await
 }
 
 /// Add a banned source to the appropriate set with a per-element timeout
-/// (`ttl_ms == 0` = permanent, e.g. an apiban entry).
+/// (`ttl_ms == 0` = permanent, e.g. an apiban entry). `EEXIST` (element already
+/// present, e.g. an apiban re-push after restart) is idempotent success;
+/// `ENOENT` (set/table gone) is a real error and surfaces.
 pub async fn add_banned(table: &str, set_v4: &str, set_v6: &str, address: IpAddr, ttl_ms: u64) -> io::Result<()> {
     let set = match SetFamily::of(&address) {
         SetFamily::V4 => set_v4,
         SetFamily::V6 => set_v6,
     };
-    let message = build_setelem(NFT_MSG_NEWSETELEM, table, set, &address, ttl_ms, 1);
-    send(wrap_batch(&[message]), 1).await
+    let message = build_setelem(NFT_MSG_NEWSETELEM, table, set, &address, Some(ttl_ms), 1);
+    send(wrap_batch(&[message]), 1, Some(EEXIST)).await
 }
 
 /// Remove a banned source (optional — the kernel auto-expires timed elements).
+/// `ENOENT` (the kernel already expired the element) is idempotent success.
 pub async fn remove_banned(table: &str, set_v4: &str, set_v6: &str, address: IpAddr) -> io::Result<()> {
     let set = match SetFamily::of(&address) {
         SetFamily::V4 => set_v4,
         SetFamily::V6 => set_v6,
     };
-    let message = build_setelem(NFT_MSG_DELSETELEM, table, set, &address, 0, 1);
-    send(wrap_batch(&[message]), 1).await
+    let message = build_setelem(NFT_MSG_DELSETELEM, table, set, &address, None, 1);
+    send(wrap_batch(&[message]), 1, Some(ENOENT)).await
 }
 
 #[cfg(test)]
@@ -574,9 +646,6 @@ mod tests {
     }
     fn u32_at(buffer: &[u8], offset: usize) -> u32 {
         u32::from_ne_bytes([buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3]])
-    }
-    fn be32_at(buffer: &[u8], offset: usize) -> u32 {
-        u32::from_be_bytes([buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3]])
     }
     fn be32(payload: &[u8]) -> u32 {
         u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]])
@@ -669,37 +738,30 @@ mod tests {
     }
 
     #[test]
-    fn new_set_carries_timeout_flag_keytype_keylen() {
+    fn new_set_carries_timeout_flag_keytype_keylen_and_set_id() {
         let message = build_new_set("siphon", "banned4", 1, SetFamily::V4, 2);
-        let mut offset = NLMSG_HDR_LEN + 4; // past nlmsghdr + nfgenmsg
-        let (mut flags, mut key_type, mut key_len) = (None, None, None);
-        while offset + 4 <= message.len() {
-            let nla_len = u16_at(&message, offset) as usize;
-            let nla_type = u16_at(&message, offset + 2) & !NLA_F_NESTED;
-            if nla_len < 4 {
-                break;
-            }
-            match nla_type {
-                NFTA_SET_FLAGS => flags = Some(be32_at(&message, offset + 4)),
-                NFTA_SET_KEY_TYPE => key_type = Some(be32_at(&message, offset + 4)),
-                NFTA_SET_KEY_LEN => key_len = Some(be32_at(&message, offset + 4)),
-                _ => {}
-            }
-            offset += align_to(nla_len, NLA_ALIGNTO);
-        }
-        assert_eq!(flags, Some(NFT_SET_TIMEOUT));
-        assert_eq!(key_type, Some(NFT_TYPE_IPADDR)); // 7
-        assert_eq!(key_len, Some(4));
+        let attrs = walk_attrs(&message[NLMSG_HDR_LEN + 4..]);
+        assert_eq!(attr(&attrs, NFTA_SET_TABLE, "table"), b"siphon\0");
+        assert_eq!(attr(&attrs, NFTA_SET_NAME, "name"), b"banned4\0");
+        assert_eq!(be32(attr(&attrs, NFTA_SET_FLAGS, "flags")), NFT_SET_TIMEOUT);
+        assert_eq!(be32(attr(&attrs, NFTA_SET_KEY_TYPE, "key type")), NFT_TYPE_IPADDR);
+        assert_eq!(be32(attr(&attrs, NFTA_SET_KEY_LEN, "key len")), 4);
+        // NFTA_SET_ID is REQUIRED by the kernel for NEWSET (nf_tables_newset
+        // returns EINVAL without it) — it identifies the set within a batch.
+        assert_eq!(be32(attr(&attrs, NFTA_SET_ID, "set id")), 1);
     }
 
     #[test]
     fn element_encodes_ipv4_key_and_be_timeout() {
-        let element = encode_element(&IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), 3_600_000);
+        let element = encode_element(&IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), Some(3_600_000));
         assert_eq!(u16_at(&element, 2) & !NLA_F_NESTED, NFTA_LIST_ELEM);
-        assert!(element.windows(4).any(|w| w == [203, 0, 113, 5]), "raw IPv4 octets");
-        assert!(
-            element.windows(8).any(|w| w == 3_600_000u64.to_be_bytes()),
-            "timeout must be big-endian u64"
+        let elem = walk_attrs(attr(&walk_attrs(&element), NFTA_LIST_ELEM, "list elem"));
+        let key = walk_attrs(attr(&elem, NFTA_SET_ELEM_KEY, "key"));
+        assert_eq!(attr(&key, NFTA_DATA_VALUE, "key value"), &[203, 0, 113, 5]);
+        assert_eq!(
+            attr(&elem, NFTA_SET_ELEM_TIMEOUT, "timeout"),
+            &3_600_000u64.to_be_bytes(),
+            "timeout must be big-endian u64 milliseconds"
         );
     }
 
@@ -709,8 +771,47 @@ mod tests {
         assert_eq!(SetFamily::V6.key_type(), NFT_TYPE_IP6ADDR);
         assert_eq!(SetFamily::of(&IpAddr::V6(Ipv6Addr::LOCALHOST)), SetFamily::V6);
         let octets: [u8; 16] = "2001:db8::1".parse::<Ipv6Addr>().unwrap().octets();
-        let element = encode_element(&IpAddr::V6("2001:db8::1".parse().unwrap()), 0);
+        let element = encode_element(&IpAddr::V6("2001:db8::1".parse().unwrap()), Some(0));
         assert!(element.windows(16).any(|w| w == octets));
+    }
+
+    #[test]
+    fn setelem_add_carries_table_set_key_and_timeout() {
+        let address: IpAddr = "203.0.113.5".parse().unwrap();
+        let message = build_setelem(
+            NFT_MSG_NEWSETELEM,
+            "siphon",
+            "banned4",
+            &address,
+            Some(60_000),
+            1,
+        );
+        assert_eq!(u16_at(&message, 4), nft_type(NFT_MSG_NEWSETELEM));
+        let attrs = walk_attrs(&message[NLMSG_HDR_LEN + 4..]);
+        assert_eq!(attr(&attrs, NFTA_SET_ELEM_LIST_TABLE, "table"), b"siphon\0");
+        assert_eq!(attr(&attrs, NFTA_SET_ELEM_LIST_SET, "set"), b"banned4\0");
+        let elements = walk_attrs(attr(&attrs, NFTA_SET_ELEM_LIST_ELEMENTS, "elements"));
+        let elem = walk_attrs(attr(&elements, NFTA_LIST_ELEM, "list elem"));
+        let key = walk_attrs(attr(&elem, NFTA_SET_ELEM_KEY, "key"));
+        assert_eq!(attr(&key, NFTA_DATA_VALUE, "key value"), &[203, 0, 113, 5]);
+        assert_eq!(attr(&elem, NFTA_SET_ELEM_TIMEOUT, "timeout"), &60_000u64.to_be_bytes());
+    }
+
+    #[test]
+    fn setelem_delete_matches_on_key_alone() {
+        // A delete matches on the key; it must not carry a timeout attribute.
+        let address: IpAddr = "203.0.113.5".parse().unwrap();
+        let message = build_setelem(NFT_MSG_DELSETELEM, "siphon", "banned4", &address, None, 1);
+        assert_eq!(u16_at(&message, 4), nft_type(NFT_MSG_DELSETELEM));
+        let attrs = walk_attrs(&message[NLMSG_HDR_LEN + 4..]);
+        let elements = walk_attrs(attr(&attrs, NFTA_SET_ELEM_LIST_ELEMENTS, "elements"));
+        let elem = walk_attrs(attr(&elements, NFTA_LIST_ELEM, "list elem"));
+        let key = walk_attrs(attr(&elem, NFTA_SET_ELEM_KEY, "key"));
+        assert_eq!(attr(&key, NFTA_DATA_VALUE, "key value"), &[203, 0, 113, 5]);
+        assert!(
+            !elem.iter().any(|(ty, _)| *ty == NFTA_SET_ELEM_TIMEOUT),
+            "delete must not carry NFTA_SET_ELEM_TIMEOUT"
+        );
     }
 
     #[test]
@@ -842,13 +943,31 @@ mod tests {
     #[test]
     fn count_acks_success_and_error() {
         let ok = nlmsg(NLMSG_ERROR, 0, 1, &0i32.to_ne_bytes());
-        assert_eq!(count_acks(&ok).unwrap(), 1);
-        let eexist = nlmsg(NLMSG_ERROR, 0, 1, &(-17i32).to_ne_bytes());
-        assert_eq!(count_acks(&eexist).unwrap(), 1); // idempotent
-        let enoent = nlmsg(NLMSG_ERROR, 0, 1, &(-2i32).to_ne_bytes());
-        assert_eq!(count_acks(&enoent).unwrap(), 1); // idempotent delete
+        assert_eq!(count_acks(&ok, None).unwrap(), 1);
         let eperm = nlmsg(NLMSG_ERROR, 0, 1, &(-1i32).to_ne_bytes());
-        assert!(count_acks(&eperm).is_err());
+        assert!(count_acks(&eperm, None).is_err());
+        // Two acks coalesced into one datagram both count.
+        let mut two = nlmsg(NLMSG_ERROR, 0, 1, &0i32.to_ne_bytes());
+        two.extend_from_slice(&nlmsg(NLMSG_ERROR, 0, 2, &0i32.to_ne_bytes()));
+        assert_eq!(count_acks(&two, None).unwrap(), 2);
+    }
+
+    #[test]
+    fn count_acks_benign_errno_is_operation_scoped() {
+        let eexist = nlmsg(NLMSG_ERROR, 0, 1, &(-EEXIST).to_ne_bytes());
+        let enoent = nlmsg(NLMSG_ERROR, 0, 1, &(-ENOENT).to_ne_bytes());
+        // Add: re-adding an existing element is idempotent success...
+        assert_eq!(count_acks(&eexist, Some(EEXIST)).unwrap(), 1);
+        // ...but a missing set/table (operator flushed the ruleset) is a REAL
+        // error — swallowing it would silently disable kernel enforcement.
+        assert!(count_acks(&enoent, Some(EEXIST)).is_err());
+        // Delete: removing an already-expired element is idempotent success.
+        assert_eq!(count_acks(&enoent, Some(ENOENT)).unwrap(), 1);
+        assert!(count_acks(&eexist, Some(ENOENT)).is_err());
+        // Ensure: nothing is benign — every object uses NLM_F_CREATE, so any
+        // errno means the atomic batch was rolled back.
+        assert!(count_acks(&eexist, None).is_err());
+        assert!(count_acks(&enoent, None).is_err());
     }
 
     /// End-to-end against the real kernel. Needs `CAP_NET_ADMIN`; run in a
@@ -869,12 +988,36 @@ mod tests {
             add_banned("siphon", "banned4", "banned6", "203.0.113.5".parse().unwrap(), 3_600_000)
                 .await
                 .expect("add v4");
+            // Timed element that STAYS, so `nft list` shows its timeout below.
+            add_banned("siphon", "banned4", "banned6", "198.51.100.7".parse().unwrap(), 3_600_000)
+                .await
+                .expect("add v4 timed");
             add_banned("siphon", "banned4", "banned6", "2001:db8::1".parse().unwrap(), 0)
                 .await
                 .expect("add v6 permanent");
+            // Re-adding an existing element (apiban re-push after restart) is
+            // idempotent success, not an error.
+            add_banned("siphon", "banned4", "banned6", "2001:db8::1".parse().unwrap(), 0)
+                .await
+                .expect("re-add v6 must be idempotent");
             remove_banned("siphon", "banned4", "banned6", "203.0.113.5".parse().unwrap())
                 .await
                 .expect("remove v4");
+            // Removing an element the kernel already expired/never had is
+            // idempotent success.
+            remove_banned("siphon", "banned4", "banned6", "203.0.113.99".parse().unwrap())
+                .await
+                .expect("remove of a missing element must be idempotent");
+            // But an add into a missing set is a REAL failure and must surface
+            // (a swallowed ENOENT here would silently disable kernel
+            // enforcement while siphon believes bans are being dropped).
+            add_banned("siphon", "no_such_set", "no_such_set6", "203.0.113.5".parse().unwrap(), 0)
+                .await
+                .expect_err("add into a missing set must error, not silently succeed");
+            // manage_rule=false owns only table + sets — no chain, no rules.
+            ensure_firewall("siphon_sets", "input", "banned4", "banned6", false)
+                .await
+                .expect("ensure_firewall sets-only");
         });
 
         let output = std::process::Command::new("nft")
@@ -887,11 +1030,27 @@ mod tests {
         assert!(text.contains("2001:db8::1"), "v6 permanent element missing:\n{text}");
         assert!(text.contains("flags timeout"), "timeout flag missing:\n{text}");
         assert!(!text.contains("203.0.113.5"), "removed v4 element still present:\n{text}");
+        // The timed element must carry a kernel-side expiry.
+        assert!(text.contains("198.51.100.7"), "timed v4 element missing:\n{text}");
+        assert!(text.contains("expires"), "per-element timeout not armed:\n{text}");
         // Self-contained chain + drop rules.
         assert!(text.contains("chain input"), "base chain missing:\n{text}");
         assert!(text.contains("@banned4") && text.contains("@banned6"), "drop rules missing:\n{text}");
         assert!(text.contains("drop"), "drop verdict missing:\n{text}");
         // The double ensure_firewall must NOT have duplicated the rules.
         assert_eq!(text.matches("@banned4 drop").count(), 1, "duplicate v4 drop rule:\n{text}");
+        assert_eq!(text.matches("@banned6 drop").count(), 1, "duplicate v6 drop rule:\n{text}");
+
+        // The sets-only table: sets exist, but no chain and no rules.
+        let output = std::process::Command::new("nft")
+            .args(["list", "table", "inet", "siphon_sets"])
+            .output()
+            .expect("run nft");
+        let sets_only = String::from_utf8_lossy(&output.stdout);
+        assert!(sets_only.contains("banned4"), "sets-only table missing sets:\n{sets_only}");
+        assert!(
+            !sets_only.contains("chain"),
+            "manage_rule=false must not create a chain:\n{sets_only}"
+        );
     }
 }

--- a/src/firewall/nftables.rs
+++ b/src/firewall/nftables.rs
@@ -33,7 +33,9 @@ const NLMSG_ALIGNTO: usize = 4;
 
 const NLM_F_REQUEST: u16 = 0x001;
 const NLM_F_ACK: u16 = 0x004;
+const NLM_F_EXCL: u16 = 0x200;
 const NLM_F_CREATE: u16 = 0x400;
+const NLM_F_APPEND: u16 = 0x800;
 
 const NLMSG_ERROR: u16 = 0x2;
 
@@ -91,6 +93,61 @@ const NFTA_DATA_VALUE: u16 = 1;
 // Generic `enum nft_list_attributes` element wrapper.
 const NFTA_LIST_ELEM: u16 = 1;
 
+// --- self-contained chain + drop rule (manage_rule) ------------------------
+
+const NFT_MSG_NEWCHAIN: u16 = 3;
+const NFT_MSG_NEWRULE: u16 = 6;
+
+const NFPROTO_IPV4: u8 = 2;
+const NFPROTO_IPV6: u8 = 10;
+const NF_INET_LOCAL_IN: u32 = 1;
+const NF_DROP: u32 = 0;
+
+// `enum nft_chain_attributes`
+const NFTA_CHAIN_TABLE: u16 = 1;
+const NFTA_CHAIN_NAME: u16 = 3;
+const NFTA_CHAIN_HOOK: u16 = 4;
+const NFTA_CHAIN_TYPE: u16 = 7;
+// `enum nft_hook_attributes`
+const NFTA_HOOK_HOOKNUM: u16 = 1;
+const NFTA_HOOK_PRIORITY: u16 = 2;
+
+// `enum nft_rule_attributes`
+const NFTA_RULE_TABLE: u16 = 1;
+const NFTA_RULE_CHAIN: u16 = 2;
+const NFTA_RULE_EXPRESSIONS: u16 = 4;
+// `enum nft_expr_attributes`
+const NFTA_EXPR_NAME: u16 = 1;
+const NFTA_EXPR_DATA: u16 = 2;
+
+// expression payloads
+const NFTA_PAYLOAD_DREG: u16 = 1;
+const NFTA_PAYLOAD_BASE: u16 = 2;
+const NFTA_PAYLOAD_OFFSET: u16 = 3;
+const NFTA_PAYLOAD_LEN: u16 = 4;
+const NFT_PAYLOAD_NETWORK_HEADER: u32 = 1;
+
+const NFTA_LOOKUP_SET: u16 = 1;
+const NFTA_LOOKUP_SREG: u16 = 2;
+
+const NFTA_IMMEDIATE_DREG: u16 = 1;
+const NFTA_IMMEDIATE_DATA: u16 = 2;
+const NFTA_VERDICT_CODE: u16 = 1;
+const NFTA_DATA_VERDICT: u16 = 2;
+
+const NFTA_META_DREG: u16 = 1;
+const NFTA_META_KEY: u16 = 2;
+const NFT_META_NFPROTO: u32 = 15;
+
+const NFTA_CMP_SREG: u16 = 1;
+const NFTA_CMP_OP: u16 = 2;
+const NFTA_CMP_DATA: u16 = 3;
+const NFT_CMP_EQ: u32 = 0;
+
+// nf_tables registers: `NFT_REG_1` (first data register), `NFT_REG_VERDICT`.
+const NFT_REG_1: u32 = 1;
+const NFT_REG_VERDICT: u32 = 0;
+
 /// Which IP family a set holds. An `inet` table holds both via two typed sets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SetFamily {
@@ -110,6 +167,21 @@ impl SetFamily {
         match self {
             SetFamily::V4 => NFT_TYPE_IPADDR,
             SetFamily::V6 => NFT_TYPE_IP6ADDR,
+        }
+    }
+
+    fn nfproto(self) -> u8 {
+        match self {
+            SetFamily::V4 => NFPROTO_IPV4,
+            SetFamily::V6 => NFPROTO_IPV6,
+        }
+    }
+
+    /// Offset of the source address within the L3 (network) header.
+    fn saddr_offset(self) -> u32 {
+        match self {
+            SetFamily::V4 => 12,
+            SetFamily::V6 => 8,
         }
     }
 
@@ -193,12 +265,6 @@ const OBJECT_FLAGS: u16 = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE;
 
 // --- object message builders (each returns one full nlmsg) -----------------
 
-fn build_new_table(table: &str, seq: u32) -> Vec<u8> {
-    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
-    push_nla_str(&mut body, NFTA_TABLE_NAME, table);
-    nlmsg(nft_type(NFT_MSG_NEWTABLE), OBJECT_FLAGS, seq, &body)
-}
-
 /// Create a timeout set (`flags timeout`) keyed by a bare IPv4/IPv6 address.
 /// Idempotent (`NLM_F_CREATE`, no `NLM_F_EXCL`) so re-running siphon does not
 /// error on an existing set.
@@ -240,6 +306,92 @@ fn build_setelem(msg: u16, table: &str, set: &str, address: &IpAddr, ttl_ms: u64
     let elements = encode_element(address, ttl_ms);
     push_nla_nested(&mut body, NFTA_SET_ELEM_LIST_ELEMENTS, &elements);
     nlmsg(nft_type(msg), OBJECT_FLAGS, seq, &body)
+}
+
+// --- self-contained chain + drop rule builders -----------------------------
+
+/// Create the base chain that hosts the drop rules
+/// (`type filter hook input priority 0; policy accept`). Idempotent.
+fn build_new_chain(table: &str, chain: &str, seq: u32) -> Vec<u8> {
+    let mut hook = Vec::new();
+    push_nla_be32(&mut hook, NFTA_HOOK_HOOKNUM, NF_INET_LOCAL_IN);
+    push_nla_be32(&mut hook, NFTA_HOOK_PRIORITY, 0); // NF_IP_PRI_FILTER
+
+    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
+    push_nla_str(&mut body, NFTA_CHAIN_TABLE, table);
+    push_nla_str(&mut body, NFTA_CHAIN_NAME, chain);
+    push_nla_nested(&mut body, NFTA_CHAIN_HOOK, &hook);
+    push_nla_str(&mut body, NFTA_CHAIN_TYPE, "filter");
+    nlmsg(nft_type(NFT_MSG_NEWCHAIN), OBJECT_FLAGS, seq, &body)
+}
+
+/// Like `build_new_table` but with `NLM_F_EXCL`, so it fails with `EEXIST` when
+/// the table already exists. This lets the caller tell a first run (create the
+/// chain + rules) from a restart (they already exist) without deleting anything.
+fn build_new_table_exclusive(table: &str, seq: u32) -> Vec<u8> {
+    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
+    push_nla_str(&mut body, NFTA_TABLE_NAME, table);
+    nlmsg(nft_type(NFT_MSG_NEWTABLE), OBJECT_FLAGS | NLM_F_EXCL, seq, &body)
+}
+
+/// Append one expression: `NFTA_LIST_ELEM { NFTA_EXPR_NAME, NFTA_EXPR_DATA }`.
+fn push_expr(list: &mut Vec<u8>, name: &str, data: &[u8]) {
+    let mut expr = Vec::new();
+    push_nla_str(&mut expr, NFTA_EXPR_NAME, name);
+    push_nla_nested(&mut expr, NFTA_EXPR_DATA, data);
+    push_nla_nested(list, NFTA_LIST_ELEM, &expr);
+}
+
+/// Build a rule that drops packets whose source address is in `set`, scoped to
+/// `family` via a leading `meta nfproto` guard (the chain is `inet`, so it sees
+/// both families): `meta nfproto <fam>; <fam> saddr @<set>; drop`.
+fn build_drop_rule(table: &str, chain: &str, set: &str, family: SetFamily, seq: u32) -> Vec<u8> {
+    // meta nfproto -> reg1
+    let mut meta = Vec::new();
+    push_nla_be32(&mut meta, NFTA_META_KEY, NFT_META_NFPROTO);
+    push_nla_be32(&mut meta, NFTA_META_DREG, NFT_REG_1);
+
+    // cmp reg1 == nfproto (a single byte)
+    let mut cmp_value = Vec::new();
+    push_nla(&mut cmp_value, NFTA_DATA_VALUE, &[family.nfproto()]);
+    let mut cmp = Vec::new();
+    push_nla_be32(&mut cmp, NFTA_CMP_SREG, NFT_REG_1);
+    push_nla_be32(&mut cmp, NFTA_CMP_OP, NFT_CMP_EQ);
+    push_nla_nested(&mut cmp, NFTA_CMP_DATA, &cmp_value);
+
+    // payload: load the network-header source address into reg1
+    let mut payload = Vec::new();
+    push_nla_be32(&mut payload, NFTA_PAYLOAD_DREG, NFT_REG_1);
+    push_nla_be32(&mut payload, NFTA_PAYLOAD_BASE, NFT_PAYLOAD_NETWORK_HEADER);
+    push_nla_be32(&mut payload, NFTA_PAYLOAD_OFFSET, family.saddr_offset());
+    push_nla_be32(&mut payload, NFTA_PAYLOAD_LEN, family.key_len());
+
+    // lookup reg1 in @set (by name — the set is already committed).
+    let mut lookup = Vec::new();
+    push_nla_be32(&mut lookup, NFTA_LOOKUP_SREG, NFT_REG_1);
+    push_nla_str(&mut lookup, NFTA_LOOKUP_SET, set);
+
+    // immediate verdict drop
+    let mut verdict = Vec::new();
+    push_nla_be32(&mut verdict, NFTA_VERDICT_CODE, NF_DROP);
+    let mut immediate_data = Vec::new();
+    push_nla_nested(&mut immediate_data, NFTA_DATA_VERDICT, &verdict);
+    let mut immediate = Vec::new();
+    push_nla_be32(&mut immediate, NFTA_IMMEDIATE_DREG, NFT_REG_VERDICT);
+    push_nla_nested(&mut immediate, NFTA_IMMEDIATE_DATA, &immediate_data);
+
+    let mut expressions = Vec::new();
+    push_expr(&mut expressions, "meta", &meta);
+    push_expr(&mut expressions, "cmp", &cmp);
+    push_expr(&mut expressions, "payload", &payload);
+    push_expr(&mut expressions, "lookup", &lookup);
+    push_expr(&mut expressions, "immediate", &immediate);
+
+    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
+    push_nla_str(&mut body, NFTA_RULE_TABLE, table);
+    push_nla_str(&mut body, NFTA_RULE_CHAIN, chain);
+    push_nla_nested(&mut body, NFTA_RULE_EXPRESSIONS, &expressions);
+    nlmsg(nft_type(NFT_MSG_NEWRULE), OBJECT_FLAGS | NLM_F_APPEND, seq, &body)
 }
 
 // --- batch framing + transport ---------------------------------------------
@@ -335,16 +487,101 @@ fn count_acks(buffer: &[u8]) -> io::Result<usize> {
     Ok(ok)
 }
 
+/// The errno of the first `NLMSG_ERROR` in a reply, or `None` if there is none.
+fn first_errno(buffer: &[u8]) -> Option<i32> {
+    let mut offset = 0;
+    while offset + NLMSG_HDR_LEN <= buffer.len() {
+        let len = u32::from_ne_bytes([
+            buffer[offset],
+            buffer[offset + 1],
+            buffer[offset + 2],
+            buffer[offset + 3],
+        ]) as usize;
+        let msg_type = u16::from_ne_bytes([buffer[offset + 4], buffer[offset + 5]]);
+        if len < NLMSG_HDR_LEN || offset + len > buffer.len() {
+            return None;
+        }
+        if msg_type == NLMSG_ERROR && len >= NLMSG_HDR_LEN + 4 {
+            return Some(i32::from_ne_bytes([
+                buffer[offset + NLMSG_HDR_LEN],
+                buffer[offset + NLMSG_HDR_LEN + 1],
+                buffer[offset + NLMSG_HDR_LEN + 2],
+                buffer[offset + NLMSG_HDR_LEN + 3],
+            ]));
+        }
+        offset += align_to(len, NLMSG_ALIGNTO);
+    }
+    None
+}
+
+/// Send a single-object batch and report whether the object was newly created
+/// (`Ok(true)`) or already existed (`Ok(false)`, from `EEXIST`).
+async fn send_create_exclusive(message: Vec<u8>) -> io::Result<bool> {
+    const EEXIST: i32 = 17;
+    let batch = wrap_batch(&[message]);
+    let expected = batch.len();
+    tokio::task::spawn_blocking(move || -> io::Result<bool> {
+        let socket = Socket::new(NETLINK_NETFILTER)?;
+        socket.connect(&SocketAddr::new(0, 0))?;
+        let sent = socket.send(&batch, 0)?;
+        if sent != expected {
+            return Err(io::Error::other(format!("nftables: short send ({sent}/{expected})")));
+        }
+        let mut response = vec![0u8; 8192];
+        let received = socket.recv(&mut &mut response[..], 0)?;
+        match first_errno(&response[..received]) {
+            Some(0) | None => Ok(true),
+            Some(errno) if -errno == EEXIST => Ok(false),
+            Some(errno) => Err(io::Error::from_raw_os_error(-errno)),
+        }
+    })
+    .await
+    .map_err(|join| io::Error::other(format!("nftables netlink task panic: {join}")))?
+}
+
 // --- public operations ------------------------------------------------------
 
-/// Ensure the `inet` table + both timeout sets exist (idempotent).
-pub async fn ensure_sets(table: &str, set_v4: &str, set_v6: &str) -> io::Result<()> {
-    let messages = vec![
-        build_new_table(table, 1),
-        build_new_set(table, set_v4, 1, SetFamily::V4, 2),
-        build_new_set(table, set_v6, 2, SetFamily::V6, 3),
-    ];
-    send(wrap_batch(&messages), messages.len()).await
+/// Ensure the `inet` table + both timeout sets exist, and — when `manage_rule`
+/// — the base chain + drop rules that reference them, all in one idempotent,
+/// atomic transaction. With `manage_rule` the operator needs no manual `nft`
+/// step at all; without it siphon owns only the sets and the operator adds the
+/// rule.
+pub async fn ensure_firewall(
+    table: &str,
+    chain: &str,
+    set_v4: &str,
+    set_v6: &str,
+    manage_rule: bool,
+) -> io::Result<()> {
+    // Create the table exclusively so we can tell a first run (table newly
+    // created) from a restart (table already there). On a restart the chain +
+    // drop rules already exist, so we skip re-adding them and never duplicate.
+    let table_is_new = send_create_exclusive(build_new_table_exclusive(table, 1)).await?;
+
+    // Ensure both timeout sets exist (idempotent).
+    send(
+        wrap_batch(&[
+            build_new_set(table, set_v4, 1, SetFamily::V4, 1),
+            build_new_set(table, set_v6, 2, SetFamily::V6, 2),
+        ]),
+        2,
+    )
+    .await?;
+
+    if manage_rule && table_is_new {
+        // Fresh table: create the base chain, then the drop rules that look the
+        // source address up in the (now committed) sets by name.
+        send(wrap_batch(&[build_new_chain(table, chain, 1)]), 1).await?;
+        send(
+            wrap_batch(&[
+                build_drop_rule(table, chain, set_v4, SetFamily::V4, 1),
+                build_drop_rule(table, chain, set_v6, SetFamily::V6, 2),
+            ]),
+            2,
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 /// Add a banned source to the appropriate set with a per-element timeout
@@ -481,7 +718,7 @@ mod tests {
 
     #[test]
     fn batch_wraps_begin_and_end() {
-        let inner = build_new_table("siphon", 1);
+        let inner = build_new_table_exclusive("siphon", 1);
         let batch = wrap_batch(std::slice::from_ref(&inner));
         assert_eq!(u16_at(&batch, 4), NFNL_MSG_BATCH_BEGIN);
         let after_begin = 20; // BATCH_BEGIN = 16 hdr + 4 nfgenmsg
@@ -510,8 +747,13 @@ mod tests {
     fn live_kernel_roundtrip() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
-            ensure_sets("siphon", "banned4", "banned6").await.expect("ensure_sets");
-            ensure_sets("siphon", "banned4", "banned6").await.expect("ensure_sets idempotent");
+            ensure_firewall("siphon", "input", "banned4", "banned6", true)
+                .await
+                .expect("ensure_firewall");
+            // Restart: must be idempotent AND not stack duplicate rules.
+            ensure_firewall("siphon", "input", "banned4", "banned6", true)
+                .await
+                .expect("ensure_firewall restart");
             add_banned("siphon", "banned4", "banned6", "203.0.113.5".parse().unwrap(), 3_600_000)
                 .await
                 .expect("add v4");
@@ -528,9 +770,16 @@ mod tests {
             .output()
             .expect("run nft");
         let text = String::from_utf8_lossy(&output.stdout);
+        // Sets + elements.
         assert!(text.contains("banned4") && text.contains("banned6"), "sets missing:\n{text}");
         assert!(text.contains("2001:db8::1"), "v6 permanent element missing:\n{text}");
         assert!(text.contains("flags timeout"), "timeout flag missing:\n{text}");
         assert!(!text.contains("203.0.113.5"), "removed v4 element still present:\n{text}");
+        // Self-contained chain + drop rules.
+        assert!(text.contains("chain input"), "base chain missing:\n{text}");
+        assert!(text.contains("@banned4") && text.contains("@banned6"), "drop rules missing:\n{text}");
+        assert!(text.contains("drop"), "drop verdict missing:\n{text}");
+        // The double ensure_firewall must NOT have duplicated the rules.
+        assert_eq!(text.matches("@banned4 drop").count(), 1, "duplicate v4 drop rule:\n{text}");
     }
 }

--- a/src/firewall/nftables.rs
+++ b/src/firewall/nftables.rs
@@ -1,0 +1,536 @@
+//! Direct nf_tables netlink backend.
+//!
+//! Programs a kernel nf_tables `inet` table + timeout sets of banned source
+//! IPs, so abusive traffic is dropped in the kernel before it ever reaches
+//! siphon's socket. Hand-rolled over `netlink-sys` (the same foundation the
+//! IPsec XFRM backend uses in [`crate::ipsec::netlink`]) — no `nft` shell-out,
+//! no libnftnl/libmnl C dependency, no external daemon.
+//!
+//! Wire format references:
+//! - `linux/netfilter/nf_tables.h` (message types + attribute enums)
+//! - `linux/netfilter/nfnetlink.h` (`NFNL_MSG_BATCH_*`, `NFNL_SUBSYS_NFTABLES`)
+//! - <https://wiki.nftables.org/wiki-nftables/index.php/Element_timeouts>
+//!
+//! Every mutation is one atomic transaction: `NFNL_MSG_BATCH_BEGIN` … object
+//! message(s) … `NFNL_MSG_BATCH_END`. Elements carry `NFTA_SET_ELEM_TIMEOUT`
+//! (milliseconds; `0` = never), so the kernel auto-expires bans with no
+//! userspace unban event — mirroring siphon's lazy in-memory ban expiry.
+//!
+//! **Endianness note:** unlike rtnetlink/XFRM (host-endian), nf_tables integer
+//! attributes are **big-endian** (`nla_put_be32`/`be64`). The IP key data is
+//! also network order (raw octets). Strings are NUL-terminated.
+
+use std::io;
+use std::net::IpAddr;
+
+use netlink_sys::{protocols::NETLINK_NETFILTER, Socket, SocketAddr};
+
+// --- netlink framing (shared shape with src/ipsec/netlink.rs) --------------
+
+const NLMSG_HDR_LEN: usize = 16;
+const NLA_ALIGNTO: usize = 4;
+const NLMSG_ALIGNTO: usize = 4;
+
+const NLM_F_REQUEST: u16 = 0x001;
+const NLM_F_ACK: u16 = 0x004;
+const NLM_F_CREATE: u16 = 0x400;
+
+const NLMSG_ERROR: u16 = 0x2;
+
+/// Nested-attribute flag (`NLA_F_NESTED`); libnftnl sets it, so we match.
+const NLA_F_NESTED: u16 = 0x8000;
+
+// --- nfnetlink / nf_tables constants (from the kernel UAPI headers) --------
+
+const NFNL_SUBSYS_NFTABLES: u16 = 10;
+const NFNL_MSG_BATCH_BEGIN: u16 = 16; // = NLMSG_MIN_TYPE
+const NFNL_MSG_BATCH_END: u16 = 17;
+
+// nf_tables message types (subsystem-relative). Wire type =
+// `(NFNL_SUBSYS_NFTABLES << 8) | msg`.
+const NFT_MSG_NEWTABLE: u16 = 0;
+const NFT_MSG_NEWSET: u16 = 9;
+const NFT_MSG_NEWSETELEM: u16 = 12;
+const NFT_MSG_DELSETELEM: u16 = 14;
+
+// nftables address families.
+const NFPROTO_UNSPEC: u8 = 0;
+const NFPROTO_INET: u8 = 1;
+
+// `enum nft_table_attributes`
+const NFTA_TABLE_NAME: u16 = 1;
+
+// `enum nft_set_attributes`
+const NFTA_SET_TABLE: u16 = 1;
+const NFTA_SET_NAME: u16 = 2;
+const NFTA_SET_FLAGS: u16 = 3;
+const NFTA_SET_KEY_TYPE: u16 = 4;
+const NFTA_SET_KEY_LEN: u16 = 5;
+const NFTA_SET_ID: u16 = 10;
+
+// `enum nft_set_flags`
+const NFT_SET_TIMEOUT: u32 = 0x10;
+
+// nft datatypes for `NFTA_SET_KEY_TYPE` (informational, but the kernel wants
+// it present): `ipv4_addr` = 7, `ipv6_addr` = 8.
+const NFT_TYPE_IPADDR: u32 = 7;
+const NFT_TYPE_IP6ADDR: u32 = 8;
+
+// `enum nft_set_elem_list_attributes`
+const NFTA_SET_ELEM_LIST_TABLE: u16 = 1;
+const NFTA_SET_ELEM_LIST_SET: u16 = 2;
+const NFTA_SET_ELEM_LIST_ELEMENTS: u16 = 3;
+
+// `enum nft_set_elem_attributes`
+const NFTA_SET_ELEM_KEY: u16 = 1;
+const NFTA_SET_ELEM_TIMEOUT: u16 = 4;
+
+// `enum nft_data_attributes`
+const NFTA_DATA_VALUE: u16 = 1;
+
+// Generic `enum nft_list_attributes` element wrapper.
+const NFTA_LIST_ELEM: u16 = 1;
+
+/// Which IP family a set holds. An `inet` table holds both via two typed sets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetFamily {
+    V4,
+    V6,
+}
+
+impl SetFamily {
+    fn key_len(self) -> u32 {
+        match self {
+            SetFamily::V4 => 4,
+            SetFamily::V6 => 16,
+        }
+    }
+
+    fn key_type(self) -> u32 {
+        match self {
+            SetFamily::V4 => NFT_TYPE_IPADDR,
+            SetFamily::V6 => NFT_TYPE_IP6ADDR,
+        }
+    }
+
+    fn of(address: &IpAddr) -> Self {
+        match address {
+            IpAddr::V4(_) => SetFamily::V4,
+            IpAddr::V6(_) => SetFamily::V6,
+        }
+    }
+}
+
+// --- byte helpers ----------------------------------------------------------
+
+#[inline]
+const fn align_to(value: usize, alignment: usize) -> usize {
+    (value + alignment - 1) & !(alignment - 1)
+}
+
+/// Push a 4-byte-aligned netlink attribute (`__u16 nla_len | __u16 nla_type |
+/// payload`, padded to `NLA_ALIGNTO`).
+fn push_nla(buffer: &mut Vec<u8>, attr_type: u16, payload: &[u8]) {
+    let total_len = 4 + payload.len();
+    buffer.extend_from_slice(&(total_len as u16).to_ne_bytes());
+    buffer.extend_from_slice(&attr_type.to_ne_bytes());
+    buffer.extend_from_slice(payload);
+    for _ in 0..(align_to(total_len, NLA_ALIGNTO) - total_len) {
+        buffer.push(0);
+    }
+}
+
+/// A NUL-terminated string attribute (nftables names are null-terminated).
+fn push_nla_str(buffer: &mut Vec<u8>, attr_type: u16, value: &str) {
+    let mut payload = value.as_bytes().to_vec();
+    payload.push(0);
+    push_nla(buffer, attr_type, &payload);
+}
+
+/// nf_tables integer attributes are **big-endian** (`nla_put_be32`).
+fn push_nla_be32(buffer: &mut Vec<u8>, attr_type: u16, value: u32) {
+    push_nla(buffer, attr_type, &value.to_be_bytes());
+}
+
+fn push_nla_be64(buffer: &mut Vec<u8>, attr_type: u16, value: u64) {
+    push_nla(buffer, attr_type, &value.to_be_bytes());
+}
+
+/// Push a nested attribute (its payload is itself a sequence of attributes).
+fn push_nla_nested(buffer: &mut Vec<u8>, attr_type: u16, payload: &[u8]) {
+    push_nla(buffer, attr_type | NLA_F_NESTED, payload);
+}
+
+/// `struct nfgenmsg { __u8 nfgen_family; __u8 version; __be16 res_id; }`.
+fn nfgenmsg(family: u8, res_id: u16) -> [u8; 4] {
+    let res = res_id.to_be_bytes();
+    [family, 0 /* NFNETLINK_V0 */, res[0], res[1]]
+}
+
+/// Wrap an object body (`nfgenmsg` + attributes) in a netlink message header.
+fn nlmsg(msg_type: u16, flags: u16, seq: u32, body: &[u8]) -> Vec<u8> {
+    let total_len = NLMSG_HDR_LEN + body.len();
+    let aligned = align_to(total_len, NLMSG_ALIGNTO);
+    let mut message = Vec::with_capacity(aligned);
+    message.extend_from_slice(&(total_len as u32).to_ne_bytes()); // nlmsg_len
+    message.extend_from_slice(&msg_type.to_ne_bytes()); // nlmsg_type
+    message.extend_from_slice(&flags.to_ne_bytes()); // nlmsg_flags
+    message.extend_from_slice(&seq.to_ne_bytes()); // nlmsg_seq
+    message.extend_from_slice(&0u32.to_ne_bytes()); // nlmsg_pid (kernel fills)
+    message.extend_from_slice(body);
+    while message.len() < aligned {
+        message.push(0);
+    }
+    message
+}
+
+#[inline]
+fn nft_type(msg: u16) -> u16 {
+    (NFNL_SUBSYS_NFTABLES << 8) | msg
+}
+
+const OBJECT_FLAGS: u16 = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE;
+
+// --- object message builders (each returns one full nlmsg) -----------------
+
+fn build_new_table(table: &str, seq: u32) -> Vec<u8> {
+    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
+    push_nla_str(&mut body, NFTA_TABLE_NAME, table);
+    nlmsg(nft_type(NFT_MSG_NEWTABLE), OBJECT_FLAGS, seq, &body)
+}
+
+/// Create a timeout set (`flags timeout`) keyed by a bare IPv4/IPv6 address.
+/// Idempotent (`NLM_F_CREATE`, no `NLM_F_EXCL`) so re-running siphon does not
+/// error on an existing set.
+fn build_new_set(table: &str, set: &str, set_id: u32, family: SetFamily, seq: u32) -> Vec<u8> {
+    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
+    push_nla_str(&mut body, NFTA_SET_TABLE, table);
+    push_nla_str(&mut body, NFTA_SET_NAME, set);
+    push_nla_be32(&mut body, NFTA_SET_FLAGS, NFT_SET_TIMEOUT);
+    push_nla_be32(&mut body, NFTA_SET_KEY_TYPE, family.key_type());
+    push_nla_be32(&mut body, NFTA_SET_KEY_LEN, family.key_len());
+    push_nla_be32(&mut body, NFTA_SET_ID, set_id);
+    nlmsg(nft_type(NFT_MSG_NEWSET), OBJECT_FLAGS, seq, &body)
+}
+
+/// Encode one set element: nested `NFTA_LIST_ELEM { KEY { DATA_VALUE=ip },
+/// TIMEOUT=ttl_ms }`. `ttl_ms == 0` means never expire.
+fn encode_element(address: &IpAddr, ttl_ms: u64) -> Vec<u8> {
+    let key_value: Vec<u8> = match address {
+        IpAddr::V4(v4) => v4.octets().to_vec(),
+        IpAddr::V6(v6) => v6.octets().to_vec(),
+    };
+
+    let mut data = Vec::new();
+    push_nla(&mut data, NFTA_DATA_VALUE, &key_value);
+
+    let mut elem = Vec::new();
+    push_nla_nested(&mut elem, NFTA_SET_ELEM_KEY, &data);
+    push_nla_be64(&mut elem, NFTA_SET_ELEM_TIMEOUT, ttl_ms);
+
+    let mut list_elem = Vec::new();
+    push_nla_nested(&mut list_elem, NFTA_LIST_ELEM, &elem);
+    list_elem
+}
+
+fn build_setelem(msg: u16, table: &str, set: &str, address: &IpAddr, ttl_ms: u64, seq: u32) -> Vec<u8> {
+    let mut body = nfgenmsg(NFPROTO_INET, 0).to_vec();
+    push_nla_str(&mut body, NFTA_SET_ELEM_LIST_TABLE, table);
+    push_nla_str(&mut body, NFTA_SET_ELEM_LIST_SET, set);
+    let elements = encode_element(address, ttl_ms);
+    push_nla_nested(&mut body, NFTA_SET_ELEM_LIST_ELEMENTS, &elements);
+    nlmsg(nft_type(msg), OBJECT_FLAGS, seq, &body)
+}
+
+// --- batch framing + transport ---------------------------------------------
+
+/// Wrap object messages in `BATCH_BEGIN`/`BATCH_END` so the kernel applies
+/// them as one atomic transaction. The batch envelope's `nfgenmsg.res_id`
+/// selects the nf_tables subsystem. Object seqs run 1..=N; BATCH_END is N+1.
+fn wrap_batch(messages: &[Vec<u8>]) -> Vec<u8> {
+    let begin = nlmsg(
+        NFNL_MSG_BATCH_BEGIN,
+        NLM_F_REQUEST,
+        0,
+        &nfgenmsg(NFPROTO_UNSPEC, NFNL_SUBSYS_NFTABLES),
+    );
+    let end = nlmsg(
+        NFNL_MSG_BATCH_END,
+        NLM_F_REQUEST,
+        (messages.len() + 1) as u32,
+        &nfgenmsg(NFPROTO_UNSPEC, NFNL_SUBSYS_NFTABLES),
+    );
+    let mut buffer = begin;
+    for message in messages {
+        buffer.extend_from_slice(message);
+    }
+    buffer.extend_from_slice(&end);
+    buffer
+}
+
+/// Send a batch and read its `object_count` per-message acks. A successful
+/// batch yields one errno-0 `NLMSG_ERROR` per acked object message; a failure
+/// yields the offending message's errno and rolls the transaction back
+/// atomically. Blocking I/O is offloaded to `spawn_blocking` (bans are rare, a
+/// fresh socket per transaction is fine — matches the XFRM backend).
+async fn send(buffer: Vec<u8>, object_count: usize) -> io::Result<()> {
+    let expected = buffer.len();
+    tokio::task::spawn_blocking(move || -> io::Result<()> {
+        let socket = Socket::new(NETLINK_NETFILTER)?;
+        socket.connect(&SocketAddr::new(0, 0))?;
+        let sent = socket.send(&buffer, 0)?;
+        if sent != expected {
+            return Err(io::Error::other(format!("nftables: short send ({sent}/{expected})")));
+        }
+        let mut seen = 0usize;
+        let mut response = vec![0u8; 8192];
+        while seen < object_count {
+            let received = socket.recv(&mut &mut response[..], 0)?;
+            seen += count_acks(&response[..received])?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|join| io::Error::other(format!("nftables netlink task panic: {join}")))?
+}
+
+/// Count the errno-0 acks in a reply, returning `Err` on a real kernel error.
+/// `EEXIST` (add of an existing element) and `ENOENT` (delete of a missing
+/// element, e.g. one the kernel already expired) are benign idempotency cases
+/// and count as success.
+fn count_acks(buffer: &[u8]) -> io::Result<usize> {
+    const EEXIST: i32 = 17;
+    const ENOENT: i32 = 2;
+    let mut offset = 0;
+    let mut ok = 0;
+    while offset + NLMSG_HDR_LEN <= buffer.len() {
+        let len = u32::from_ne_bytes([
+            buffer[offset],
+            buffer[offset + 1],
+            buffer[offset + 2],
+            buffer[offset + 3],
+        ]) as usize;
+        let msg_type = u16::from_ne_bytes([buffer[offset + 4], buffer[offset + 5]]);
+        if len < NLMSG_HDR_LEN || offset + len > buffer.len() {
+            return Err(io::Error::other("nftables: malformed reply"));
+        }
+        if msg_type == NLMSG_ERROR {
+            if len < NLMSG_HDR_LEN + 4 {
+                return Err(io::Error::other("nftables: short NLMSG_ERROR"));
+            }
+            let errno = i32::from_ne_bytes([
+                buffer[offset + NLMSG_HDR_LEN],
+                buffer[offset + NLMSG_HDR_LEN + 1],
+                buffer[offset + NLMSG_HDR_LEN + 2],
+                buffer[offset + NLMSG_HDR_LEN + 3],
+            ]);
+            if errno == 0 || -errno == EEXIST || -errno == ENOENT {
+                ok += 1;
+            } else {
+                return Err(io::Error::from_raw_os_error(-errno));
+            }
+        }
+        offset += align_to(len, NLMSG_ALIGNTO);
+    }
+    Ok(ok)
+}
+
+// --- public operations ------------------------------------------------------
+
+/// Ensure the `inet` table + both timeout sets exist (idempotent).
+pub async fn ensure_sets(table: &str, set_v4: &str, set_v6: &str) -> io::Result<()> {
+    let messages = vec![
+        build_new_table(table, 1),
+        build_new_set(table, set_v4, 1, SetFamily::V4, 2),
+        build_new_set(table, set_v6, 2, SetFamily::V6, 3),
+    ];
+    send(wrap_batch(&messages), messages.len()).await
+}
+
+/// Add a banned source to the appropriate set with a per-element timeout
+/// (`ttl_ms == 0` = permanent, e.g. an apiban entry).
+pub async fn add_banned(table: &str, set_v4: &str, set_v6: &str, address: IpAddr, ttl_ms: u64) -> io::Result<()> {
+    let set = match SetFamily::of(&address) {
+        SetFamily::V4 => set_v4,
+        SetFamily::V6 => set_v6,
+    };
+    let message = build_setelem(NFT_MSG_NEWSETELEM, table, set, &address, ttl_ms, 1);
+    send(wrap_batch(&[message]), 1).await
+}
+
+/// Remove a banned source (optional — the kernel auto-expires timed elements).
+pub async fn remove_banned(table: &str, set_v4: &str, set_v6: &str, address: IpAddr) -> io::Result<()> {
+    let set = match SetFamily::of(&address) {
+        SetFamily::V4 => set_v4,
+        SetFamily::V6 => set_v6,
+    };
+    let message = build_setelem(NFT_MSG_DELSETELEM, table, set, &address, 0, 1);
+    send(wrap_batch(&[message]), 1).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn u16_at(buffer: &[u8], offset: usize) -> u16 {
+        u16::from_ne_bytes([buffer[offset], buffer[offset + 1]])
+    }
+    fn u32_at(buffer: &[u8], offset: usize) -> u32 {
+        u32::from_ne_bytes([buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3]])
+    }
+    fn be32_at(buffer: &[u8], offset: usize) -> u32 {
+        u32::from_be_bytes([buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3]])
+    }
+
+    #[test]
+    fn align_is_4() {
+        assert_eq!(align_to(1, 4), 4);
+        assert_eq!(align_to(4, 4), 4);
+        assert_eq!(align_to(5, 4), 8);
+    }
+
+    #[test]
+    fn push_nla_pads_to_4() {
+        let mut buffer = Vec::new();
+        push_nla(&mut buffer, 7, &[0xaa, 0xbb, 0xcc]); // 4 hdr + 3 = 7 -> pad to 8
+        assert_eq!(buffer.len(), 8);
+        assert_eq!(u16_at(&buffer, 0), 7); // nla_len excludes padding
+        assert_eq!(u16_at(&buffer, 2), 7); // nla_type
+        assert_eq!(&buffer[4..7], &[0xaa, 0xbb, 0xcc]);
+        assert_eq!(buffer[7], 0); // pad
+    }
+
+    #[test]
+    fn str_attr_is_nul_terminated() {
+        let mut buffer = Vec::new();
+        push_nla_str(&mut buffer, NFTA_TABLE_NAME, "ab"); // 4 hdr + "ab\0" = 7 -> 8
+        assert_eq!(buffer.len(), 8);
+        assert_eq!(u16_at(&buffer, 0), 7);
+        assert_eq!(&buffer[4..7], b"ab\0");
+    }
+
+    #[test]
+    fn integer_attrs_are_big_endian() {
+        // nf_tables uses network byte order for integer attributes.
+        let mut buffer = Vec::new();
+        push_nla_be32(&mut buffer, NFTA_SET_KEY_LEN, 4);
+        assert_eq!(&buffer[4..8], &[0, 0, 0, 4]); // 4 as be32
+    }
+
+    #[test]
+    fn nfgenmsg_layout() {
+        assert_eq!(nfgenmsg(NFPROTO_INET, 0), [1, 0, 0, 0]);
+        assert_eq!(nfgenmsg(NFPROTO_UNSPEC, NFNL_SUBSYS_NFTABLES), [0, 0, 0, 10]);
+    }
+
+    #[test]
+    fn nlmsg_header_and_wire_type() {
+        let message = nlmsg(nft_type(NFT_MSG_NEWSET), NLM_F_REQUEST | NLM_F_ACK, 3, &[0xde, 0xad]);
+        assert_eq!(u32_at(&message, 0), 18); // 16 hdr + 2 body
+        assert_eq!(u16_at(&message, 4), (10 << 8) | 9); // (NFTABLES<<8)|NEWSET
+        assert_eq!(u16_at(&message, 6), NLM_F_REQUEST | NLM_F_ACK);
+        assert_eq!(u32_at(&message, 8), 3); // seq
+        assert_eq!(message.len(), 20); // padded to 4
+    }
+
+    #[test]
+    fn new_set_carries_timeout_flag_keytype_keylen() {
+        let message = build_new_set("siphon", "banned4", 1, SetFamily::V4, 2);
+        let mut offset = NLMSG_HDR_LEN + 4; // past nlmsghdr + nfgenmsg
+        let (mut flags, mut key_type, mut key_len) = (None, None, None);
+        while offset + 4 <= message.len() {
+            let nla_len = u16_at(&message, offset) as usize;
+            let nla_type = u16_at(&message, offset + 2) & !NLA_F_NESTED;
+            if nla_len < 4 {
+                break;
+            }
+            match nla_type {
+                NFTA_SET_FLAGS => flags = Some(be32_at(&message, offset + 4)),
+                NFTA_SET_KEY_TYPE => key_type = Some(be32_at(&message, offset + 4)),
+                NFTA_SET_KEY_LEN => key_len = Some(be32_at(&message, offset + 4)),
+                _ => {}
+            }
+            offset += align_to(nla_len, NLA_ALIGNTO);
+        }
+        assert_eq!(flags, Some(NFT_SET_TIMEOUT));
+        assert_eq!(key_type, Some(NFT_TYPE_IPADDR)); // 7
+        assert_eq!(key_len, Some(4));
+    }
+
+    #[test]
+    fn element_encodes_ipv4_key_and_be_timeout() {
+        let element = encode_element(&IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), 3_600_000);
+        assert_eq!(u16_at(&element, 2) & !NLA_F_NESTED, NFTA_LIST_ELEM);
+        assert!(element.windows(4).any(|w| w == [203, 0, 113, 5]), "raw IPv4 octets");
+        assert!(
+            element.windows(8).any(|w| w == 3_600_000u64.to_be_bytes()),
+            "timeout must be big-endian u64"
+        );
+    }
+
+    #[test]
+    fn ipv6_set_family() {
+        assert_eq!(SetFamily::V6.key_len(), 16);
+        assert_eq!(SetFamily::V6.key_type(), NFT_TYPE_IP6ADDR);
+        assert_eq!(SetFamily::of(&IpAddr::V6(Ipv6Addr::LOCALHOST)), SetFamily::V6);
+        let octets: [u8; 16] = "2001:db8::1".parse::<Ipv6Addr>().unwrap().octets();
+        let element = encode_element(&IpAddr::V6("2001:db8::1".parse().unwrap()), 0);
+        assert!(element.windows(16).any(|w| w == octets));
+    }
+
+    #[test]
+    fn batch_wraps_begin_and_end() {
+        let inner = build_new_table("siphon", 1);
+        let batch = wrap_batch(std::slice::from_ref(&inner));
+        assert_eq!(u16_at(&batch, 4), NFNL_MSG_BATCH_BEGIN);
+        let after_begin = 20; // BATCH_BEGIN = 16 hdr + 4 nfgenmsg
+        assert_eq!(u16_at(&batch, after_begin + 4), nft_type(NFT_MSG_NEWTABLE));
+        let end_offset = after_begin + inner.len();
+        assert_eq!(u16_at(&batch, end_offset + 4), NFNL_MSG_BATCH_END);
+    }
+
+    #[test]
+    fn count_acks_success_and_error() {
+        let ok = nlmsg(NLMSG_ERROR, 0, 1, &0i32.to_ne_bytes());
+        assert_eq!(count_acks(&ok).unwrap(), 1);
+        let eexist = nlmsg(NLMSG_ERROR, 0, 1, &(-17i32).to_ne_bytes());
+        assert_eq!(count_acks(&eexist).unwrap(), 1); // idempotent
+        let enoent = nlmsg(NLMSG_ERROR, 0, 1, &(-2i32).to_ne_bytes());
+        assert_eq!(count_acks(&enoent).unwrap(), 1); // idempotent delete
+        let eperm = nlmsg(NLMSG_ERROR, 0, 1, &(-1i32).to_ne_bytes());
+        assert!(count_acks(&eperm).is_err());
+    }
+
+    /// End-to-end against the real kernel. Needs `CAP_NET_ADMIN`; run in a
+    /// throwaway net namespace so it touches nothing real:
+    ///   `unshare -rn cargo test -- --ignored live_kernel_roundtrip --nocapture`
+    #[test]
+    #[ignore = "requires CAP_NET_ADMIN (run under `unshare -rn`)"]
+    fn live_kernel_roundtrip() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            ensure_sets("siphon", "banned4", "banned6").await.expect("ensure_sets");
+            ensure_sets("siphon", "banned4", "banned6").await.expect("ensure_sets idempotent");
+            add_banned("siphon", "banned4", "banned6", "203.0.113.5".parse().unwrap(), 3_600_000)
+                .await
+                .expect("add v4");
+            add_banned("siphon", "banned4", "banned6", "2001:db8::1".parse().unwrap(), 0)
+                .await
+                .expect("add v6 permanent");
+            remove_banned("siphon", "banned4", "banned6", "203.0.113.5".parse().unwrap())
+                .await
+                .expect("remove v4");
+        });
+
+        let output = std::process::Command::new("nft")
+            .args(["list", "ruleset"])
+            .output()
+            .expect("run nft");
+        let text = String::from_utf8_lossy(&output.stdout);
+        assert!(text.contains("banned4") && text.contains("banned6"), "sets missing:\n{text}");
+        assert!(text.contains("2001:db8::1"), "v6 permanent element missing:\n{text}");
+        assert!(text.contains("flags timeout"), "timeout flag missing:\n{text}");
+        assert!(!text.contains("203.0.113.5"), "removed v4 element still present:\n{text}");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod dispatcher;
 pub mod dns;
 pub mod hep;
 pub mod error;
+pub mod firewall;
 pub mod nat;
 pub mod presence;
 pub mod proxy;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -187,6 +187,16 @@ pub struct SiphonMetrics {
     /// `security.rate_limit.max_requests` within the window (PIKE-style flood
     /// protection). trusted_cidrs are never counted.
     pub rate_limited_total: IntCounter,
+    /// Total kernel-firewall (nf_tables) commands dropped before reaching the
+    /// netlink actor because its queue was full — only plausible under a ban
+    /// storm. The userspace ACL still enforces the dropped ban; a sustained
+    /// rate means kernel enforcement is lagging the ban rate.
+    pub firewall_commands_dropped_total: IntCounter,
+    /// Total kernel-firewall (nf_tables) netlink commands that failed. Any
+    /// non-zero rate means bans are NOT being enforced in the kernel (ruleset
+    /// deleted out from under siphon, capability lost, nf_tables broken) —
+    /// alert on it; the userspace ACL is the only enforcement left.
+    pub firewall_command_failures_total: IntCounter,
 
     // --- Diameter ---
     pub diameter_peers_connected: IntGauge,
@@ -403,6 +413,16 @@ impl SiphonMetrics {
             "Total inbound requests dropped because the source exceeded security.rate_limit.max_requests within the window",
         )?;
 
+        let firewall_commands_dropped_total = IntCounter::new(
+            "siphon_firewall_commands_dropped_total",
+            "Total kernel-firewall (nf_tables) commands dropped because the netlink actor queue was full",
+        )?;
+
+        let firewall_command_failures_total = IntCounter::new(
+            "siphon_firewall_command_failures_total",
+            "Total kernel-firewall (nf_tables) netlink commands that failed — bans not enforced in the kernel",
+        )?;
+
         let diameter_peers_connected = IntGauge::new(
             "siphon_diameter_peers_connected",
             "Number of currently connected Diameter peers",
@@ -515,6 +535,8 @@ impl SiphonMetrics {
         registry.register(Box::new(malformed_messages_total.clone()))?;
         registry.register(Box::new(scanner_blocked_total.clone()))?;
         registry.register(Box::new(rate_limited_total.clone()))?;
+        registry.register(Box::new(firewall_commands_dropped_total.clone()))?;
+        registry.register(Box::new(firewall_command_failures_total.clone()))?;
         registry.register(Box::new(diameter_peers_connected.clone()))?;
         registry.register(Box::new(diameter_requests_total.clone()))?;
         registry.register(Box::new(diameter_request_errors_total.clone()))?;
@@ -567,6 +589,8 @@ impl SiphonMetrics {
             malformed_messages_total,
             scanner_blocked_total,
             rate_limited_total,
+            firewall_commands_dropped_total,
+            firewall_command_failures_total,
             diameter_peers_connected,
             diameter_requests_total,
             diameter_request_errors_total,

--- a/src/security.rs
+++ b/src/security.rs
@@ -285,6 +285,41 @@ impl AutoBanStore {
         self.bans.len()
     }
 
+    /// Currently-banned sources with their remaining ban time in seconds
+    /// (expired-but-not-yet-pruned entries are skipped). For the admin API's
+    /// `GET /admin/bans`.
+    pub fn banned_sources(&self) -> Vec<(IpAddr, u64)> {
+        let now = Instant::now();
+        self.bans
+            .iter()
+            .filter_map(|entry| {
+                let remaining = entry.value().saturating_duration_since(now);
+                if remaining.is_zero() {
+                    None
+                } else {
+                    Some((*entry.key(), remaining.as_secs()))
+                }
+            })
+            .collect()
+    }
+
+    /// Lift the ban on `source` early — an operator clearing a false positive
+    /// (via the admin API). Removes the userspace ban and the failure window,
+    /// and, when the kernel firewall is wired, removes the source from the
+    /// nf_tables set too so the in-kernel drop is lifted in lockstep. Returns
+    /// `true` if a ban was actually present.
+    pub fn unban(&self, source: IpAddr) -> bool {
+        let was_banned = self.bans.remove(&source).is_some();
+        // Always clear any failure window so the source starts clean.
+        self.failures.remove(&source);
+        if was_banned {
+            if let Some(firewall) = self.firewall.get() {
+                firewall.unban(source);
+            }
+        }
+        was_banned
+    }
+
     /// Drop expired bans and stale failure windows. Call periodically to keep
     /// memory bounded under scanner churn.
     pub fn prune(&self) {
@@ -580,6 +615,44 @@ mod tests {
         assert!(store.record_failure(source)); // ban
         assert!(!store.record_failure(source)); // already banned -> not "newly banned"
         assert!(store.is_banned(source));
+    }
+
+    #[test]
+    fn unban_lifts_an_active_ban() {
+        let store = AutoBanStore::new(1, 600, 3600, &[], 1);
+        let source = ip("203.0.113.40");
+        assert!(store.record_failure(source)); // threshold 1 -> banned
+        assert!(store.is_banned(source));
+        assert!(store.unban(source)); // present -> true
+        assert!(!store.is_banned(source)); // lifted
+        assert_eq!(store.active_bans(), 0);
+    }
+
+    #[test]
+    fn unban_of_an_unbanned_source_is_false() {
+        let store = AutoBanStore::new(3, 600, 3600, &[], 1);
+        let source = ip("203.0.113.41");
+        // Never banned -> nothing to lift.
+        assert!(!store.unban(source));
+        // A failure count without a ban is still cleared, and reports false.
+        store.record_failure(source);
+        assert!(!store.unban(source));
+    }
+
+    #[test]
+    fn banned_sources_lists_active_bans_with_remaining() {
+        let store = AutoBanStore::new(1, 600, 3600, &[], 1);
+        let one = ip("203.0.113.42");
+        let two = ip("2001:db8::42");
+        store.record_failure(one);
+        store.record_failure(two);
+        let mut listed = store.banned_sources();
+        listed.sort_by_key(|(address, _)| address.to_string());
+        assert_eq!(listed.len(), 2);
+        // Both carry a positive remaining TTL (≤ the 3600 s ban duration).
+        assert!(listed.iter().all(|(_, remaining)| *remaining > 0 && *remaining <= 3600));
+        assert!(listed.iter().any(|(address, _)| *address == one));
+        assert!(listed.iter().any(|(address, _)| *address == two));
     }
 
     #[test]

--- a/src/security.rs
+++ b/src/security.rs
@@ -141,6 +141,9 @@ pub struct AutoBanStore {
     /// these unambiguous signals faster than a bare scanning probe (weight 1)
     /// while reusing the single per-IP window. Always ≥ 1.
     strong_weight: u32,
+    /// Optional kernel-firewall handle. When wired, every new ban is also
+    /// pushed to the nf_tables set so the source is dropped pre-userspace.
+    firewall: OnceLock<crate::firewall::KernelFirewall>,
 }
 
 impl AutoBanStore {
@@ -166,7 +169,14 @@ impl AutoBanStore {
             window: Duration::from_secs(u64::from(window_secs.max(1))),
             ban_duration: Duration::from_secs(u64::from(ban_duration_secs.max(1))),
             strong_weight: strong_weight.max(1),
+            firewall: OnceLock::new(),
         }
+    }
+
+    /// Attach a kernel-firewall handle so new bans are also programmed into the
+    /// nf_tables set. Called once at startup; a second call is a no-op.
+    pub fn set_firewall(&self, firewall: crate::firewall::KernelFirewall) {
+        let _ = self.firewall.set(firewall);
     }
 
     fn is_trusted(&self, source: IpAddr) -> bool {
@@ -223,6 +233,14 @@ impl AutoBanStore {
         if newly_banned {
             self.failures.remove(&source);
             self.bans.insert(source, now + self.ban_duration);
+            // Mirror the ban into the kernel firewall (nf_tables) if wired, so
+            // the source is dropped before it reaches siphon's socket. The
+            // kernel element carries the same TTL as the in-memory ban, so both
+            // expire in lockstep. Non-blocking (drops silently if the actor
+            // queue is full — the userspace ACL still enforces the ban).
+            if let Some(firewall) = self.firewall.get() {
+                firewall.ban(source, self.ban_duration);
+            }
         }
         newly_banned
     }
@@ -651,6 +669,7 @@ mod tests {
             trusted_cidrs: trusted_cidrs.into_iter().map(String::from).collect(),
             failed_auth_ban: None,
             apiban: None,
+            firewall: None,
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -906,8 +906,24 @@ impl SiphonServer {
             );
         }
 
+        // --- Kernel firewall (nf_tables) — opt-in, needs CAP_NET_ADMIN ---
+        // Programs banned sources into a kernel set so abusive traffic is
+        // dropped before it reaches siphon's socket. On failure (missing
+        // capability, non-Linux) we warn and fall back to the userspace ACL —
+        // never fatal.
+        let kernel_firewall = match config.security.as_ref().and_then(|sec| sec.firewall.as_ref()) {
+            Some(firewall_config) => match crate::firewall::start(firewall_config).await {
+                Ok(handle) => Some(handle),
+                Err(error) => {
+                    warn!(%error, "kernel firewall (nf_tables) unavailable — falling back to the userspace ACL (missing CAP_NET_ADMIN?)");
+                    None
+                }
+            },
+            None => None,
+        };
+
         // --- Build transport ACL ---
-        let transport_acl = build_transport_acl(&config);
+        let transport_acl = build_transport_acl(&config, kernel_firewall.clone());
 
         // --- Auto-ban (failed_auth_ban scanner protection) ---
         // Opt-in: only installed when configured. Once installed, the auth path
@@ -923,6 +939,9 @@ impl SiphonServer {
                     fab.strong_signal_weight,
                 ));
                 crate::security::set_auto_ban(Arc::clone(&store));
+                if let Some(ref firewall) = kernel_firewall {
+                    store.set_firewall(firewall.clone());
+                }
                 info!(
                     threshold = fab.threshold,
                     window_secs = fab.window_secs,
@@ -2642,13 +2661,17 @@ fn spawn_li_tasks(
     });
 }
 
-fn build_transport_acl(config: &Config) -> Arc<transport::acl::TransportAcl> {
+fn build_transport_acl(
+    config: &Config,
+    firewall: Option<crate::firewall::KernelFirewall>,
+) -> Arc<transport::acl::TransportAcl> {
     use transport::acl::TransportAcl;
 
     if let Some(ref sec) = config.security {
         let apiban_set = if let Some(ref apiban_config) = sec.apiban {
             match crate::apiban::ApiBanClient::new(apiban_config) {
                 Ok(client) => {
+                    let client = client.with_firewall(firewall.clone());
                     let banned = client.banned();
                     client.start();
                     info!("APIBAN blocklist poller started");


### PR DESCRIPTION
## What

Adds `security.firewall`: mirror SIPhon's bans into a kernel **nf_tables** set so
abusive sources are dropped in the kernel, before they reach SIPhon's socket,
instead of only in the userspace ACL.

Bans come from the same places as today — the confidence-weighted `failed_auth_ban`
store and the APIBAN blocklist. Each auto-ban is pushed with the **same TTL** as the
in-memory ban; APIBAN entries are added permanently.

## Why

The userspace ACL drops at `recv()`/`accept()`, but the packet still travels
NIC → kernel → SIPhon first, so it does nothing against volume. Dropping at the
kernel is real defense; a userspace drop is just politeness.

## How

- **Hand-rolled nf_tables netlink** over the same `netlink-sys` socket SIPhon
  already uses for the IPsec XFRM backend. No `nft` shell-out, no libnftnl/libmnl C
  dependency, no external daemon, and **zero new dependencies**.
- **Zero-touch by default (`manage_rule: true`)**: SIPhon owns the whole ruleset —
  the `inet` table, both timeout sets, the base chain, and the `saddr @banned drop`
  rules — so `firewall: {}` is all that's needed, with no manual `nft` step. Set
  `manage_rule: false` to have SIPhon own only the sets and reference them from your
  own rule.
- The entire ensure step is **one idempotent, atomic netlink transaction**
  (`BATCH_BEGIN … BATCH_END`): the table/sets/chain are declared with `NLM_F_CREATE`
  (a no-op if present) and the chain's rules are flushed and re-appended, so a first
  run, a clean restart, and a restart after a crash mid-setup all converge to the
  same ruleset — no half-configured state, no stacked-duplicate rules, and no instant
  in which the drop rule is missing.
- The kernel **auto-expires** each ban via a per-element `timeout` matching the
  in-memory ban, so there is no unban bookkeeping (SIPhon's ban expiry is lazy).
- A single actor task owns the netlink work; the ban / auth hot paths feed it with
  a non-blocking `try_send`.
- **Opt-in**, Linux-only, needs `CAP_NET_ADMIN`. On failure it warns and **falls
  back to the userspace ACL** — never fatal.

## Validation

- Byte-layout unit tests for every builder, including the base chain and the
  five-expression drop rule (`meta`/`cmp`/`payload`/`lookup`/`immediate`) — the
  `meta nfproto` family guard, the v4/v6 saddr offset+length, the set lookup, and the
  drop verdict.
- A live-kernel roundtrip test creates the table + sets + chain + rules in a throwaway
  net namespace (`unshare -rn`), adds/removes timed elements, runs `ensure` twice to
  prove restart idempotency (asserts exactly one `@banned drop` rule), and checks
  `nft list ruleset`. That caught three real bugs byte-tests alone would miss —
  nf_tables integer attributes are big-endian, the set needs `NFTA_SET_KEY_TYPE`, and
  a batch returns multiple acks. It runs in CI on the self-hosted `ipsec` runner
  (trunk push + manual dispatch, never fork PRs), so the marshalling is exercised
  against a real kernel on every trunk push.
- `cargo test` green, clippy `-D warnings` clean, no new deps.

## Docs

- New **Kernel firewall** page: `CAP_NET_ADMIN` per runtime (systemd/Docker/K8s),
  container behaviour, the nftables-vs-XDP-in-a-pod tradeoff, the drop rule, and
  troubleshooting.
- Security cookbook expanded with the ban-scoring model.
