### PR TITLE
perf(ci): reuse the siphon image for the ipsec P-CSCF/S-CSCF

### DIFF
--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -13,6 +13,9 @@
 services:
   # ── SIPhon under test ──────────────────────────────────────────────────────
   siphon:
+    # Built once; siphon-ipsec and siphon-scscf reuse this same image instead of
+    # each rebuilding an identical one (they differ only in mounted config).
+    image: sipp-siphon
     build:
       context: ..
     container_name: siphon-test
@@ -1683,8 +1686,7 @@ services:
   # Standalone S-CSCF (local Milenage AKA, no HSS) that the P-CSCF relays
   # REGISTER to. Reachable from the P-CSCF as the network alias "ims.test".
   siphon-scscf:
-    build:
-      context: ..
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     container_name: siphon-scscf-test
     volumes:
       - ./ipsec/siphon-scscf.yaml:/etc/siphon/siphon.yaml:ro
@@ -1705,8 +1707,7 @@ services:
       - ipsec
 
   siphon-ipsec:
-    build:
-      context: ..
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     container_name: siphon-ipsec-test
     depends_on:
       siphon-scscf:


### PR DESCRIPTION
The sipp-ipsec job compiled siphon 2-3x: the `siphon`, `siphon-ipsec`, and `siphon-scscf` services each built their own identical image from the same Dockerfile (they differ only in the mounted config). Now `siphon-ipsec`/`siphon-scscf` reference `image: sipp-siphon` (built once by the `siphon` service) instead of a per-service `build:`, so `up` reuses it — no redundant cargo build. Saves ~10-15 min on a cold self-hosted run.\n\nValidated locally: `up --force-recreate siphon-ipsec` builds nothing (0 build lines) and the full VoLTE IPsec register still passes (Successful=1, Failed=0).