### PR TITLE
fix(uac): add Contact to outbound OPTIONS keepalives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   upward forever because TTL-expired entries leave the keyspace silently, a
   summed `LLEN` is truthful because expired keys are simply gone.
 
+### Fixed
+- **Outbound OPTIONS keepalives now carry a `Contact` header.** The UAC-side
+  OPTIONS builder (NAT keepalive, gateway health probe, registrar liveness probe)
+  emitted Via/From/To/Call-ID/CSeq only — no Contact. RFC 3261 §11.1 makes
+  Contact a MAY on OPTIONS, but some peers require it: Microsoft Teams Direct
+  Routing rejects an OPTIONS that carries neither Contact nor Record-Route
+  (`Q.850;cause=63;text="…Record-Route and Contact headers are missing"`) because
+  it derives the next hop from one of them. The OPTIONS now advertises the local
+  reachable address (same host:port as the Via, with `transport=` lowercased), so
+  the trunk stays healthy. The host follows `advertised_address` when set — point
+  it at the SBC FQDN for peers (Teams among them) that reject an IP in Contact.
+
 ### Security
 - **Bump `crossbeam-epoch` 0.9.18 → 0.9.20** to address RUSTSEC-2026-0204: an
   invalid pointer dereference in the `fmt::Display` impl for `Atomic`/`Shared`

--- a/src/script/api/timer.rs
+++ b/src/script/api/timer.rs
@@ -221,7 +221,7 @@ impl PyTimerHandle {
     }
 
     fn __repr__(&self) -> String {
-        format!("TimerHandle(key={:?})", &self.key)
+        format!("TimerHandle(key={:?})", self.key)
     }
 }
 

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -799,7 +799,7 @@ fn extract_handlers(
         let metadata: Option<Bound<'_, PyAny>> = item
             .get_item(4)
             .ok()
-            .and_then(|v: Bound<'_, PyAny>| if v.is_none() { None } else { Some(v) });
+            .filter(|v| !v.is_none());
 
         let kind = match kind_str.as_str() {
             "proxy.on_request" => HandlerKind::ProxyRequest(filter),

--- a/src/uac/mod.rs
+++ b/src/uac/mod.rs
@@ -254,11 +254,25 @@ impl UacSender {
             .unwrap_or_else(|| addr.ip().to_string());
         let from_uri = format!("<sip:{from_name}@{from_host_str}>;tag=uac-{cseq}");
 
+        // RFC 3261 §11.1 permits a Contact on an OPTIONS, and some peers require
+        // it: Microsoft Teams Direct Routing rejects an OPTIONS that carries
+        // neither Contact nor Record-Route ("Record-Route and Contact headers are
+        // missing") because it uses one of them to compute the next hop. Advertise
+        // our own reachable address — same host:port as the Via — so the peer can
+        // reach us for return traffic.
+        let contact = format!(
+            "<sip:{from_name}@{}:{};transport={}>",
+            addr.ip(),
+            addr.port(),
+            transport.to_string().to_lowercase(),
+        );
+
         let mut builder = SipMessageBuilder::new()
             .request(Method::Options, request_uri.clone())
             .via(via)
             .to(format!("<{request_uri}>"))
             .from(from_uri)
+            .contact(contact)
             .call_id(format!("uac-keepalive-{}", uuid::Uuid::new_v4()))
             .cseq(format!("{cseq} OPTIONS"))
             .max_forwards(70)
@@ -549,6 +563,31 @@ mod tests {
         );
 
         assert_eq!(sender.pending_count(), 1);
+    }
+
+    #[test]
+    fn send_options_includes_contact_header() {
+        // RFC 3261 §11.1 permits Contact on an OPTIONS; peers like Microsoft
+        // Teams Direct Routing require it and reject an OPTIONS carrying neither
+        // Contact nor Record-Route. The keepalive OPTIONS must advertise our own
+        // reachable address (same host:port as the Via, transport lowercased).
+        let (sender, receivers) = make_uac_sender();
+
+        let _receiver = sender.send_options(
+            "10.0.0.1:5060".parse().unwrap(),
+            Transport::Udp,
+            SipUri::new("10.0.0.1".to_string()),
+        );
+
+        // receivers[0] is the UDP egress channel from make_uac_sender().
+        let outbound = receivers[0]
+            .try_recv()
+            .expect("OPTIONS must be queued on the UDP egress channel");
+        let raw = String::from_utf8_lossy(&outbound.data);
+        assert!(
+            raw.contains("Contact: <sip:siphon@127.0.0.1:5060;transport=udp>"),
+            "OPTIONS keepalive must carry a Contact header, got:\n{raw}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Peers that poll the trunk with SIP OPTIONS can reject our keepalive. Microsoft Teams Direct Routing returned:

```
Q.850;cause=63;text="…;Record-Route and Contact headers are missing"
```

Our outbound OPTIONS builder (`send_options_on_connection_inner`, used by NAT keepalive, gateway health probing, and the registrar liveness probe) emitted `Via / From / To / Call-ID / CSeq / Max-Forwards / Content-Length` only. No `Contact`.

RFC 3261 §11.1 makes `Contact` a **MAY** on OPTIONS, so omitting it is spec-legal. But it's an interop failure: per Microsoft's own Direct Routing SIP spec, the SIP proxy derives the next hop for in-dialog transactions **and when replying to OPTIONS** from *either* `Contact` or `Record-Route`, so an OPTIONS with neither is rejected. Asterisk sends `Contact: <sip:sbc-1@host:port>` on the same ping and is accepted.

`Record-Route` on a dialogless OPTIONS is non-standard (RFC 3261 §16.6/§20.30 — it exists to keep a proxy on a *dialog's* path), and Microsoft recommends Contact-only when no proxy SBC is in play. So the fix is a `Contact`, not a `Record-Route`.

## Change

- Add a `Contact` to the outbound OPTIONS, advertising our own reachable address — same `host:port` as the Via, with `transport=` lowercased (matching the B2BUA response-Contact convention). One builder feeds every keepalive path, so this covers NAT / gateway-probe / registrar-liveness in one place.
- Unit test asserting the keepalive OPTIONS carries the `Contact` header.

The Contact host tracks `advertised_address` when set — point it at the SBC FQDN for peers that reject an IP in Contact (real Teams Direct Routing over TLS requires the FQDN to match the certificate; the private-IP peer in this case, like Asterisk, accepts an IP).

## Note — two unrelated clippy fixes folded in

CI runs `clippy -D warnings` on a floating `dtolnay/rust-toolchain@stable`. A newer stable clippy flags two pre-existing nits on `main` (`Option::filter` in `script/engine.rs`, redundant `&` in a `timer.rs` `format!`) that predate this branch, so the clippy job is red for *any* PR until they're cleared. Fixed both so the branch goes green. Happy to split them into their own cleanup PR if preferred.

## Testing

- `cargo test` — 3130 passed, 6 ignored
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
