### PR TITLE
fix(ci): recreate sipp-ipsec containers on the self-hosted runner (stale-container reuse)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -338,13 +338,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The ipsec runner is self-hosted and persistent — a stale container from
+      # a previous run (started with an older image/config, e.g. before the
+      # config had ipsec.path_host) would otherwise be reused by `up`, since the
+      # profiled services survive a bare `down`. Nuke them first.
+      - name: Reset stale test containers
+        run: docker compose -f sipp/docker-compose.yaml --profile ipsec down -v --remove-orphans || true
+
       - name: Build siphon and sipp-ipsec images
         run: |
           docker compose -f sipp/docker-compose.yaml build siphon
           docker compose -f sipp/docker-compose.yaml --profile ipsec build sipp-ipsec
 
       - name: Start P-CSCF + S-CSCF
-        run: docker compose -f sipp/docker-compose.yaml --profile ipsec up -d --wait siphon-ipsec
+        run: docker compose -f sipp/docker-compose.yaml --profile ipsec up -d --wait --force-recreate siphon-ipsec
 
       - name: SIPp IPsec VoLTE registration
         run: docker compose -f sipp/docker-compose.yaml --profile ipsec run --rm sipp-ipsec
@@ -359,7 +366,7 @@ jobs:
 
       - name: Teardown
         if: always()
-        run: docker compose -f sipp/docker-compose.yaml down --remove-orphans
+        run: docker compose -f sipp/docker-compose.yaml --profile ipsec down -v --remove-orphans
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
The sipp-ipsec job runs on a persistent self-hosted runner. Its `siphon-ipsec`/`siphon-scscf`/`sipp-ipsec` services are behind the `ipsec` compose profile, but the Teardown ran `docker compose down` WITHOUT `--profile ipsec` — so the profiled containers were never stopped. They survived every run, and each run's `up -d` reused the stale container instead of recreating it. That container was created before the config gained `ipsec.path_host`, so it kept throwing `add_pcscf_path: ipsec.path_host not configured` (500) on every REGISTER, even though main's config and images were correct (verified: the full VoLTE flow passes locally with fresh containers, and the P-CSCF log on the runner shows one container running continuously since 11:34 hitting the same error every run).\n\nFix: reset the profiled containers before the run, `--force-recreate` on start, and tear down WITH `--profile ipsec -v` so nothing stale survives.