### PR TITLE
docs(changelog): promote [Unreleased] to [1.2.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-07-07
+
 ### Added
 - **`@rtpengine.on_media_timeout` script hook.** The media engine reaps a call
   whose media went dead (no packets past its inactivity window) and pushes a


### PR DESCRIPTION
Promotes the accumulated `[Unreleased]` entries to `## [1.2.0]` ahead of cutting v1.2.0. No code changes.

Covers the media backends (native siphon-rtp JSON-over-TCP, classic rtpproxy text-over-UDP, `@rtpengine.on_media_timeout`), `call.set_from_host()`/`set_to_host()`, kernel nftables firewall + admin ban management, outbound mutual TLS + hostname SNI, `request.from_gateway()`/`call.from_gateway()`, automatic CDR generation, and the `cdr.write(call)` fix.