### PR TITLE
fix(sipp-ipsec): standalone local-AKA S-CSCF + loose-route REGISTER so the VoLTE IPsec test passes

### DIFF
--- a/examples/ims_pcscf.py
+++ b/examples/ims_pcscf.py
@@ -167,6 +167,11 @@ async def handle_register(request):
     request.add_pcscf_path(token)
     request.set_header("P-Visited-Network-ID", REALM)
 
+    # The UE routes the initial REGISTER through this P-CSCF via a preloaded
+    # Route (3GPP TS 24.229 §5.1.1.2); consume it so relay() forwards to the
+    # home domain (S-CSCF) instead of looping back to us. No-op when absent.
+    request.loose_route()
+
     # Relay to S-CSCF.  The 401 flow-back is handled by handle_register_reply.
     request.record_route()
     request.relay()

--- a/examples/ims_scscf_aka_lab.py
+++ b/examples/ims_scscf_aka_lab.py
@@ -1,0 +1,46 @@
+"""
+SIPhon IMS S-CSCF AKA lab script — standalone local Milenage AKA, no HSS.
+
+The AKA counterpart of ims_scscf_lab.py (which uses plain SIP digest). It
+challenges REGISTER with IMS AKA computed locally from `auth.aka_credentials`
+(3GPP TS 35.206 Milenage) via `auth.require_aka_digest`, so a P-CSCF running
+ims_pcscf.py can complete a full VoLTE IPsec sec-agree registration without a
+Diameter Cx interface or an HSS. The 401 it emits carries `ck=`/`ik=` in the
+WWW-Authenticate header, which the P-CSCF's `reply.take_av()` consumes to derive
+the IPsec SA keys.
+
+In a real deployment the S-CSCF fetches authentication vectors from the HSS over
+Cx (MAR) — see ims_scscf.py. This lab variant generates them locally so the
+IPsec/AKA path can be exercised standalone (e.g. the sipp-ipsec CI test).
+
+Config: sipp/ipsec/siphon-scscf.yaml
+"""
+from siphon import proxy, registrar, auth, log
+
+REALM = "ims.test"
+
+
+@proxy.on_request("REGISTER")
+def handle_register(request):
+    log.info(f"S-CSCF REGISTER from {request.from_uri}")
+
+    # Local IMS AKA challenge — Milenage from auth.aka_credentials. On an
+    # unauthenticated REGISTER this sends 401 with the RAND||AUTN nonce plus
+    # ck=/ik= for the P-CSCF; on the authenticated re-REGISTER it verifies the
+    # AKA response and returns True.
+    if not auth.require_aka_digest(request, realm=REALM):
+        log.info(f"sent 401 AKA challenge to {request.from_uri}")
+        return
+
+    # Authenticated — save the binding and answer 200 OK.
+    registrar.save(request)
+    log.info(f"registered {request.from_uri} at S-CSCF")
+
+
+@proxy.on_request("OPTIONS")
+def handle_options(request):
+    # Health-check / keepalive.
+    if request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+        return
+    request.relay()

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -1540,10 +1540,37 @@ services:
   #   docker compose -f sipp/docker-compose.yaml --profile ipsec \
   #     up --abort-on-container-exit sipp-ipsec
 
+  # Standalone S-CSCF (local Milenage AKA, no HSS) that the P-CSCF relays
+  # REGISTER to. Reachable from the P-CSCF as the network alias "ims.test".
+  siphon-scscf:
+    build:
+      context: ..
+    container_name: siphon-scscf-test
+    volumes:
+      - ./ipsec/siphon-scscf.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.34
+        aliases:
+          - ims.test
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:ims.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@ims.test>;tag=hc\\r\\nTo: <sip:ims.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - ipsec
+
   siphon-ipsec:
     build:
       context: ..
     container_name: siphon-ipsec-test
+    depends_on:
+      siphon-scscf:
+        condition: service_healthy
     cap_add:
       - NET_ADMIN
     volumes:

--- a/sipp/ipsec/siphon-pcscf.yaml
+++ b/sipp/ipsec/siphon-pcscf.yaml
@@ -52,6 +52,11 @@ auth:
 ipsec:
   pcscf_port_c: 5064
   pcscf_port_s: 5066
+  # Host part inserted into the Path header by request.add_pcscf_path() so MT
+  # requests route back to this P-CSCF instance (the container's sipnet IP).
+  # Required — ims_pcscf.py calls add_pcscf_path() on REGISTER, which errors
+  # if this is unset.
+  path_host: "172.20.0.35"
 
 log:
   level: debug

--- a/sipp/ipsec/siphon-scscf.yaml
+++ b/sipp/ipsec/siphon-scscf.yaml
@@ -1,0 +1,43 @@
+# Standalone IMS S-CSCF for the sipp-ipsec VoLTE test.
+#
+# Does local Milenage AKA (no HSS / Diameter Cx) via ims_scscf_aka_lab.py, so
+# the P-CSCF (siphon-pcscf.yaml) has something to relay REGISTER to and gets a
+# 401 with ck/ik back for IPsec SA setup. Reachable from the P-CSCF as the
+# docker network alias "ims.test" (see docker-compose.yaml).
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+  tcp:
+    - "0.0.0.0:5060"
+
+advertised_address: "172.20.0.34"
+
+domain:
+  local:
+    - "ims.test"
+    - "172.20.0.34"
+
+script:
+  path: "examples/ims_scscf_aka_lab.py"
+  reload: auto
+
+registrar:
+  backend: memory
+  default_expires: 600000
+  max_expires: 600000
+
+auth:
+  realm: "ims.test"
+  backend: static
+  # 3GPP TS 35.208 test set 2 — must match the aka_K/aka_OP/aka_AMF the SIPp
+  # UE uses (test set 1 contains 0x5b '[' which breaks sipp_ipsec's parser).
+  aka_credentials:
+    "001010000000001":
+      k: "0396eb317b6d1c36f19c1c84cd6ffd16"
+      op: "ff9bb4d0b607f35029a9384c2e7eb8a3"
+      amf: "2175"
+
+log:
+  level: debug
+  format: pretty


### PR DESCRIPTION
## What

Makes the `sipp-ipsec` VoLTE IPsec registration test actually pass. Follows #43 (which fixed the image build) — with the build fixed, the test step ran for the first time and failed, exposing two real gaps:

1. **`examples/ims_pcscf.py` didn't loose-route the REGISTER.** The UE routes the initial REGISTER through the P-CSCF via a preloaded Route (TS 24.229 §5.1.1.2). Without `request.loose_route()`, the P-CSCF relayed to its own Route → `482 Loop Detected`. The production P-CSCF already loose-routes here; the example was missing it. Added `request.loose_route()` in `handle_register` (no-op when no Route is present).

2. **The test had no S-CSCF to relay to.** The P-CSCF relays REGISTER upstream and needs a 401-with-ck/ik back to set up IPsec — there was no upstream node. Added a standalone **local-AKA S-CSCF**:
   - `examples/ims_scscf_aka_lab.py` — the AKA counterpart of `ims_scscf_lab.py`; challenges via `auth.require_aka_digest` (local Milenage from `auth.aka_credentials`, no HSS/Diameter Cx). Emits the 401 with `ck=`/`ik=` the P-CSCF's `reply.take_av()` needs.
   - `sipp/ipsec/siphon-scscf.yaml` — its config (3GPP TS 35.208 test-set-2 vectors, matching the SIPp UE).
   - `sipp/docker-compose.yaml` — a `siphon-scscf` service, reachable from the P-CSCF as the network alias `ims.test`; the P-CSCF `depends_on` it.
   - `sipp/ipsec/siphon-pcscf.yaml` — adds the required `ipsec.path_host` (was missing → `add_pcscf_path()` raised → 500).

## Flow (now green)

REGISTER → P-CSCF (loose-route) → S-CSCF (local AKA, 401 + ck/ik) → P-CSCF (`take_av`, IPsec SA, Security-Server) → UE sets up IPsec → protected re-REGISTER → S-CSCF verifies → 200 → de-register → 200.

## Testing

Reproduced the full test locally with real xfrm (docker + CAP_NET_ADMIN): **Successful call = 1, Failed call = 0.** SDK IMS-script tests (`test_ims_scripts.py`, incl. `TestPcscf`) still pass (51 passed) after the `ims_pcscf.py` change.

Note: `sipp-ipsec` is skipped on PRs (runs only on `main` push), so this PR's CI won't exercise it — the local run above validates it, confirmed by the post-merge `main` run.
