### PR TITLE
fix(ci): recurse submodules cloning sipp for the ipsec image (pugixml)

### DIFF
--- a/sipp/ipsec/Dockerfile
+++ b/sipp/ipsec/Dockerfile
@@ -19,7 +19,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth 1 https://github.com/carstenbock/sipp_ipsec.git /build/sipp
+# --recurse-submodules is required: SIPp vendors pugixml (and gtest) as git
+# submodules, so without it third_party/pugixml is empty and CMake fails with
+# "Cannot find source file: .../pugixml/src/pugixml.cpp".
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules \
+        https://github.com/carstenbock/sipp_ipsec.git /build/sipp
 
 WORKDIR /build/sipp
 


### PR DESCRIPTION
## What

Adds `--recurse-submodules --shallow-submodules` to the `git clone` in `sipp/ipsec/Dockerfile`.

## Why

The `sipp-ipsec` CI job has been red on `main` since the job was switched to the self-hosted runner and `continue-on-error` was dropped. It fails building the `sipp-ipsec` image, in the SIPp compile:

```
CMake Error at CMakeLists.txt:53 (add_executable): Cannot find source file:
    /build/sipp/third_party/pugixml/src/pugixml.cpp
CMake Error: No SOURCES given to target: sipp
```

The `carstenbock/sipp_ipsec` fork vendors `pugixml` (and gtest) as **git submodules**. The Dockerfile cloned with `--depth 1` but without `--recurse-submodules`, so on a fresh clone `third_party/pugixml` is empty and CMake can't generate the `sipp` target. It only appeared to build locally where a cached clone layer predated the fork adopting the submodule; the self-hosted runner does a fresh clone and fails every time.

## Testing

Reproduced the exact failure with a fresh `--no-cache` build, then confirmed the fix: with `--recurse-submodules`, the submodules are fetched (`Submodule path 'third_party/pugixml'` …), SIPp compiles, and the `sipp-ipsec` image builds cleanly.

Note: the `sipp-ipsec` job only runs on `main` pushes (skipped on PRs), so this PR's own CI won't exercise it — the fix is validated by the local fresh-clone build above and will be confirmed by the post-merge `main` run.
