### PR TITLE
feat(cache): cache.list_len + list_len_sum (live Redis list depth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
-## [1.2.1] — 2026-07-09
+### Added
+- **`cache.list_len(name, key)` and `cache.list_len_sum(name, prefix)`.** Two
+  async cache-namespace methods for Redis-backed lists. `list_len` returns a
+  single list's length (`LLEN`, `0` for a missing key). `list_len_sum` returns
+  the summed length of every list whose key matches `{prefix}*`, via a cursor
+  `SCAN` (deduped) + pipelined `LLEN` computed server-side in one await; glob
+  metacharacters in the prefix are escaped so it matches literally, and an empty
+  prefix raises `ValueError`. Both return `None` for unknown or non-Redis-backed
+  caches. This gives the live instantaneous depth of a set of sharded per-key
+  queues (e.g. summing `ims_queue_*`) — where enqueue/drain counters drift
+  upward forever because TTL-expired entries leave the keyspace silently, a
+  summed `LLEN` is truthful because expired keys are simply gone.
 
 ### Security
 - **Bump `crossbeam-epoch` 0.9.18 → 0.9.20** to address RUSTSEC-2026-0204: an

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -225,7 +225,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Auth API | **Production** | `auth.require_digest()` etc. | |
 | Gateway API | **Production** | `gateway.select()` etc. | |
 | Cache API | **Production** | `cache.fetch()` | Redis-backed |
-| Cache list / TTL / existence ops | Implemented | `cache.list_push/list_pop_all/expire/exists` | Redis-backed FIFO queue ops (atomic LRANGE+DEL drain), per-key TTL, presence check; degrades silently when Redis is unreachable |
+| Cache list / TTL / existence ops | Implemented | `cache.list_push/list_pop_all/list_len/list_len_sum/expire/exists` | Redis-backed FIFO queue ops (atomic LRANGE+DEL drain), single-list length (`LLEN`), prefix-summed depth (`SCAN`+pipelined `LLEN`, TTL-expiry-truthful), per-key TTL, presence check; degrades silently when Redis is unreachable |
 | Presence API | **Production** | `presence.*` | Used for reg-event SUBSCRIBE/NOTIFY |
 | Outbound SUBSCRIBE (RFC 6665 watcher) | Implemented | `proxy.subscribe_state.send/find/refresh` | Originate SUBSCRIBE, capture dialog state from 200 OK, correlate inbound NOTIFY by tags |
 | Reginfo XML parser (RFC 3680) | Implemented | `presence.parse_reginfo(xml)` | Watcher-side parser for `application/reginfo+xml` NOTIFY bodies |

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -1636,6 +1636,33 @@ class MockCache:
             return list(existing)
         return []
 
+    async def list_len(self, name: str, key: str) -> Optional[int]:
+        """Return the length of the list under ``key`` (``0`` for a
+        missing key), or ``None`` if the cache name is unknown."""
+        store = self._stores.get(name)
+        if store is None:
+            return None
+        existing = store.get(key)
+        if isinstance(existing, list):
+            return len(existing)
+        return 0
+
+    async def list_len_sum(self, name: str, prefix: str) -> Optional[int]:
+        """Sum the lengths of every list whose key starts with
+        ``prefix``. Returns ``0`` when nothing matches, ``None`` if the
+        cache name is unknown. Raises ``ValueError`` on an empty prefix
+        (which would scan the entire keyspace)."""
+        if not prefix:
+            raise ValueError("prefix must not be empty")
+        store = self._stores.get(name)
+        if store is None:
+            return None
+        total = 0
+        for key, value in store.items():
+            if key.startswith(prefix) and isinstance(value, list):
+                total += len(value)
+        return total
+
     async def expire(self, name: str, key: str, ttl: int) -> bool:
         """Mock TTL — records the call on ``self.expirations`` for
         assertions and returns ``True`` when the key currently exists

--- a/sdk/tests/test_cache_list_len.py
+++ b/sdk/tests/test_cache_list_len.py
@@ -1,0 +1,75 @@
+"""Tests for the SDK's ``cache.list_len`` / ``cache.list_len_sum`` mocks.
+
+Mirrors the ip-sm-gw "SMS Queued" tile pattern: the live depth of a set of
+sharded per-key queues is the summed ``LLEN`` over ``ims_queue_*`` — truthful
+because a drained (or, in production, TTL-expired) key simply leaves the
+keyspace.
+"""
+import asyncio
+
+import pytest
+
+from siphon_sdk import mock_module
+
+mock_module.install()
+
+from siphon import cache  # noqa: E402  (must come after install)
+
+
+def setup_function(_):
+    cache.clear()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_list_len_counts_pushed_items():
+    cache.set_data("queue")
+    _run(cache.list_push("queue", "ims_queue_1", "a"))
+    _run(cache.list_push("queue", "ims_queue_1", "b"))
+    assert _run(cache.list_len("queue", "ims_queue_1")) == 2
+
+
+def test_list_len_missing_key_is_zero():
+    cache.set_data("queue")
+    assert _run(cache.list_len("queue", "ims_queue_absent")) == 0
+
+
+def test_list_len_unknown_cache_is_none():
+    assert _run(cache.list_len("nope", "k")) is None
+
+
+def test_list_len_sum_over_prefix():
+    cache.set_data("queue")
+    _run(cache.list_push("queue", "ims_queue_1", "a"))
+    _run(cache.list_push("queue", "ims_queue_1", "b"))
+    _run(cache.list_push("queue", "ims_queue_2", "c"))
+    _run(cache.list_push("queue", "other_key", "z"))
+    # Only the ims_queue_* lists count (4 items pushed, 3 under the prefix).
+    assert _run(cache.list_len_sum("queue", "ims_queue_")) == 3
+
+
+def test_list_len_sum_drops_when_key_drained():
+    cache.set_data("queue")
+    _run(cache.list_push("queue", "ims_queue_1", "a"))
+    _run(cache.list_push("queue", "ims_queue_2", "b"))
+    assert _run(cache.list_len_sum("queue", "ims_queue_")) == 2
+    # Draining a key (mock analogue of a TTL expiry) drops the depth.
+    _run(cache.list_pop_all("queue", "ims_queue_1"))
+    assert _run(cache.list_len_sum("queue", "ims_queue_")) == 1
+
+
+def test_list_len_sum_no_match_is_zero():
+    cache.set_data("queue")
+    assert _run(cache.list_len_sum("queue", "ims_queue_")) == 0
+
+
+def test_list_len_sum_unknown_cache_is_none():
+    assert _run(cache.list_len_sum("nope", "ims_queue_")) is None
+
+
+def test_list_len_sum_empty_prefix_raises():
+    cache.set_data("queue")
+    with pytest.raises(ValueError):
+        _run(cache.list_len_sum("queue", ""))

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -13,6 +13,21 @@ use tracing::warn;
 
 use crate::config::NamedCacheConfig;
 
+/// Escape Redis glob metacharacters (`* ? [ ] \`) so a `SCAN MATCH`
+/// prefix is matched literally. Backslash is escaped first (it is the
+/// glob escape char) by handling it in the same per-char pass.
+#[cfg(feature = "redis-backend")]
+fn escape_glob(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if matches!(ch, '\\' | '*' | '?' | '[' | ']') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
 /// A single cached value with its insertion time.
 struct CacheEntry {
     value: String,
@@ -344,6 +359,98 @@ impl NamedCache {
         }
     }
 
+    /// Return the length of the Redis list under `key` (`LLEN`).
+    /// `Some(0)` for a missing key — Redis `LLEN` of an absent key is
+    /// 0 — and `None` when the Redis backend is unavailable or the
+    /// command failed. Local LRU is never consulted; list values live
+    /// only in Redis (consistent with `list_push`).
+    async fn list_len(&self, key: &str) -> Option<u64> {
+        #[cfg(feature = "redis-backend")]
+        {
+            let mut connection = self.get_redis_connection().await?;
+            match redis::cmd("LLEN")
+                .arg(key)
+                .query_async::<u64>(&mut connection)
+                .await
+            {
+                Ok(len) => Some(len),
+                Err(error) => {
+                    warn!(key = key, "Redis LLEN failed: {error}");
+                    None
+                }
+            }
+        }
+        #[cfg(not(feature = "redis-backend"))]
+        {
+            let _ = key;
+            debug!(key = key, "list_len: no Redis backend; returning None");
+            None
+        }
+    }
+
+    /// Sum `LLEN` over every key matching `{prefix}*`, computed
+    /// server-side so the caller gets the total in one await. Cursor
+    /// `SCAN MATCH {prefix}* COUNT 512` (deduped into a `HashSet`, since
+    /// SCAN may repeat keys under concurrent writes), then a pipelined
+    /// `LLEN` over the deduped set. Returns `Some(0)` when nothing
+    /// matches, `None` when the Redis backend is unavailable or a Redis
+    /// error occurred mid-iteration.
+    ///
+    /// `SCAN` is O(keyspace of that Redis DB) — intended for a dedicated
+    /// queue DB. Glob metacharacters (`* ? [ ] \`) in `prefix` are
+    /// escaped so an arbitrary prefix is matched literally.
+    async fn list_len_sum(&self, prefix: &str) -> Option<u64> {
+        #[cfg(feature = "redis-backend")]
+        {
+            let mut connection = self.get_redis_connection().await?;
+            let pattern = format!("{}*", escape_glob(prefix));
+            let mut keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut cursor: u64 = 0;
+            loop {
+                let (next_cursor, batch): (u64, Vec<String>) = match redis::cmd("SCAN")
+                    .arg(cursor)
+                    .arg("MATCH")
+                    .arg(&pattern)
+                    .arg("COUNT")
+                    .arg(512)
+                    .query_async(&mut connection)
+                    .await
+                {
+                    Ok(result) => result,
+                    Err(error) => {
+                        warn!(prefix = prefix, "Redis SCAN failed: {error}");
+                        return None;
+                    }
+                };
+                keys.extend(batch);
+                cursor = next_cursor;
+                if cursor == 0 {
+                    break;
+                }
+            }
+            if keys.is_empty() {
+                return Some(0);
+            }
+            let mut pipe = redis::pipe();
+            for key in &keys {
+                pipe.cmd("LLEN").arg(key);
+            }
+            match pipe.query_async::<Vec<u64>>(&mut connection).await {
+                Ok(lengths) => Some(lengths.iter().sum()),
+                Err(error) => {
+                    warn!(prefix = prefix, "Redis LLEN pipeline failed: {error}");
+                    None
+                }
+            }
+        }
+        #[cfg(not(feature = "redis-backend"))]
+        {
+            let _ = prefix;
+            debug!(prefix = prefix, "list_len_sum: no Redis backend; returning None");
+            None
+        }
+    }
+
     /// Check if `key` exists in this cache. Considers the local LRU
     /// first (cheap, in-process), then Redis. Local-only caches answer
     /// from the LRU alone.
@@ -465,6 +572,20 @@ impl CacheManager {
             Some(cache) => cache.exists(key).await,
             None => false,
         }
+    }
+
+    /// Length of the Redis list under `key` (`LLEN`). `Some(0)` for a
+    /// missing key; `None` when the cache is unknown, the Redis backend
+    /// is unavailable, or the command failed.
+    pub async fn list_len(&self, name: &str, key: &str) -> Option<u64> {
+        self.caches.get(name)?.list_len(key).await
+    }
+
+    /// Sum of `LLEN` over every key matching `{prefix}*`. `Some(0)` when
+    /// nothing matches; `None` when the cache is unknown, the Redis
+    /// backend is unavailable, or a Redis error occurred mid-iteration.
+    pub async fn list_len_sum(&self, name: &str, prefix: &str) -> Option<u64> {
+        self.caches.get(name)?.list_len_sum(prefix).await
     }
 }
 
@@ -614,5 +735,40 @@ mod tests {
     async fn expire_returns_false_for_unknown_cache_name() {
         let manager = CacheManager::empty();
         assert!(!manager.expire("nope", "key", 60).await);
+    }
+
+    #[tokio::test]
+    async fn list_len_returns_none_when_redis_unreachable() {
+        let manager = CacheManager::new(&[make_config("queue", None, None)]);
+        // Bogus Redis URL — backend is unreachable, op degrades.
+        assert!(manager.list_len("queue", "ims_queue_abc").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_len_returns_none_for_unknown_cache_name() {
+        let manager = CacheManager::empty();
+        assert!(manager.list_len("nope", "key").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_len_sum_returns_none_when_redis_unreachable() {
+        let manager = CacheManager::new(&[make_config("queue", None, None)]);
+        assert!(manager.list_len_sum("queue", "ims_queue_").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_len_sum_returns_none_for_unknown_cache_name() {
+        let manager = CacheManager::empty();
+        assert!(manager.list_len_sum("nope", "ims_queue_").await.is_none());
+    }
+
+    #[cfg(feature = "redis-backend")]
+    #[test]
+    fn escape_glob_escapes_metacharacters() {
+        // Plain prefixes (underscore is not a glob metachar) pass through.
+        assert_eq!(escape_glob("ims_queue_"), "ims_queue_");
+        // The five glob metacharacters each get a backslash prefix.
+        assert_eq!(escape_glob("a*b?c[d]e"), "a\\*b\\?c\\[d\\]e");
+        assert_eq!(escape_glob("back\\slash"), "back\\\\slash");
     }
 }

--- a/src/script/api/cache.rs
+++ b/src/script/api/cache.rs
@@ -23,6 +23,20 @@ fn validate_key(key: &str) -> PyResult<()> {
     }
 }
 
+/// Validate a `list_len_sum` prefix: reject the reserved `siphon:`
+/// prefix and reject an empty prefix (which would `SCAN` the entire
+/// keyspace). Raising `ValueError` matches `validate_key`'s style for
+/// programming errors.
+fn validate_prefix(prefix: &str) -> PyResult<()> {
+    validate_key(prefix)?;
+    if prefix.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "prefix must not be empty (would scan the entire keyspace)",
+        ));
+    }
+    Ok(())
+}
+
 /// Python-facing cache namespace.
 #[pyclass(name = "CacheNamespace")]
 pub struct PyCacheNamespace {
@@ -162,6 +176,66 @@ impl PyCacheNamespace {
         })
     }
 
+    /// Return the length of the Redis list under ``key`` (``LLEN``).
+    ///
+    /// Args:
+    ///     name: Cache name (must reference a Redis-backed entry —
+    ///         local-LRU-only caches don't have list semantics).
+    ///     key: List key. Reserved keys (``siphon:`` prefix) are rejected.
+    ///
+    /// Returns the list length (``0`` for a missing key — Redis
+    /// ``LLEN`` of an absent key is 0), or ``None`` when the cache is
+    /// unknown, the cache has no Redis backend, or the command failed.
+    fn list_len<'py>(
+        &self,
+        py: Python<'py>,
+        name: String,
+        key: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        validate_key(&key)?;
+        let manager = Arc::clone(&self.manager);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            Ok(manager.list_len(&name, &key).await)
+        })
+    }
+
+    /// Sum ``LLEN`` over every key matching ``{prefix}*`` — the live
+    /// depth of a set of sharded per-key lists (e.g. summing
+    /// ``ims_queue_*``), computed server-side in one await.
+    ///
+    /// Implemented with a cursor ``SCAN MATCH {prefix}* COUNT 512`` loop
+    /// (deduped, since ``SCAN`` may repeat keys under concurrent writes)
+    /// then a pipelined ``LLEN`` over the deduped set. Glob
+    /// metacharacters in ``prefix`` are escaped so it matches literally.
+    /// TTL-expired keys are simply gone from the keyspace, so the sum is
+    /// a truthful instantaneous depth.
+    ///
+    /// Args:
+    ///     name: Cache name (must reference a Redis-backed entry).
+    ///     prefix: Non-empty key prefix. Reserved (``siphon:``) prefixes
+    ///         are rejected; an empty prefix raises ``ValueError`` (it
+    ///         would scan the entire keyspace).
+    ///
+    /// Returns the summed length (``0`` when nothing matches), or
+    /// ``None`` when the cache is unknown, the cache has no Redis
+    /// backend, or a Redis error occurred mid-iteration.
+    ///
+    /// Note:
+    ///     ``SCAN`` is O(keyspace of that Redis DB) — intended for a
+    ///     dedicated queue DB.
+    fn list_len_sum<'py>(
+        &self,
+        py: Python<'py>,
+        name: String,
+        prefix: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        validate_prefix(&prefix)?;
+        let manager = Arc::clone(&self.manager);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            Ok(manager.list_len_sum(&name, &prefix).await)
+        })
+    }
+
     /// Check whether ``key`` exists in the named cache.
     ///
     /// Considers the local LRU first (in-process), then Redis. Returns
@@ -177,5 +251,26 @@ impl PyCacheNamespace {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             Ok(manager.exists(&name, &key).await)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_prefix_rejects_empty() {
+        // Empty prefix would SCAN the whole keyspace — reject it.
+        assert!(validate_prefix("").is_err());
+    }
+
+    #[test]
+    fn validate_prefix_rejects_reserved() {
+        assert!(validate_prefix("siphon:internal").is_err());
+    }
+
+    #[test]
+    fn validate_prefix_accepts_normal() {
+        assert!(validate_prefix("ims_queue_").is_ok());
     }
 }


### PR DESCRIPTION
## What

Adds two async methods to the Python `cache` namespace for Redis-backed lists:

- **`cache.list_len(name, key) -> int | None`** — `LLEN` on the named cache's
  Redis backend. `0` for a missing key (Redis `LLEN` of an absent key is 0);
  `None` when the cache is unknown, has no Redis backend (local-LRU-only caches
  have no list semantics, consistent with `list_push`), or the command failed.
- **`cache.list_len_sum(name, prefix) -> int | None`** — server-side sum of
  `LLEN` over every key matching `{prefix}*`. Cursor `SCAN MATCH {prefix}*
  COUNT 512` loop, deduped into a `HashSet` (SCAN may repeat keys under
  concurrent writes), then a pipelined `LLEN` over the deduped set. `0` when
  nothing matches; `None` on unknown/non-Redis cache or a Redis error
  mid-iteration. An empty prefix raises `ValueError` (guards against a
  full-keyspace scan); glob metacharacters (`* ? [ ] \`) in the prefix are
  escaped so arbitrary prefixes stay literal.

## Why

The existing `list_push` / `list_pop_all` / `expire` ops have no way to read the
*instantaneous* depth of a set of sharded per-key queues. Enqueue/drain counters
can't give it either: when entries leave a Redis list via TTL expiry there is no
drain increment, so `enqueue − drain` drifts upward forever and never reflects
real depth. A summed `LLEN` is truthful because TTL-expired keys are simply gone
from the keyspace. This lets a script export the live queue depth, e.g.:

```python
depth = await cache.list_len_sum('queue', 'ims_queue_')
metrics.gauge('ipsmgw_queue_depth', 'SMS currently queued').set(depth)
```

## Changes

- `src/cache/mod.rs` — `NamedCache::list_len` / `list_len_sum` (byte-for-byte the
  `list_push` shape, incl. the no-Redis-backend `None` arm), `CacheManager`
  passthroughs, and a cfg-gated `escape_glob` helper. The SCAN cursor loop
  mirrors the existing `registrar::backend` pattern; the pipeline mirrors
  `list_pop_all`.
- `src/script/api/cache.rs` — `list_len` / `list_len_sum` `#[pymethods]` and a
  `validate_prefix` helper (reserved-prefix + empty-prefix guard).
- `sdk/siphon_sdk/mock_module.py` — mirror both methods on the `MockCache`.
- `sdk/tests/test_cache_list_len.py` — mock coverage incl. "drained key drops the
  summed depth" (the TTL-expiry analogue) and the empty-prefix `ValueError`.
- `docs/feature-readiness-matrix.md`, `CHANGELOG.md` — updated.

## Tests

- `src/cache/mod.rs`: `list_len` / `list_len_sum` return `None` on unreachable
  Redis and unknown cache name; `escape_glob` metachar escaping.
- `src/script/api/cache.rs`: `validate_prefix` rejects empty + reserved,
  accepts normal.
- Full Rust suite green (3133 passed), full SDK suite green (371 passed), clippy
  clean (`--all-targets --all-features -D warnings`).
- Happy-path list semantics against a live Redis are exercised by the SDK mock;
  the Rust unit tests use a bogus Redis URL (graceful-degradation path), matching
  the existing `list_push` / `list_pop_all` / `expire` tests.
