### PR TITLE
feat(control): experimental remote-control websocket poc (handover + answer/hangup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **Experimental external control plane (proof-of-concept).** A new optional
+  `control:` config block enables a loopback WebSocket on which an out-of-process
+  application drives B2BUA calls that a `@b2bua.on_invite` handler explicitly
+  hands over with the new `call.handover("app")` API (ARI *Stasis* model — calls
+  that are not handed over are unaffected). The wire protocol is JSON
+  (`command`/`reply`/`event`), auth is a per-app `Authorization: Bearer` token
+  checked before the WebSocket upgrade, and the app drives the call with `answer`
+  and `hangup` verbs. Events (`StasisStart`/`StasisEnd`) are fanned out over a
+  bounded, drop-oldest per-connection queue that can never block the dispatcher
+  or a leg actor. Off by default (no `control:` block = disabled); plain
+  WebSocket only binds on a loopback address. This is a POC of the control plane
+  — TLS/mTLS, channels/bridges, originate, and media control are not included.
+  SDK: `call.handover(app)` mock added.
+
 ## [1.1.1] — 2026-07-02
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -228,8 +229,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 redis = { version = "1", features = ["tokio-comp"], optional = true }
 tokio-postgres = { version = "0.7", optional = true }
 prometheus = { version = "0.14", features = ["process"] }
-axum = { version = "0.8.8", features = ["tokio"] }
+axum = { version = "0.8.8", features = ["tokio", "ws"] }
 tower = { version = "0.5.3", features = ["util"] }
 
 # Lawful Intercept — ETSI ASN.1/BER + XML

--- a/examples/remote_control/README.md
+++ b/examples/remote_control/README.md
@@ -1,0 +1,78 @@
+# Remote-control client examples (experimental)
+
+Two small external applications — one Python, one TypeScript — that drive live
+calls over siphon's control WebSocket. A B2BUA script hands a call over with
+`call.handover("ivr-app")` (the ARI *Stasis* model); the out-of-process app then
+answers and hangs it up. Calls that are not handed over are unaffected.
+
+This is a proof-of-concept: the control plane currently exposes two verbs,
+`answer` and `hangup`. play / dtmf / bridge / transfer / originate arrive in later
+phases over the same protocol and envelope.
+
+## Wire protocol
+
+Single WebSocket per app, JSON text frames, request-id correlated:
+
+```
+command  (client → siphon)  { "id":"c-1", "type":"command", "verb":"answer",
+                              "target":{"channel":"<id>"}, "args":{} }
+reply    (siphon → client)  { "id":"c-1", "type":"reply", "status":"ok",
+                              "result":{...} }        // or "status":"error", "error":{code,message}
+event    (siphon → client)  { "type":"event", "event":"StasisStart",
+                              "channel":"<id>", "app":"ivr-app", "payload":{...} }
+```
+
+The connection authenticates with `Authorization: Bearer <token>` on the WebSocket
+upgrade (a bad/missing token is rejected `401` before the socket opens), then sends
+a first `hello` command whose `app` must match the token's configured application.
+
+## siphon configuration
+
+Add a `control:` block to `siphon.yaml`:
+
+```yaml
+control:
+  listen: "127.0.0.1:9092"        # loopback for local testing
+  event_queue_depth: 1024          # per-connection bounded event queue (optional)
+  apps:
+    - name: "ivr-app"
+      token: "${IVR_APP_TOKEN:-changeme-dev-token}"
+```
+
+Hand matching calls over from the B2BUA script:
+
+```python
+from siphon import b2bua
+
+@b2bua.on_invite
+async def route(call):
+    if call.to_uri.endswith("@ivr.example.com"):
+        call.handover("ivr-app")     # → external control
+    else:
+        call.dial(call.ruri)         # normal B2BUA
+```
+
+## Run the Python client
+
+```bash
+pip install "websockets>=14"
+IVR_APP_TOKEN=changeme-dev-token python control_client.py
+```
+
+## Run the TypeScript client
+
+```bash
+npm install
+IVR_APP_TOKEN=changeme-dev-token npm start
+```
+
+Both accept the same environment overrides:
+
+| variable              | default                              |
+| --------------------- | ------------------------------------ |
+| `SIPHON_CONTROL_URL`  | `ws://127.0.0.1:9092/control/ws`     |
+| `SIPHON_CONTROL_APP`  | `ivr-app`                            |
+| `IVR_APP_TOKEN`       | `changeme-dev-token`                 |
+
+Place a call to a handed-over destination and the client will log `StasisStart`,
+answer the call, hold it briefly, then hang up.

--- a/examples/remote_control/control_client.py
+++ b/examples/remote_control/control_client.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Example external control client for the siphon control plane (experimental).
+
+Connects to siphon's control WebSocket, registers as an application, and drives
+calls that a B2BUA script hands over with ``call.handover("ivr-app")`` (the ARI
+*Stasis* model). Calls that are not handed over are unaffected.
+
+The proof-of-concept exposes two verbs, ``answer`` and ``hangup``; this app
+answers each handed-over call, holds it briefly, then hangs up. Later phases add
+play / dtmf / bridge / originate over the same protocol.
+
+Usage:
+    pip install "websockets>=14"
+    IVR_APP_TOKEN=changeme-dev-token python control_client.py
+
+See README.md for the matching siphon ``control:`` config and handover script.
+"""
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+import os
+
+import websockets
+
+CONTROL_URL = os.environ.get("SIPHON_CONTROL_URL", "ws://127.0.0.1:9092/control/ws")
+APP_NAME = os.environ.get("SIPHON_CONTROL_APP", "ivr-app")
+TOKEN = os.environ.get("IVR_APP_TOKEN", "changeme-dev-token")
+ANSWER_HOLD_SECONDS = 5.0
+
+
+class ControlClient:
+    """A minimal control-plane client with request/reply correlation."""
+
+    def __init__(self, connection) -> None:
+        self._connection = connection
+        self._ids = itertools.count(1)
+        self._pending: dict[str, asyncio.Future] = {}
+        self._tasks: set[asyncio.Task] = set()
+
+    async def rpc(self, verb: str, *, target: dict | None = None, args: dict | None = None) -> dict:
+        """Send a command and await its correlated reply frame."""
+        request_id = f"c-{next(self._ids)}"
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        await self._connection.send(
+            json.dumps(
+                {
+                    "id": request_id,
+                    "type": "command",
+                    "verb": verb,
+                    "target": target or {},
+                    "args": args or {},
+                }
+            )
+        )
+        return await future
+
+    async def run(self) -> None:
+        """Register as APP_NAME, then dispatch replies + events until close."""
+        # Start reading first so the hello reply can be correlated.
+        reader = asyncio.ensure_future(self._read_loop())
+        hello = await self.rpc("hello", args={"app": APP_NAME, "protocol": 1})
+        if hello.get("status") != "ok":
+            reader.cancel()
+            raise RuntimeError(f"hello rejected: {hello.get('error')}")
+        print(f"[control] registered as {APP_NAME!r}")
+        await reader
+
+    async def _read_loop(self) -> None:
+        async for raw in self._connection:
+            frame = json.loads(raw)
+            kind = frame.get("type")
+            if kind == "reply":
+                future = self._pending.pop(frame.get("id", ""), None)
+                if future is not None and not future.done():
+                    future.set_result(frame)
+            elif kind == "event":
+                # Handle each event concurrently so a long call flow never
+                # blocks the read loop (and thus never stalls other calls).
+                self._spawn(self._on_event(frame))
+
+    def _spawn(self, coro) -> None:
+        task = asyncio.ensure_future(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _on_event(self, event: dict) -> None:
+        name = event.get("event")
+        channel = event.get("channel")
+        if name == "StasisStart":
+            print(f"[event] StasisStart {channel} {event.get('payload')}")
+            await self._handle_call(channel)
+        else:
+            print(f"[event] {name} {channel}")
+
+    async def _handle_call(self, channel: str) -> None:
+        target = {"channel": channel}
+        answered = await self.rpc("answer", target=target)
+        if answered.get("status") != "ok":
+            print(f"[call] answer rejected: {answered.get('error')}")
+            return
+        print(f"[call] answered {channel}; holding for {ANSWER_HOLD_SECONDS}s")
+        await asyncio.sleep(ANSWER_HOLD_SECONDS)
+        hung = await self.rpc("hangup", target=target)
+        print(f"[call] hangup {channel}: {hung.get('status')}")
+
+
+async def main() -> None:
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with websockets.connect(CONTROL_URL, additional_headers=headers) as connection:
+        print(f"[control] connected to {CONTROL_URL}")
+        await ControlClient(connection).run()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n[control] interrupted")

--- a/examples/remote_control/control_client.ts
+++ b/examples/remote_control/control_client.ts
@@ -1,0 +1,124 @@
+/**
+ * Example external control client for the siphon control plane (experimental).
+ *
+ * Connects to siphon's control WebSocket, registers as an application, and drives
+ * calls that a B2BUA script hands over with `call.handover("ivr-app")` (the ARI
+ * *Stasis* model). Calls that are not handed over are unaffected.
+ *
+ * The proof-of-concept exposes two verbs, `answer` and `hangup`; this app answers
+ * each handed-over call, holds it briefly, then hangs up. Later phases add
+ * play / dtmf / bridge / originate over the same protocol.
+ *
+ * Usage:
+ *   npm install
+ *   IVR_APP_TOKEN=changeme-dev-token npm start
+ *
+ * See README.md for the matching siphon `control:` config and handover script.
+ */
+import WebSocket from "ws";
+
+const CONTROL_URL = process.env.SIPHON_CONTROL_URL ?? "ws://127.0.0.1:9092/control/ws";
+const APP_NAME = process.env.SIPHON_CONTROL_APP ?? "ivr-app";
+const TOKEN = process.env.IVR_APP_TOKEN ?? "changeme-dev-token";
+const ANSWER_HOLD_MS = 5000;
+
+interface ReplyFrame {
+  id: string;
+  type: "reply";
+  status: "ok" | "error";
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+interface EventFrame {
+  type: "event";
+  event: string;
+  channel?: string;
+  app?: string;
+  payload?: unknown;
+}
+
+type InboundFrame = ReplyFrame | EventFrame;
+
+/** A minimal control-plane client with request/reply correlation. */
+class ControlClient {
+  private nextId = 1;
+  private readonly pending = new Map<string, (reply: ReplyFrame) => void>();
+
+  constructor(private readonly socket: WebSocket) {
+    socket.on("message", (data) => this.onMessage(data.toString()));
+  }
+
+  /** Send a command and resolve with its correlated reply frame. */
+  rpc(verb: string, target: unknown = {}, args: unknown = {}): Promise<ReplyFrame> {
+    const id = `c-${this.nextId++}`;
+    return new Promise((resolve) => {
+      this.pending.set(id, resolve);
+      this.socket.send(JSON.stringify({ id, type: "command", verb, target, args }));
+    });
+  }
+
+  private onMessage(raw: string): void {
+    const frame = JSON.parse(raw) as InboundFrame;
+    if (frame.type === "reply") {
+      const resolve = this.pending.get(frame.id);
+      if (resolve) {
+        this.pending.delete(frame.id);
+        resolve(frame);
+      }
+    } else if (frame.type === "event") {
+      // Handle each event concurrently so a long call flow never blocks the
+      // read loop (and thus never stalls other calls).
+      void this.onEvent(frame);
+    }
+  }
+
+  private async onEvent(event: EventFrame): Promise<void> {
+    if (event.event === "StasisStart" && event.channel) {
+      console.log(`[event] StasisStart ${event.channel}`, event.payload ?? {});
+      await this.handleCall(event.channel);
+    } else {
+      console.log(`[event] ${event.event} ${event.channel ?? ""}`);
+    }
+  }
+
+  private async handleCall(channel: string): Promise<void> {
+    const target = { channel };
+    const answered = await this.rpc("answer", target);
+    if (answered.status !== "ok") {
+      console.log("[call] answer rejected:", answered.error);
+      return;
+    }
+    console.log(`[call] answered ${channel}; holding for ${ANSWER_HOLD_MS}ms`);
+    await new Promise((resolve) => setTimeout(resolve, ANSWER_HOLD_MS));
+    const hung = await this.rpc("hangup", target);
+    console.log(`[call] hangup ${channel}: ${hung.status}`);
+  }
+
+  /** Register this connection as APP_NAME (the hello handshake). */
+  async register(): Promise<void> {
+    const hello = await this.rpc("hello", {}, { app: APP_NAME, protocol: 1 });
+    if (hello.status !== "ok") {
+      throw new Error(`hello rejected: ${JSON.stringify(hello.error)}`);
+    }
+    console.log(`[control] registered as ${APP_NAME}`);
+  }
+}
+
+function main(): void {
+  const socket = new WebSocket(CONTROL_URL, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+  const client = new ControlClient(socket);
+  socket.on("open", () => {
+    console.log(`[control] connected to ${CONTROL_URL}`);
+    client.register().catch((error) => {
+      console.error(error);
+      socket.close();
+    });
+  });
+  socket.on("error", (error) => console.error("[control] socket error:", error));
+  socket.on("close", () => console.log("[control] connection closed"));
+}
+
+main();

--- a/examples/remote_control/package.json
+++ b/examples/remote_control/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "siphon-control-client-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Example external control client for the siphon control plane",
+  "scripts": {
+    "start": "tsx control_client.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.12",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/remote_control/tsconfig.json
+++ b/examples/remote_control/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["control_client.ts"]
+}

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -352,6 +352,30 @@ class Call:
         self._state = "terminated"
         self._actions.append(Action(kind="terminate"))
 
+    def handover(self, app: str) -> None:
+        """Hand this call over to an external control application (experimental).
+
+        Instead of dialling a B-leg, siphon keeps the call alive (a ``180
+        Ringing`` goes to the caller) and offers it to the named application
+        over the control WebSocket (the ARI *Stasis* model).  The out-of-process
+        app then drives the call with ``answer`` / ``hangup`` commands.  Calls
+        that are not handed over are unaffected.
+
+        Args:
+            app: The control application name, matching a ``control.apps[].name``
+                entry in ``siphon.yaml`` and the app's ``hello`` handshake.
+
+        Example::
+
+            @b2bua.on_invite
+            async def route(call):
+                if is_ivr_number(call.to_uri):
+                    call.handover("ivr-app")
+                else:
+                    call.dial(call.ruri)
+        """
+        self._actions.append(Action(kind="handover", app=app))
+
     def accept_refer(self) -> None:
         """Accept an incoming REFER and initiate the transfer.
 

--- a/sdk/siphon_sdk/types.py
+++ b/sdk/siphon_sdk/types.py
@@ -199,7 +199,12 @@ class Action:
 
     kind: str
     """Action type: ``"reply"``, ``"relay"``, ``"fork"``, ``"reject"``,
-    ``"dial"``, ``"terminate"``, ``"record_route"``, ``"silent_drop"``."""
+    ``"dial"``, ``"terminate"``, ``"handover"``, ``"record_route"``,
+    ``"silent_drop"``."""
+
+    app: Optional[str] = None
+    """For ``handover`` — the external control application name the call was
+    handed over to (``call.handover("ivr-app")``)."""
 
     status_code: Optional[int] = None
     """For ``reply`` / ``reject`` — the SIP status code (e.g. 200, 404)."""

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -629,6 +629,13 @@ pub struct CallActor {
     /// the call is still un-answered. `None` = no application timeout (the 24h
     /// orphan backstop still applies).
     pub answer_deadline: Option<std::time::Instant>,
+    /// When `Some(app)`, this call has been handed over to an external control
+    /// application (experimental control plane). While controlled, the orphan
+    /// sweep leaves the call alone — an out-of-process app owns its lifecycle
+    /// and answers/hangs up over the control WebSocket. This is the POC's
+    /// lightweight stand-in for a full `CallState::Parked` variant (avoids
+    /// auditing every `CallState` match site).
+    pub controlled: Option<String>,
 }
 
 impl CallActor {
@@ -657,6 +664,7 @@ impl CallActor {
             a_leg_supports_100rel: false,
             auth_retry_count: 0,
             answer_deadline: None,
+            controlled: None,
         }
     }
 
@@ -1401,6 +1409,7 @@ impl CallActorStore {
         self.calls.iter()
             .filter(|entry| {
                 matches!(entry.state, CallState::Calling | CallState::Ringing)
+                    && entry.controlled.is_none()
                     && entry.answer_deadline.is_some_and(|deadline| now >= deadline)
             })
             .map(|entry| entry.id.clone())
@@ -2240,6 +2249,26 @@ mod tests {
         // Nothing was removed.
         assert_eq!(store.count(), 4);
         let _ = (waiting, answered, no_deadline);
+    }
+
+    #[test]
+    fn take_timed_out_calls_skips_controlled_calls() {
+        // A call handed over to an external control application must never be
+        // swept by the orphan timeout, even past its deadline — the app owns
+        // its lifecycle. Handover clears the deadline anyway; the `controlled`
+        // guard is the belt-and-suspenders backstop.
+        let store = CallActorStore::new();
+        let now = std::time::Instant::now();
+        let past = now - std::time::Duration::from_secs(1);
+
+        let controlled = store.create_call(make_a_leg());
+        store.set_answer_deadline(&controlled, past);
+        if let Some(mut call) = store.get_call_mut(&controlled) {
+            call.controlled = Some("ivr-app".to_string());
+        }
+
+        assert!(store.take_timed_out_calls(now).is_empty());
+        assert_eq!(store.count(), 1);
     }
 
     // --- LegRegistry tests ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,11 @@ pub struct Config {
     /// `None` = disabled.
     pub admin: Option<AdminConfig>,
 
+    /// External remote-control plane (experimental, POC). A WebSocket listener
+    /// that lets an out-of-process application drive B2BUA calls handed over via
+    /// `call.handover("app")`. `None` = disabled (the default).
+    pub control: Option<ControlConfig>,
+
     /// Server and User-Agent header values injected into responses.
     pub server: Option<ServerIdentityConfig>,
 
@@ -1404,6 +1409,56 @@ fn default_metrics_path() -> String {
 pub struct AdminConfig {
     /// Address to expose the admin API on (e.g. "0.0.0.0:9091").
     pub listen: String,
+}
+
+// ---------------------------------------------------------------------------
+// External control plane (experimental, POC)
+// ---------------------------------------------------------------------------
+
+/// Configuration for the experimental external control plane (`control:`).
+///
+/// A single bidirectional WebSocket per application. Out-of-process apps
+/// connect, authenticate with a per-app bearer token, and drive B2BUA calls
+/// that a Python `@b2bua.on_invite` handler explicitly hands over via
+/// `call.handover("app")` (ARI Stasis model).
+///
+/// OFF by default (the whole block is `None` when absent). This POC only binds
+/// on a loopback address with plain WebSocket and bearer-token auth; TLS/mTLS,
+/// ACLs and per-app scopes are follow-ups.
+///
+/// ```yaml
+/// control:
+///   listen: "127.0.0.1:9092"
+///   apps:
+///     - name: "ivr-app"
+///       token: "${IVR_APP_TOKEN}"
+/// ```
+#[derive(Debug, Deserialize, Clone)]
+pub struct ControlConfig {
+    /// Address to expose the control WebSocket on (e.g. "127.0.0.1:9092").
+    pub listen: String,
+    /// Applications allowed to connect, each with its own bearer token.
+    #[serde(default)]
+    pub apps: Vec<ControlAppConfig>,
+    /// Per-connection bounded event-queue depth. Full queue drops the oldest
+    /// event (never blocks the publisher). Default: 1024.
+    #[serde(default = "default_control_event_queue_depth")]
+    pub event_queue_depth: usize,
+}
+
+/// A single application registered with the control plane.
+#[derive(Debug, Deserialize, Clone)]
+pub struct ControlAppConfig {
+    /// Application name — must match the `hello` frame's `app` and the
+    /// `call.handover("<name>")` argument.
+    pub name: String,
+    /// Bearer token presented in the WebSocket-upgrade `Authorization` header.
+    /// Supports `${ENV}` expansion via the standard config env substitution.
+    pub token: String,
+}
+
+fn default_control_event_queue_depth() -> usize {
+    1024
 }
 
 // ---------------------------------------------------------------------------
@@ -2793,6 +2848,51 @@ log:
         assert!(config.registrant.is_none());
         assert!(config.lawful_intercept.is_none());
         assert!(config.diameter.is_none());
+        assert!(config.control.is_none());
+    }
+
+    #[test]
+    fn parses_control_config() {
+        let yaml = format!(
+            "{}{}",
+            minimal_yaml(),
+            r#"
+control:
+  listen: "127.0.0.1:9092"
+  event_queue_depth: 256
+  apps:
+    - name: "ivr-app"
+      token: "s3cr3t"
+    - name: "screening-app"
+      token: "another-token"
+"#
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let control = config.control.expect("control block present");
+        assert_eq!(control.listen, "127.0.0.1:9092");
+        assert_eq!(control.event_queue_depth, 256);
+        assert_eq!(control.apps.len(), 2);
+        assert_eq!(control.apps[0].name, "ivr-app");
+        assert_eq!(control.apps[0].token, "s3cr3t");
+        assert_eq!(control.apps[1].name, "screening-app");
+    }
+
+    #[test]
+    fn control_config_event_queue_depth_defaults() {
+        let yaml = format!(
+            "{}{}",
+            minimal_yaml(),
+            r#"
+control:
+  listen: "127.0.0.1:9092"
+  apps:
+    - name: "ivr-app"
+      token: "s3cr3t"
+"#
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let control = config.control.expect("control block present");
+        assert_eq!(control.event_queue_depth, 1024);
     }
 
     #[test]

--- a/src/control/listener.rs
+++ b/src/control/listener.rs
@@ -1,0 +1,558 @@
+//! The control-plane WebSocket listener (axum).
+//!
+//! ## I/O discipline (the whole point)
+//!
+//! Per connection there are exactly two async tokio tasks and nothing else:
+//!
+//! - a **read task** that parses inbound frames, hands each command to the
+//!   dispatcher over an **unbounded** `flume` channel (a send that never blocks)
+//!   and then `.await`s a `oneshot` for the *local* reply, and
+//! - a **write task** that serialises replies and pushed events onto the socket,
+//!   draining the connection's **bounded** event queue.
+//!
+//! No control I/O ever runs on `py_executor` or the dispatcher; a slow/dead peer
+//! stalls only its own two tasks.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{ConnectInfo, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use futures_util::stream::SplitSink;
+use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use crate::config::ControlAppConfig;
+
+use super::protocol::{
+    CommandFrame, ControlErrorCode, ControlResult, HelloArgs, ReplyFrame,
+};
+use super::registry::{ControlBus, ControlCommand, EventQueue};
+
+/// Shared state for the control listener router.
+#[derive(Clone)]
+pub struct ControlServerState {
+    /// Configured applications (name + bearer token).
+    pub apps: Arc<Vec<ControlAppConfig>>,
+    /// The process-global control bus.
+    pub bus: Arc<ControlBus>,
+}
+
+/// Start the control-plane WebSocket server. Mirrors `admin::serve`: logs and
+/// returns on bind error rather than panicking.
+pub async fn serve(listen_addr: SocketAddr, state: ControlServerState) {
+    let app = router(state);
+
+    info!(%listen_addr, "control plane (experimental) listening");
+
+    let listener = match tokio::net::TcpListener::bind(listen_addr).await {
+        Ok(listener) => listener,
+        Err(error) => {
+            warn!(%listen_addr, %error, "failed to bind control plane listener");
+            return;
+        }
+    };
+
+    let make_service = app.into_make_service_with_connect_info::<SocketAddr>();
+    if let Err(error) = axum::serve(listener, make_service).await {
+        warn!(%error, "control plane server error");
+    }
+}
+
+/// Build the control router (also used by tests without binding a port).
+pub fn router(state: ControlServerState) -> Router {
+    Router::new()
+        .route("/control/ws", get(ws_handler))
+        .with_state(state)
+}
+
+/// Constant-time byte comparison for bearer tokens.
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference: u8 = 0;
+    for (a, b) in left.iter().zip(right.iter()) {
+        difference |= a ^ b;
+    }
+    difference == 0
+}
+
+/// Validate the `Authorization: Bearer <token>` header against the configured
+/// apps. Returns the matching app name, or `None` when unauthenticated.
+fn authenticate(headers: &HeaderMap, apps: &[ControlAppConfig]) -> Option<String> {
+    let value = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = value
+        .strip_prefix("Bearer ")
+        .or_else(|| value.strip_prefix("bearer "))?;
+    for app in apps {
+        if constant_time_eq(token.as_bytes(), app.token.as_bytes()) {
+            return Some(app.name.clone());
+        }
+    }
+    None
+}
+
+/// The WS upgrade handler. Rejects a bad/missing token with `401` **before** the
+/// socket exists (no half-open state for unauthenticated peers).
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<ControlServerState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Response {
+    let app = match authenticate(&headers, &state.apps) {
+        Some(app) => app,
+        None => {
+            // Feed the existing auto-ban store so brute-forcing control tokens
+            // gets the source IP banned just like a SIP scanner.
+            crate::security::record_handshake_failure(peer.ip(), "control");
+            warn!(remote = %peer, "control plane: rejected unauthenticated upgrade");
+            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+        }
+    };
+
+    let bus = Arc::clone(&state.bus);
+    ws.on_upgrade(move |socket| handle_socket(socket, app, bus, peer))
+}
+
+/// Drive one authenticated control connection to completion.
+async fn handle_socket(socket: WebSocket, app: String, bus: Arc<ControlBus>, peer: SocketAddr) {
+    let conn = bus.register_connection(&app);
+    info!(remote = %peer, %app, conn_id = conn.id, "control plane: connection open");
+
+    let (ws_sink, mut ws_source) = socket.split();
+    // Replies are 1:1 with in-flight commands and must never be dropped by
+    // backpressure (a dropped reply would hang the client's rpc). Bounded so a
+    // client that stops reading stalls only its own connection.
+    let (reply_tx, reply_rx) = mpsc::channel::<ReplyFrame>(64);
+
+    let writer_events = Arc::clone(&conn.events);
+    let writer = tokio::spawn(write_task(ws_sink, writer_events, reply_rx));
+
+    let mut said_hello = false;
+    while let Some(message) = ws_source.next().await {
+        let message = match message {
+            Ok(message) => message,
+            Err(error) => {
+                debug!(conn_id = conn.id, %error, "control plane: read error");
+                break;
+            }
+        };
+        match message {
+            Message::Text(text) => {
+                if !read_text_frame(text.as_str(), &mut said_hello, &app, &bus, &reply_tx).await {
+                    break;
+                }
+            }
+            Message::Close(_) => {
+                debug!(conn_id = conn.id, "control plane: client closed");
+                break;
+            }
+            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Binary(_) => {
+                warn!(conn_id = conn.id, "control plane: ignoring binary frame");
+            }
+        }
+    }
+
+    // Teardown: dropping reply_tx and closing the queue both wake the writer.
+    conn.events.close();
+    drop(reply_tx);
+    bus.unregister_connection(&conn);
+    let _ = writer.await;
+    info!(remote = %peer, %app, conn_id = conn.id, "control plane: connection closed");
+}
+
+/// Handle one inbound text frame. Returns `false` when the connection should
+/// close (fatal protocol error / handshake failure).
+async fn read_text_frame(
+    text: &str,
+    said_hello: &mut bool,
+    app: &str,
+    bus: &Arc<ControlBus>,
+    reply_tx: &mpsc::Sender<ReplyFrame>,
+) -> bool {
+    let frame: CommandFrame = match serde_json::from_str(text) {
+        Ok(frame) => frame,
+        Err(error) => {
+            warn!(%error, "control plane: malformed frame");
+            // No id to correlate; drop the frame but keep the connection.
+            return true;
+        }
+    };
+
+    let id = frame.id.clone();
+
+    if !*said_hello {
+        return handle_hello(&frame, id, said_hello, app, reply_tx).await;
+    }
+
+    handle_command(frame, id, bus, reply_tx).await;
+    true
+}
+
+/// Process the mandatory first `hello` frame.
+async fn handle_hello(
+    frame: &CommandFrame,
+    id: String,
+    said_hello: &mut bool,
+    app: &str,
+    reply_tx: &mpsc::Sender<ReplyFrame>,
+) -> bool {
+    if frame.verb != "hello" {
+        let reply = ControlResult::error(
+            ControlErrorCode::ProtocolError,
+            "first frame must be a hello command",
+        )
+        .into_reply(id);
+        let _ = reply_tx.send(reply).await;
+        return false;
+    }
+
+    let hello: HelloArgs = match serde_json::from_value(frame.args.clone()) {
+        Ok(hello) => hello,
+        Err(error) => {
+            let reply = ControlResult::error(
+                ControlErrorCode::BadRequest,
+                format!("invalid hello args: {error}"),
+            )
+            .into_reply(id);
+            let _ = reply_tx.send(reply).await;
+            return false;
+        }
+    };
+
+    // The token's configured app must equal the asserted app (closes cross-app
+    // impersonation).
+    if hello.app != app {
+        let reply = ControlResult::error(
+            ControlErrorCode::Forbidden,
+            "hello app does not match the authenticated token",
+        )
+        .into_reply(id);
+        let _ = reply_tx.send(reply).await;
+        return false;
+    }
+
+    *said_hello = true;
+    let reply = ControlResult::Ok(serde_json::json!({
+        "app": app,
+        "protocol": 1,
+        "subprotocol": "siphon-control.v1",
+    }))
+    .into_reply(id);
+    reply_tx.send(reply).await.is_ok()
+}
+
+/// Route a command to the dispatcher and await its *local* reply.
+async fn handle_command(
+    frame: CommandFrame,
+    id: String,
+    bus: &Arc<ControlBus>,
+    reply_tx: &mpsc::Sender<ReplyFrame>,
+) {
+    let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+    let command = ControlCommand {
+        id: frame.id,
+        verb: frame.verb,
+        target: frame.target,
+        args: frame.args,
+        response_tx,
+    };
+
+    // Unbounded flume send — cannot block the read task (rule 3).
+    if bus.command_sender().send(command).is_err() {
+        let reply = ControlResult::error(
+            ControlErrorCode::Unavailable,
+            "control command consumer is not running",
+        )
+        .into_reply(id);
+        let _ = reply_tx.send(reply).await;
+        return;
+    }
+
+    // Async wait for the local result — never a far-end wait, never a thread
+    // block (rule 4/5). The far-end outcome arrives later as an event.
+    let result = match response_rx.await {
+        Ok(result) => result,
+        Err(_) => {
+            ControlResult::error(ControlErrorCode::Unavailable, "control command was dropped")
+        }
+    };
+    let _ = reply_tx.send(result.into_reply(id)).await;
+}
+
+/// The connection's single write task: multiplexes correlated replies and pushed
+/// events onto the socket.
+async fn write_task(
+    mut ws_sink: SplitSink<WebSocket, Message>,
+    events: Arc<EventQueue>,
+    mut reply_rx: mpsc::Receiver<ReplyFrame>,
+) {
+    'outer: loop {
+        tokio::select! {
+            maybe_reply = reply_rx.recv() => {
+                match maybe_reply {
+                    Some(reply) => {
+                        if !send_json(&mut ws_sink, &reply).await {
+                            break 'outer;
+                        }
+                    }
+                    // Reader gone (after all buffered replies drained) → done.
+                    None => break 'outer,
+                }
+            }
+            frames = events.recv_many() => {
+                if frames.is_empty() {
+                    // The event queue was closed on teardown. Drain any replies
+                    // still buffered (e.g. a handshake rejection) before closing,
+                    // so a queue-closed race can't swallow the correlated reply.
+                    while let Some(reply) = reply_rx.recv().await {
+                        if !send_json(&mut ws_sink, &reply).await {
+                            break;
+                        }
+                    }
+                    break 'outer;
+                }
+                for frame in frames {
+                    if !send_json(&mut ws_sink, &frame).await {
+                        break 'outer;
+                    }
+                }
+                if events.disconnect_requested() {
+                    break 'outer;
+                }
+            }
+        }
+    }
+    let _ = ws_sink.send(Message::Close(None)).await;
+}
+
+/// Serialise a frame to a text WS message. Returns `false` on send failure.
+async fn send_json<T: Serialize>(ws_sink: &mut SplitSink<WebSocket, Message>, frame: &T) -> bool {
+    let text = match serde_json::to_string(frame) {
+        Ok(text) => text,
+        Err(error) => {
+            warn!(%error, "control plane: failed to serialise outbound frame");
+            return true; // don't tear down the connection over one bad frame
+        }
+    };
+    ws_sink.send(Message::Text(text.into())).await.is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::protocol::EventFrame;
+    use crate::control::registry::SlowConsumerPolicy;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    use tokio_tungstenite::tungstenite::http::HeaderValue;
+    use tokio_tungstenite::tungstenite::Message as ClientMessage;
+
+    fn test_apps() -> Arc<Vec<ControlAppConfig>> {
+        Arc::new(vec![ControlAppConfig {
+            name: "ivr-app".to_string(),
+            token: "s3cr3t".to_string(),
+        }])
+    }
+
+    async fn start_server(
+        bus: Arc<ControlBus>,
+    ) -> SocketAddr {
+        let state = ControlServerState {
+            apps: test_apps(),
+            bus,
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let make_service = router(state).into_make_service_with_connect_info::<SocketAddr>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, make_service).await;
+        });
+        addr
+    }
+
+    fn client_request(addr: SocketAddr, token: &str) -> tokio_tungstenite::tungstenite::handshake::client::Request {
+        let mut request = format!("ws://{addr}/control/ws")
+            .into_client_request()
+            .unwrap();
+        request.headers_mut().insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+        request
+    }
+
+    #[test]
+    fn constant_time_eq_matches_and_rejects() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn authenticate_extracts_app() {
+        let apps = test_apps();
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Bearer s3cr3t"));
+        assert_eq!(authenticate(&headers, &apps).as_deref(), Some("ivr-app"));
+
+        let mut bad = HeaderMap::new();
+        bad.insert("authorization", HeaderValue::from_static("Bearer nope"));
+        assert!(authenticate(&bad, &apps).is_none());
+
+        assert!(authenticate(&HeaderMap::new(), &apps).is_none());
+    }
+
+    #[tokio::test]
+    async fn bad_token_rejected_with_401_before_upgrade() {
+        let (command_tx, _command_rx) = flume::unbounded();
+        let bus = ControlBus::new(command_tx, 64, SlowConsumerPolicy::DropOldest);
+        let addr = start_server(bus).await;
+
+        let result = tokio_tungstenite::connect_async(client_request(addr, "wrong")).await;
+        match result {
+            Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            }
+            other => panic!("expected HTTP 401, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn good_token_hello_then_event_then_command() {
+        let (command_tx, command_rx) = flume::unbounded();
+        let bus = ControlBus::new(command_tx, 64, SlowConsumerPolicy::DropOldest);
+        let addr = start_server(Arc::clone(&bus)).await;
+
+        // Stand in for the dispatcher's apply consumer: answer every command Ok.
+        tokio::spawn(async move {
+            while let Ok(command) = command_rx.recv_async().await {
+                let _ = command
+                    .response_tx
+                    .send(ControlResult::Ok(serde_json::json!({ "verb": command.verb })));
+            }
+        });
+
+        let (mut ws, _response) = tokio_tungstenite::connect_async(client_request(addr, "s3cr3t"))
+            .await
+            .expect("handshake with good token must succeed");
+
+        // hello → ok reply
+        ws.send(ClientMessage::Text(
+            serde_json::json!({
+                "id": "1",
+                "type": "command",
+                "verb": "hello",
+                "args": { "app": "ivr-app", "protocol": 1 }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+        let hello_reply = next_json(&mut ws).await;
+        assert_eq!(hello_reply["type"], "reply");
+        assert_eq!(hello_reply["id"], "1");
+        assert_eq!(hello_reply["status"], "ok");
+
+        // A synthetic event pushed server-side must reach the client.
+        let conn = {
+            let mut found = None;
+            for _ in 0..100 {
+                if let Some(conn) = bus.pick_connection("ivr-app") {
+                    found = Some(conn);
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            found.expect("connection should be registered after hello")
+        };
+        bus.register_channel("ch1", Arc::clone(&conn), "call-uuid");
+        assert!(bus.publish_to_channel(
+            "ch1",
+            EventFrame::new("StasisStart", "ch1", "ivr-app", serde_json::json!({ "call_id": "x" })),
+        ));
+
+        let event = next_json(&mut ws).await;
+        assert_eq!(event["type"], "event");
+        assert_eq!(event["event"], "StasisStart");
+        assert_eq!(event["channel"], "ch1");
+
+        // A command → correlated reply.
+        ws.send(ClientMessage::Text(
+            serde_json::json!({
+                "id": "42",
+                "type": "command",
+                "verb": "answer",
+                "target": { "channel": "ch1" },
+                "args": { "code": 200 }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+        let reply = next_json(&mut ws).await;
+        assert_eq!(reply["type"], "reply");
+        assert_eq!(reply["id"], "42");
+        assert_eq!(reply["status"], "ok");
+        assert_eq!(reply["result"]["verb"], "answer");
+    }
+
+    #[tokio::test]
+    async fn hello_with_wrong_app_is_forbidden() {
+        let (command_tx, _command_rx) = flume::unbounded();
+        let bus = ControlBus::new(command_tx, 64, SlowConsumerPolicy::DropOldest);
+        let addr = start_server(bus).await;
+
+        let (mut ws, _response) = tokio_tungstenite::connect_async(client_request(addr, "s3cr3t"))
+            .await
+            .unwrap();
+        ws.send(ClientMessage::Text(
+            serde_json::json!({
+                "id": "1",
+                "type": "command",
+                "verb": "hello",
+                "args": { "app": "someone-else" }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+        let reply = next_json(&mut ws).await;
+        assert_eq!(reply["status"], "error");
+        assert_eq!(reply["error"]["code"], "forbidden");
+    }
+
+    async fn next_json(
+        ws: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    ) -> serde_json::Value {
+        loop {
+            let message = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+                .await
+                .expect("timed out waiting for a frame")
+                .expect("stream closed")
+                .expect("ws error");
+            if let ClientMessage::Text(text) = message {
+                return serde_json::from_str(text.as_str()).unwrap();
+            }
+        }
+    }
+}

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,0 +1,36 @@
+//! External remote-control plane (experimental, proof-of-concept).
+//!
+//! An out-of-process application connects over a single bidirectional WebSocket
+//! and drives B2BUA calls that a Python `@b2bua.on_invite` handler explicitly
+//! hands over with `call.handover("app")` (the ARI *Stasis* model). Calls that
+//! are not handed over cost nothing.
+//!
+//! This POC proves one thing end-to-end: a WebSocket app can drive a live B2BUA
+//! call **without ever blocking siphon's pools or dispatcher**. The protocol,
+//! auth, event bus + backpressure, and the `handover` + `answer`/`hangup` verbs
+//! are wired; everything else in the design (channels/bridges/originate/media/
+//! adapters/TLS/SS7/SMPP) is out of scope.
+//!
+//! ## Layout
+//!
+//! - [`protocol`] — the JSON wire DTOs (command/reply/event).
+//! - [`registry`] — [`ControlBus`], the app/connection/channel registry and the
+//!   bounded per-connection event queue.
+//! - [`listener`] — the axum WebSocket server (token auth + async read/write
+//!   tasks).
+//!
+//! The dispatcher owns the command *apply* consumer (co-located with the B2BUA
+//! handlers), so it can reach the `CallActorStore` and SIP send helpers.
+
+pub mod listener;
+pub mod protocol;
+pub mod registry;
+
+pub use listener::{router, serve, ControlServerState};
+pub use protocol::{
+    CommandFrame, ControlErrorCode, ControlResult, EventFrame, ReplyFrame, ReplyStatus,
+};
+pub use registry::{
+    ChannelOwner, ConnHandle, ControlBus, ControlCommand, EventQueue, PushOutcome,
+    SlowConsumerPolicy,
+};

--- a/src/control/protocol.rs
+++ b/src/control/protocol.rs
@@ -1,0 +1,300 @@
+//! Wire protocol for the external control plane (`siphon-control.v1`).
+//!
+//! Single WebSocket per application, JSON text frames both directions:
+//!
+//! - **command** (client → siphon): `{id, type:"command", verb, target, args}`
+//! - **reply** (siphon → client, `id` echoed): `{id, type:"reply", status, result|error}`
+//! - **event** (siphon → client, un-id'd, pushed): `{type:"event", event, channel, payload}`
+//!
+//! The substrate never interprets `verb`/`args`/`target` beyond routing — they
+//! are handed opaquely (`serde_json::Value`) to the adapter that applies them.
+
+use serde::{Deserialize, Serialize};
+
+/// Discriminator for the `type` field of every frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FrameType {
+    /// A command from the client.
+    Command,
+    /// A correlated reply to a command.
+    Reply,
+    /// A pushed event (no id).
+    Event,
+}
+
+/// A command frame received from a control application (client → siphon).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandFrame {
+    /// Client-owned request id, echoed verbatim in the reply.
+    pub id: String,
+    /// Always [`FrameType::Command`].
+    #[serde(rename = "type")]
+    pub frame_type: FrameType,
+    /// The verb to apply (e.g. `"answer"`, `"hangup"`, `"hello"`).
+    pub verb: String,
+    /// Adapter-defined target (e.g. `{"channel": "…"}`). Absent → JSON null.
+    #[serde(default)]
+    pub target: serde_json::Value,
+    /// Adapter-defined arguments. Absent → JSON null.
+    #[serde(default)]
+    pub args: serde_json::Value,
+}
+
+impl CommandFrame {
+    /// Extract the `target.channel` string when present.
+    pub fn channel_target(&self) -> Option<String> {
+        self.target
+            .get("channel")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+    }
+}
+
+/// Status of a reply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReplyStatus {
+    /// The command was accepted (the *local* action was performed).
+    Ok,
+    /// The command was rejected.
+    Error,
+}
+
+/// Stable error codes returned in a reply's `error.code`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlErrorCode {
+    /// Authentication failed (bad/missing token).
+    Unauthorized,
+    /// The connection's app does not own the target resource.
+    Forbidden,
+    /// The target channel does not exist.
+    NotFound,
+    /// The frame or its arguments were malformed.
+    BadRequest,
+    /// The command exceeded a rate limit.
+    RateLimited,
+    /// The verb is not implemented by the adapter.
+    UnsupportedVerb,
+    /// The frame violated the protocol (e.g. duplicate id, bad handshake).
+    ProtocolError,
+    /// The control plane could not service the command right now.
+    Unavailable,
+}
+
+/// The error body of a failed reply.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplyError {
+    /// Stable machine-readable code.
+    pub code: ControlErrorCode,
+    /// Human-readable detail.
+    pub message: String,
+}
+
+/// A reply frame (siphon → client, `id` echoed).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplyFrame {
+    /// The command id this reply correlates to.
+    pub id: String,
+    /// Always [`FrameType::Reply`].
+    #[serde(rename = "type")]
+    pub frame_type: FrameType,
+    /// Whether the command was accepted.
+    pub status: ReplyStatus,
+    /// Present on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Present on failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ReplyError>,
+}
+
+/// A pushed event frame (siphon → client, un-id'd).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventFrame {
+    /// Always [`FrameType::Event`].
+    #[serde(rename = "type")]
+    pub frame_type: FrameType,
+    /// Event name (e.g. `"StasisStart"`, `"StasisEnd"`).
+    pub event: String,
+    /// The channel this event concerns, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// The application the channel was handed to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app: Option<String>,
+    /// Event-specific payload.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub payload: serde_json::Value,
+}
+
+impl EventFrame {
+    /// Build an event frame for a channel.
+    pub fn new(
+        event: impl Into<String>,
+        channel: impl Into<String>,
+        app: impl Into<String>,
+        payload: serde_json::Value,
+    ) -> Self {
+        Self {
+            frame_type: FrameType::Event,
+            event: event.into(),
+            channel: Some(channel.into()),
+            app: Some(app.into()),
+            payload,
+        }
+    }
+}
+
+/// The outcome of applying a command — carried back to the connection's read
+/// task over a `oneshot` and rendered into a [`ReplyFrame`].
+///
+/// A `ControlResult` is the reply to the *local* action only. It is emphatically
+/// **not** a far-end outcome: an accepted `answer`/`hangup` returns `Ok`
+/// immediately, and the callee's actual answer / BYE-200 arrive later as events.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlResult {
+    /// The local action was accepted.
+    Ok(serde_json::Value),
+    /// The command was rejected.
+    Error {
+        /// Machine-readable error code.
+        code: ControlErrorCode,
+        /// Human-readable detail.
+        message: String,
+    },
+}
+
+impl ControlResult {
+    /// Convenience constructor for an error result.
+    pub fn error(code: ControlErrorCode, message: impl Into<String>) -> Self {
+        ControlResult::Error {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Render into a wire reply frame for the given command id.
+    pub fn into_reply(self, id: String) -> ReplyFrame {
+        match self {
+            ControlResult::Ok(result) => ReplyFrame {
+                id,
+                frame_type: FrameType::Reply,
+                status: ReplyStatus::Ok,
+                result: Some(result),
+                error: None,
+            },
+            ControlResult::Error { code, message } => ReplyFrame {
+                id,
+                frame_type: FrameType::Reply,
+                status: ReplyStatus::Error,
+                result: None,
+                error: Some(ReplyError { code, message }),
+            },
+        }
+    }
+}
+
+/// Arguments of the `hello` handshake command (`args`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelloArgs {
+    /// The application name — must equal the token's configured app.
+    pub app: String,
+    /// Protocol version the client speaks. Optional; defaults to 1.
+    #[serde(default)]
+    pub protocol: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_frame_round_trip() {
+        let frame = CommandFrame {
+            id: "c-42".to_string(),
+            frame_type: FrameType::Command,
+            verb: "answer".to_string(),
+            target: serde_json::json!({ "channel": "ch_9f3a" }),
+            args: serde_json::json!({ "code": 200 }),
+        };
+        let text = serde_json::to_string(&frame).unwrap();
+        assert!(text.contains("\"type\":\"command\""));
+        let parsed: CommandFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, frame);
+        assert_eq!(parsed.channel_target().as_deref(), Some("ch_9f3a"));
+    }
+
+    #[test]
+    fn command_frame_defaults_missing_target_and_args() {
+        let text = r#"{"id":"1","type":"command","verb":"hello"}"#;
+        let parsed: CommandFrame = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed.verb, "hello");
+        assert!(parsed.target.is_null());
+        assert!(parsed.args.is_null());
+        assert_eq!(parsed.channel_target(), None);
+    }
+
+    #[test]
+    fn ok_reply_round_trip() {
+        let reply = ControlResult::Ok(serde_json::json!({ "state": "answered" }))
+            .into_reply("c-42".to_string());
+        let text = serde_json::to_string(&reply).unwrap();
+        assert!(text.contains("\"status\":\"ok\""));
+        assert!(!text.contains("\"error\""));
+        let parsed: ReplyFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, reply);
+        assert_eq!(parsed.status, ReplyStatus::Ok);
+    }
+
+    #[test]
+    fn error_reply_round_trip() {
+        let reply = ControlResult::error(ControlErrorCode::NotFound, "no such channel")
+            .into_reply("c-7".to_string());
+        let text = serde_json::to_string(&reply).unwrap();
+        assert!(text.contains("\"status\":\"error\""));
+        assert!(text.contains("\"code\":\"not_found\""));
+        assert!(!text.contains("\"result\""));
+        let parsed: ReplyFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, reply);
+    }
+
+    #[test]
+    fn event_frame_round_trip() {
+        let event = EventFrame::new(
+            "StasisStart",
+            "ch_9f3a",
+            "ivr-app",
+            serde_json::json!({ "call_id": "abc" }),
+        );
+        let text = serde_json::to_string(&event).unwrap();
+        assert!(text.contains("\"type\":\"event\""));
+        assert!(text.contains("\"event\":\"StasisStart\""));
+        let parsed: EventFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, event);
+    }
+
+    #[test]
+    fn event_frame_omits_null_payload() {
+        let event = EventFrame::new("StasisEnd", "ch_1", "ivr-app", serde_json::Value::Null);
+        let text = serde_json::to_string(&event).unwrap();
+        assert!(!text.contains("payload"));
+    }
+
+    #[test]
+    fn hello_args_parse() {
+        let args = serde_json::json!({ "app": "ivr-app", "protocol": 1 });
+        let hello: HelloArgs = serde_json::from_value(args).unwrap();
+        assert_eq!(hello.app, "ivr-app");
+        assert_eq!(hello.protocol, Some(1));
+    }
+
+    #[test]
+    fn error_code_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::UnsupportedVerb).unwrap(),
+            "\"unsupported_verb\""
+        );
+    }
+}

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -1,0 +1,514 @@
+//! `ControlBus` — the process-global app/connection/channel registry and the
+//! bounded per-connection event queue.
+//!
+//! Installed once at boot (like `registrar_arc()` / `set_uac_sender()`), read by
+//! the dispatcher when a controlled call needs an event pushed and by the
+//! control WebSocket listener when a connection registers or a command arrives.
+//!
+//! ## Isolation invariant
+//!
+//! Publishing an event to a connection is a **non-blocking `try_push`** onto a
+//! **bounded** queue — it never `.await`s and never parks the caller (the
+//! dispatcher / a leg actor). A stalled application backs up only its own queue;
+//! on overflow the oldest event is dropped (default) or the connection is marked
+//! for disconnect. Pressure never reaches the signaling plane.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use dashmap::DashMap;
+use tokio::sync::{oneshot, Notify};
+
+use super::protocol::{ControlResult, EventFrame};
+
+/// Overflow policy for a per-connection event queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SlowConsumerPolicy {
+    /// Drop the oldest queued event to make room (default).
+    #[default]
+    DropOldest,
+    /// Mark the connection for disconnect (the writer task closes it).
+    Disconnect,
+}
+
+/// Result of a single [`EventQueue::try_push`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushOutcome {
+    /// The event was queued.
+    Delivered,
+    /// The queue was full; the oldest event was dropped to make room.
+    DroppedOldest,
+    /// The queue was full and the policy is `Disconnect`; the event was dropped
+    /// and the connection is now flagged for disconnect.
+    OverflowDisconnect,
+}
+
+/// A bounded, non-blocking, drop-oldest event queue for one connection.
+///
+/// The producer (dispatcher / leg actor) calls [`try_push`](Self::try_push) —
+/// a brief lock, never held across an `.await`. The connection's async writer
+/// task calls [`recv_many`](Self::recv_many) which parks on a `Notify` until
+/// events are available, then drains them all under one lock.
+#[derive(Debug)]
+pub struct EventQueue {
+    inner: Mutex<VecDeque<EventFrame>>,
+    notify: Notify,
+    capacity: usize,
+    policy: SlowConsumerPolicy,
+    dropped: AtomicU64,
+    disconnect: AtomicBool,
+    closed: AtomicBool,
+}
+
+impl EventQueue {
+    /// Create a queue with the given capacity and overflow policy.
+    pub fn new(capacity: usize, policy: SlowConsumerPolicy) -> Self {
+        Self {
+            inner: Mutex::new(VecDeque::with_capacity(capacity.min(64))),
+            notify: Notify::new(),
+            capacity: capacity.max(1),
+            policy,
+            dropped: AtomicU64::new(0),
+            disconnect: AtomicBool::new(false),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, VecDeque<EventFrame>> {
+        match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    /// Push one event without ever blocking or awaiting.
+    pub fn try_push(&self, frame: EventFrame) -> PushOutcome {
+        let outcome = {
+            let mut queue = self.lock();
+            if queue.len() >= self.capacity {
+                match self.policy {
+                    SlowConsumerPolicy::DropOldest => {
+                        queue.pop_front();
+                        self.dropped.fetch_add(1, Ordering::Relaxed);
+                        queue.push_back(frame);
+                        PushOutcome::DroppedOldest
+                    }
+                    SlowConsumerPolicy::Disconnect => {
+                        self.dropped.fetch_add(1, Ordering::Relaxed);
+                        self.disconnect.store(true, Ordering::SeqCst);
+                        PushOutcome::OverflowDisconnect
+                    }
+                }
+            } else {
+                queue.push_back(frame);
+                PushOutcome::Delivered
+            }
+        };
+        // Wake the writer (outside the lock). Even on disconnect we notify so
+        // the writer observes the flag and closes.
+        self.notify.notify_one();
+        outcome
+    }
+
+    /// Await and drain all currently-queued events. Returns an empty vector only
+    /// when the queue has been [`closed`](Self::close).
+    pub async fn recv_many(&self) -> Vec<EventFrame> {
+        loop {
+            {
+                let mut queue = self.lock();
+                if !queue.is_empty() {
+                    return queue.drain(..).collect();
+                }
+            }
+            if self.closed.load(Ordering::SeqCst) {
+                return Vec::new();
+            }
+            self.notify.notified().await;
+        }
+    }
+
+    /// Signal the writer to stop (used on connection teardown).
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::SeqCst);
+        self.notify.notify_one();
+    }
+
+    /// Number of events dropped so far due to overflow.
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Whether the queue has requested a disconnect (overflow under the
+    /// `Disconnect` policy).
+    pub fn disconnect_requested(&self) -> bool {
+        self.disconnect.load(Ordering::SeqCst)
+    }
+
+    /// Current queued depth (test/observability only).
+    pub fn depth(&self) -> usize {
+        self.lock().len()
+    }
+}
+
+/// A single control connection registered with the bus.
+#[derive(Debug)]
+pub struct ConnHandle {
+    /// Process-unique connection id.
+    pub id: u64,
+    /// The application this connection authenticated as.
+    pub app: String,
+    /// The connection's bounded outbound event queue.
+    pub events: Arc<EventQueue>,
+}
+
+/// The owner of a controlled channel (for command routing + authZ).
+#[derive(Debug, Clone)]
+pub struct ChannelOwner {
+    /// The application that owns the channel.
+    pub app: String,
+    /// The specific connection the channel was handed to.
+    pub conn: Arc<ConnHandle>,
+    /// The internal `CallActor` id backing this channel.
+    pub call_actor_id: String,
+}
+
+/// The set of connections for one application, with a round-robin cursor.
+#[derive(Debug, Default)]
+struct AppFanout {
+    conns: Mutex<Vec<Arc<ConnHandle>>>,
+    cursor: AtomicUsize,
+}
+
+impl AppFanout {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<Arc<ConnHandle>>> {
+        match self.conns.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn add(&self, conn: Arc<ConnHandle>) {
+        self.lock().push(conn);
+    }
+
+    fn remove(&self, id: u64) {
+        self.lock().retain(|conn| conn.id != id);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.lock().is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    fn pick(&self) -> Option<Arc<ConnHandle>> {
+        let conns = self.lock();
+        if conns.is_empty() {
+            return None;
+        }
+        let index = self.cursor.fetch_add(1, Ordering::Relaxed) % conns.len();
+        Some(Arc::clone(&conns[index]))
+    }
+}
+
+/// A command received from a control connection, en route to the dispatcher's
+/// apply consumer. `response_tx` carries the *local* [`ControlResult`] back.
+#[derive(Debug)]
+pub struct ControlCommand {
+    /// Client-owned request id (echoed in the reply).
+    pub id: String,
+    /// The verb to apply.
+    pub verb: String,
+    /// Adapter-defined target (`serde_json::Value`).
+    pub target: serde_json::Value,
+    /// Adapter-defined arguments (`serde_json::Value`).
+    pub args: serde_json::Value,
+    /// Channel back to the connection's read task with the local result.
+    pub response_tx: oneshot::Sender<ControlResult>,
+}
+
+impl ControlCommand {
+    /// Extract the `target.channel` string when present.
+    pub fn channel_target(&self) -> Option<String> {
+        self.target
+            .get("channel")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+    }
+}
+
+/// Process-global control-plane registry.
+#[derive(Debug)]
+pub struct ControlBus {
+    apps: DashMap<String, AppFanout>,
+    channels: DashMap<String, ChannelOwner>,
+    command_tx: flume::Sender<ControlCommand>,
+    event_queue_depth: usize,
+    slow_consumer: SlowConsumerPolicy,
+    next_conn_id: AtomicU64,
+}
+
+static CONTROL_BUS: OnceLock<Arc<ControlBus>> = OnceLock::new();
+
+impl ControlBus {
+    /// Build a new bus. `command_tx` feeds the dispatcher's apply consumer.
+    pub fn new(
+        command_tx: flume::Sender<ControlCommand>,
+        event_queue_depth: usize,
+        slow_consumer: SlowConsumerPolicy,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            apps: DashMap::new(),
+            channels: DashMap::new(),
+            command_tx,
+            event_queue_depth: event_queue_depth.max(1),
+            slow_consumer,
+            next_conn_id: AtomicU64::new(1),
+        })
+    }
+
+    /// Install the process-global bus. Returns `Err` if already installed.
+    pub fn install(bus: Arc<ControlBus>) -> Result<(), Arc<ControlBus>> {
+        CONTROL_BUS.set(bus)
+    }
+
+    /// The process-global bus, if installed.
+    pub fn global() -> Option<Arc<ControlBus>> {
+        CONTROL_BUS.get().cloned()
+    }
+
+    /// A cloneable sender for the command channel (used by the listener).
+    pub fn command_sender(&self) -> flume::Sender<ControlCommand> {
+        self.command_tx.clone()
+    }
+
+    /// Register a new connection for `app`. Returns the handle whose `events`
+    /// queue the connection's writer task drains.
+    pub fn register_connection(&self, app: &str) -> Arc<ConnHandle> {
+        let id = self.next_conn_id.fetch_add(1, Ordering::Relaxed);
+        let handle = Arc::new(ConnHandle {
+            id,
+            app: app.to_string(),
+            events: Arc::new(EventQueue::new(self.event_queue_depth, self.slow_consumer)),
+        });
+        self.apps
+            .entry(app.to_string())
+            .or_default()
+            .add(Arc::clone(&handle));
+        handle
+    }
+
+    /// Remove a connection from its application fanout. Also drops the app entry
+    /// once it has no more connections, so `apps` drains to baseline.
+    pub fn unregister_connection(&self, conn: &ConnHandle) {
+        if let Some(fanout) = self.apps.get(&conn.app) {
+            fanout.remove(conn.id);
+        }
+        conn.events.close();
+        self.apps.remove_if(&conn.app, |_, fanout| fanout.is_empty());
+    }
+
+    /// Round-robin select a connection of `app` (the `StasisStart` owner).
+    pub fn pick_connection(&self, app: &str) -> Option<Arc<ConnHandle>> {
+        self.apps.get(app).and_then(|fanout| fanout.pick())
+    }
+
+    /// Register a controlled channel to an owning connection.
+    pub fn register_channel(
+        &self,
+        channel_id: &str,
+        conn: Arc<ConnHandle>,
+        call_actor_id: &str,
+    ) {
+        self.channels.insert(
+            channel_id.to_string(),
+            ChannelOwner {
+                app: conn.app.clone(),
+                conn,
+                call_actor_id: call_actor_id.to_string(),
+            },
+        );
+    }
+
+    /// Remove a channel and return its former owner.
+    pub fn remove_channel(&self, channel_id: &str) -> Option<ChannelOwner> {
+        self.channels.remove(channel_id).map(|(_, owner)| owner)
+    }
+
+    /// The owner of a channel, if registered.
+    pub fn channel_owner(&self, channel_id: &str) -> Option<ChannelOwner> {
+        self.channels.get(channel_id).map(|entry| entry.value().clone())
+    }
+
+    /// Publish an event to a channel's owning connection (non-blocking).
+    /// Returns `false` if the channel is unknown.
+    pub fn publish_to_channel(&self, channel_id: &str, frame: EventFrame) -> bool {
+        match self.channels.get(channel_id) {
+            Some(entry) => {
+                entry.value().conn.events.try_push(frame);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Number of registered channels (drains to baseline — leak gate).
+    pub fn channel_count(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Number of applications with at least one connection.
+    pub fn app_count(&self) -> usize {
+        self.apps.len()
+    }
+
+    /// Number of connections registered for `app`.
+    pub fn app_connection_count(&self, app: &str) -> usize {
+        self.apps.get(app).map(|fanout| fanout.len()).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_bus(depth: usize, policy: SlowConsumerPolicy) -> Arc<ControlBus> {
+        let (command_tx, _command_rx) = flume::unbounded();
+        ControlBus::new(command_tx, depth, policy)
+    }
+
+    fn stasis_start(channel: &str, app: &str) -> EventFrame {
+        EventFrame::new("StasisStart", channel, app, serde_json::json!({}))
+    }
+
+    #[test]
+    fn register_and_pick_connection() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        assert_eq!(bus.app_count(), 0);
+        let conn = bus.register_connection("ivr-app");
+        assert_eq!(bus.app_count(), 1);
+        assert_eq!(bus.app_connection_count("ivr-app"), 1);
+        let picked = bus.pick_connection("ivr-app").unwrap();
+        assert_eq!(picked.id, conn.id);
+        assert!(bus.pick_connection("other-app").is_none());
+    }
+
+    #[test]
+    fn round_robin_pick_rotates() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let a = bus.register_connection("app");
+        let b = bus.register_connection("app");
+        let first = bus.pick_connection("app").unwrap().id;
+        let second = bus.pick_connection("app").unwrap().id;
+        assert_ne!(first, second);
+        let mut ids = [first, second];
+        ids.sort_unstable();
+        let mut expected = [a.id, b.id];
+        expected.sort_unstable();
+        assert_eq!(ids, expected);
+    }
+
+    #[test]
+    fn channel_register_and_publish_to_owner() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("ch1", Arc::clone(&conn), "call-uuid-1");
+        assert_eq!(bus.channel_count(), 1);
+        assert!(bus.publish_to_channel("ch1", stasis_start("ch1", "ivr-app")));
+        assert_eq!(conn.events.depth(), 1);
+        assert!(!bus.publish_to_channel("nope", stasis_start("nope", "ivr-app")));
+    }
+
+    /// Steady-state leak gate: register N conns + hand over N channels + hang up
+    /// all of them + disconnect all conns → both maps drain to their starting
+    /// `len()`. This is the co-located analogue of `mem_leak_test.sh` gating
+    /// `siphon_proxy_dialog_sessions → 0`.
+    #[test]
+    fn steady_state_drains_to_baseline() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let start_apps = bus.app_count();
+        let start_channels = bus.channel_count();
+        assert_eq!(start_apps, 0);
+        assert_eq!(start_channels, 0);
+
+        for cycle in 0..5 {
+            let mut conns = Vec::new();
+            for index in 0..8 {
+                let conn = bus.register_connection("ivr-app");
+                let channel = format!("ch-{cycle}-{index}");
+                bus.register_channel(&channel, Arc::clone(&conn), &format!("call-{cycle}-{index}"));
+                bus.publish_to_channel(&channel, stasis_start(&channel, "ivr-app"));
+                conns.push((conn, channel));
+            }
+            assert_eq!(bus.channel_count(), 8);
+            assert_eq!(bus.app_connection_count("ivr-app"), 8);
+
+            for (conn, channel) in conns {
+                // hangup path: remove the channel + emit StasisEnd to owner.
+                let owner = bus.remove_channel(&channel).unwrap();
+                owner
+                    .conn
+                    .events
+                    .try_push(EventFrame::new("StasisEnd", &channel, "ivr-app", serde_json::json!({})));
+                bus.unregister_connection(&conn);
+            }
+
+            assert_eq!(bus.channel_count(), start_channels, "channels leaked on cycle {cycle}");
+            assert_eq!(bus.app_count(), start_apps, "apps leaked on cycle {cycle}");
+        }
+    }
+
+    #[test]
+    fn event_queue_bounded_drop_oldest() {
+        let queue = EventQueue::new(2, SlowConsumerPolicy::DropOldest);
+        assert_eq!(queue.try_push(stasis_start("c", "a")), PushOutcome::Delivered);
+        assert_eq!(queue.try_push(stasis_start("c", "a")), PushOutcome::Delivered);
+        // Full now — a slow/stuck consumer never grows the queue past capacity.
+        assert_eq!(queue.try_push(stasis_start("c", "a")), PushOutcome::DroppedOldest);
+        assert_eq!(queue.try_push(stasis_start("c", "a")), PushOutcome::DroppedOldest);
+        assert_eq!(queue.depth(), 2, "queue must stay bounded at capacity");
+        assert_eq!(queue.dropped_count(), 2);
+        assert!(!queue.disconnect_requested());
+    }
+
+    #[test]
+    fn event_queue_disconnect_policy_flags_slow_consumer() {
+        let queue = EventQueue::new(1, SlowConsumerPolicy::Disconnect);
+        assert_eq!(queue.try_push(stasis_start("c", "a")), PushOutcome::Delivered);
+        assert_eq!(
+            queue.try_push(stasis_start("c", "a")),
+            PushOutcome::OverflowDisconnect
+        );
+        assert!(queue.disconnect_requested());
+        assert_eq!(queue.depth(), 1, "queue must stay bounded at capacity");
+    }
+
+    #[tokio::test]
+    async fn event_queue_recv_many_delivers_pushed_events() {
+        let queue = Arc::new(EventQueue::new(8, SlowConsumerPolicy::DropOldest));
+        let writer = Arc::clone(&queue);
+        let handle = tokio::spawn(async move { writer.recv_many().await });
+        queue.try_push(stasis_start("c1", "a"));
+        let frames = handle.await.unwrap();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].channel.as_deref(), Some("c1"));
+    }
+
+    #[tokio::test]
+    async fn publishing_never_blocks_a_stuck_consumer() {
+        // A consumer that never drains: publishing must return immediately and
+        // the queue must stay bounded rather than grow without limit.
+        let bus = test_bus(4, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("ch", Arc::clone(&conn), "call");
+        for _ in 0..1000 {
+            // If this ever awaited/blocked, the test would hang.
+            bus.publish_to_channel("ch", stasis_start("ch", "ivr-app"));
+        }
+        assert_eq!(conn.events.depth(), 4);
+        assert_eq!(conn.events.dropped_count(), 996);
+    }
+}

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -365,6 +365,7 @@ pub async fn run(
     rtpengine_events_rx: tokio::sync::mpsc::Receiver<crate::rtpengine::events::RtpEngineEvent>,
     rf_charger: Option<Arc<crate::diameter::rf_service::RfChargingService>>,
     drain: Arc<DrainState>,
+    control_command_rx: Option<flume::Receiver<crate::control::ControlCommand>>,
     product_name: &'static str,
     product_version: &'static str,
 ) {
@@ -902,6 +903,28 @@ pub async fn run(
                     }
                 }
             }
+        });
+    }
+
+    // --- External control plane: sibling command consumer ---
+    //
+    // A separate tokio task drains the control command channel and applies each
+    // command as a plain async task — ZERO blocking-pool slots, off the inbound
+    // hot path entirely. Correctness is via the `CallActorStore` per-key
+    // DashMap lock (the real serializer), so control application races nothing
+    // the inbound-SIP path doesn't already race. There is no Python handler in
+    // the v1 verbs, so these never touch `py_executor`.
+    if let Some(control_command_rx) = control_command_rx {
+        let control_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            info!("control command consumer started");
+            while let Ok(command) = control_command_rx.recv_async().await {
+                let task_state = Arc::clone(&control_state);
+                tokio::spawn(async move {
+                    apply_control_command(command, &task_state).await;
+                });
+            }
+            info!("control command consumer stopped (channel closed)");
         });
     }
 
@@ -7601,6 +7624,409 @@ fn handle_b2bua_invite(
             // Actor stays alive — the A-leg dialog is now confirmed and the
             // @b2bua.on_bye handler takes over when the UAC BYEs.
         }
+        CallAction::Handover { app } => {
+            b2bua_handover_to_control(&call_id, &app, &message_guard, &inbound, state);
+        }
+    }
+}
+
+/// Hand a B2BUA call over to an external control application (ARI *Stasis*).
+///
+/// Keeps the `CallActor` alive un-dialed, sends a `180 Ringing` to the A-leg,
+/// clears the answer deadline (so the orphan sweep won't 408 the parked call),
+/// registers the call in the [`ControlBus`](crate::control::ControlBus) and
+/// emits a `StasisStart` event to a connection of the named app. If no app is
+/// connected, the call is rejected `480` rather than silently black-holed.
+fn b2bua_handover_to_control(
+    call_id: &str,
+    app: &str,
+    original_request: &SipMessage,
+    inbound: &InboundMessage,
+    state: &DispatcherState,
+) {
+    // Ringback while the control app decides.
+    let ringing = build_response(
+        original_request,
+        180,
+        "Ringing",
+        state.server_header.as_deref(),
+        &[],
+    );
+    send_message_from(
+        ringing,
+        inbound.transport,
+        inbound.remote_addr,
+        inbound.connection_id,
+        Some(inbound.local_addr),
+        state,
+    );
+
+    let channel = call_id.to_string();
+    let handed_over = match crate::control::ControlBus::global() {
+        Some(bus) => match bus.pick_connection(app) {
+            Some(conn) => {
+                if let Some(mut call) = state.call_actors.get_call_mut(call_id) {
+                    call.controlled = Some(app.to_string());
+                    // Clear the app answer deadline — the control app owns the
+                    // call's lifecycle now (the `controlled` guard is the
+                    // belt-and-suspenders backstop in the orphan sweep).
+                    call.answer_deadline = None;
+                    call.state = CallState::Ringing;
+                }
+                bus.register_channel(&channel, Arc::clone(&conn), call_id);
+                let payload = handover_stasis_payload(original_request, &channel);
+                conn.events.try_push(crate::control::EventFrame::new(
+                    "StasisStart",
+                    &channel,
+                    app,
+                    payload,
+                ));
+                info!(call_id = %call_id, %app, "B2BUA: handed over to control app");
+                true
+            }
+            None => false,
+        },
+        None => false,
+    };
+
+    if !handed_over {
+        warn!(
+            call_id = %call_id,
+            %app,
+            "B2BUA: no control app connected for handover — rejecting 480"
+        );
+        let response = build_response(
+            original_request,
+            480,
+            "Temporarily Unavailable",
+            state.server_header.as_deref(),
+            &[],
+        );
+        send_message_from(
+            response,
+            inbound.transport,
+            inbound.remote_addr,
+            inbound.connection_id,
+            Some(inbound.local_addr),
+            state,
+        );
+        state.call_actors.remove_call(call_id);
+        state.call_event_receivers.remove(call_id);
+    }
+}
+
+/// Build the `StasisStart` payload for a handed-over call.
+fn handover_stasis_payload(invite: &SipMessage, channel: &str) -> serde_json::Value {
+    serde_json::json!({
+        "channel": channel,
+        "caller": invite.headers.from().cloned(),
+        "callee": invite.headers.to().cloned(),
+        "call_id": invite.headers.call_id().cloned(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Control-plane command application
+// ---------------------------------------------------------------------------
+
+/// A local SIP action decided by [`apply_control_verb`], rendered into an actual
+/// send by [`apply_control_command`]. Kept separate from the store mutation so
+/// the verb core is a synchronous, easily-tested function that touches only the
+/// [`CallActorStore`] — and so the SIP message is built **outside** the DashMap
+/// lock (never nesting the message mutex under the store lock).
+//
+// `large_enum_variant`: `ByeALeg` carries a full `Leg` while `RespondToALeg`
+// holds a handful of small fields — the size gap is real, but these live in a
+// per-command `Vec` of tiny cardinality at signaling rate, so boxing would only
+// add an allocation to the local action with no benefit.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum ControlEffect {
+    /// Send a response (built from the stored A-leg INVITE) to the A-leg.
+    RespondToALeg {
+        invite: Arc<Mutex<SipMessage>>,
+        transport: LegTransport,
+        code: u16,
+        reason: String,
+        /// UAS To-tag to stamp on the response (dialog establishment).
+        to_tag: Option<String>,
+        body: Option<Vec<u8>>,
+        content_type: Option<String>,
+    },
+    /// Send an in-dialog BYE to the A-leg, built from the leg's dialog state.
+    ByeALeg { leg: Leg },
+}
+
+/// The outcome of applying one control command: the *local* reply, the SIP
+/// effects to perform, and whether the channel is now ended (→ remove it from
+/// the bus + emit `StasisEnd`).
+#[derive(Debug)]
+struct ControlOutcome {
+    result: crate::control::ControlResult,
+    effects: Vec<ControlEffect>,
+    end_channel: bool,
+}
+
+impl ControlOutcome {
+    fn error(code: crate::control::ControlErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            result: crate::control::ControlResult::error(code, message),
+            effects: Vec::new(),
+            end_channel: false,
+        }
+    }
+}
+
+/// Apply one control command as a plain async task (zero blocking-pool slots).
+///
+/// **The load-bearing rule:** this performs only the *bounded, local* action —
+/// mutate the store and send at most one SIP message — and returns "accepted"
+/// immediately. It NEVER waits for the callee to answer, for an ACK, or for a
+/// BYE 200; those far-end outcomes arrive later as async events. The single
+/// `.await`s here are the localhost UDP/TCP sends (already non-blocking) and the
+/// final `oneshot` reply — never a dialog-progress wait.
+async fn apply_control_command(command: crate::control::ControlCommand, state: &DispatcherState) {
+    let outcome = apply_control_verb(&state.call_actors, &command);
+
+    // Render the local SIP effect(s). Each builds a message (locking the A-leg
+    // INVITE mutex standalone — no store lock held) and hands it to the
+    // non-blocking outbound path.
+    for effect in &outcome.effects {
+        match effect {
+            ControlEffect::RespondToALeg {
+                invite,
+                transport,
+                code,
+                reason,
+                to_tag,
+                body,
+                content_type,
+            } => {
+                let response = {
+                    let guard = match invite.lock() {
+                        Ok(guard) => guard,
+                        Err(poisoned) => poisoned.into_inner(),
+                    };
+                    let mut response = build_response(
+                        &guard,
+                        *code,
+                        reason,
+                        state.server_header.as_deref(),
+                        &[],
+                    );
+                    if let Some(tag) = to_tag {
+                        if let Some(current_to) =
+                            response.headers.get("To").map(|value| value.to_string())
+                        {
+                            response.headers.set(
+                                "To",
+                                crate::b2bua::actor::ensure_tag(&current_to, Some(tag)),
+                            );
+                        }
+                    }
+                    if let Some(body_bytes) = body {
+                        if let Some(content_type) = content_type {
+                            response.headers.set("Content-Type", content_type.clone());
+                        }
+                        response
+                            .headers
+                            .set("Content-Length", body_bytes.len().to_string());
+                        response.body = body_bytes.clone();
+                    }
+                    response
+                };
+                send_message(
+                    response,
+                    transport.transport,
+                    transport.remote_addr,
+                    transport.connection_id,
+                    state,
+                );
+            }
+            ControlEffect::ByeALeg { leg } => {
+                if let Some(bye) = build_b2bua_bye(leg, state) {
+                    send_message(
+                        bye,
+                        leg.transport.transport,
+                        leg.transport.remote_addr,
+                        leg.transport.connection_id,
+                        state,
+                    );
+                }
+            }
+        }
+    }
+
+    // Channel teardown: drop it from the bus and tell the owning app.
+    if outcome.end_channel {
+        if let Some(channel) = command.channel_target() {
+            if let Some(bus) = crate::control::ControlBus::global() {
+                if let Some(owner) = bus.remove_channel(&channel) {
+                    owner.conn.events.try_push(crate::control::EventFrame::new(
+                        "StasisEnd",
+                        &channel,
+                        &owner.app,
+                        serde_json::json!({}),
+                    ));
+                }
+            }
+        }
+    }
+
+    let _ = command.response_tx.send(outcome.result);
+}
+
+/// The synchronous verb core: mutate the store and decide the local SIP effect.
+///
+/// This is deliberately a plain function over the [`CallActorStore`] so it is
+/// unit-testable against an in-process store, and so it structurally cannot
+/// await a far-end result. Lock discipline: the A-leg INVITE mutex and the
+/// store's per-key lock are **never** held simultaneously (each acquired,
+/// used, and dropped in turn), matching the inbound path's ordering.
+fn apply_control_verb(
+    store: &CallActorStore,
+    command: &crate::control::ControlCommand,
+) -> ControlOutcome {
+    use crate::control::{ControlErrorCode, ControlResult};
+
+    let Some(channel) = command.channel_target() else {
+        return ControlOutcome::error(
+            ControlErrorCode::BadRequest,
+            "command target must be {\"channel\": \"…\"}",
+        );
+    };
+
+    match command.verb.as_str() {
+        "answer" => {
+            // Step 1: snapshot under the store lock (no message lock held).
+            let Some((invite, transport, to_tag)) = ({
+                match store.get_call(&channel) {
+                    Some(call) => call.a_leg_invite.as_ref().map(|invite| {
+                        (
+                            Arc::clone(invite),
+                            call.a_leg.transport.clone(),
+                            call.a_leg.dialog.local_tag.clone(),
+                        )
+                    }),
+                    None => {
+                        return ControlOutcome::error(
+                            ControlErrorCode::NotFound,
+                            format!("no such channel: {channel}"),
+                        )
+                    }
+                }
+            }) else {
+                return ControlOutcome::error(
+                    ControlErrorCode::Unavailable,
+                    "channel has no stored A-leg INVITE",
+                );
+            };
+
+            // Step 2: read the INVITE (message lock only) — echo its offer SDP.
+            let (to_value, from_value, contact_value, body, content_type) = {
+                let guard = match invite.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                let body = if guard.body.is_empty() {
+                    None
+                } else {
+                    Some(guard.body.clone())
+                };
+                let content_type = guard
+                    .headers
+                    .get("Content-Type")
+                    .map(|value| value.to_string())
+                    .or_else(|| body.as_ref().map(|_| "application/sdp".to_string()));
+                (
+                    guard.headers.to().cloned(),
+                    guard.headers.from().cloned(),
+                    guard
+                        .headers
+                        .get("Contact")
+                        .map(|value| crate::b2bua::actor::extract_contact_uri(value)),
+                    body,
+                    content_type,
+                )
+            };
+
+            // Step 3: mutate the call (store lock only). Populate the A-leg
+            // dialog so a later `hangup` builds a coherent in-dialog BYE.
+            let Some(mut call) = store.get_call_mut(&channel) else {
+                return ControlOutcome::error(
+                    ControlErrorCode::NotFound,
+                    format!("no such channel: {channel}"),
+                );
+            };
+            call.a_leg.dialog.local_from_uri = to_value; // INVITE To → our From
+            call.a_leg.dialog.remote_to_uri = from_value; // INVITE From → our To
+            if let Some(contact) = contact_value {
+                call.a_leg.dialog.remote_contact = Some(contact);
+            }
+            call.state = CallState::Answered;
+            drop(call);
+
+            ControlOutcome {
+                result: ControlResult::Ok(serde_json::json!({
+                    "channel": channel,
+                    "state": "answered",
+                })),
+                effects: vec![ControlEffect::RespondToALeg {
+                    invite,
+                    transport,
+                    code: 200,
+                    reason: "OK".to_string(),
+                    to_tag: Some(to_tag),
+                    body,
+                    content_type,
+                }],
+                end_channel: false,
+            }
+        }
+        "hangup" => {
+            let effect = {
+                let Some(mut call) = store.get_call_mut(&channel) else {
+                    return ControlOutcome::error(
+                        ControlErrorCode::NotFound,
+                        format!("no such channel: {channel}"),
+                    );
+                };
+                let answered = matches!(call.state, CallState::Answered);
+                call.state = CallState::Terminated;
+                if answered {
+                    // In-dialog BYE (built from the leg's cloned dialog state —
+                    // no message mutex touched under the store lock).
+                    Some(ControlEffect::ByeALeg {
+                        leg: call.a_leg.clone(),
+                    })
+                } else {
+                    // Not yet answered → decline the pending INVITE.
+                    call.a_leg_invite.clone().map(|invite| ControlEffect::RespondToALeg {
+                        invite,
+                        transport: call.a_leg.transport.clone(),
+                        code: 603,
+                        reason: "Decline".to_string(),
+                        to_tag: None,
+                        body: None,
+                        content_type: None,
+                    })
+                }
+            };
+            store.remove_call(&channel);
+
+            ControlOutcome {
+                result: ControlResult::Ok(serde_json::json!({
+                    "channel": channel,
+                    "state": "terminated",
+                })),
+                effects: effect.into_iter().collect(),
+                end_channel: true,
+            }
+        }
+        other => ControlOutcome::error(
+            ControlErrorCode::UnsupportedVerb,
+            format!("unsupported verb: {other}"),
+        ),
     }
 }
 
@@ -14021,4 +14447,163 @@ a=rtpmap:8 PCMA/8000\r\n";
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Control-plane apply verb tests (against an in-process CallActorStore).
+    //
+    // These assert `apply_control_verb` performs only the LOCAL action and
+    // returns immediately — it is a synchronous function, so it structurally
+    // cannot await a far-end result. Each test checks the store mutation and
+    // the decided SIP effect.
+    // -----------------------------------------------------------------------
+
+    fn control_invite() -> SipMessage {
+        let mut message = SipMessageBuilder::new()
+            .request(
+                Method::Invite,
+                SipUri::new("example.com".to_string()).with_user("ivr".to_string()),
+            )
+            .via("SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-ctrl".to_string())
+            .from("Alice <sip:alice@atlanta.com>;tag=alicetag".to_string())
+            .to("<sip:ivr@example.com>".to_string())
+            .call_id("control-call-1@10.0.0.1".to_string())
+            .cseq("1 INVITE".to_string())
+            .header("Contact", "<sip:alice@10.0.0.1:5060>".to_string())
+            .content_length(0)
+            .build()
+            .expect("builds control invite");
+        message.headers.set("Content-Type", "application/sdp".to_string());
+        message.body = b"v=0\r\no=- 1 1 IN IP4 10.0.0.1\r\n".to_vec();
+        message
+    }
+
+    fn control_test_store() -> (CallActorStore, String) {
+        let store = CallActorStore::new();
+        let transport = LegTransport {
+            remote_addr: "127.0.0.1:5060".parse().unwrap(),
+            connection_id: ConnectionId::default(),
+            transport: Transport::Udp,
+        };
+        let leg = Leg::new_a_leg(
+            "control-call-1@10.0.0.1".to_string(),
+            "alicetag".to_string(),
+            "z9hG4bK-ctrl".to_string(),
+            transport,
+        );
+        let channel = store.create_call(leg);
+        store.set_a_leg_invite(&channel, Arc::new(Mutex::new(control_invite())));
+        (store, channel)
+    }
+
+    fn control_command(verb: &str, channel: Option<&str>) -> crate::control::ControlCommand {
+        let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+        let target = match channel {
+            Some(channel) => serde_json::json!({ "channel": channel }),
+            None => serde_json::Value::Null,
+        };
+        crate::control::ControlCommand {
+            id: "c1".to_string(),
+            verb: verb.to_string(),
+            target,
+            args: serde_json::json!({}),
+            response_tx,
+        }
+    }
+
+    #[test]
+    fn apply_verb_answer_marks_answered_echoes_sdp_and_returns() {
+        let (store, channel) = control_test_store();
+        let outcome = apply_control_verb(&store, &control_command("answer", Some(&channel)));
+
+        // Ok result, channel NOT ended (a call in progress, not torn down).
+        assert!(matches!(outcome.result, crate::control::ControlResult::Ok(_)));
+        assert!(!outcome.end_channel);
+
+        // Only the local action happened: state flipped to Answered, no B-leg
+        // dialed, and the call is still present (not awaiting the far end).
+        let call = store.get_call(&channel).expect("call still present");
+        assert_eq!(call.state, CallState::Answered);
+        assert!(call.b_legs.is_empty());
+        // Dialog populated so a later BYE is coherent.
+        assert!(call.a_leg.dialog.local_from_uri.is_some());
+        assert!(call.a_leg.dialog.remote_to_uri.is_some());
+        assert!(call.a_leg.dialog.remote_contact.is_some());
+        drop(call);
+
+        // Effect: a 200 OK to the A-leg with a UAS To-tag echoing the offer SDP.
+        assert_eq!(outcome.effects.len(), 1);
+        match &outcome.effects[0] {
+            ControlEffect::RespondToALeg { code, to_tag, body, content_type, .. } => {
+                assert_eq!(*code, 200);
+                assert!(to_tag.is_some());
+                assert_eq!(body.as_deref(), Some(&b"v=0\r\no=- 1 1 IN IP4 10.0.0.1\r\n"[..]));
+                assert_eq!(content_type.as_deref(), Some("application/sdp"));
+            }
+            other => panic!("expected RespondToALeg, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_verb_hangup_answered_sends_bye_and_ends_channel() {
+        let (store, channel) = control_test_store();
+        // Answer first so the call is in the Answered state with a real dialog.
+        let _ = apply_control_verb(&store, &control_command("answer", Some(&channel)));
+
+        let outcome = apply_control_verb(&store, &control_command("hangup", Some(&channel)));
+        assert!(matches!(outcome.result, crate::control::ControlResult::Ok(_)));
+        assert!(outcome.end_channel);
+        assert_eq!(outcome.effects.len(), 1);
+        assert!(matches!(outcome.effects[0], ControlEffect::ByeALeg { .. }));
+        // The call was removed from the store.
+        assert!(store.get_call(&channel).is_none());
+    }
+
+    #[test]
+    fn apply_verb_hangup_unanswered_declines_and_ends_channel() {
+        let (store, channel) = control_test_store();
+        let outcome = apply_control_verb(&store, &control_command("hangup", Some(&channel)));
+        assert!(outcome.end_channel);
+        assert_eq!(outcome.effects.len(), 1);
+        match &outcome.effects[0] {
+            ControlEffect::RespondToALeg { code, .. } => assert_eq!(*code, 603),
+            other => panic!("expected a 603 decline, got {other:?}"),
+        }
+        assert!(store.get_call(&channel).is_none());
+    }
+
+    #[test]
+    fn apply_verb_unknown_channel_is_not_found() {
+        let (store, _channel) = control_test_store();
+        let outcome = apply_control_verb(&store, &control_command("answer", Some("bogus")));
+        match outcome.result {
+            crate::control::ControlResult::Error { code, .. } => {
+                assert_eq!(code, crate::control::ControlErrorCode::NotFound);
+            }
+            other => panic!("expected NotFound error, got {other:?}"),
+        }
+        assert!(outcome.effects.is_empty());
+    }
+
+    #[test]
+    fn apply_verb_unsupported_verb_errors() {
+        let (store, channel) = control_test_store();
+        let outcome = apply_control_verb(&store, &control_command("frobnicate", Some(&channel)));
+        match outcome.result {
+            crate::control::ControlResult::Error { code, .. } => {
+                assert_eq!(code, crate::control::ControlErrorCode::UnsupportedVerb);
+            }
+            other => panic!("expected UnsupportedVerb, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_verb_missing_target_is_bad_request() {
+        let (store, _channel) = control_test_store();
+        let outcome = apply_control_verb(&store, &control_command("answer", None));
+        match outcome.result {
+            crate::control::ControlResult::Error { code, .. } => {
+                assert_eq!(code, crate::control::ControlErrorCode::BadRequest);
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod b2bua;
 pub mod cache;
 pub mod config;
+pub mod control;
 pub mod diameter;
 pub mod dialog;
 pub mod dispatcher;

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -72,6 +72,13 @@ pub enum CallAction {
         body: Option<Vec<u8>>,
         content_type: Option<String>,
     },
+    /// Hand the call over to an external control application (ARI *Stasis*
+    /// model). The dispatcher keeps the `CallActor` alive un-dialed, sends a
+    /// `180 Ringing` to the A-leg, clears the answer deadline so the orphan
+    /// sweep won't 408 it, registers the call with the control bus, and emits
+    /// a `StasisStart` event to the named application. The out-of-process app
+    /// then drives the call with `answer`/`hangup` verbs.
+    Handover { app: String },
 }
 
 /// Which side initiated a BYE.
@@ -723,6 +730,27 @@ impl PyCall {
         self.action = CallAction::Terminate;
     }
 
+    /// Hand this call over to an external control application (experimental).
+    ///
+    /// The `@b2bua.on_invite` handler stops here: instead of dialling a B-leg,
+    /// siphon keeps the call alive (a `180 Ringing` goes to the caller) and
+    /// offers it to the named application over the control WebSocket. The app
+    /// then drives it with `answer` / `hangup` commands. Calls that are not
+    /// handed over are unaffected.
+    ///
+    /// Usage:
+    ///   @b2bua.on_invite
+    ///   async def route(call):
+    ///       if is_ivr_number(call.to_uri):
+    ///           call.handover("ivr-app")
+    ///       else:
+    ///           call.dial(call.ruri)
+    fn handover(&mut self, app: &str) {
+        self.action = CallAction::Handover {
+            app: app.to_string(),
+        };
+    }
+
     /// Set per-call session timer parameters (overrides global config).
     ///
     /// Usage in Python:
@@ -929,6 +957,19 @@ mod tests {
             &CallAction::Reject {
                 code: 404,
                 reason: "Not Found".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn call_handover_sets_action() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string());
+        call.handover("ivr-app");
+        assert_eq!(
+            call.action(),
+            &CallAction::Handover {
+                app: "ivr-app".to_string()
             }
         );
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1767,6 +1767,55 @@ impl SiphonServer {
             }
         }
 
+        // --- External control plane (experimental, POC) ---
+        // OFF unless a `control:` block is present. Installs the process-global
+        // ControlBus, boots the WebSocket listener, and hands the command
+        // receiver to the dispatcher's sibling consumer.
+        let control_command_rx = if let Some(ref control_config) = config.control {
+            match control_config.listen.parse::<std::net::SocketAddr>() {
+                Ok(listen_addr) => {
+                    // Fail closed: plain-WS control only binds on loopback in
+                    // this build (TLS/mTLS are follow-ups).
+                    if !listen_addr.ip().is_loopback() {
+                        error!(
+                            listen = %control_config.listen,
+                            "control.listen must be a loopback address in this build; control plane not started"
+                        );
+                        None
+                    } else {
+                        let (command_tx, command_rx) = flume::unbounded();
+                        let bus = crate::control::ControlBus::new(
+                            command_tx,
+                            control_config.event_queue_depth,
+                            crate::control::SlowConsumerPolicy::DropOldest,
+                        );
+                        if crate::control::ControlBus::install(Arc::clone(&bus)).is_err() {
+                            error!("control bus already installed; control plane not started");
+                            None
+                        } else {
+                            let control_state = crate::control::ControlServerState {
+                                apps: Arc::new(control_config.apps.clone()),
+                                bus: Arc::clone(&bus),
+                            };
+                            tokio::spawn(crate::control::serve(listen_addr, control_state));
+                            info!(
+                                listen = %control_config.listen,
+                                apps = control_config.apps.len(),
+                                "control plane (experimental) enabled"
+                            );
+                            Some(command_rx)
+                        }
+                    }
+                }
+                Err(error) => {
+                    error!(listen = %control_config.listen, "invalid control.listen address: {error}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let dispatcher_handle = tokio::spawn(dispatcher::run(
             inbound_rx,
             outbound_senders,
@@ -1788,6 +1837,7 @@ impl SiphonServer {
             rtpengine_events_rx,
             rf_charger.clone(),
             Arc::clone(&drain),
+            control_command_rx,
             product_name,
             product_version,
         ));


### PR DESCRIPTION
## What this proves

A proof-of-concept of siphon's external remote-control plane (ARI/ESL-class): an
out-of-process app connected over a WebSocket can drive a **live B2BUA call**
without ever blocking siphon's pools or the dispatcher. A Python
`@b2bua.on_invite` handler hands a call over with `call.handover("app")` (the ARI
*Stasis* model); the app then answers and hangs up the call over the WS. Calls
that are not handed over cost nothing (one `Option::is_none()` check on the
handover path).

Everything else in the larger design (channels/bridges/originate, media/rtpengine
control, DTMF/play/transfer/hold, the `ControlAdapter` trait, TLS/mTLS, SS7/SMPP
adapters) is intentionally **out of scope** here.

## The I/O contract it upholds (the whole point)

1. **Control-socket I/O is pure async tokio** (axum WS): per connection one async
   read task + one async write task. Never on `py_executor`, never a blocking call.
2. **Event fan-out is `try_send` on a bounded per-conn queue, never `.await`.** A
   full queue drops the oldest event (or, under the alternate policy, disconnects);
   publishing an event can never park the dispatcher/leg-actor.
3. **Command ingress** goes into an **unbounded** `flume` channel (a send that
   can't block), then the read task `.await`s a `oneshot` for the reply.
4. **A command reply ≠ a far-end result.** `apply` performs only the bounded LOCAL
   action (mutate the store / send one SIP message) and returns "accepted"
   immediately. It never waits for the callee to answer, for an ACK, or for a BYE
   200 — far-end outcomes arrive later as async events.
5. **`apply` runs as a plain async task** (zero blocking-pool slots). Correctness is
   the `CallActorStore` per-key DashMap lock (the real serializer); POC commands do
   not route through `py_executor` (no Python handler is involved).
6. No sync `Mutex` held across `.await`; the A-leg INVITE mutex and the store's
   per-key lock are never nested; every queue is bounded except the ingress channel.

### Command path (no pool ever blocked)

`client → WS read task (async) → flume(unbounded).send (non-blocking) → dispatcher
sibling consumer → tokio::spawn(apply) → apply_control_verb mutates the
CallActorStore + builds one SIP message → send_message (non-blocking outbound) →
oneshot reply → WS write task (async) → client`. Every await is either a localhost
send or the oneshot; none is a dialog-progress wait. `apply_control_verb` is a
synchronous function over the store, so it structurally cannot await a far end —
the far-end answer/BYE-200 come back through the normal SIP path as events later.

## Shipped verbs

- `call.handover("app")` (Python + Rust `CallAction::Handover`) — parks the call,
  sends `180 Ringing` to the caller, clears the answer deadline, registers the
  channel, emits `StasisStart`; rejects `480` if no app is connected.
- `answer` — builds a `200 OK` to the A-leg INVITE, echoing the offer SDP as the
  answer body (no rtpengine), stamps a UAS To-tag, marks answered.
- `hangup` — in-dialog BYE to the A-leg if answered, else `603 Decline`; removes
  the channel and emits `StasisEnd`.

## Simplifications (POC)

- `controlled: Option<String>` flag on `CallActor` instead of a full
  `CallState::Parked` variant (avoids auditing every `CallState` match; the orphan
  sweep skips controlled calls).
- `answer` echoes the offer SDP; no rtpengine anchoring.
- Loopback bind + bearer-token auth only (fail-closed: plain WS refuses a
  non-loopback `control.listen`). No TLS/mTLS/ACL yet.
- Auth failures feed `security::record_handshake_failure` so brute-forcing control
  tokens gets the source IP auto-banned like a SIP scanner.

## How to run

```yaml
control:
  listen: "127.0.0.1:9092"
  apps:
    - name: "ivr-app"
      token: "${IVR_APP_TOKEN}"
```

```python
# siphon script
@b2bua.on_invite
async def route(call):
    if is_ivr_number(call.to_uri):
        call.handover("ivr-app")
    else:
        call.dial(call.ruri)
```

The app connects `ws://127.0.0.1:9092/control/ws` with
`Authorization: Bearer ${IVR_APP_TOKEN}`, sends `{"id":"1","type":"command",
"verb":"hello","args":{"app":"ivr-app"}}`, then on `StasisStart` sends
`{"verb":"answer","target":{"channel":"…"}}` and later
`{"verb":"hangup","target":{"channel":"…"}}`.

## Tests

- Protocol serde round-trips (command/reply/event), config parse of a `control:`
  block + default event-queue depth.
- `ControlBus` register/pick/round-robin + a **steady-state leak test** (N conns +
  N handovers + N hangups over 5 cycles → `channels`/`apps` maps drain to
  baseline).
- Bounded-queue backpressure: a stuck consumer causes drop-oldest (queue stays at
  capacity, dropped counter climbs) rather than unbounded growth or a blocked
  publisher; a disconnect-policy variant flags the slow consumer.
- `apply_control_verb` per verb against an in-process store mock (returns
  immediately, mutates the store, decides the right SIP effect; not-found /
  unsupported-verb / bad-request errors).
- Integration `#[tokio::test]`: real listener on an ephemeral loopback port +
  `tokio-tungstenite` client — bad token → HTTP 401 before upgrade; good token +
  `hello` → ok reply; a pushed event reaches the client; a command → correlated
  reply; wrong-app `hello` → forbidden.
- `CallAction::Handover` set/read; orphan sweep skips controlled calls.

`cargo test` (3043 passed), `cargo clippy --all-targets --all-features -D
warnings` (clean), SDK `pytest` (348 passed).

Draft — for review, not merge.
