### PR TITLE
ci: run sipp-ipsec on the self-hosted ipsec runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -325,18 +325,16 @@ jobs:
       - name: Run fuzz target (60s)
         run: PYO3_PYTHON=python3.14 cargo +nightly fuzz run sip_parser_fuzz -- -max_total_time=60
 
-  # ── SIPp IPsec VoLTE test (manual-only) ────────────────────────────────
+  # ── SIPp IPsec VoLTE test (self-hosted) ────────────────────────────────
   # IPsec XFRM SA installation needs CAP_NET_ADMIN, which GitHub-hosted runners
-  # don't grant — this can NEVER pass here. It used to run on every push/PR,
-  # burning ~7 min compiling siphon for a guaranteed (continue-on-error) red.
-  # Now it only runs on a manual `workflow_dispatch`, so point that at a
-  # privileged/self-hosted runner when you actually want it. The ipsec logic is
+  # don't grant. Runs on the self-hosted `ipsec` runner (real xfrm) on trusted
+  # triggers only — pushes to trunk and manual dispatch, never fork PRs — so
+  # untrusted code can't reach the privileged box. The ipsec logic is also
   # covered by the unit tests in rust-tests.
   sipp-ipsec:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    runs-on: [self-hosted, linux, x64, ipsec]
     needs: rust-tests
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
sipp-ipsec needs CAP_NET_ADMIN for xfrm SA installation, which GitHub-hosted
runners can't grant, so it was pinned to manual workflow_dispatch and marked
continue-on-error (a guaranteed red that proved nothing). There is now a
self-hosted runner with the xfrm modules loaded, labeled `ipsec`.

This points sipp-ipsec at `[self-hosted, linux, x64, ipsec]` and lets it run on
pushes to trunk and manual dispatch. It deliberately does not run on
pull_request, so fork PR code never reaches the privileged box. continue-on-error
is dropped, so a real IPsec regression now fails CI instead of going silently red.

rust-tests still runs on GitHub-hosted and gates this job via `needs`.

The runner is start-on-demand, so the first post-merge run waits a minute or two
for the box to boot (cold cache); later runs are fast off the warm cargo cache.
