### PR TITLE
feat(media): classic rtpproxy control backend (text-over-UDP)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,6 +303,52 @@ jobs:
             siphon-b2bua.log
             *.log
 
+  # ── rtpproxy functional test ───────────────────────────────────────────
+  # Drives a real INVITE→200→ACK→BYE through siphon configured with
+  # `media.backend: rtpproxy`, anchoring media via a mock rtpproxy. Proves the
+  # text-protocol client + siphon-side SDP rewrite work end-to-end.
+  sipp-rtpproxy:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-rtpproxy image
+        run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy build siphon-rtpproxy
+
+      - name: Start mock rtpproxy + siphon-rtpproxy
+        run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy up -d --wait mock-rtpproxy siphon-rtpproxy
+
+      - name: Register bob
+        run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy run --rm sipp-rtpproxy-register
+
+      - name: rtpproxy call (INVITE → media anchor → 200 → BYE)
+        # Gate on the UAC: it drives the call to completion (BYE→200) and exits
+        # 0, after which the abort tears down the lingering UAS (which would
+        # otherwise show a teardown-race 255). --exit-code-from makes the UAC's
+        # result authoritative — same pattern as the b2bua call steps.
+        run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy up --abort-on-container-exit --exit-code-from sipp-rtpproxy-uac sipp-rtpproxy-uac sipp-rtpproxy-uas
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-rtpproxy > siphon-rtpproxy.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs mock-rtpproxy > mock-rtpproxy.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-rtpproxy-logs
+          path: |
+            siphon-rtpproxy.log
+            mock-rtpproxy.log
+            *.log
+
   # ── Fuzz testing (nightly) ─────────────────────────────────────────────
   fuzz:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,36 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
     `media.rtpengine` configs are untouched. SIPREC/MPTY subscriptions are not
     yet implemented on `siphon-rtp` and surface a clear engine error there.
   - Depends on the published `siphon-rtp-proto` crate (the shared wire contract).
+- **Classic `rtpproxy` media backend (text-over-UDP).** siphon can now drive a
+  classic `rtpproxy` relay (the Sippy/Kamailio/OpenSIPS media proxy) as a third
+  media-control backend — for migrating an existing deployment to siphon while
+  keeping its in-place rtpproxy. Select it per deployment:
+  ```yaml
+  media:
+    backend: rtpproxy             # default: rtpengine
+    rtpproxy:
+      address: "127.0.0.1:22222"  # rtpproxy -s udp:<addr>
+      timeout_ms: 1000
+      retries: 2                  # UDP retransmits (same cookie); default 2
+  ```
+  - Speaks the classic cookie-prefixed `U`/`L`/`D`/`V` protocol over UDP, with
+    cookie-keyed request/response correlation and **idempotent retransmits** for
+    reliability over UDP (rtpproxy de-duplicates by cookie).
+  - rtpproxy only allocates a relay port, so **siphon rewrites the SDP itself**
+    (`c=`/`m=`), per media stream, including multi-stream offers (media-id tag
+    suffix) and held media (`m=… 0`, left untouched).
+  - The Python `rtpengine` scripting API and media profiles are **unchanged** —
+    `rtpengine.offer/answer/delete/ping` and `call.media` map onto rtpproxy. The
+    profile's NAT `direction` (e.g. `["internal","external"]`) and `asymmetric`
+    flag map to rtpproxy bridge/symmetry modifiers; IPv6 is detected per stream.
+  - **HA / load-balancing parity with rtpengine:** `media.rtpproxy` accepts a
+    single `address` or an `instances:` list with weights (weighted round-robin
+    plus per-call-id affinity); per-instance health is probed (`V`) and exported
+    alongside the existing rtpengine health metrics.
+  - **Backward compatible:** the default backend remains `rtpengine`. The
+    rtpengine-only verbs (announcements, DTMF injection, gating, SIPREC/MPTY) are
+    not available on rtpproxy and surface a clear engine error there; rtpproxy
+    pushes no async events, so the `media.events` listener is unused.
 - **B2BUA `call.set_from_host()` / `call.set_to_host()`** — pin the host part of
   the B-leg From / To URI, mirroring `set_from_user` / `set_to_user`. By default
   the B2BUA rewrites the B-leg From host to its own advertised address (topology

--- a/docs/cookbook/media-rtp.md
+++ b/docs/cookbook/media-rtp.md
@@ -36,12 +36,17 @@ media:
 
 ## Choosing a media engine
 
-SIPhon drives one of two media engines, chosen with `media.backend`:
-[RTPEngine](https://github.com/sipwise/rtpengine) (`rtpengine`, the default) or
-the in-house **siphon-rtp** (`siphon-rtp`). Everything on this page — the
-`offer` / `answer` / `delete` lifecycle, the profiles, and the `rtpengine`
-scripting namespace — is **identical** for both; only the engine you run and the
-`media:` block that points at it change.
+SIPhon drives one of three media engines, chosen with `media.backend`:
+
+| `media.backend` | Engine | Control transport |
+|---|---|---|
+| `rtpengine` *(default)* | [RTPEngine](https://github.com/sipwise/rtpengine) | NG protocol, bencode over UDP |
+| `siphon-rtp` | the in-house **siphon-rtp** engine | native JSON over a persistent TCP connection |
+| `rtpproxy` | classic [rtpproxy](https://github.com/sippy/rtpproxy) relay | text protocol over UDP |
+
+Everything else on this page — the `offer` / `answer` / `delete` lifecycle, the
+profiles, and the `rtpengine` scripting namespace — is **identical** for all
+backends; only the transport underneath changes.
 
 !!! warning "siphon-rtp is experimental"
     The siphon-rtp engine is pre-release, so this backend is **experimental** —
@@ -50,6 +55,45 @@ scripting namespace — is **identical** for both; only the engine you run and t
 
 See [Media engines: rtpengine vs siphon-rtp](../media-engines.md) for the full
 comparison, the `media.siphon_rtp` config, and how to run and operate each engine.
+
+### Classic rtpproxy (keep your existing relay)
+
+Migrating an OpenSIPS / Kamailio / Sippy deployment? Point siphon at your existing
+`rtpproxy` instead of standing up a new media engine — the script is unchanged, only
+the config differs:
+
+```yaml
+media:
+  backend: rtpproxy
+  rtpproxy:
+    address: "127.0.0.1:22222"     # rtpproxy -s udp:<addr>
+    timeout_ms: 1000
+    retries: 2                     # UDP retransmits (same cookie); rtpproxy de-dupes
+
+# or several, for HA / weighted load-balancing (per-call-id affinity)
+media:
+  backend: rtpproxy
+  rtpproxy:
+    instances:
+      - { address: "10.0.0.1:22222", weight: 2 }
+      - { address: "10.0.0.2:22222", weight: 1 }
+```
+
+siphon speaks rtpproxy's classic `U`/`L`/`D` protocol on the wire. Because rtpproxy
+only hands back a relay port (it does **not** rewrite SDP itself), siphon rewrites the
+`c=`/`m=` lines for you — per media stream, including held media (`m=… 0`). Profiles
+still apply, but only the flags rtpproxy understands: a profile's
+`direction: ["internal","external"]` becomes bridge mode (`ie`/`ei`) and an
+`asymmetric` flag maps through; IPv6 is detected per stream. SRTP/DTLS/ICE flags are
+ignored — rtpproxy is a plain RTP relay (use `rtpengine` or `siphon-rtp` for SRTP↔RTP,
+WebRTC, or transcoding). It has the same weighted round-robin + per-call-id affinity
+and per-instance `V` health probes as the other backends.
+
+!!! note "rtpproxy is anchor-only"
+    The extra `rtpengine` verbs — announcements / tones (`play_media`, `play_dtmf`),
+    gating (`silence_media` / `block_media`), DTMF events, and SIPREC/MPTY
+    subscriptions — are not available on the rtpproxy backend and raise a clear
+    error. They need `rtpengine` or `siphon-rtp`.
 
 ## The offer / answer / delete lifecycle
 

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -138,6 +138,8 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | RTPEngine load balancing | Implemented | `media.rtpengine.instances[]` | Weighted distribution |
 | Native siphon-rtp backend (JSON/TCP) | **Experimental** | `media.backend: siphon-rtp` + `media.siphon_rtp` | Persistent TCP control, auth handshake, reconnect, server-pushed DTMF/media-timeout events; same `rtpengine` API/profiles. The siphon-rtp engine is pre-release — use rtpengine in production. SIPREC/MPTY not yet supported on this engine. |
 | Native siphon-rtp load balancing | **Experimental** | `media.siphon_rtp.instances[]` | Weighted round-robin + per-call-id connection affinity; per-instance health probes (parity with rtpengine) |
+| Classic rtpproxy backend (text/UDP) | Implemented | `media.backend: rtpproxy` + `media.rtpproxy` | Classic `U`/`L`/`D`/`V` protocol with cookie correlation + idempotent retransmits; siphon-side SDP rewrite (multi-stream, held media); same `rtpengine` API/profiles. For migrating OpenSIPS/Kamailio/Sippy + rtpproxy. No prompts/DTMF/gating/SIPREC on this engine. Validate end-to-end against a live rtpproxy. |
+| Classic rtpproxy load balancing | Implemented | `media.rtpproxy.instances[]` | Weighted round-robin + per-call-id affinity; per-instance health probes (`V`) |
 | Built-in profile: SRTP↔RTP | Implemented | `srtp_to_rtp` | SRTP UE ↔ RTP core |
 | Built-in profile: WS↔RTP | Implemented | `ws_to_rtp` | WebSocket UE ↔ RTP core |
 | Built-in profile: WSS↔RTP | Implemented | `wss_to_rtp` | DTLS-SRTP/AVPF + ICE ↔ RTP |

--- a/examples/proxy_rtpproxy.py
+++ b/examples/proxy_rtpproxy.py
@@ -1,0 +1,85 @@
+"""
+SIPhon proxy script with classic rtpproxy media anchoring.
+
+Used for functional testing: anchors media through a classic `rtpproxy` relay
+(selected via `media.backend: rtpproxy`) on INVITE (offer) and reply (answer),
+deletes on BYE.
+
+This is byte-for-byte the same code as `examples/proxy_rtpengine.py` except for
+the profile name: the Python `rtpengine` namespace is backend-agnostic, so a
+deployment migrating off OpenSIPS/Kamailio/Sippy keeps its scripts unchanged and
+only switches `media.backend` in siphon.yaml. `rtp_passthrough` is the realistic
+profile for rtpproxy (a plain RTP relay — rtpproxy does no SRTP/DTLS).
+"""
+from siphon import proxy, registrar, auth, rtpengine, log
+
+DOMAIN = "siphon.test"
+PROFILE = "rtp_passthrough"
+
+
+@proxy.on_request
+async def route(request):
+    # Local OPTIONS ping
+    if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+        return
+
+    # In-dialog sequential requests
+    if request.in_dialog:
+        if request.method == "BYE":
+            await rtpengine.delete(request)
+            log.info(f"rtpproxy delete for BYE call_id={request.call_id}")
+        elif request.method == "INVITE" and request.body:
+            # Re-INVITE: renegotiate media (hold/resume/codec change)
+            await rtpengine.offer(request, profile=PROFILE)
+            log.info(f"rtpproxy offer for re-INVITE call_id={request.call_id}")
+
+        if request.loose_route():
+            request.relay()
+        else:
+            request.reply(404, "Not Here")
+        return
+
+    if request.method == "REGISTER":
+        if not auth.require_digest(request, realm=DOMAIN):
+            return
+        registrar.save(request)
+        return
+
+    if not request.ruri.user:
+        request.reply(484, "Address Incomplete")
+        return
+
+    contacts = registrar.lookup(request.ruri)
+    if not contacts:
+        request.reply(404, "Not Found")
+        return
+
+    # For INVITE with SDP, anchor media through rtpproxy (offer)
+    if request.method == "INVITE" and request.body:
+        await rtpengine.offer(request, profile=PROFILE)
+        log.info(f"rtpproxy offer for INVITE call_id={request.call_id}")
+
+    request.record_route()
+    request.fork([c.uri for c in contacts])
+
+
+@proxy.on_reply
+async def reply_route(request, reply):
+    # For 200 OK to INVITE with SDP, anchor media through rtpproxy (answer)
+    if reply.status_code >= 200 and reply.status_code < 300:
+        if reply.has_body("application/sdp"):
+            await rtpengine.answer(reply, profile=PROFILE)
+            log.info(f"rtpproxy answer for reply call_id={reply.call_id}")
+
+    reply.relay()
+
+
+@proxy.on_cancel
+async def cancel_route(request):
+    # The INVITE was CANCELled before any final response. on_reply/on_failure
+    # never fire for a cancel — the proxy answers 487 at the transaction layer
+    # and the session is gone — so without this hook the media anchored on the
+    # INVITE offer above would linger until rtpproxy's own inactivity timeout.
+    await rtpengine.delete(request)
+    log.info(f"rtpproxy delete for CANCEL call_id={request.call_id}")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -7,6 +7,7 @@
 #   ./scripts/run-tests.sh --skip-rust  # Skip Rust tests (Docker only)
 #   ./scripts/run-tests.sh --call       # Also run call scenarios (UAC+UAS)
 #   ./scripts/run-tests.sh --rtpengine  # Also run B2BUA + RTPEngine tests
+#   ./scripts/run-tests.sh --rtpproxy   # Also run classic rtpproxy media test
 #   ./scripts/run-tests.sh --b2bua     # Also run B2BUA call/session-timer/cancel/failure tests
 set -euo pipefail
 
@@ -26,6 +27,7 @@ RUN_IPSEC=false
 RUN_CALL=false
 RUN_PRESENCE=false
 RUN_RTPENGINE=false
+RUN_RTPPROXY=false
 RUN_REINVITE=false
 RUN_B2BUA=false
 RUN_GATEWAY=false
@@ -43,6 +45,7 @@ for arg in "$@"; do
     --call)       RUN_CALL=true ;;
     --presence)   RUN_PRESENCE=true ;;
     --rtpengine)  RUN_RTPENGINE=true ;;
+    --rtpproxy)   RUN_RTPPROXY=true ;;
     --reinvite)   RUN_REINVITE=true ;;
     --b2bua)      RUN_B2BUA=true ;;
     --gateway)    RUN_GATEWAY=true ;;
@@ -54,7 +57,7 @@ for arg in "$@"; do
     --webrtc)     RUN_WEBRTC=true ;;
     --skip-rust)  SKIP_RUST=true ;;
     --help|-h)
-      echo "Usage: $0 [--ipsec] [--call] [--presence] [--rtpengine] [--reinvite] [--b2bua] [--gateway] [--auto100] [--http-auth] [--wedge] [--banscan] [--security] [--webrtc] [--skip-rust]"
+      echo "Usage: $0 [--ipsec] [--call] [--presence] [--rtpengine] [--rtpproxy] [--reinvite] [--b2bua] [--gateway] [--auto100] [--http-auth] [--wedge] [--banscan] [--security] [--webrtc] [--skip-rust]"
       exit 0
       ;;
     *)
@@ -122,6 +125,14 @@ if [[ "$RUN_RTPENGINE" == true ]]; then
   echo "=== SIPp RTPEngine test (register bob → INVITE with media anchoring) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile rtpengine run --rm sipp-rtpengine-register
   run_sipp docker compose -f "$COMPOSE_FILE" --profile rtpengine up --abort-on-container-exit sipp-rtpengine-uac sipp-rtpengine-uas
+fi
+
+# ── Step 7b: Classic rtpproxy proxy test (optional) ───────────────────────
+if [[ "$RUN_RTPPROXY" == true ]]; then
+  echo "=== SIPp rtpproxy test (register bob → INVITE with siphon-side SDP rewrite) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile rtpproxy run --rm sipp-rtpproxy-register
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile rtpproxy up --abort-on-container-exit --exit-code-from sipp-rtpproxy-uac sipp-rtpproxy-uac sipp-rtpproxy-uas
+  docker compose -f "$COMPOSE_FILE" --profile rtpproxy rm -sf sipp-rtpproxy-uac sipp-rtpproxy-uas 2>/dev/null || true
 fi
 
 # ── Step 8: RTPEngine re-INVITE tests (optional) ──────────────────────────

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -437,17 +437,21 @@ auth:
 #     local_max_entries: 10000
 
 # ---------------------------------------------------------------------------
-# Media engine (rtpengine or native siphon-rtp)
+# Media engine (rtpengine, native siphon-rtp, or classic rtpproxy)
 # ---------------------------------------------------------------------------
-# siphon drives one of two media-control backends, selected by `media.backend`:
+# siphon drives one of three media-control backends, selected by `media.backend`:
 #   rtpengine  (default) — rtpengine NG protocol, bencode over UDP
 #   siphon-rtp           — native siphon-rtp engine, JSON over a persistent TCP
 #                          connection (reliable, optional auth, server-pushed
 #                          DTMF/media-timeout events on the same connection).
 #                          EXPERIMENTAL — the siphon-rtp engine is pre-release;
 #                          use rtpengine in production until it stabilises.
+#   rtpproxy             — classic rtpproxy relay, text over UDP (siphon rewrites
+#                          the SDP itself); for migrating an existing
+#                          OpenSIPS/Kamailio/Sippy + rtpproxy deployment
 # The Python `rtpengine` scripting API and all media profiles are identical for
-# both backends — only the transport underneath differs.
+# every backend — only the transport (and, for rtpproxy, the supported verbs)
+# differ.
 #
 # --- rtpengine backend (default) ---
 # Single instance:
@@ -500,6 +504,38 @@ auth:
 #   # `profiles:` and `health_check_interval_secs:` apply to this backend too.
 #   # The rtpengine-only `media.events:` listener is not used here — events ride
 #   # the control connection.
+#
+# --- classic rtpproxy backend (legacy media relay) ---
+# For migrating an existing OpenSIPS/Kamailio/Sippy deployment to siphon while
+# keeping its in-place rtpproxy. siphon speaks the classic cookie-prefixed
+# U/L/D/V protocol over UDP and rewrites the SDP itself (rtpproxy only allocates
+# the relay port). The rtpengine-only verbs (announcements, DTMF injection,
+# gating, SIPREC/MPTY) are NOT available on this backend.
+# Single instance:
+# media:
+#   backend: rtpproxy
+#   rtpproxy:
+#     address: "127.0.0.1:22222"    # rtpproxy -s udp:<addr>
+#     timeout_ms: 1000               # per-command budget, split across retransmits
+#     retries: 2                     # UDP retransmits after the first send (same cookie)
+#
+# Multiple instances (weighted round-robin + per-call-id affinity, same as
+# rtpengine):
+# media:
+#   backend: rtpproxy
+#   rtpproxy:
+#     timeout_ms: 1000               # default; per-instance timeout_ms overrides
+#     retries: 2
+#     instances:
+#       - address: "10.0.0.1:22222"
+#         weight: 2
+#       - address: "10.0.0.2:22222"
+#         weight: 1
+#         timeout_ms: 1500
+#   # `profiles:` and `health_check_interval_secs:` apply here too. A profile's
+#   # NAT `direction` (["internal","external"]) and `asymmetric` flag map to
+#   # rtpproxy bridge/symmetry modifiers; IPv6 is auto-detected per stream.
+#   # The `media.events:` listener is unused — rtpproxy pushes no async events.
 #
 # Custom media profiles (extend or override built-ins):
 #

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -620,6 +620,146 @@ services:
     profiles:
       - rtpengine
 
+  # ── rtpproxy proxy test ───────────────────────────────────────────────────
+  # Tests media anchoring through a mock classic rtpproxy via proxy script.
+  # Same flow + SIPp scenarios as the rtpengine test, but the backend is
+  # `media.backend: rtpproxy` and siphon rewrites the SDP itself (rtpproxy only
+  # allocates the relay port). Requires the "rtpproxy" profile.
+  #
+  # Usage:
+  #   docker compose -f sipp/docker-compose.yaml --profile rtpproxy \
+  #     up --abort-on-container-exit sipp-rtpproxy-uac sipp-rtpproxy-uas
+
+  # Mock rtpproxy — Python script simulating the text protocol on UDP 22222
+  mock-rtpproxy:
+    image: python:3.12-slim
+    container_name: mock-rtpproxy
+    volumes:
+      - ./rtpproxy:/app:ro
+    working_dir: /app
+    command: ["python3", "mock_rtpproxy.py"]
+    environment:
+      RTPPROXY_PORT: "22222"
+      MOCK_MEDIA_IP: "203.0.113.1"
+      MOCK_MEDIA_PORT: "30000"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.44
+    healthcheck:
+      # Send a `V` (version) query and expect a digit-led reply.
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'hc V', ('127.0.0.1',22222)); d=s.recv(1024); s.close(); exit(0 if d.split(b' ',1)[1][:1].isdigit() else 1)\""]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+    profiles:
+      - rtpproxy
+
+  # SIPhon proxy with rtpproxy config (media.backend: rtpproxy)
+  siphon-rtpproxy:
+    build:
+      context: ..
+    container_name: siphon-rtpproxy-test
+    depends_on:
+      mock-rtpproxy:
+        condition: service_healthy
+    volumes:
+      - ./rtpproxy/siphon-rtpproxy.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.45
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - rtpproxy
+
+  # Register bob from the UAS IP so proxy knows where to relay
+  sipp-rtpproxy-register:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-rtpproxy:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.46
+    entrypoint:
+      - sipp
+      - "172.20.0.45:5060"
+      - -sf
+      - /sipp/scenarios/register.xml
+      - -s
+      - bob
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+    profiles:
+      - rtpproxy
+
+  # B-leg UAS: receives INVITE relayed by proxy with rtpproxy-rewritten SDP.
+  # Reuses the rtpengine SIPp scenarios — the mock returns the same media addr.
+  sipp-rtpproxy-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-rtpproxy-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.46
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/rtpengine_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - rtpproxy
+
+  # A-leg UAC: sends INVITE to proxy with SDP, expects rtpproxy-rewritten 200 OK
+  sipp-rtpproxy-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-rtpproxy:
+        condition: service_healthy
+      sipp-rtpproxy-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.47
+    entrypoint:
+      - sipp
+      - "172.20.0.45:5060"
+      - -sf
+      - /sipp/scenarios/rtpproxy_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - rtpproxy
+
   # ── RTPEngine re-INVITE test (hold/resume) ────────────────────────────────
   # Tests mid-dialog re-INVITE with RTPEngine offer/answer cycle.
   # Flow: INVITE → 200 → ACK → re-INVITE(hold) → 200 → ACK

--- a/sipp/rtpengine_uac.xml
+++ b/sipp/rtpengine_uac.xml
@@ -44,19 +44,21 @@ a=fmtp:101 0-15
   <label id="1" />
   <recv response="180" optional="true" next="1" />
 
-  <!-- Expect 200 OK -->
-  <recv response="200" rtd="true" crlf="true" />
+  <!-- Expect 200 OK; capture the Record-Route set (rrs) for in-dialog routing -->
+  <recv response="200" rtd="true" crlf="true" rrs="true" />
 
-  <!-- Send ACK -->
+  <!-- Send ACK (in-dialog: Contact from 200 OK via [next_url] + [routes]).
+       Hardcoding the R-URI to the proxy would self-route at the proxy after
+       loose_route() pops its own Route, dropping the ACK / 482-looping the BYE. -->
   <send>
     <![CDATA[
-ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+ACK [next_url] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
 From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
 To: <sip:bob@[remote_ip]>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: 1 ACK
-Route: <sip:[remote_ip]:[remote_port];lr>
+[routes]
 Max-Forwards: 70
 Content-Length: 0
 
@@ -66,16 +68,16 @@ Content-Length: 0
   <!-- Hold call briefly -->
   <pause milliseconds="500" />
 
-  <!-- Send BYE -->
+  <!-- Send BYE (in-dialog: Contact from 200 OK via [next_url] + [routes]) -->
   <send retrans="500">
     <![CDATA[
-BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+BYE [next_url] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
 From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
 To: <sip:bob@[remote_ip]>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: 2 BYE
-Route: <sip:[remote_ip]:[remote_port];lr>
+[routes]
 Max-Forwards: 70
 Content-Length: 0
 

--- a/sipp/rtpproxy/mock_rtpproxy.py
+++ b/sipp/rtpproxy/mock_rtpproxy.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Mock rtpproxy control server for functional testing.
+
+Speaks the classic rtpproxy text protocol over UDP: each request is
+``<cookie> <command>`` in a single datagram, and the reply is
+``<cookie> <result>``.
+
+Unlike rtpengine (which rewrites the SDP itself), rtpproxy only allocates a
+relay port and returns ``<port> <address>`` — siphon rewrites the SDP. So this
+mock just hands back a fixed ``MOCK_MEDIA_PORT MOCK_MEDIA_IP`` for every
+create/lookup (``U``/``L``), a version for ``V``, and ``0`` for delete (``D``).
+"""
+
+import os
+import socket
+
+LISTEN_PORT = int(os.environ.get("RTPPROXY_PORT", "22222"))
+MOCK_MEDIA_IP = os.environ.get("MOCK_MEDIA_IP", "203.0.113.1")
+MOCK_MEDIA_PORT = os.environ.get("MOCK_MEDIA_PORT", "30000")
+# Classic rtpproxy version token (an 8-digit date), returned for `V`.
+VERSION = os.environ.get("RTPPROXY_VERSION", "20040107")
+
+
+def handle_command(command: str) -> str:
+    """Return the result string for a command (without the cookie)."""
+    # The command letter is the first char; optional modifiers follow with no
+    # separator (e.g. "Uie", "Lei"), then space-separated args.
+    letter = command[:1].upper()
+    if letter == "V":
+        return VERSION
+    if letter in ("U", "L"):
+        # create/lookup → allocate a relay port + advertise the media address.
+        return f"{MOCK_MEDIA_PORT} {MOCK_MEDIA_IP}"
+    if letter == "D":
+        return "0"
+    # Q (info), I (info), X (delete-all), etc. — answer benignly.
+    return "0"
+
+
+def main() -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("0.0.0.0", LISTEN_PORT))
+    print(f"Mock rtpproxy listening on UDP port {LISTEN_PORT}", flush=True)
+    print(f"  Media IP: {MOCK_MEDIA_IP}, Media port: {MOCK_MEDIA_PORT}", flush=True)
+
+    while True:
+        data, address = sock.recvfrom(65535)
+        cookie = b""
+        try:
+            # Protocol: "<cookie> <command>"
+            space_index = data.index(b" ")
+            cookie = data[:space_index]
+            command = data[space_index + 1:].decode(errors="replace").strip()
+            letter = command[:1].upper() if command else "?"
+            print(f"[{address[0]}:{address[1]}] {letter} :: {command}", flush=True)
+
+            result = handle_command(command)
+            reply = cookie + b" " + result.encode()
+            sock.sendto(reply, address)
+        except Exception as error:  # noqa: BLE001 — best-effort mock
+            print(f"Error processing request from {address}: {error}", flush=True)
+            try:
+                sock.sendto(cookie + b" E1", address)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/sipp/rtpproxy/siphon-rtpproxy.yaml
+++ b/sipp/rtpproxy/siphon-rtpproxy.yaml
@@ -1,0 +1,46 @@
+# siphon config for proxy + classic rtpproxy functional test
+#
+# Used with: sipp/docker-compose.yaml (rtpproxy profile)
+# Script:    examples/proxy_rtpproxy.py
+#
+# Same proxy script shape as the rtpengine test — only `media.backend` and the
+# profile name differ — demonstrating the scripting API is backend-agnostic.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+advertised_address: "172.20.0.45"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.45"
+    - "127.0.0.1"
+
+script:
+  path: "examples/proxy_rtpproxy.py"
+  reload: auto
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+media:
+  backend: rtpproxy
+  rtpproxy:
+    address: "172.20.0.44:22222"
+    timeout_ms: 2000
+    retries: 2
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/rtpproxy_uac.xml
+++ b/sipp/rtpproxy_uac.xml
@@ -5,13 +5,13 @@
   rtpproxy proxy UAC scenario:
   INVITE (with SDP) → 180 → 200 OK → ACK → BYE → 200
 
-  Same as rtpengine_uac.xml, but with an optional 100-Trying absorber before the
-  BYE's 200 OK: siphon's NIST timer may auto-emit a 100 for the in-dialog BYE
-  (it does the same for the INVITE, absorbed below) when the relay round-trip
-  exceeds transaction.auto_100_delay. Without the absorber the UAC aborts on the
-  unexpected 100. The proxy calls rtpengine.offer() before relaying the INVITE,
-  rtpengine.answer() on the 200 OK, and rtpengine.delete() on the BYE — all of
-  which map onto rtpproxy via media.backend.
+  The proxy anchors media via rtpproxy.offer() on the INVITE, rtpproxy.answer()
+  on the 200 OK, and rtpproxy.delete() on the BYE (all mapped onto rtpproxy via
+  media.backend). In-dialog requests (ACK/BYE) are routed correctly through the
+  record-routing proxy: `rrs="true"` captures the Record-Route set on the 200 OK,
+  and ACK/BYE use `[next_url]` (the UAS Contact) + `[routes]` — mirroring
+  invite_uac.xml. Hardcoding the in-dialog R-URI to the proxy (as the older
+  rtpengine_uac.xml does) would self-route at the proxy and 482-loop.
 -->
 <scenario name="rtpproxy proxy UAC">
 
@@ -20,7 +20,7 @@
     <![CDATA[
 INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
-From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
 To: <sip:bob@[remote_ip]>
 Call-ID: [call_id]
 CSeq: 1 INVITE
@@ -49,19 +49,19 @@ a=fmtp:101 0-15
   <label id="1" />
   <recv response="180" optional="true" next="1" />
 
-  <!-- Expect 200 OK -->
-  <recv response="200" rtd="true" crlf="true" />
+  <!-- Expect 200 OK; capture the Record-Route set (rrs) for in-dialog routing -->
+  <recv response="200" rtd="true" crlf="true" rrs="true" />
 
-  <!-- Send ACK -->
+  <!-- Send ACK (in-dialog: Contact from 200 OK via [next_url] + [routes]) -->
   <send>
     <![CDATA[
-ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+ACK [next_url] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
-From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
 To: <sip:bob@[remote_ip]>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: 1 ACK
-Route: <sip:[remote_ip]:[remote_port];lr>
+[routes]
 Max-Forwards: 70
 Content-Length: 0
 
@@ -71,24 +71,23 @@ Content-Length: 0
   <!-- Hold call briefly -->
   <pause milliseconds="500" />
 
-  <!-- Send BYE -->
+  <!-- Send BYE (in-dialog: Contact from 200 OK via [next_url] + [routes]) -->
   <send retrans="500">
     <![CDATA[
-BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+BYE [next_url] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
-From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
 To: <sip:bob@[remote_ip]>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: 2 BYE
-Route: <sip:[remote_ip]:[remote_port];lr>
+[routes]
 Max-Forwards: 70
 Content-Length: 0
 
 ]]>
   </send>
 
-  <!-- Absorb an optional 100 Trying for the BYE, then expect its 200 OK -->
-  <recv response="100" optional="true" />
+  <!-- Expect 200 OK for BYE -->
   <recv response="200" rtd="true" />
 
 </scenario>

--- a/sipp/rtpproxy_uac.xml
+++ b/sipp/rtpproxy_uac.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  rtpproxy proxy UAC scenario:
+  INVITE (with SDP) → 180 → 200 OK → ACK → BYE → 200
+
+  Same as rtpengine_uac.xml, but with an optional 100-Trying absorber before the
+  BYE's 200 OK: siphon's NIST timer may auto-emit a 100 for the in-dialog BYE
+  (it does the same for the INVITE, absorbed below) when the relay round-trip
+  exceeds transaction.auto_100_delay. Without the absorber the UAC aborts on the
+  unexpected 100. The proxy calls rtpengine.offer() before relaying the INVITE,
+  rtpengine.answer() on the 200 OK, and rtpengine.delete() on the BYE — all of
+  which map onto rtpproxy via media.backend.
+-->
+<scenario name="rtpproxy proxy UAC">
+
+  <!-- Send INVITE with SDP to proxy -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/rtpproxy-test-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <!-- Absorb provisionals -->
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <!-- Expect 200 OK -->
+  <recv response="200" rtd="true" crlf="true" />
+
+  <!-- Send ACK -->
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Route: <sip:[remote_ip]:[remote_port];lr>
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Hold call briefly -->
+  <pause milliseconds="500" />
+
+  <!-- Send BYE -->
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Route: <sip:[remote_ip]:[remote_port];lr>
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Absorb an optional 100 Trying for the BYE, then expect its 200 OK -->
+  <recv response="100" optional="true" />
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/src/config.rs
+++ b/src/config.rs
@@ -1585,6 +1585,8 @@ pub enum MediaBackendKind {
     Rtpengine,
     /// Native `siphon-rtp` control protocol (JSON over TCP).
     SiphonRtp,
+    /// Classic `rtpproxy` control protocol (text over UDP).
+    Rtpproxy,
 }
 
 /// Media proxy configuration.
@@ -1602,6 +1604,9 @@ pub struct MediaConfig {
     /// Native `siphon-rtp` engine connection. Required when `backend: siphon-rtp`.
     #[serde(default)]
     pub siphon_rtp: Option<SiphonRtpConfig>,
+    /// Classic `rtpproxy` relay connection. Required when `backend: rtpproxy`.
+    #[serde(default)]
+    pub rtpproxy: Option<RtpProxyConfig>,
     /// Custom media profiles (name → offer/answer NG flags).
     /// Built-in profiles (srtp_to_rtp, ws_to_rtp, wss_to_rtp, rtp_passthrough)
     /// are always available; custom entries here extend or override them.
@@ -1701,6 +1706,82 @@ pub struct SiphonRtpInstanceConfig {
     /// Weight for load-balancing (higher = more traffic). Default: 1.
     #[serde(default = "default_rtpengine_weight")]
     pub weight: u32,
+}
+
+/// Connection to a classic `rtpproxy` media relay (text-over-UDP control).
+///
+/// Accepts a single relay (`address`) or several (`instances`) for HA /
+/// load-balancing, mirroring `media.rtpengine`. Per-call-id affinity keeps all
+/// of a call's commands on one relay (the allocated ports live on one instance).
+///
+/// rtpproxy only allocates relay ports and returns them; siphon rewrites the SDP
+/// itself. The rtpengine-only verbs (announcements, DTMF injection, gating,
+/// SIPREC/MPTY) are not available on this backend. The rtpengine `media.events`
+/// listener is also unused — rtpproxy pushes no async events.
+#[derive(Debug, Deserialize, Clone)]
+pub struct RtpProxyConfig {
+    /// Single control endpoint, e.g. ``"127.0.0.1:22222"``
+    /// (`rtpproxy -s udp:<addr>`). Shorthand for one instance; ignored when
+    /// `instances` is non-empty.
+    #[serde(default)]
+    pub address: Option<String>,
+    /// Multiple control endpoints for HA / weighted load-balancing. Takes
+    /// precedence over `address` when present.
+    #[serde(default)]
+    pub instances: Vec<RtpProxyInstanceConfig>,
+    /// Default per-command response budget in milliseconds, split across
+    /// retransmits (per-instance `timeout_ms` overrides it). Default: 1000.
+    #[serde(default = "default_rtpproxy_timeout_ms")]
+    pub timeout_ms: u64,
+    /// Retransmits after the first send before giving up. rtpproxy de-duplicates
+    /// by cookie, so retransmitting the same command is safe and is the standard
+    /// way to ride out UDP loss. Default: 2 (i.e. up to 3 sends).
+    #[serde(default = "default_rtpproxy_retries")]
+    pub retries: u32,
+}
+
+impl RtpProxyConfig {
+    /// Normalized `(address, timeout_ms, weight)` tuples — from `instances` when
+    /// present, else the single `address`. Empty when neither is configured.
+    pub fn instances(&self) -> Vec<(String, u64, u32)> {
+        if !self.instances.is_empty() {
+            self.instances
+                .iter()
+                .map(|instance| {
+                    (
+                        instance.address.clone(),
+                        instance.timeout_ms.unwrap_or(self.timeout_ms),
+                        instance.weight,
+                    )
+                })
+                .collect()
+        } else if let Some(address) = &self.address {
+            vec![(address.clone(), self.timeout_ms, 1)]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// One `rtpproxy` control endpoint in a multi-instance set.
+#[derive(Debug, Deserialize, Clone)]
+pub struct RtpProxyInstanceConfig {
+    /// Control endpoint, e.g. ``"10.0.0.1:22222"``.
+    pub address: String,
+    /// Response timeout in ms; falls back to the parent `timeout_ms` when unset.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    /// Weight for load-balancing (higher = more traffic). Default: 1.
+    #[serde(default = "default_rtpengine_weight")]
+    pub weight: u32,
+}
+
+fn default_rtpproxy_timeout_ms() -> u64 {
+    1000
+}
+
+fn default_rtpproxy_retries() -> u32 {
+    2
 }
 
 fn default_siphon_rtp_timeout_ms() -> u64 {
@@ -3747,6 +3828,71 @@ media:
         // First inherits the parent timeout; second overrides it.
         assert_eq!(instances[0], ("10.0.0.1:8080".to_string(), 1500, 2));
         assert_eq!(instances[1], ("10.0.0.2:8080".to_string(), 3000, 1));
+    }
+
+    #[test]
+    fn parses_media_backend_rtpproxy() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+media:
+  backend: rtpproxy
+  rtpproxy:
+    address: "127.0.0.1:22222"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        let media = config.media.unwrap();
+        assert_eq!(media.backend, MediaBackendKind::Rtpproxy);
+        assert!(media.rtpengine.is_none());
+        assert!(media.siphon_rtp.is_none());
+        let rtpproxy = media.rtpproxy.expect("rtpproxy block configured");
+        assert_eq!(rtpproxy.address.as_deref(), Some("127.0.0.1:22222"));
+        assert_eq!(rtpproxy.timeout_ms, 1000); // default
+        assert_eq!(rtpproxy.retries, 2); // default
+        let instances = rtpproxy.instances();
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0], ("127.0.0.1:22222".to_string(), 1000, 1));
+    }
+
+    #[test]
+    fn parses_media_rtpproxy_multiple_instances() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+media:
+  backend: rtpproxy
+  rtpproxy:
+    timeout_ms: 1500
+    retries: 3
+    instances:
+      - address: "10.0.0.1:22222"
+        weight: 2
+      - address: "10.0.0.2:22222"
+        weight: 1
+        timeout_ms: 3000
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        let media = config.media.unwrap();
+        assert_eq!(media.backend, MediaBackendKind::Rtpproxy);
+        let rtpproxy = media.rtpproxy.expect("rtpproxy block configured");
+        assert_eq!(rtpproxy.retries, 3);
+        let instances = rtpproxy.instances();
+        assert_eq!(instances.len(), 2);
+        // First inherits the parent timeout; second overrides it.
+        assert_eq!(instances[0], ("10.0.0.1:22222".to_string(), 1500, 2));
+        assert_eq!(instances[1], ("10.0.0.2:22222".to_string(), 3000, 1));
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -4576,6 +4576,7 @@ pub fn init_rtpengine(
         crate::config::MediaBackendKind::SiphonRtp => {
             build_siphon_rtp_backend(media_config, event_sender)
         }
+        crate::config::MediaBackendKind::Rtpproxy => build_rtpproxy_backend(media_config),
     };
     let backend = match backend {
         Some(backend) => Arc::new(backend),
@@ -4702,6 +4703,55 @@ fn build_siphon_rtp_backend(
         }
         Err(error) => {
             error!(error = %error, "failed to initialize siphon-rtp client set");
+            None
+        }
+    }
+}
+
+/// Build the classic rtpproxy text-over-UDP backend from `media.rtpproxy`.
+fn build_rtpproxy_backend(
+    media_config: &crate::config::MediaConfig,
+) -> Option<crate::rtpengine::MediaBackend> {
+    let rtpproxy_config = match &media_config.rtpproxy {
+        Some(config) => config,
+        None => {
+            error!("media.backend is 'rtpproxy' but no media.rtpproxy block is configured");
+            return None;
+        }
+    };
+
+    let mut instance_tuples = Vec::new();
+    for (address, timeout_ms, weight) in rtpproxy_config.instances() {
+        match address.parse::<std::net::SocketAddr>() {
+            Ok(parsed) => instance_tuples.push((parsed, timeout_ms, weight)),
+            Err(parse_error) => error!(
+                address = %address,
+                error = %parse_error,
+                "invalid rtpproxy control address, skipping"
+            ),
+        }
+    }
+    if instance_tuples.is_empty() {
+        error!("media.backend is 'rtpproxy' but no valid control address is configured");
+        return None;
+    }
+
+    let count = instance_tuples.len();
+    let retries = rtpproxy_config.retries;
+    let handle = tokio::runtime::Handle::current();
+    match tokio::task::block_in_place(|| {
+        handle.block_on(crate::rtpengine::RtpProxyClientSet::new(instance_tuples, retries))
+    }) {
+        Ok(set) => {
+            info!(
+                instances = count,
+                "rtpproxy media backend configured ({count} instance{})",
+                if count == 1 { "" } else { "s" }
+            );
+            Some(crate::rtpengine::MediaBackend::RtpProxy(set))
+        }
+        Err(error) => {
+            error!(error = %error, "failed to initialize rtpproxy client set");
             None
         }
     }

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -1,15 +1,22 @@
 //! Media-control backend abstraction.
 //!
-//! siphon can drive either the legacy rtpengine NG/bencode-over-UDP engine
-//! ([`RtpEngineSet`]) or the native `siphon-rtp` JSON-over-TCP engine
-//! ([`SiphonRtpClient`]).  Both expose the same media-control verbs; this enum
-//! is a thin dispatcher so the dispatcher and the Python `rtpengine` namespace
-//! call one type regardless of which is configured (`media.backend`).
+//! siphon can drive one of three media engines, all behind the same media-control
+//! verbs:
+//! - the legacy rtpengine NG/bencode-over-UDP engine ([`RtpEngineSet`]),
+//! - the native `siphon-rtp` JSON-over-TCP engine ([`SiphonRtpClientSet`]),
+//! - the classic `rtpproxy` text-over-UDP relay ([`RtpProxyClientSet`]) — for
+//!   migrating an existing OpenSIPS/Kamailio/Sippy deployment to siphon while
+//!   keeping its in-place rtpproxy.
+//!
+//! This enum is a thin dispatcher so the dispatcher and the Python `rtpengine`
+//! namespace call one type regardless of which is configured (`media.backend`).
 //!
 //! Enum dispatch (rather than `Arc<dyn Trait>`) keeps the methods as plain
-//! `async fn` with no `async-trait` dependency, and there are exactly two
-//! backends.  Every method mirrors [`RtpEngineSet`]'s signature verbatim so all
-//! existing call sites compile unchanged when the field type is swapped.
+//! `async fn` with no `async-trait` dependency.  Every method mirrors
+//! [`RtpEngineSet`]'s signature verbatim so all existing call sites compile
+//! unchanged when the field type is swapped.  rtpproxy only allocates relay
+//! ports, so the rtpengine-only verbs (prompts, DTMF, gating, SIPREC/MPTY)
+//! return a clear [`RtpEngineError::EngineError`] on that backend.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -17,6 +24,7 @@ use std::sync::Arc;
 use super::client::{PlayMediaSource, RtpEngineSet};
 use super::error::RtpEngineError;
 use super::profile::NgFlags;
+use super::rtpproxy::RtpProxyClientSet;
 use super::siphon_rtp::SiphonRtpClientSet;
 
 /// The configured media-control backend.
@@ -25,6 +33,8 @@ pub enum MediaBackend {
     RtpEngine(Arc<RtpEngineSet>),
     /// Native `siphon-rtp` control protocol (JSON over TCP), one or more instances.
     SiphonRtp(Arc<SiphonRtpClientSet>),
+    /// Classic `rtpproxy` control protocol (text over UDP), one or more instances.
+    RtpProxy(Arc<RtpProxyClientSet>),
 }
 
 impl MediaBackend {
@@ -39,6 +49,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.offer(call_id, from_tag, sdp, flags).await,
             Self::SiphonRtp(client) => client.offer(call_id, from_tag, sdp, flags).await,
+            Self::RtpProxy(client) => client.offer(call_id, from_tag, sdp, flags).await,
         }
     }
 
@@ -54,6 +65,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.answer(call_id, from_tag, to_tag, sdp, flags).await,
             Self::SiphonRtp(client) => client.answer(call_id, from_tag, to_tag, sdp, flags).await,
+            Self::RtpProxy(client) => client.answer(call_id, from_tag, to_tag, sdp, flags).await,
         }
     }
 
@@ -62,6 +74,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.delete(call_id, from_tag).await,
             Self::SiphonRtp(client) => client.delete(call_id, from_tag).await,
+            Self::RtpProxy(client) => client.delete(call_id, from_tag).await,
         }
     }
 
@@ -103,6 +116,19 @@ impl MediaBackend {
                     )
                     .await
             }
+            Self::RtpProxy(client) => {
+                client
+                    .play_media(
+                        call_id,
+                        from_tag,
+                        source,
+                        repeat_times,
+                        start_pos_ms,
+                        duration_ms,
+                        to_tag,
+                    )
+                    .await
+            }
         }
     }
 
@@ -111,6 +137,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.stop_media(call_id, from_tag).await,
             Self::SiphonRtp(client) => client.stop_media(call_id, from_tag).await,
+            Self::RtpProxy(client) => client.stop_media(call_id, from_tag).await,
         }
     }
 
@@ -136,6 +163,11 @@ impl MediaBackend {
                     .play_dtmf(call_id, from_tag, code, duration_ms, volume_dbm0, pause_ms, to_tag)
                     .await
             }
+            Self::RtpProxy(client) => {
+                client
+                    .play_dtmf(call_id, from_tag, code, duration_ms, volume_dbm0, pause_ms, to_tag)
+                    .await
+            }
         }
     }
 
@@ -144,6 +176,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.silence_media(call_id, from_tag).await,
             Self::SiphonRtp(client) => client.silence_media(call_id, from_tag).await,
+            Self::RtpProxy(client) => client.silence_media(call_id, from_tag).await,
         }
     }
 
@@ -156,6 +189,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.unsilence_media(call_id, from_tag).await,
             Self::SiphonRtp(client) => client.unsilence_media(call_id, from_tag).await,
+            Self::RtpProxy(client) => client.unsilence_media(call_id, from_tag).await,
         }
     }
 
@@ -164,6 +198,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.block_media(call_id, from_tag).await,
             Self::SiphonRtp(client) => client.block_media(call_id, from_tag).await,
+            Self::RtpProxy(client) => client.block_media(call_id, from_tag).await,
         }
     }
 
@@ -172,6 +207,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.unblock_media(call_id, from_tag).await,
             Self::SiphonRtp(client) => client.unblock_media(call_id, from_tag).await,
+            Self::RtpProxy(client) => client.unblock_media(call_id, from_tag).await,
         }
     }
 
@@ -191,6 +227,9 @@ impl MediaBackend {
             Self::SiphonRtp(client) => {
                 client.subscribe_request(call_id, from_tag, to_tag, sdp, flags).await
             }
+            Self::RtpProxy(client) => {
+                client.subscribe_request(call_id, from_tag, to_tag, sdp, flags).await
+            }
         }
     }
 
@@ -206,6 +245,9 @@ impl MediaBackend {
                 set.subscribe_request_siprec(call_id, from_tags, profile_flags).await
             }
             Self::SiphonRtp(client) => {
+                client.subscribe_request_siprec(call_id, from_tags, profile_flags).await
+            }
+            Self::RtpProxy(client) => {
                 client.subscribe_request_siprec(call_id, from_tags, profile_flags).await
             }
         }
@@ -227,6 +269,9 @@ impl MediaBackend {
             Self::SiphonRtp(client) => {
                 client.subscribe_answer(call_id, from_tag, to_tag, sdp, flags).await
             }
+            Self::RtpProxy(client) => {
+                client.subscribe_answer(call_id, from_tag, to_tag, sdp, flags).await
+            }
         }
     }
 
@@ -240,6 +285,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.unsubscribe(call_id, from_tag, to_tag).await,
             Self::SiphonRtp(client) => client.unsubscribe(call_id, from_tag, to_tag).await,
+            Self::RtpProxy(client) => client.unsubscribe(call_id, from_tag, to_tag).await,
         }
     }
 
@@ -248,6 +294,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.ping().await,
             Self::SiphonRtp(client) => client.ping().await,
+            Self::RtpProxy(client) => client.ping().await,
         }
     }
 
@@ -256,6 +303,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.health_check().await,
             Self::SiphonRtp(client) => client.health_check().await,
+            Self::RtpProxy(client) => client.health_check().await,
         }
     }
 
@@ -264,6 +312,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.active_sessions(),
             Self::SiphonRtp(client) => client.active_sessions(),
+            Self::RtpProxy(client) => client.active_sessions(),
         }
     }
 
@@ -272,6 +321,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.instance_count(),
             Self::SiphonRtp(client) => client.instance_count(),
+            Self::RtpProxy(client) => client.instance_count(),
         }
     }
 
@@ -280,6 +330,7 @@ impl MediaBackend {
         match self {
             Self::RtpEngine(set) => set.instance_addresses(),
             Self::SiphonRtp(client) => client.instance_addresses(),
+            Self::RtpProxy(client) => client.instance_addresses(),
         }
     }
 }

--- a/src/rtpengine/mod.rs
+++ b/src/rtpengine/mod.rs
@@ -15,6 +15,7 @@ pub mod client;
 pub mod error;
 pub mod events;
 pub mod profile;
+pub mod rtpproxy;
 pub mod session;
 pub mod siphon_rtp;
 
@@ -22,5 +23,6 @@ pub use backend::MediaBackend;
 pub use client::{RtpEngineClient, RtpEngineSet};
 pub use error::RtpEngineError;
 pub use profile::{NgFlags, ProfileEntry, ProfileRegistry};
+pub use rtpproxy::{RtpProxyClient, RtpProxyClientSet};
 pub use session::{MediaSession, MediaSessionStore};
 pub use siphon_rtp::{SiphonRtpClient, SiphonRtpClientSet};

--- a/src/rtpengine/rtpproxy.rs
+++ b/src/rtpengine/rtpproxy.rs
@@ -1,0 +1,1244 @@
+//! Classic `rtpproxy` control-protocol client (text-over-UDP).
+//!
+//! `rtpproxy` (the Sippy/Kamailio/OpenSIPS media relay) speaks a small text
+//! protocol over UDP: each request is `<cookie> <command>` in a single datagram,
+//! and the reply is `<cookie> <result>`.  The cookie correlates reply to request
+//! and lets the engine de-duplicate retransmits idempotently — so this client
+//! resends the *same* cookie on timeout rather than failing immediately, which is
+//! the standard way to get reliability over UDP.
+//!
+//! Unlike rtpengine NG and the native siphon-rtp engine — which rewrite the SDP
+//! server-side and hand back the finished body — `rtpproxy` only **allocates a
+//! relay port** and returns `<port> [<address>]`.  siphon therefore rewrites the
+//! SDP itself: for each media stream it sends an `U`/`L` command carrying that
+//! stream's advertised address/port, then writes the returned relay address/port
+//! back into the `c=`/`m=` lines (via [`crate::media::sdp`]).
+//!
+//! This client mirrors the public method surface of
+//! [`RtpEngineSet`](super::client::RtpEngineSet) so it is interchangeable behind
+//! [`MediaBackend`](super::backend::MediaBackend).  Only the four media-anchoring
+//! verbs are supported — `offer` (`U`), `answer` (`L`), `delete` (`D`) and `ping`
+//! (`V`); the rtpengine-only extras (prompts, DTMF injection, gating,
+//! SIPREC/MPTY subscriptions) surface a clear [`RtpEngineError::EngineError`].
+//! The primary use case is migrating an existing OpenSIPS/Kamailio/Sippy
+//! deployment to siphon while keeping its in-place rtpproxy as the media relay.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::BytesMut;
+use dashmap::DashMap;
+use futures_util::future::join_all;
+use tokio::net::UdpSocket;
+use tokio::sync::oneshot;
+use tracing::{debug, error, trace, warn};
+
+use crate::media::sdp::{MediaLine, SdpBody};
+
+use super::client::PlayMediaSource;
+use super::error::RtpEngineError;
+use super::profile::NgFlags;
+
+/// Maximum UDP datagram we will accept from rtpproxy (responses are tiny).
+const RECV_BUFFER_SIZE: usize = 65535;
+/// Floor for a single send attempt's wait when the per-call budget is split
+/// across retransmits, so a tight `timeout_ms` still leaves time to hear back.
+const MIN_PER_ATTEMPT_MS: u64 = 50;
+
+/// Async client for one `rtpproxy` control endpoint.
+pub struct RtpProxyClient {
+    /// Local UDP socket bound to an ephemeral port.
+    socket: Arc<UdpSocket>,
+    /// rtpproxy control address (`rtpproxy -s udp:<host>:<port>`).
+    address: SocketAddr,
+    /// In-flight requests awaiting a response, keyed by cookie.
+    pending: Arc<DashMap<String, oneshot::Sender<String>>>,
+    /// Total per-command response budget in milliseconds (split across attempts).
+    timeout_ms: u64,
+    /// Number of retransmits after the first send (same cookie each time).
+    retries: u32,
+    /// Active call-ids (offer→insert, delete→remove) — mirrors `RtpEngineSet`'s
+    /// affinity count for the `rtpengine.active_sessions` Python getter.
+    sessions: DashMap<String, ()>,
+}
+
+impl RtpProxyClient {
+    /// Create a client and spawn the background receiver task.
+    pub async fn new(
+        address: SocketAddr,
+        timeout_ms: u64,
+        retries: u32,
+    ) -> Result<Arc<Self>, RtpEngineError> {
+        // Bind a v4 or v6 ephemeral socket to match the control address family.
+        let bind_addr = if address.is_ipv6() {
+            "[::]:0"
+        } else {
+            "0.0.0.0:0"
+        };
+        let socket = Arc::new(UdpSocket::bind(bind_addr).await?);
+        let pending: Arc<DashMap<String, oneshot::Sender<String>>> = Arc::new(DashMap::new());
+
+        {
+            let socket = Arc::clone(&socket);
+            let pending = Arc::clone(&pending);
+            tokio::spawn(async move { receiver_loop(socket, pending).await });
+        }
+
+        Ok(Arc::new(Self {
+            socket,
+            address,
+            pending,
+            timeout_ms,
+            retries,
+            sessions: DashMap::new(),
+        }))
+    }
+
+    /// Send `U` (create/update) for an offer and return the rewritten SDP.
+    pub async fn offer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        let rewritten = self
+            .negotiate('U', call_id, from_tag, None, sdp, flags)
+            .await?;
+        self.sessions.insert(call_id.to_string(), ());
+        Ok(rewritten)
+    }
+
+    /// Send `L` (lookup) for an answer and return the rewritten SDP.
+    pub async fn answer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        to_tag: &str,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        self.negotiate('L', call_id, from_tag, Some(to_tag), sdp, flags)
+            .await
+    }
+
+    /// Send `D` (delete) to tear down a session and drop its active-session entry.
+    pub async fn delete(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
+        let command = format!("D {call_id} {from_tag}");
+        let response = self.request(&command).await;
+        self.sessions.remove(call_id);
+        let response = response?;
+        let trimmed = response.trim();
+        if let Some(code) = trimmed.strip_prefix('E') {
+            return Err(RtpEngineError::EngineError(format!(
+                "rtpproxy delete error {code}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Liveness check: `V` returns the protocol version (e.g. `20040107`).
+    pub async fn ping(&self) -> Result<(), RtpEngineError> {
+        let response = self.request("V").await?;
+        let trimmed = response.trim();
+        if let Some(code) = trimmed.strip_prefix('E') {
+            return Err(RtpEngineError::EngineError(format!(
+                "rtpproxy version error {code}"
+            )));
+        }
+        if !trimmed.is_empty() && trimmed.bytes().all(|byte| byte.is_ascii_digit()) {
+            Ok(())
+        } else {
+            Err(RtpEngineError::Protocol(format!(
+                "unexpected rtpproxy version response: {trimmed:?}"
+            )))
+        }
+    }
+
+    /// Probe health: a single-element `(address, healthy)` vec, shaped like
+    /// [`RtpEngineSet::health_check`](super::client::RtpEngineSet::health_check).
+    pub async fn health_check(&self) -> Vec<(SocketAddr, bool)> {
+        vec![(self.address, self.ping().await.is_ok())]
+    }
+
+    /// Control endpoint this client talks to.
+    pub fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    /// Number of active call-ids (offer without a matching delete).
+    pub fn active_sessions(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Always 1 — a single client drives one rtpproxy endpoint.
+    pub fn instance_count(&self) -> usize {
+        1
+    }
+
+    /// The single control endpoint, shaped like `RtpEngineSet::instance_addresses`.
+    pub fn instance_addresses(&self) -> Vec<SocketAddr> {
+        vec![self.address]
+    }
+
+    /// Drive an `U`/`L` exchange across every media stream and return the SDP
+    /// rewritten to point at the rtpproxy relay.
+    ///
+    /// One command is issued per media section whose port is non-zero (a `0` port
+    /// is held/declined media — RFC 4566 — and is left untouched). With more than
+    /// one media section, the media index (1-based) is appended to the from/to
+    /// tag (`tag;1`, `tag;2`, …) so rtpproxy can distinguish the streams; this is
+    /// applied identically on the matching `offer`/`answer` so the engine
+    /// correlates them.
+    async fn negotiate(
+        &self,
+        command_letter: char,
+        call_id: &str,
+        from_tag: &str,
+        to_tag: Option<&str>,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        let sdp_text = std::str::from_utf8(sdp)
+            .map_err(|_| RtpEngineError::Protocol("SDP body is not valid UTF-8".to_string()))?;
+        let mut parsed = SdpBody::parse(sdp_text);
+
+        // Clone the session-level c= up front so no borrow of `parsed` is held
+        // across the awaits below (we mutate `parsed.media_sections` in the loop).
+        let session_connection = parsed.connection().map(str::to_string);
+        let multi_stream = parsed.media_sections.len() > 1;
+        let mut relay_address_for_session: Option<String> = None;
+
+        for index in 0..parsed.media_sections.len() {
+            let advertised_port = parsed.media_sections[index].port;
+            if advertised_port == 0 {
+                // Held/declined media — nothing to anchor for this stream.
+                continue;
+            }
+
+            let media_connection = parsed.media_sections[index].connection().map(str::to_string);
+            let connection = media_connection
+                .as_deref()
+                .or(session_connection.as_deref())
+                .ok_or_else(|| {
+                    RtpEngineError::Protocol(
+                        "SDP has no connection address (c=) for an active media stream"
+                            .to_string(),
+                    )
+                })?;
+            let (is_ipv6, advertised_address) = parse_connection(connection)?;
+
+            let modifiers = command_modifiers(flags, is_ipv6);
+            let tag_suffix = if multi_stream {
+                format!(";{}", index + 1)
+            } else {
+                String::new()
+            };
+            let from = format!("{from_tag}{tag_suffix}");
+            let to = to_tag.map(|tag| format!("{tag}{tag_suffix}"));
+
+            let command = build_command(
+                command_letter,
+                &modifiers,
+                call_id,
+                &advertised_address,
+                advertised_port,
+                &from,
+                to.as_deref(),
+            );
+
+            let response = self.request(&command).await?;
+            let (relay_address, relay_port) =
+                parse_session_response(&response, self.address.ip())?;
+
+            parsed.media_sections[index].port = relay_port;
+            if media_connection.is_some() {
+                set_media_connection(&mut parsed.media_sections[index], &relay_address);
+            }
+            if relay_address_for_session.is_none() {
+                relay_address_for_session = Some(relay_address);
+            }
+        }
+
+        if let Some(relay_address) = relay_address_for_session {
+            set_session_connection(&mut parsed, &relay_address);
+        }
+
+        Ok(parsed.to_string().into_bytes())
+    }
+
+    /// Send a command datagram and await the correlated reply, retransmitting the
+    /// same cookie on a per-attempt timeout (rtpproxy de-duplicates by cookie).
+    async fn request(&self, payload: &str) -> Result<String, RtpEngineError> {
+        let cookie = generate_cookie();
+        let datagram = format!("{cookie} {payload}");
+
+        let (sender, mut receiver) = oneshot::channel();
+        self.pending.insert(cookie.clone(), sender);
+
+        let attempts = self.retries + 1;
+        let per_attempt = Duration::from_millis((self.timeout_ms / attempts as u64).max(MIN_PER_ATTEMPT_MS));
+
+        for attempt in 0..attempts {
+            if let Err(error) = self.socket.send_to(datagram.as_bytes(), self.address).await {
+                self.pending.remove(&cookie);
+                return Err(RtpEngineError::Io(error));
+            }
+            trace!(cookie = %cookie, attempt, address = %self.address, "sent rtpproxy command");
+
+            match tokio::time::timeout(per_attempt, &mut receiver).await {
+                Ok(Ok(response)) => {
+                    // The receiver loop already removed the pending entry.
+                    debug!(cookie = %cookie, "received rtpproxy response");
+                    return Ok(response);
+                }
+                Ok(Err(_)) => {
+                    self.pending.remove(&cookie);
+                    return Err(RtpEngineError::Protocol(
+                        "response channel closed unexpectedly".to_string(),
+                    ));
+                }
+                Err(_) => {
+                    // Per-attempt timeout — resend the same cookie unless exhausted.
+                    trace!(cookie = %cookie, attempt, "rtpproxy timeout, retransmitting");
+                    continue;
+                }
+            }
+        }
+
+        self.pending.remove(&cookie);
+        Err(RtpEngineError::Timeout {
+            timeout_ms: self.timeout_ms,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-instance set (weighted round-robin + per-call-id affinity)
+// ---------------------------------------------------------------------------
+
+/// A set of `rtpproxy` endpoints for HA / load-balancing.
+///
+/// Mirrors [`RtpEngineSet`](super::client::RtpEngineSet): weighted round-robin
+/// instance selection with per-call-id affinity, so every command for a call
+/// goes to the same rtpproxy (splitting a call across relays would orphan the
+/// allocated ports).
+pub struct RtpProxyClientSet {
+    clients: Vec<Arc<RtpProxyClient>>,
+    /// Cumulative weights for weighted selection.
+    cumulative_weights: Vec<u32>,
+    total_weight: u32,
+    /// Atomic counter for round-robin.
+    counter: AtomicU64,
+    /// Call-ID → client index affinity.
+    affinity: DashMap<String, usize>,
+}
+
+impl RtpProxyClientSet {
+    /// Build a set from `(address, timeout_ms, weight)` triples, binding one UDP
+    /// socket per instance. Returns an error when `instances` is empty.
+    pub async fn new(
+        instances: Vec<(SocketAddr, u64, u32)>,
+        retries: u32,
+    ) -> Result<Arc<Self>, RtpEngineError> {
+        if instances.is_empty() {
+            return Err(RtpEngineError::Protocol(
+                "at least one rtpproxy instance is required".to_string(),
+            ));
+        }
+
+        let mut clients = Vec::with_capacity(instances.len());
+        let mut cumulative_weights = Vec::with_capacity(instances.len());
+        let mut running_total = 0u32;
+        for (address, timeout_ms, weight) in &instances {
+            clients.push(RtpProxyClient::new(*address, *timeout_ms, retries).await?);
+            running_total += weight;
+            cumulative_weights.push(running_total);
+        }
+
+        Ok(Arc::new(Self {
+            clients,
+            cumulative_weights,
+            total_weight: running_total,
+            counter: AtomicU64::new(0),
+            affinity: DashMap::new(),
+        }))
+    }
+
+    /// Select a client by call-id affinity or weighted round-robin.
+    fn select(&self, call_id: &str) -> &Arc<RtpProxyClient> {
+        if self.clients.len() == 1 {
+            return &self.clients[0];
+        }
+        if let Some(index) = self.affinity.get(call_id) {
+            return &self.clients[*index];
+        }
+        let tick = self.counter.fetch_add(1, Ordering::Relaxed);
+        let position = (tick % self.total_weight as u64) as u32;
+        let index = self
+            .cumulative_weights
+            .iter()
+            .position(|&cumulative| position < cumulative)
+            .unwrap_or(0);
+        &self.clients[index]
+    }
+
+    /// Record call-id affinity after the first command (multi-instance only).
+    fn bind_affinity(&self, call_id: &str) {
+        if self.clients.len() <= 1 || self.affinity.contains_key(call_id) {
+            return;
+        }
+        let tick = self.counter.load(Ordering::Relaxed).wrapping_sub(1);
+        let position = (tick % self.total_weight as u64) as u32;
+        let index = self
+            .cumulative_weights
+            .iter()
+            .position(|&cumulative| position < cumulative)
+            .unwrap_or(0);
+        self.affinity.insert(call_id.to_string(), index);
+    }
+
+    /// Send an `offer`, binding call-id affinity to the selected instance.
+    pub async fn offer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        let result = self.select(call_id).offer(call_id, from_tag, sdp, flags).await?;
+        self.bind_affinity(call_id);
+        Ok(result)
+    }
+
+    /// Send an `answer` to the affinity-bound instance.
+    pub async fn answer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        to_tag: &str,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        self.select(call_id)
+            .answer(call_id, from_tag, to_tag, sdp, flags)
+            .await
+    }
+
+    /// Send a `delete` and drop affinity.
+    pub async fn delete(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
+        let result = self.select(call_id).delete(call_id, from_tag).await;
+        self.affinity.remove(call_id);
+        result
+    }
+
+    /// Inject an audio prompt — unsupported by rtpproxy.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn play_media(
+        &self,
+        _call_id: &str,
+        _from_tag: &str,
+        _source: &PlayMediaSource,
+        _repeat_times: Option<u64>,
+        _start_pos_ms: Option<u64>,
+        _duration_ms: Option<u64>,
+        _to_tag: Option<&str>,
+    ) -> Result<Option<u64>, RtpEngineError> {
+        Err(unsupported("play_media"))
+    }
+
+    /// Stop a prompt — unsupported by rtpproxy.
+    pub async fn stop_media(&self, _call_id: &str, _from_tag: &str) -> Result<(), RtpEngineError> {
+        Err(unsupported("stop_media"))
+    }
+
+    /// Inject DTMF — unsupported by rtpproxy.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn play_dtmf(
+        &self,
+        _call_id: &str,
+        _from_tag: &str,
+        _code: &str,
+        _duration_ms: Option<u64>,
+        _volume_dbm0: Option<i64>,
+        _pause_ms: Option<u64>,
+        _to_tag: Option<&str>,
+    ) -> Result<(), RtpEngineError> {
+        Err(unsupported("play_dtmf"))
+    }
+
+    /// Replace egress audio with silence — unsupported by rtpproxy.
+    pub async fn silence_media(&self, _call_id: &str, _from_tag: &str) -> Result<(), RtpEngineError> {
+        Err(unsupported("silence_media"))
+    }
+
+    /// Resume egress audio — unsupported by rtpproxy.
+    pub async fn unsilence_media(
+        &self,
+        _call_id: &str,
+        _from_tag: &str,
+    ) -> Result<(), RtpEngineError> {
+        Err(unsupported("unsilence_media"))
+    }
+
+    /// Drop egress packets — unsupported by rtpproxy.
+    pub async fn block_media(&self, _call_id: &str, _from_tag: &str) -> Result<(), RtpEngineError> {
+        Err(unsupported("block_media"))
+    }
+
+    /// Resume egress packets — unsupported by rtpproxy.
+    pub async fn unblock_media(&self, _call_id: &str, _from_tag: &str) -> Result<(), RtpEngineError> {
+        Err(unsupported("unblock_media"))
+    }
+
+    /// Create a media subscription — unsupported by rtpproxy.
+    pub async fn subscribe_request(
+        &self,
+        _call_id: &str,
+        _from_tag: &str,
+        _to_tag: &str,
+        _sdp: Option<&[u8]>,
+        _flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        Err(unsupported("subscribe_request"))
+    }
+
+    /// SIPREC-mode subscription — unsupported by rtpproxy.
+    pub async fn subscribe_request_siprec(
+        &self,
+        _call_id: &str,
+        _from_tags: &[&str],
+        _profile_flags: Option<&NgFlags>,
+    ) -> Result<(Vec<u8>, String), RtpEngineError> {
+        Err(unsupported("subscribe_request_siprec"))
+    }
+
+    /// Complete a subscription's SDP negotiation — unsupported by rtpproxy.
+    pub async fn subscribe_answer(
+        &self,
+        _call_id: &str,
+        _from_tag: &str,
+        _to_tag: &str,
+        _sdp: &[u8],
+        _flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        Err(unsupported("subscribe_answer"))
+    }
+
+    /// Tear down a subscription — unsupported by rtpproxy.
+    pub async fn unsubscribe(
+        &self,
+        _call_id: &str,
+        _from_tag: &str,
+        _to_tag: &str,
+    ) -> Result<(), RtpEngineError> {
+        Err(unsupported("unsubscribe"))
+    }
+
+    /// Ping any one instance (the first). For quick health checks.
+    pub async fn ping(&self) -> Result<(), RtpEngineError> {
+        match self.clients.first() {
+            Some(client) => client.ping().await,
+            None => Err(RtpEngineError::Protocol("no rtpproxy instances".to_string())),
+        }
+    }
+
+    /// Ping every instance in parallel and return per-instance health status.
+    pub async fn health_check(&self) -> Vec<(SocketAddr, bool)> {
+        let probes = self
+            .clients
+            .iter()
+            .map(|client| async move { (client.address(), client.ping().await.is_ok()) });
+        join_all(probes).await
+    }
+
+    /// Total active call-ids across all instances.
+    pub fn active_sessions(&self) -> usize {
+        self.clients.iter().map(|client| client.active_sessions()).sum()
+    }
+
+    /// Number of configured instances.
+    pub fn instance_count(&self) -> usize {
+        self.clients.len()
+    }
+
+    /// Addresses of every configured instance, in registration order.
+    pub fn instance_addresses(&self) -> Vec<SocketAddr> {
+        self.clients.iter().map(|client| client.address()).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Protocol helpers
+// ---------------------------------------------------------------------------
+
+/// Generate a random cookie for request/response correlation (and retransmit
+/// de-duplication). Eight hex chars is ample collision resistance for in-flight
+/// commands to one engine.
+fn generate_cookie() -> String {
+    uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
+}
+
+/// Error for the rtpengine-only verbs that rtpproxy cannot serve.
+fn unsupported(operation: &str) -> RtpEngineError {
+    RtpEngineError::EngineError(format!(
+        "rtpproxy backend does not support '{operation}' \
+         (use the rtpengine or siphon-rtp backend)"
+    ))
+}
+
+/// Build the modifier suffix for a `U`/`L` command from the profile flags and
+/// the stream's address family.
+///
+/// Mapping (the common rtpproxy flags; extend as deployments need them):
+/// - `direction: ["internal", "external"]` → `ie` (bridge mode; the offer and
+///   answer carry their own [`NgFlags`], so a profile sets `["internal",
+///   "external"]` for the offer and `["external", "internal"]` for the answer to
+///   get the `ie`/`ei` pairing rtpproxy bridging expects).
+/// - a `flags` entry of `"asymmetric"` → `a` (rtpproxy defaults to symmetric).
+/// - an IPv6 stream → `6`.
+fn command_modifiers(flags: &NgFlags, is_ipv6: bool) -> String {
+    let mut modifiers = String::new();
+    for direction in &flags.direction {
+        let lower = direction.to_ascii_lowercase();
+        if lower.starts_with("int") || lower == "in" {
+            modifiers.push('i');
+        } else if lower.starts_with("ext") || lower.starts_with("pub") || lower == "out" {
+            modifiers.push('e');
+        }
+    }
+    if flags
+        .flags
+        .iter()
+        .any(|flag| flag.eq_ignore_ascii_case("asymmetric"))
+    {
+        modifiers.push('a');
+    }
+    if is_ipv6 {
+        modifiers.push('6');
+    }
+    modifiers
+}
+
+/// Build a `U`/`L` command line (without the leading cookie).
+fn build_command(
+    command_letter: char,
+    modifiers: &str,
+    call_id: &str,
+    address: &str,
+    port: u16,
+    from_tag: &str,
+    to_tag: Option<&str>,
+) -> String {
+    let mut command = format!("{command_letter}{modifiers} {call_id} {address} {port} {from_tag}");
+    if let Some(to_tag) = to_tag {
+        command.push(' ');
+        command.push_str(to_tag);
+    }
+    command
+}
+
+/// Parse a `U`/`L` response: `<port> [<address> …]` or `E<code>` on error.
+///
+/// rtpproxy returns the allocated relay port and, on newer builds, one or more
+/// advertised addresses. When no address is returned, the relay lives at the
+/// control endpoint's IP, so we fall back to `default_address`.
+fn parse_session_response(
+    response: &str,
+    default_address: IpAddr,
+) -> Result<(String, u16), RtpEngineError> {
+    let trimmed = response.trim();
+    if let Some(code) = trimmed.strip_prefix('E') {
+        return Err(RtpEngineError::EngineError(format!("rtpproxy error {code}")));
+    }
+
+    let mut tokens = trimmed.split_whitespace();
+    let port_token = tokens
+        .next()
+        .ok_or_else(|| RtpEngineError::Protocol("empty rtpproxy response".to_string()))?;
+    let port: u16 = port_token.parse().map_err(|_| {
+        RtpEngineError::Protocol(format!("invalid rtpproxy port {port_token:?}"))
+    })?;
+    if port == 0 {
+        return Err(RtpEngineError::EngineError(
+            "rtpproxy returned port 0 (allocation declined)".to_string(),
+        ));
+    }
+
+    let address = tokens
+        .next()
+        .map(str::to_string)
+        .unwrap_or_else(|| default_address.to_string());
+    Ok((address, port))
+}
+
+/// Parse an SDP `c=` value (`IN IP4 10.0.0.1`, `IN IP6 ::1`, with an optional
+/// `/ttl` or `/ttl/count` multicast suffix) into `(is_ipv6, address)`.
+fn parse_connection(connection: &str) -> Result<(bool, String), RtpEngineError> {
+    let mut tokens = connection.split_whitespace();
+    let _network_type = tokens.next(); // "IN"
+    let address_type = tokens.next().unwrap_or("IP4");
+    let address = tokens.next().ok_or_else(|| {
+        RtpEngineError::Protocol(format!("malformed connection line: c={connection}"))
+    })?;
+    // Strip any multicast TTL/count suffix.
+    let address = address.split('/').next().unwrap_or(address).to_string();
+    Ok((address_type.eq_ignore_ascii_case("IP6"), address))
+}
+
+/// Format a `c=` line for a relay address, picking the family from the address.
+fn connection_line(address: &str) -> String {
+    let family = if address.contains(':') { "IP6" } else { "IP4" };
+    format!("c=IN {family} {address}")
+}
+
+/// Replace (or insert) the session-level `c=` line with the relay address.
+fn set_session_connection(sdp: &mut SdpBody, address: &str) {
+    let new_line = connection_line(address);
+    if let Some(position) = sdp.session_lines.iter().position(|line| line.starts_with("c=")) {
+        sdp.session_lines[position] = new_line;
+        return;
+    }
+    // RFC 4566 orders c= after s= (and after o=); insert there, else append.
+    let insert_at = sdp
+        .session_lines
+        .iter()
+        .position(|line| line.starts_with("s="))
+        .map(|position| position + 1)
+        .or_else(|| {
+            sdp.session_lines
+                .iter()
+                .position(|line| line.starts_with("o="))
+                .map(|position| position + 1)
+        })
+        .unwrap_or(sdp.session_lines.len());
+    sdp.session_lines.insert(insert_at, new_line);
+}
+
+/// Replace (or insert) a media-level `c=` line with the relay address.
+fn set_media_connection(media: &mut MediaLine, address: &str) {
+    let new_line = connection_line(address);
+    if let Some(position) = media.other_attrs.iter().position(|line| line.starts_with("c=")) {
+        media.other_attrs[position] = new_line;
+    } else {
+        // A media-level c= must precede the a= lines.
+        media.other_attrs.insert(0, new_line);
+    }
+}
+
+/// Background receiver loop — reads UDP responses and dispatches to waiters.
+async fn receiver_loop(
+    socket: Arc<UdpSocket>,
+    pending: Arc<DashMap<String, oneshot::Sender<String>>>,
+) {
+    let mut buffer = BytesMut::zeroed(RECV_BUFFER_SIZE);
+    loop {
+        match socket.recv_from(&mut buffer).await {
+            Ok((size, source)) => {
+                let data = &buffer[..size];
+                trace!(size, source = %source, "received rtpproxy response packet");
+
+                let space_position = match data.iter().position(|&byte| byte == b' ') {
+                    Some(position) => position,
+                    None => {
+                        warn!("rtpproxy response missing space separator, ignoring");
+                        continue;
+                    }
+                };
+                let cookie = match std::str::from_utf8(&data[..space_position]) {
+                    Ok(cookie) => cookie.to_string(),
+                    Err(_) => {
+                        warn!("rtpproxy response cookie is not valid UTF-8, ignoring");
+                        continue;
+                    }
+                };
+                let payload = match std::str::from_utf8(&data[space_position + 1..]) {
+                    Ok(payload) => payload.trim_end().to_string(),
+                    Err(_) => {
+                        warn!(cookie = %cookie, "rtpproxy response payload is not valid UTF-8");
+                        continue;
+                    }
+                };
+
+                if let Some((_, sender)) = pending.remove(&cookie) {
+                    let _ = sender.send(payload);
+                } else {
+                    debug!(cookie = %cookie, "no pending rtpproxy request for cookie (stale or duplicate)");
+                }
+            }
+            Err(error) => {
+                error!(error = %error, "rtpproxy receiver socket error");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- pure-function unit tests (no socket) --
+
+    #[test]
+    fn cookie_is_eight_hex_chars() {
+        let cookie = generate_cookie();
+        assert_eq!(cookie.len(), 8);
+        assert!(cookie.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn modifiers_empty_for_default_flags() {
+        let flags = NgFlags::default();
+        assert_eq!(command_modifiers(&flags, false), "");
+    }
+
+    #[test]
+    fn modifiers_bridge_internal_external() {
+        let flags = NgFlags {
+            direction: vec!["internal".to_string(), "external".to_string()],
+            ..NgFlags::default()
+        };
+        assert_eq!(command_modifiers(&flags, false), "ie");
+    }
+
+    #[test]
+    fn modifiers_bridge_reversed_for_answer() {
+        let flags = NgFlags {
+            direction: vec!["external".to_string(), "internal".to_string()],
+            ..NgFlags::default()
+        };
+        assert_eq!(command_modifiers(&flags, false), "ei");
+    }
+
+    #[test]
+    fn modifiers_asymmetric_and_ipv6() {
+        let flags = NgFlags {
+            flags: vec!["asymmetric".to_string()],
+            ..NgFlags::default()
+        };
+        assert_eq!(command_modifiers(&flags, true), "a6");
+    }
+
+    #[test]
+    fn build_offer_command_without_to_tag() {
+        let command = build_command('U', "", "call-1", "10.0.0.1", 8000, "ftag", None);
+        assert_eq!(command, "U call-1 10.0.0.1 8000 ftag");
+    }
+
+    #[test]
+    fn build_answer_command_with_modifiers_and_to_tag() {
+        let command = build_command('L', "ei", "call-1", "10.0.0.2", 9000, "ftag", Some("ttag"));
+        assert_eq!(command, "Lei call-1 10.0.0.2 9000 ftag ttag");
+    }
+
+    #[test]
+    fn parse_response_port_and_address() {
+        let default_addr: IpAddr = "203.0.113.7".parse().unwrap();
+        let (address, port) = parse_session_response("30000 203.0.113.1", default_addr).unwrap();
+        assert_eq!(address, "203.0.113.1");
+        assert_eq!(port, 30000);
+    }
+
+    #[test]
+    fn parse_response_port_only_falls_back_to_control_ip() {
+        let default_addr: IpAddr = "203.0.113.7".parse().unwrap();
+        let (address, port) = parse_session_response("40002", default_addr).unwrap();
+        assert_eq!(address, "203.0.113.7");
+        assert_eq!(port, 40002);
+    }
+
+    #[test]
+    fn parse_response_error_code() {
+        let default_addr: IpAddr = "203.0.113.7".parse().unwrap();
+        let result = parse_session_response("E7", default_addr);
+        assert!(matches!(result, Err(RtpEngineError::EngineError(_))));
+    }
+
+    #[test]
+    fn parse_response_port_zero_is_declined() {
+        let default_addr: IpAddr = "203.0.113.7".parse().unwrap();
+        let result = parse_session_response("0", default_addr);
+        assert!(matches!(result, Err(RtpEngineError::EngineError(_))));
+    }
+
+    #[test]
+    fn parse_connection_ipv4_and_ipv6() {
+        assert_eq!(
+            parse_connection("IN IP4 10.0.0.1").unwrap(),
+            (false, "10.0.0.1".to_string())
+        );
+        assert_eq!(
+            parse_connection("IN IP6 2001:db8::1").unwrap(),
+            (true, "2001:db8::1".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_connection_strips_multicast_ttl() {
+        assert_eq!(
+            parse_connection("IN IP4 224.2.1.1/127").unwrap(),
+            (false, "224.2.1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn connection_line_picks_family() {
+        assert_eq!(connection_line("10.0.0.1"), "c=IN IP4 10.0.0.1");
+        assert_eq!(connection_line("2001:db8::1"), "c=IN IP6 2001:db8::1");
+    }
+
+    #[test]
+    fn set_session_connection_replaces_existing() {
+        let mut sdp = SdpBody::parse("v=0\r\no=- 1 1 IN IP4 10.0.0.1\r\ns=-\r\nc=IN IP4 10.0.0.1\r\nt=0 0\r\n");
+        set_session_connection(&mut sdp, "203.0.113.1");
+        assert_eq!(sdp.connection(), Some("IN IP4 203.0.113.1"));
+        // Exactly one c= line.
+        assert_eq!(
+            sdp.session_lines.iter().filter(|l| l.starts_with("c=")).count(),
+            1
+        );
+    }
+
+    #[test]
+    fn set_session_connection_inserts_when_missing() {
+        let mut sdp = SdpBody::parse("v=0\r\no=- 1 1 IN IP4 10.0.0.1\r\ns=-\r\nt=0 0\r\n");
+        set_session_connection(&mut sdp, "203.0.113.1");
+        assert_eq!(sdp.connection(), Some("IN IP4 203.0.113.1"));
+        // c= lands after s=.
+        let s_pos = sdp.session_lines.iter().position(|l| l.starts_with("s=")).unwrap();
+        let c_pos = sdp.session_lines.iter().position(|l| l.starts_with("c=")).unwrap();
+        assert_eq!(c_pos, s_pos + 1);
+    }
+
+    // -- socket-backed tests against an in-process mock rtpproxy --
+
+    /// Spawn a mock rtpproxy that echoes the cookie and replies per command:
+    /// `V` → version, `U`/`L` → `<port> <addr>`, `D` → `0`.
+    async fn spawn_mock_rtpproxy(reply_address: &'static str, reply_port: u16) -> SocketAddr {
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let address = socket.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buffer = BytesMut::zeroed(4096);
+            while let Ok((size, source)) = socket.recv_from(&mut buffer).await {
+                let data = &buffer[..size];
+                let space = data.iter().position(|&b| b == b' ').unwrap();
+                let cookie = std::str::from_utf8(&data[..space]).unwrap();
+                let command = std::str::from_utf8(&data[space + 1..]).unwrap();
+                let result = if command.starts_with('V') {
+                    "20040107".to_string()
+                } else if command.starts_with('U') || command.starts_with('L') {
+                    format!("{reply_port} {reply_address}")
+                } else {
+                    // D and anything else
+                    "0".to_string()
+                };
+                let reply = format!("{cookie} {result}");
+                let _ = socket.send_to(reply.as_bytes(), source).await;
+            }
+        });
+        address
+    }
+
+    fn sample_offer_sdp() -> &'static [u8] {
+        concat!(
+            "v=0\r\n",
+            "o=- 1 1 IN IP4 10.0.0.1\r\n",
+            "s=-\r\n",
+            "c=IN IP4 10.0.0.1\r\n",
+            "t=0 0\r\n",
+            "m=audio 8000 RTP/AVP 0 8\r\n",
+            "a=rtpmap:0 PCMU/8000\r\n",
+            "a=rtpmap:8 PCMA/8000\r\n",
+        )
+        .as_bytes()
+    }
+
+    #[tokio::test]
+    async fn ping_roundtrip() {
+        let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        client.ping().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn offer_rewrites_sdp_to_relay() {
+        let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        let flags = NgFlags::default();
+
+        let rewritten = client
+            .offer("call-1", "ftag", sample_offer_sdp(), &flags)
+            .await
+            .unwrap();
+        let text = String::from_utf8(rewritten).unwrap();
+
+        // c= now points at the relay; m= carries the relay port; codecs intact.
+        assert!(text.contains("c=IN IP4 203.0.113.1"), "sdp was: {text}");
+        assert!(text.contains("m=audio 30000 RTP/AVP 0 8"), "sdp was: {text}");
+        assert!(text.contains("a=rtpmap:0 PCMU/8000"));
+        // The original endpoint must be gone from the connection line.
+        assert!(!text.contains("c=IN IP4 10.0.0.1"));
+        assert_eq!(client.active_sessions(), 1);
+    }
+
+    #[tokio::test]
+    async fn answer_rewrites_sdp_to_relay() {
+        let address = spawn_mock_rtpproxy("203.0.113.1", 31000).await;
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        let flags = NgFlags::default();
+
+        let answer_sdp = concat!(
+            "v=0\r\n",
+            "o=- 2 2 IN IP4 10.0.0.2\r\n",
+            "s=-\r\n",
+            "c=IN IP4 10.0.0.2\r\n",
+            "t=0 0\r\n",
+            "m=audio 9000 RTP/AVP 0\r\n",
+        )
+        .as_bytes();
+
+        let rewritten = client
+            .answer("call-1", "ftag", "ttag", answer_sdp, &flags)
+            .await
+            .unwrap();
+        let text = String::from_utf8(rewritten).unwrap();
+        assert!(text.contains("c=IN IP4 203.0.113.1"), "sdp was: {text}");
+        assert!(text.contains("m=audio 31000 RTP/AVP 0"), "sdp was: {text}");
+    }
+
+    #[tokio::test]
+    async fn offer_command_wire_format_is_exact() {
+        // A mock that captures the exact command line it received.
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let address = socket.local_addr().unwrap();
+        let (capture_tx, capture_rx) = oneshot::channel::<String>();
+        tokio::spawn(async move {
+            let mut buffer = BytesMut::zeroed(4096);
+            if let Ok((size, source)) = socket.recv_from(&mut buffer).await {
+                let data = &buffer[..size];
+                let space = data.iter().position(|&b| b == b' ').unwrap();
+                let cookie = std::str::from_utf8(&data[..space]).unwrap();
+                let command = std::str::from_utf8(&data[space + 1..]).unwrap().to_string();
+                let reply = format!("{cookie} 30000 203.0.113.1");
+                let _ = socket.send_to(reply.as_bytes(), source).await;
+                let _ = capture_tx.send(command);
+            }
+        });
+
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        let flags = NgFlags::default();
+        client
+            .offer("abc123", "from-tag-1", sample_offer_sdp(), &flags)
+            .await
+            .unwrap();
+
+        let command = capture_rx.await.unwrap();
+        // Single media stream → no media-id suffix on the tag.
+        assert_eq!(command, "U abc123 10.0.0.1 8000 from-tag-1");
+    }
+
+    #[tokio::test]
+    async fn multi_stream_appends_media_id_suffix() {
+        // Capture both command lines for a 2-stream offer.
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let address = socket.local_addr().unwrap();
+        let (capture_tx, mut capture_rx) = tokio::sync::mpsc::channel::<String>(4);
+        tokio::spawn(async move {
+            let mut buffer = BytesMut::zeroed(4096);
+            let mut port = 30000u16;
+            while let Ok((size, source)) = socket.recv_from(&mut buffer).await {
+                let data = &buffer[..size];
+                let space = data.iter().position(|&b| b == b' ').unwrap();
+                let cookie = std::str::from_utf8(&data[..space]).unwrap();
+                let command = std::str::from_utf8(&data[space + 1..]).unwrap().to_string();
+                let reply = format!("{cookie} {port} 203.0.113.1");
+                port += 2;
+                let _ = socket.send_to(reply.as_bytes(), source).await;
+                let _ = capture_tx.send(command).await;
+            }
+        });
+
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        let flags = NgFlags::default();
+        let two_stream = concat!(
+            "v=0\r\n",
+            "o=- 1 1 IN IP4 10.0.0.1\r\n",
+            "s=-\r\n",
+            "c=IN IP4 10.0.0.1\r\n",
+            "t=0 0\r\n",
+            "m=audio 8000 RTP/AVP 0\r\n",
+            "m=video 8002 RTP/AVP 96\r\n",
+        )
+        .as_bytes();
+        let rewritten = client.offer("c2", "ft", two_stream, &flags).await.unwrap();
+        let text = String::from_utf8(rewritten).unwrap();
+        assert!(text.contains("m=audio 30000 RTP/AVP 0"), "sdp: {text}");
+        assert!(text.contains("m=video 30002 RTP/AVP 96"), "sdp: {text}");
+
+        let first = capture_rx.recv().await.unwrap();
+        let second = capture_rx.recv().await.unwrap();
+        assert_eq!(first, "U c2 10.0.0.1 8000 ft;1");
+        assert_eq!(second, "U c2 10.0.0.1 8002 ft;2");
+    }
+
+    #[tokio::test]
+    async fn held_media_at_port_zero_is_not_anchored() {
+        // The mock replies to any U/L; if a command is sent for the port-0
+        // stream the test would still pass, so assert the port stays 0.
+        let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        let flags = NgFlags::default();
+        let held = concat!(
+            "v=0\r\n",
+            "o=- 1 1 IN IP4 10.0.0.1\r\n",
+            "s=-\r\n",
+            "c=IN IP4 0.0.0.0\r\n",
+            "t=0 0\r\n",
+            "m=audio 0 RTP/AVP 0\r\n",
+        )
+        .as_bytes();
+        let rewritten = client.offer("held", "ft", held, &flags).await.unwrap();
+        let text = String::from_utf8(rewritten).unwrap();
+        assert!(text.contains("m=audio 0 RTP/AVP 0"), "sdp: {text}");
+        // No stream anchored → session c= left as-is.
+        assert!(text.contains("c=IN IP4 0.0.0.0"), "sdp: {text}");
+    }
+
+    #[tokio::test]
+    async fn delete_clears_session() {
+        let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        let flags = NgFlags::default();
+        client.offer("call-1", "ft", sample_offer_sdp(), &flags).await.unwrap();
+        assert_eq!(client.active_sessions(), 1);
+        client.delete("call-1", "ft").await.unwrap();
+        assert_eq!(client.active_sessions(), 0);
+    }
+
+    #[tokio::test]
+    async fn timeout_when_engine_silent() {
+        // Bind but never reply.
+        let silent = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let silent_addr = silent.local_addr().unwrap();
+        let _keep_alive = silent;
+        let client = RtpProxyClient::new(silent_addr, 120, 2).await.unwrap();
+        let result = client.ping().await;
+        assert!(matches!(result, Err(RtpEngineError::Timeout { .. })));
+    }
+
+    /// The pending-correlation map MUST drain to empty after every command
+    /// settles, on both the success and timeout paths — a leaked entry is one
+    /// `oneshot::Sender` retained per command for the life of the process.
+    #[tokio::test]
+    async fn pending_map_drains_on_success() {
+        let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let client = RtpProxyClient::new(address, 1000, 1).await.unwrap();
+        let flags = NgFlags::default();
+        for index in 0..300 {
+            let call_id = format!("leak-{index}");
+            client.offer(&call_id, "ft", sample_offer_sdp(), &flags).await.unwrap();
+            client.answer(&call_id, "ft", "tt", sample_offer_sdp(), &flags).await.unwrap();
+            client.delete(&call_id, "ft").await.unwrap();
+        }
+        assert_eq!(
+            client.pending.len(),
+            0,
+            "pending map must drain after completed commands"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_map_drains_on_timeout() {
+        let silent = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let silent_addr = silent.local_addr().unwrap();
+        let _keep_alive = silent;
+        let client = RtpProxyClient::new(silent_addr, 90, 2).await.unwrap();
+        for _ in 0..15 {
+            let result = client.ping().await;
+            assert!(result.is_err());
+        }
+        assert_eq!(
+            client.pending.len(),
+            0,
+            "pending map must drain on the timeout path too"
+        );
+    }
+
+    #[tokio::test]
+    async fn retransmit_succeeds_when_first_attempt_dropped() {
+        // Mock that ignores the first datagram and answers the second (same
+        // cookie). Exercises the retransmit path.
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let address = socket.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buffer = BytesMut::zeroed(4096);
+            let mut seen = 0;
+            while let Ok((size, source)) = socket.recv_from(&mut buffer).await {
+                seen += 1;
+                if seen == 1 {
+                    continue; // drop the first attempt
+                }
+                let data = &buffer[..size];
+                let space = data.iter().position(|&b| b == b' ').unwrap();
+                let cookie = std::str::from_utf8(&data[..space]).unwrap();
+                let reply = format!("{cookie} 20040107");
+                let _ = socket.send_to(reply.as_bytes(), source).await;
+            }
+        });
+        // 3 attempts within ~300ms; first dropped, second answers.
+        let client = RtpProxyClient::new(address, 300, 2).await.unwrap();
+        client.ping().await.unwrap();
+    }
+
+    // -- set tests --
+
+    #[tokio::test]
+    async fn set_single_instance_offer_answer_delete() {
+        let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let set = RtpProxyClientSet::new(vec![(address, 1000, 1)], 1).await.unwrap();
+        assert_eq!(set.instance_count(), 1);
+        let flags = NgFlags::default();
+        set.offer("c1", "ft", sample_offer_sdp(), &flags).await.unwrap();
+        assert_eq!(set.active_sessions(), 1);
+        set.answer("c1", "ft", "tt", sample_offer_sdp(), &flags).await.unwrap();
+        set.delete("c1", "ft").await.unwrap();
+        assert_eq!(set.active_sessions(), 0);
+    }
+
+    #[tokio::test]
+    async fn set_call_id_affinity() {
+        let address1 = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let address2 = spawn_mock_rtpproxy("203.0.113.2", 31000).await;
+        let set = RtpProxyClientSet::new(vec![(address1, 1000, 1), (address2, 1000, 1)], 1)
+            .await
+            .unwrap();
+        let flags = NgFlags::default();
+        set.offer("call-affinity", "ft", sample_offer_sdp(), &flags).await.unwrap();
+        // One affinity entry recorded; total active sessions == 1.
+        assert_eq!(set.active_sessions(), 1);
+        set.delete("call-affinity", "ft").await.unwrap();
+        assert_eq!(set.active_sessions(), 0);
+    }
+
+    #[tokio::test]
+    async fn set_empty_rejected() {
+        let result = RtpProxyClientSet::new(vec![], 1).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn set_unsupported_ops_error_clearly() {
+        let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
+        let set = RtpProxyClientSet::new(vec![(address, 1000, 1)], 1).await.unwrap();
+        let error = set.silence_media("c1", "ft").await.unwrap_err();
+        assert!(matches!(error, RtpEngineError::EngineError(_)));
+        assert!(error.to_string().contains("does not support"));
+    }
+}

--- a/tests/integration/rtpproxy_tests.rs
+++ b/tests/integration/rtpproxy_tests.rs
@@ -1,0 +1,122 @@
+//! Integration tests for the classic `rtpproxy` media backend.
+//!
+//! Verifies the `MediaBackend` abstraction drives the text-over-UDP rtpproxy
+//! protocol end-to-end: a SIP INVITE's SDP is offered to a fake rtpproxy control
+//! server (speaking the real cookie/`U`/`L`/`D`/`V` wire format), and siphon's
+//! own SDP rewrite comes back through the same `MediaBackend` API the rtpengine
+//! NG backend uses. Complements the unit tests in `src/rtpengine/rtpproxy.rs`.
+
+use std::sync::Arc;
+
+use siphon::rtpengine::profile::NgFlags;
+use siphon::rtpengine::{MediaBackend, RtpProxyClientSet};
+use siphon::sip::parser::parse_sip_message;
+
+use bytes::BytesMut;
+use tokio::net::UdpSocket;
+
+/// Spawn a fake rtpproxy that allocates `reply_port`/`reply_address` for every
+/// `U`/`L`, answers `V` with a version, and `D`/anything else with `0`.
+/// Returns the bound control address.
+async fn spawn_fake_rtpproxy(
+    reply_address: &'static str,
+    reply_port: u16,
+) -> std::net::SocketAddr {
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let address = socket.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut buffer = BytesMut::zeroed(8192);
+        while let Ok((size, source)) = socket.recv_from(&mut buffer).await {
+            let data = &buffer[..size];
+            let space = match data.iter().position(|&byte| byte == b' ') {
+                Some(position) => position,
+                None => continue,
+            };
+            let cookie = std::str::from_utf8(&data[..space]).unwrap();
+            let command = std::str::from_utf8(&data[space + 1..]).unwrap();
+            let result = if command.starts_with('V') {
+                "20040107".to_string()
+            } else if command.starts_with('U') || command.starts_with('L') {
+                format!("{reply_port} {reply_address}")
+            } else {
+                "0".to_string()
+            };
+            let reply = format!("{cookie} {result}");
+            let _ = socket.send_to(reply.as_bytes(), source).await;
+        }
+    });
+    address
+}
+
+const INVITE_WITH_SDP: &str = concat!(
+    "INVITE sip:bob@biloxi.com SIP/2.0\r\n",
+    "Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bK776\r\n",
+    "From: Alice <sip:alice@atlanta.com>;tag=alice-tag\r\n",
+    "To: Bob <sip:bob@biloxi.com>\r\n",
+    "Call-ID: rtpproxy-call-1@atlanta.com\r\n",
+    "CSeq: 1 INVITE\r\n",
+    "Content-Type: application/sdp\r\n",
+    "Content-Length: 89\r\n",
+    "\r\n",
+    "v=0\r\n",
+    "o=alice 0 0 IN IP4 10.0.0.1\r\n",
+    "s=-\r\n",
+    "c=IN IP4 10.0.0.1\r\n",
+    "t=0 0\r\n",
+    "m=audio 8000 RTP/AVP 0\r\n",
+);
+
+#[tokio::test]
+async fn media_backend_rtpproxy_offer_rewrites_sdp() {
+    let address = spawn_fake_rtpproxy("203.0.113.1", 30000).await;
+    let set = RtpProxyClientSet::new(vec![(address, 1000, 1)], 2).await.unwrap();
+    let backend = MediaBackend::RtpProxy(set);
+
+    // Confirm the abstraction reports the rtpproxy backend's shape.
+    assert_eq!(backend.instance_count(), 1);
+    assert_eq!(backend.instance_addresses(), vec![address]);
+    backend.ping().await.unwrap();
+
+    // Parse a real SIP INVITE and offer its SDP body through the backend.
+    let (_, message) = parse_sip_message(INVITE_WITH_SDP).unwrap();
+    let call_id = "rtpproxy-call-1@atlanta.com";
+    let body = &message.body;
+    assert!(!body.is_empty());
+
+    let rewritten = backend
+        .offer(call_id, "alice-tag", body, &NgFlags::default())
+        .await
+        .unwrap();
+    let rewritten = String::from_utf8_lossy(&rewritten);
+    // siphon rewrote c=/m= to the relay rtpproxy returned.
+    assert!(
+        rewritten.contains("c=IN IP4 203.0.113.1"),
+        "SDP not rewritten: {rewritten}"
+    );
+    assert!(rewritten.contains("m=audio 30000 RTP/AVP 0"), "SDP: {rewritten}");
+    // The original endpoint must be gone from the connection line.
+    assert!(!rewritten.contains("c=IN IP4 10.0.0.1"), "SDP: {rewritten}");
+    assert_eq!(backend.active_sessions(), 1);
+
+    backend.delete(call_id, "alice-tag").await.unwrap();
+    assert_eq!(backend.active_sessions(), 0);
+}
+
+#[tokio::test]
+async fn media_backend_rtpproxy_unsupported_op_errors_cleanly() {
+    let address = spawn_fake_rtpproxy("203.0.113.1", 30000).await;
+    let set = RtpProxyClientSet::new(vec![(address, 1000, 1)], 2).await.unwrap();
+    let backend = MediaBackend::RtpProxy(set);
+
+    // rtpengine-only verbs must surface a clear error, not panic or hang.
+    let error = backend.silence_media("c1", "ft").await.unwrap_err();
+    assert!(error.to_string().contains("does not support"), "{error}");
+}
+
+#[tokio::test]
+async fn media_backend_rtpproxy_is_send_sync() {
+    // The backend is shared across tokio workers as `Arc<MediaBackend>`; assert
+    // it satisfies the bounds the dispatcher/PyRtpEngine rely on.
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Arc<MediaBackend>>();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -24,6 +24,9 @@ mod rtpengine_tests;
 #[path = "integration/siphon_rtp_tests.rs"]
 mod siphon_rtp_tests;
 
+#[path = "integration/rtpproxy_tests.rs"]
+mod rtpproxy_tests;
+
 #[path = "integration/diameter_tests.rs"]
 mod diameter_tests;
 


### PR DESCRIPTION
Adds a **third media-control backend** so siphon can drive a classic **`rtpproxy`** relay (the Sippy/Kamailio/OpenSIPS media proxy) over its cookie-prefixed `U`/`L`/`D`/`V` text protocol on UDP — alongside the existing **rtpengine NG/bencode-over-UDP** (default) and the **native siphon-rtp JSON-over-TCP** backend. Selected per deployment via `media.backend`.

> Rebased onto `main` now that the siphon-rtp backend (#11) has merged — this builds on the `MediaBackend` enum it introduced (the follow-up #11 listed: "a `sippy/rtpproxy` backend as a third `MediaBackend` variant"). Supersedes #16, which GitHub auto-closed when #11's squash-merge deleted its base branch.

**Why:** let an existing OpenSIPS/Kamailio/Sippy deployment move its signalling to siphon while keeping its in-place rtpproxy as the media relay.

```yaml
media:
  backend: rtpproxy             # default: rtpengine
  rtpproxy:
    address: "127.0.0.1:22222"  # rtpproxy -s udp:<addr>
    timeout_ms: 1000
    retries: 2                  # UDP retransmits (same cookie); default 2
```

## What changed

- **`MediaBackend::RtpProxy`** — third enum variant; dispatcher call sites and the Python `rtpengine` namespace are unchanged.
- **`RtpProxyClient` / `RtpProxyClientSet`** — UDP client with cookie-keyed correlation + idempotent retransmits (rtpproxy de-dupes by cookie); weighted round-robin + per-call-id affinity; per-instance `V` health probes — HA parity with rtpengine.
- **siphon-side SDP rewrite** — rtpproxy only allocates a relay port, so siphon rewrites `c=`/`m=` itself via `media::sdp` (multi-stream via media-id tag suffix; held media `m=… 0` untouched).
- **Unchanged scripting contract** — `rtpengine.offer/answer/delete/ping` and `call.media` map onto rtpproxy. A profile's NAT `direction` and `asymmetric` flag map to rtpproxy bridge/symmetry modifiers; IPv6 detected per stream.
- **Config** — `media.backend: rtpproxy` + `media.rtpproxy` (single `address` or weighted `instances`, `timeout_ms`, `retries`); wired through `init_rtpengine` / `build_rtpproxy_backend`.

## Compatibility / scope

- Default backend stays `rtpengine`; existing configs and the Python API untouched.
- The rtpengine-only verbs (announcements, DTMF injection, gating, SIPREC/MPTY) are not available on rtpproxy and surface a clear engine error there. rtpproxy pushes no async events, so the `media.events` listener is unused.

## Tests & verification

- **Unit tests** (`src/rtpengine/rtpproxy.rs`): wire format, response/SDP parsing, modifier mapping, multi-stream + held-media rewrite, retransmit, pending-map drain (success + timeout).
- **Integration tests** (`tests/integration/rtpproxy_tests.rs`): offer/answer/delete through `MediaBackend` against an in-process fake rtpproxy.
- **Compose functional test** (`media.backend: rtpproxy` + mock rtpproxy + SIPp UAC/UAS): real `INVITE → 180 → 200 → ACK → BYE → 200` with media anchored via rtpproxy offer/answer/delete. Run via `scripts/run-tests.sh --rtpproxy` or the dedicated `sipp-rtpproxy` CI job. **Verified end-to-end** (3× deterministic, exit 0): clean offer/answer/delete, BYE = 1 sent / 1×200 / 0 unexpected, no loop-detected.
  - The UAC scenario uses **correct in-dialog routing** (`rrs="true"` + `[next_url]`/`[routes]`, like `invite_uac.xml`) — **not** a workaround. An earlier revision hardcoded the in-dialog R-URI to the proxy, which self-routes and 482-loops the BYE; that is fixed by doing proper dialog routing. The same latent self-loop in `rtpengine_uac.xml` is fixed here too, so that scenario actually exercises its BYE.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo test`: 3121 passed, 6 ignored.
- Docs: CHANGELOG `[Unreleased]`, `siphon.yaml`, feature-readiness matrix, and the **Media & RTP profiles** cookbook page.

## Related

- **#19 — `fix(transaction): RFC 4320 §4.2 timing for the non-INVITE 100 Trying`** (already merged to `main`). Independent core fix: siphon was emitting a premature `100 Trying` for non-INVITE requests over UDP. This PR does **not** depend on it — the compose test passes because correct dialog routing answers the BYE in milliseconds — but that bug was surfaced while removing this PR's original workaround, and #19 is its proper home.

## Follow-ups (out of scope)

- Validate against a real `rtpproxy` daemon (the compose test uses a faithful mock).
- Optional `c<codecs>` modifier mapping for rtpproxy-side codec negotiation.
