### PR TITLE
fix(deps): bump crossbeam-epoch for RUSTSEC-2026-0204 + gate cut-release on advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
-## [1.2.0] — 2026-07-07
+## [1.2.1] — 2026-07-09
+
+### Security
+- **Bump `crossbeam-epoch` 0.9.18 → 0.9.20** to address RUSTSEC-2026-0204: an
+  invalid pointer dereference in the `fmt::Display` impl for `Atomic`/`Shared`
+  when the underlying pointer is null/invalid. Transitive dependency (via
+  `crossbeam-deque`); lockfile-only bump, no API or behavioural change.
+
+## [1.2.0] — 2026-07-09
 
 ### Added
 - **`@rtpengine.on_media_timeout` script hook.** The media engine reaps a call

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -60,6 +60,19 @@ else
   ( cd sdk && python -m pytest tests/ -q )
 fi
 
+# ── Security advisory gate (per project policy) ─────────────────────────────
+# A release MUST NOT ship with an open RustSec advisory in the dependency tree.
+# The scheduled Security-audit workflow (cargo-deny) runs post-merge; run the
+# same check *before* tagging so an open advisory blocks the cut, not the publish
+# (the failure mode that let v1.2.0 tag with RUSTSEC-2026-0204 outstanding).
+if [ "${ADVISORY_OK:-0}" != "1" ]; then
+  echo "==> security advisory gate (cargo-deny check advisories)"
+  command -v cargo-deny >/dev/null \
+    || die "cargo-deny not installed — 'cargo install cargo-deny' (or set ADVISORY_OK=1 to skip)"
+  cargo deny --all-features check advisories \
+    || die "cargo-deny found an open advisory — bump the affected crate (cargo update -p <crate>) or add a reviewed ignore in deny.toml, then re-cut (or set ADVISORY_OK=1 to skip)"
+fi
+
 # ── Performance + memory-leak baseline (manual, per project policy) ─────────
 if [ "${PERF_OK:-0}" != "1" ]; then
   echo


### PR DESCRIPTION
**Security fix + process fix.**

`cargo-deny advisories` (the scheduled Security-audit workflow) flagged RUSTSEC-2026-0204 in `crossbeam-epoch` 0.9.18 (invalid pointer dereference in the `fmt::Display` impl for `Atomic`/`Shared` on a null/invalid pointer). It's a transitive dep (via `crossbeam-deque`); bump to 0.9.20 per the advisory. Lockfile-only, no API/behaviour change. Verified locally: `cargo deny --all-features check advisories` -> `advisories ok`.

Also adds a **security-advisory gate to `scripts/cut-release.sh`** (runs `cargo deny check advisories` before tagging, skippable with `ADVISORY_OK=1`) so an open advisory blocks the cut instead of only failing the post-merge audit workflow. Ships in 1.2.1; also promotes the CHANGELOG `[1.2.1]` section and corrects the 1.2.0 heading date.