### PR TITLE
feat(b2bua): call.set_from_host / set_to_host — pin B-leg From/To host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **B2BUA `call.set_from_host()` / `call.set_to_host()`** — pin the host part of
+  the B-leg From / To URI, mirroring `set_from_user` / `set_to_user`. By default
+  the B2BUA rewrites the B-leg From host to its own advertised address (topology
+  hiding) and the To host to the dial-target host. `set_from_host()` opts a leg
+  out of the From host-rewrite so the original domain survives — needed for a
+  multitenant SBC whose downstream selects the tenant from the From domain (a
+  domainless call would otherwise land in an unauthenticated/default routing
+  context). `set_to_host()` pins the To host declaratively (replaces the raw
+  `set_header("To", "<sip:…>")` idiom). Only the host changes; scheme/user/port/
+  params and tags are preserved. Applies to both `call.dial()` and `call.fork()`.
+  Mirrored in the `siphon-sip` SDK mock; new SIPp acceptance scenario
+  (`sipp/b2bua_set_host_uas.xml`).
+
 ## [1.1.1] — 2026-07-02
 
 ### Security

--- a/docs/cookbook/sbc.md
+++ b/docs/cookbook/sbc.md
@@ -42,8 +42,28 @@ def on_cancel(call):                            # caller abandoned before answer
 Each B-leg gets its own Call-ID and From-tag by default, so the two dialogs are fully
 decoupled — **topology hiding out of the box**. Other call methods: `call.fork(targets)`
 (ring several B-legs), `call.reject(code, reason)`, `call.terminate()`,
-`call.set_header` / `remove_header`, and B-leg userpart rewrites
-(`call.set_ruri_user` / `set_from_user` / `set_to_user`).
+`call.set_header` / `remove_header`, and B-leg URI rewrites — userpart
+(`call.set_ruri_user` / `set_from_user` / `set_to_user`) and host
+(`call.set_from_host` / `set_to_host`).
+
+### Keeping a tenant domain in the From
+
+Topology hiding rewrites the B-leg From host to SIPhon's advertised address and the To
+host to the dial target. That's the right default, but a multitenant downstream that
+selects the tenant from the From domain needs the original domain to survive — a
+domainless From lands the call in its unauthenticated/default routing context. Pin it:
+
+```python
+@b2bua.on_invite
+def on_invite(call):
+    call.set_from_host("tenant.example.com")   # keep the tenant domain in From
+    call.dial(str(call.ruri), next_hop="sip:pbx.example.com:5060")
+```
+
+`set_from_host` opts that leg out of the From host-rewrite; `set_to_host` pins the To
+host the same way (a declarative replacement for hand-building
+`set_header("To", "<sip:user@host>")`). Only the host changes — scheme, user, port,
+params, and tags are preserved — and both apply to `call.dial()` and `call.fork()`.
 
 ## Header policies — control what crosses the boundary
 

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -506,6 +506,60 @@ class Call:
         if self._to_uri is not None:
             self._to_uri.user = value
 
+    def set_from_host(self, value: str) -> None:
+        """Pin the host part of the B-leg From header URI.
+
+        By default the B2BUA rewrites the From URI host to its own advertised
+        address (topology hiding — masking the A-leg identity).  At a
+        multitenant edge the downstream selects the tenant from the From
+        domain: a domainless call lands in an unauthenticated/default routing
+        context, so the tenant domain must survive.  ``set_from_host()`` opts
+        this leg out of the From host-rewrite and pins the host to ``value``.
+
+        Only the host changes; scheme/user/port/params and the From-tag are
+        preserved.  ``value`` is a bare host (no port).  Must be called before
+        :meth:`dial` for the change to take effect on the B-leg INVITE — same
+        model as :meth:`set_from_user`.
+
+        Args:
+            value: New host (e.g. ``"tenant.example.com"``).
+
+        Example::
+
+            @b2bua.on_invite
+            async def on_invite(call):
+                call.set_from_host("tenant.example.com")
+                call.dial(str(call.ruri), next_hop="sip:pbx.example.com:5060")
+        """
+        if self._from_uri is not None:
+            self._from_uri.host = value
+
+    def set_to_host(self, value: str) -> None:
+        """Pin the host part of the B-leg To header URI.
+
+        By default the B2BUA rewrites the To URI host to the dial-target host.
+        ``set_to_host()`` pins it to ``value`` instead, so the To domain does
+        what the script says regardless of the routing next-hop (declarative
+        replacement for the raw ``set_header("To", "<sip:user@host>")`` idiom).
+
+        Only the host changes; scheme/user/port/params and any To-tag are
+        preserved.  ``value`` is a bare host (no port).  Must be called before
+        :meth:`dial` — same model as :meth:`set_to_user`.
+
+        Args:
+            value: New host (e.g. ``"trunk.example.com"``).
+
+        Example::
+
+            @b2bua.on_invite
+            async def on_invite(call):
+                call.set_to_user(callee)
+                call.set_to_host(TRUNK_DOMAIN)
+                call.dial(str(call.ruri))
+        """
+        if self._to_uri is not None:
+            self._to_uri.host = value
+
     # -- Header access ---------------------------------------------------------
 
     def get_header(self, name: str) -> Optional[str]:

--- a/sipp/b2bua_set_host_uac.xml
+++ b/sipp/b2bua_set_host_uac.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  UAC for the call.set_from_host() / set_to_host() acceptance test.
+  INVITE → 180 → 200 → ACK → BYE → 200, straight to the B2BUA.
+
+  Pairs with sipp/b2bua_set_host_uas.xml (which asserts the pinned From/To
+  host on the B-leg) and sipp/set_host_b2bua.py. See the UAS header for the
+  native run procedure.
+-->
+<scenario name="B2BUA set_from_host UAC">
+
+  <!-- Send INVITE to the B2BUA -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/set-host-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <!-- ACK directly to the B2BUA (it owns the dialog) -->
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/b2bua_set_host_uas.xml
+++ b/sipp/b2bua_set_host_uas.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  call.set_from_host() / call.set_to_host() acceptance test — UAS (B-leg) side.
+
+  The B2BUA (set_host_b2bua.py) pins the B-leg From host to tenant.example.test
+  and the To host to trunk.example.test before dialling. This UAS asserts, on
+  the received INVITE, that:
+    - the From URI host == tenant.example.test  (NOT the advertised 127.0.0.1)
+    - the To   URI host == trunk.example.test
+  via check_it="true" regex actions. If the overrides did not take effect the
+  From host would be the B2BUA advertised address and the assertion fails the
+  call -> sipp non-zero exit. So this scenario fails if set_from_host() /
+  set_to_host() are not honoured on the wire.
+
+  Pairs with b2bua_set_host_uac.xml + set_host_b2bua.py + set_host_test.yaml.
+
+  Native run (3 terminals, from the repo root):
+    1. PYO3_PYTHON=python3 ./target/debug/siphon -c sipp/set_host_test.yaml
+    2. sipp -sf sipp/b2bua_set_host_uas.xml -i 127.0.0.2 -p 5061 -m 1
+    3. sipp -sf sipp/b2bua_set_host_uac.xml 127.0.0.1:5060 -i 127.0.0.50 -p 5062 -m 1
+
+  Expected: both UAC and UAS report 1 Successful call, 0 Failed, 0 Unexpected.
+-->
+<scenario name="B2BUA set_from_host UAS">
+
+  <!-- Receive INVITE from the B2BUA (B-leg) and assert the pinned From/To host -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="@tenant\.example\.test"
+            search_in="hdr" header="From:" check_it="true"
+            assign_to="from_host_ok" />
+      <ereg regexp="@trunk\.example\.test"
+            search_in="hdr" header="To:" check_it="true"
+            assign_to="to_host_ok" />
+      <!-- Reference the assigned vars so SIPp doesn't reject them as unused;
+           the actual pass/fail gate is check_it on the eregs above. -->
+      <log message="B-leg host assertions: from=[$from_host_ok] to=[$to_host_ok]" />
+    </action>
+  </recv>
+
+  <!-- Send 180 Ringing -->
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!-- Send 200 OK with SDP -->
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/set_host_b2bua.py
+++ b/sipp/set_host_b2bua.py
@@ -1,0 +1,44 @@
+"""Test fixture B2BUA script for the call.set_from_host() / set_to_host() acceptance scenario.
+
+On every out-of-dialog INVITE the B2BUA pins the B-leg From host to a tenant
+domain and the To host to a trunk domain, then dials a fixed downstream UAS.
+This is the multitenant-SBC shape: the downstream selects the tenant from the
+From domain, so the B-leg From host must carry the tenant domain instead of the
+B2BUA advertised address (topology-hiding default).
+
+The UAS (sipp/b2bua_set_host_uas.xml) asserts on the wire that the received
+INVITE's From host == TENANT_DOMAIN and To host == TRUNK_DOMAIN. Without the
+overrides the From host would be the advertised address (127.0.0.1) and the
+assertion would fail.
+
+Native run: see sipp/b2bua_set_host_uas.xml header.
+"""
+from siphon import b2bua, log
+
+TENANT_DOMAIN = "tenant.example.test"
+TRUNK_DOMAIN = "trunk.example.test"
+UAS_NEXT_HOP = "sip:127.0.0.2:5061"
+
+
+@b2bua.on_invite
+def on_invite(call):
+    log.info(f"[set-host-test] on_invite ruri={call.ruri} from={call.from_uri}")
+    call.set_from_host(TENANT_DOMAIN)
+    call.set_to_host(TRUNK_DOMAIN)
+    call.dial(str(call.ruri), next_hop=UAS_NEXT_HOP)
+
+
+@b2bua.on_answer
+def on_answer(call, reply):
+    log.info(f"[set-host-test] answered {reply.status_code}")
+
+
+@b2bua.on_bye
+def on_bye(call, initiator):
+    log.info(f"[set-host-test] bye by {initiator.side}")
+
+
+@b2bua.on_failure
+def on_failure(call, code, reason):
+    log.warn(f"[set-host-test] failure {code} {reason}")
+    call.reject(code, reason)

--- a/sipp/set_host_test.yaml
+++ b/sipp/set_host_test.yaml
@@ -1,0 +1,23 @@
+# Minimal B2BUA config for the call.set_from_host() / set_to_host() acceptance scenario.
+# See sipp/b2bua_set_host_uas.xml for the full native run procedure.
+#
+# advertised_address is 127.0.0.1: without the set_from_host() override the
+# B-leg From host would be rewritten to 127.0.0.1 (topology hiding). The UAS
+# asserts it is tenant.example.test instead, proving the override works.
+listen:
+  udp:
+    - "127.0.0.1:5060"
+
+domain:
+  local:
+    - "example.com"
+    - "127.0.0.1"
+
+advertised_address: "127.0.0.1"
+
+script:
+  path: "sipp/set_host_b2bua.py"
+  reload: sighup
+
+log:
+  level: info

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -598,6 +598,14 @@ pub struct CallActor {
     pub li_record: bool,
     /// When true, copy the A-leg Call-ID to B-leg(s).
     pub preserve_call_id: bool,
+    /// Script-pinned B-leg From URI host (`call.set_from_host()`). When set,
+    /// the B-leg INVITE From host is rewritten to this instead of the B2BUA
+    /// advertised address — opts out of From topology-hiding for multitenant
+    /// edges that key the tenant on the From domain.
+    pub from_host_override: Option<String>,
+    /// Script-pinned B-leg To URI host (`call.set_to_host()`). When set, the
+    /// B-leg INVITE To host is rewritten to this instead of the dial-target host.
+    pub to_host_override: Option<String>,
     /// Pre-built ACK for the winning B-leg, deferred until A-leg ACKs (late ACK pattern).
     /// Contains (ACK message, transport, destination address).
     pub pending_b_leg_ack: Option<(SipMessage, crate::transport::Transport, std::net::SocketAddr)>,
@@ -652,6 +660,8 @@ impl CallActor {
             digest_nc: crate::auth::NonceCounter::new(),
             li_record: false,
             preserve_call_id: false,
+            from_host_override: None,
+            to_host_override: None,
             pending_b_leg_ack: None,
             resolved_header_policy: None,
             a_leg_supports_100rel: false,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -7409,12 +7409,21 @@ fn handle_b2bua_invite(
     let engine_state = state.engine.state();
     let handlers = engine_state.handlers_for(&HandlerKind::B2buaInvite);
 
-    let (action, timer_override, credentials, li_record, preserve_call_id, policy_input) = Python::attach(|python| {
+    let (
+        action,
+        timer_override,
+        credentials,
+        li_record,
+        preserve_call_id,
+        policy_input,
+        from_host_override,
+        to_host_override,
+    ) = Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {
             Ok(obj) => obj,
             Err(error) => {
                 error!("failed to create PyCall: {error}");
-                return (CallAction::None, None, None, false, false, None);
+                return (CallAction::None, None, None, false, false, None, None, None);
             }
         };
 
@@ -7428,7 +7437,7 @@ fn handle_b2bua_invite(
                             return (CallAction::Reject {
                                 code: 500,
                                 reason: "Script Error".to_string(),
-                            }, None, None, false, false, None);
+                            }, None, None, false, false, None, None, None);
                         }
                     }
                 }
@@ -7437,7 +7446,7 @@ fn handle_b2bua_invite(
                     return (CallAction::Reject {
                         code: 500,
                         reason: "Script Error".to_string(),
-                    }, None, None, false, false, None);
+                    }, None, None, false, false, None, None, None);
                 }
             }
         }
@@ -7449,7 +7458,9 @@ fn handle_b2bua_invite(
         let li_record = borrowed.li_record();
         let preserve_cid = borrowed.preserve_call_id();
         let policy_input = borrowed.header_policy_input().cloned();
-        (action, timer_override, credentials, li_record, preserve_cid, policy_input)
+        let from_host_ovr = borrowed.from_host_override().map(String::from);
+        let to_host_ovr = borrowed.to_host_override().map(String::from);
+        (action, timer_override, credentials, li_record, preserve_cid, policy_input, from_host_ovr, to_host_ovr)
     });
 
     // Store the A-leg INVITE for later use by on_answer/on_failure/on_bye handlers
@@ -7501,6 +7512,8 @@ fn handle_b2bua_invite(
         || li_record
         || preserve_call_id
         || resolved_policy.is_some()
+        || from_host_override.is_some()
+        || to_host_override.is_some()
     {
         if let Some(mut call) = state.call_actors.get_call_mut(&call_id) {
             if let Some(override_config) = timer_override {
@@ -7515,6 +7528,12 @@ fn handle_b2bua_invite(
             call.preserve_call_id = preserve_call_id;
             if resolved_policy.is_some() {
                 call.resolved_header_policy = resolved_policy;
+            }
+            if from_host_override.is_some() {
+                call.from_host_override = from_host_override;
+            }
+            if to_host_override.is_some() {
+                call.to_host_override = to_host_override;
             }
         }
     }
@@ -7710,16 +7729,24 @@ fn b2bua_send_b_leg_invite(
     // Generate fresh dialog identifiers for the B-leg (proper B2BUA behavior).
     // Call-ID is new by default unless the script called call.preserve_call_id().
     // From-tag is always unique per B-leg regardless.
-    let (per_call_override, preserve_call_id, a_leg_call_id, a_leg_from_tag) =
-        match state.call_actors.get_call(call_id) {
-            Some(c) => (
-                c.session_timer_override.clone(),
-                c.preserve_call_id,
-                c.a_leg.dialog.call_id.clone(),
-                c.a_leg.dialog.remote_tag.clone().unwrap_or_default(),
-            ),
-            None => (None, false, String::new(), String::new()),
-        };
+    let (
+        per_call_override,
+        preserve_call_id,
+        a_leg_call_id,
+        a_leg_from_tag,
+        from_host_override,
+        to_host_override,
+    ) = match state.call_actors.get_call(call_id) {
+        Some(c) => (
+            c.session_timer_override.clone(),
+            c.preserve_call_id,
+            c.a_leg.dialog.call_id.clone(),
+            c.a_leg.dialog.remote_tag.clone().unwrap_or_default(),
+            c.from_host_override.clone(),
+            c.to_host_override.clone(),
+        ),
+        None => (None, false, String::new(), String::new(), None, None),
+    };
 
     let b_leg_call_id = if preserve_call_id {
         a_leg_call_id
@@ -7733,7 +7760,7 @@ fn b2bua_send_b_leg_invite(
 
     // Rewrite From for B-leg dialog:
     //  - Replace the tag with a fresh B-leg tag
-    //  - Rewrite the URI host to the B2BUA's own domain (mask A-leg identity)
+    //  - Rewrite the URI host (default: mask A-leg identity with our own host)
     if let Some(from) = b_leg_invite.headers.get("From")
         .or_else(|| b_leg_invite.headers.get("f"))
     {
@@ -7741,16 +7768,22 @@ fn b2bua_send_b_leg_invite(
         let new_pattern = format!("tag={}", b_leg_from_tag);
         let mut new_from = from.replace(&old_pattern, &new_pattern);
 
-        // Rewrite the host in the From URI to the B2BUA's advertised address.
+        // Rewrite the host in the From URI.  Default: the B2BUA advertised
+        // address (topology hiding — mask A-leg identity).  When the script
+        // pinned a host via `call.set_from_host()`, use that instead — opt
+        // out of From topology-hiding for multitenant edges that select the
+        // tenant from the From domain (a domainless call would otherwise land
+        // in the downstream's unauthenticated/default routing context).
         // From header format: ["Display" ]<sip:user@host[:port][;params]>[;tag=...]
-        let b2bua_host = state.via_host(&outbound_transport);
+        let from_host = from_host_override
+            .unwrap_or_else(|| state.via_host(&outbound_transport));
         if let Some(at_pos) = new_from.find('@') {
             // Find the end of the host: first occurrence of '>', ':', or ';' after '@'
             let after_at = &new_from[at_pos + 1..];
             let host_end = after_at.find(['>', ';', ':'])
                 .unwrap_or(after_at.len());
             let end_pos = at_pos + 1 + host_end;
-            new_from = format!("{}{}{}", &new_from[..at_pos + 1], b2bua_host, &new_from[end_pos..]);
+            new_from = format!("{}{}{}", &new_from[..at_pos + 1], from_host, &new_from[end_pos..]);
         }
 
         b_leg_invite.headers.set("From", new_from);
@@ -7781,22 +7814,28 @@ fn b2bua_send_b_leg_invite(
         if let Some(tag_start) = new_to.find(";tag=") {
             new_to = new_to[..tag_start].to_string();
         }
-        // Rewrite To URI host to the dial target's host
-        if let Ok(target_parsed) = parse_uri_standalone(target_uri) {
-            if let Some(at_pos) = new_to.find('@') {
-                let after_at = &new_to[at_pos + 1..];
-                let host_end = after_at.find(['>', ';', ':'])
-                    .unwrap_or(after_at.len());
-                let end_pos = at_pos + 1 + host_end;
-                let target_host = &target_parsed.host;
+        // Rewrite the To URI host.  Default: the dial-target host (topology
+        // hiding).  When the script pinned a host via `call.set_to_host()`,
+        // use that instead (host only — the original To port is preserved).
+        if let Some(at_pos) = new_to.find('@') {
+            let after_at = &new_to[at_pos + 1..];
+            let host_end = after_at.find(['>', ';', ':'])
+                .unwrap_or(after_at.len());
+            let end_pos = at_pos + 1 + host_end;
+            let replacement = if let Some(ref pinned) = to_host_override {
+                pinned.clone()
+            } else if let Ok(target_parsed) = parse_uri_standalone(target_uri) {
                 // Include port if present in target
-                let host_with_port = if let Some(port) = target_parsed.port {
-                    format!("{}:{}", target_host, port)
+                if let Some(port) = target_parsed.port {
+                    format!("{}:{}", target_parsed.host, port)
                 } else {
-                    target_host.clone()
-                };
-                new_to = format!("{}{}{}", &new_to[..at_pos + 1], host_with_port, &new_to[end_pos..]);
-            }
+                    target_parsed.host.clone()
+                }
+            } else {
+                // Unparseable target and no override — leave the host as-is.
+                new_to[at_pos + 1..end_pos].to_string()
+            };
+            new_to = format!("{}{}{}", &new_to[..at_pos + 1], replacement, &new_to[end_pos..]);
         }
         b_leg_invite.headers.set("To", new_to);
     }

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -173,6 +173,14 @@ pub struct PyCall {
     li_record_flag: bool,
     /// When true, copy the A-leg Call-ID to B-leg instead of generating a new one.
     preserve_call_id_flag: bool,
+    /// When set, pin the B-leg From URI host to this value instead of the
+    /// B2BUA advertised address (opts out of From topology-hiding — needed
+    /// for multitenant edges where the downstream selects the tenant from the
+    /// From domain). Set via `set_from_host()`.
+    from_host_override: Option<String>,
+    /// When set, pin the B-leg To URI host to this value instead of the
+    /// dial-target host. Set via `set_to_host()`.
+    to_host_override: Option<String>,
     /// Per-call header policy input captured from `call.dial(header_policy=…, …)`
     /// or `call.fork(…)`.  The dispatcher resolves `policy_name` against
     /// the preset registry and applies deltas to produce a
@@ -218,6 +226,8 @@ impl PyCall {
             outbound_credentials: None,
             li_record_flag: false,
             preserve_call_id_flag: false,
+            from_host_override: None,
+            to_host_override: None,
             header_policy_input: None,
         }
     }
@@ -352,6 +362,20 @@ impl PyCall {
     /// Whether the script wants to preserve the A-leg Call-ID on the B-leg.
     pub fn preserve_call_id(&self) -> bool {
         self.preserve_call_id_flag
+    }
+
+    /// Script-pinned B-leg From host, if `set_from_host()` was called.
+    /// Read by the dispatcher when building the B-leg INVITE — when `Some`,
+    /// it replaces the advertised-address rewrite of the From URI host.
+    pub fn from_host_override(&self) -> Option<&str> {
+        self.from_host_override.as_deref()
+    }
+
+    /// Script-pinned B-leg To host, if `set_to_host()` was called.
+    /// Read by the dispatcher when building the B-leg INVITE — when `Some`,
+    /// it replaces the dial-target rewrite of the To URI host.
+    pub fn to_host_override(&self) -> Option<&str> {
+        self.to_host_override.as_deref()
     }
 
     /// Set the Refer-To information (called by B2BUA core before firing on_refer).
@@ -855,6 +879,93 @@ impl PyCall {
         Ok(())
     }
 
+    /// Pin the host part of the B-leg From header URI.
+    ///
+    /// By default the B2BUA rewrites the From URI host to its own advertised
+    /// address (topology hiding — masking the A-leg identity).  At a
+    /// multitenant edge the downstream selects the tenant from the From
+    /// domain: a domainless call lands in an unauthenticated/default routing
+    /// context, so the tenant domain must survive.  `set_from_host()` opts
+    /// this leg out of the From host-rewrite and pins the host to `value`.
+    ///
+    /// Only the host changes; scheme/user/port/params and the From-tag are
+    /// preserved.  `value` is a bare host (no port) — the existing port is
+    /// kept.  Must be called before [`dial`] to take effect on the B-leg
+    /// INVITE — same model as [`set_from_user`].
+    ///
+    /// Usage in Python:
+    ///   call.set_from_host("tenant.example.com")
+    ///   call.dial(str(call.ruri), next_hop="sip:pbx.example.com:5060")
+    fn set_from_host(&mut self, value: &str) -> PyResult<()> {
+        {
+            let mut message = self.message.lock().map_err(|error| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+            })?;
+            let from_raw = message.headers.get("From")
+                .or_else(|| message.headers.get("f"))
+                .cloned();
+            if let Some(raw) = from_raw {
+                if let Ok(nameaddr) = crate::sip::headers::nameaddr::NameAddr::parse(&raw) {
+                    let mut uri = nameaddr.uri;
+                    uri.host = value.to_string();
+                    let mut new_from = if let Some(ref display) = nameaddr.display_name {
+                        format!("\"{display}\" <{uri}>")
+                    } else {
+                        format!("<{uri}>")
+                    };
+                    if let Some(ref tag) = nameaddr.tag {
+                        new_from.push_str(&format!(";tag={tag}"));
+                    }
+                    message.headers.set("From", new_from);
+                }
+            }
+        }
+        self.from_host_override = Some(value.to_string());
+        Ok(())
+    }
+
+    /// Pin the host part of the B-leg To header URI.
+    ///
+    /// By default the B2BUA rewrites the To URI host to the dial-target host.
+    /// `set_to_host()` pins it to `value` instead, so the To domain does what
+    /// the script says regardless of the routing next-hop (declarative
+    /// replacement for the raw `set_header("To", "<sip:user@host>")` idiom).
+    ///
+    /// Only the host changes; scheme/user/port/params and any To-tag are
+    /// preserved.  `value` is a bare host (no port).  Must be called before
+    /// [`dial`] — same model as [`set_to_user`].
+    ///
+    /// Usage in Python:
+    ///   call.set_to_user(callee)
+    ///   call.set_to_host(TRUNK_DOMAIN)
+    fn set_to_host(&mut self, value: &str) -> PyResult<()> {
+        {
+            let mut message = self.message.lock().map_err(|error| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+            })?;
+            let to_raw = message.headers.get("To")
+                .or_else(|| message.headers.get("t"))
+                .cloned();
+            if let Some(raw) = to_raw {
+                if let Ok(nameaddr) = crate::sip::headers::nameaddr::NameAddr::parse(&raw) {
+                    let mut uri = nameaddr.uri;
+                    uri.host = value.to_string();
+                    let mut new_to = if let Some(ref display) = nameaddr.display_name {
+                        format!("\"{display}\" <{uri}>")
+                    } else {
+                        format!("<{uri}>")
+                    };
+                    if let Some(ref tag) = nameaddr.tag {
+                        new_to.push_str(&format!(";tag={tag}"));
+                    }
+                    message.headers.set("To", new_to);
+                }
+            }
+        }
+        self.to_host_override = Some(value.to_string());
+        Ok(())
+    }
+
     /// Copy the A-leg Call-ID to the B-leg instead of generating a new one.
     ///
     /// By default the B2BUA generates a fresh Call-ID for each B-leg to fully
@@ -1211,6 +1322,60 @@ mod tests {
         let to = msg.headers.get("To").unwrap();
         assert!(to.contains("5112@example.com"), "To should contain new user: {to}");
         assert!(to.contains(";tag=remote-tag"), "To should preserve existing tag: {to}");
+    }
+
+    #[test]
+    fn call_set_from_host() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message.clone(), "10.0.0.1".to_string());
+        call.set_from_host("tenant.example.com").unwrap();
+        let msg = message.lock().unwrap();
+        let from = msg.headers.get("From").unwrap();
+        assert!(from.contains("alice@tenant.example.com"), "From host should change: {from}");
+        assert!(!from.contains("atlanta.com"), "old From host must be gone: {from}");
+        assert!(from.contains(";tag=abc"), "From should preserve tag: {from}");
+        drop(msg);
+        assert_eq!(call.from_host_override(), Some("tenant.example.com"));
+    }
+
+    #[test]
+    fn call_set_from_host_preserves_display_user_port_tag() {
+        let mut invite = make_invite();
+        invite.headers.set(
+            "From",
+            "\"Alice\" <sip:1001@old.example.com:5060>;tag=xyz".to_string(),
+        );
+        let message = Arc::new(Mutex::new(invite));
+        let mut call = PyCall::new("test-id".to_string(), message.clone(), "10.0.0.1".to_string());
+        call.set_from_host("tenant.example.com").unwrap();
+        let msg = message.lock().unwrap();
+        let from = msg.headers.get("From").unwrap();
+        assert!(from.contains("\"Alice\""), "display name preserved: {from}");
+        assert!(from.contains("1001@tenant.example.com:5060"), "user+host+port: {from}");
+        assert!(from.contains(";tag=xyz"), "tag preserved: {from}");
+        assert!(!from.contains("old.example.com"), "old host gone: {from}");
+    }
+
+    #[test]
+    fn call_set_to_host() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message.clone(), "10.0.0.1".to_string());
+        call.set_to_host("trunk.example.com").unwrap();
+        let msg = message.lock().unwrap();
+        let to = msg.headers.get("To").unwrap();
+        assert!(to.contains("bob@trunk.example.com"), "To host should change: {to}");
+        assert!(!to.contains("example.com>") || to.contains("trunk.example.com"), "old host replaced: {to}");
+        assert!(!to.contains(";tag="), "initial INVITE To must not gain a tag: {to}");
+        drop(msg);
+        assert_eq!(call.to_host_override(), Some("trunk.example.com"));
+    }
+
+    #[test]
+    fn call_set_from_host_none_by_default() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string());
+        assert_eq!(call.from_host_override(), None);
+        assert_eq!(call.to_host_override(), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds two B2BUA `Call` methods, mirroring the existing `set_from_user` / `set_to_user`:

- `call.set_from_host(host)` — pin the B-leg **From** URI host.
- `call.set_to_host(host)` — pin the B-leg **To** URI host.

Only the host changes; scheme/user/port/params and tags are preserved. Both must be called before `dial()` and apply to `call.dial()` **and** `call.fork()` (both route through `b2bua_send_b_leg_invite`).

## Why

The B-leg builder rewrites the From/To host for topology hiding:

- **From** host → the B2BUA advertised address (unconditional, "mask A-leg identity").
- **To** host → the dial-target host.

That leaves no way for a script to keep the original domain in the From. A multitenant SBC whose downstream selects the tenant from the **From domain** needs it: a domainless From lands the call in the downstream's unauthenticated/default routing context. `set_header("From", …)` doesn't help — the host is overwritten after the script runs, and setting From without a tag strips the mandatory From-tag.

`set_from_host()` opts the leg out of the From host-rewrite and pins the host. `set_to_host()` pins the To host declaratively (replacing the raw `set_header("To", "<sip:user@host>")` idiom, which only worked when the To happened to equal the dial target). Default behaviour is unchanged when neither is called.

## How

- `PyCall` gains `from_host_override` / `to_host_override`, set by the new methods (which also mutate the captured From/To host so in-handler reads are consistent).
- Threaded through to `CallActor`, read in the B-leg builder: From uses the override instead of `via_host`; To uses it instead of the dial-target host (host only, original port preserved).

## Tests

- Unit tests for both setters (host swap, display/user/port/tag preservation, override accessor, default-None).
- New SIPp acceptance scenario (`sipp/b2bua_set_host_uas.xml` + UAC + fixture script/config) that asserts on the wire the B-leg From host is the pinned tenant domain and the To host the pinned trunk domain (`check_it` regex, native-run procedure in the scenario header). Ran locally: 1 Successful / 0 Failed both legs; captured B-leg `From: <sip:alice@tenant.example.test>` (advertised address does not leak).
- `siphon-sip` SDK mock mirrored; `CHANGELOG.md` `[Unreleased]` updated.
- `cargo clippy --all-targets --all-features -D warnings` clean; full `cargo test` green; SDK pytest 348 passed.