### PR TITLE
fix: honor FQDN advertised_address in UAC-originated Via/From/Contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   reachable address (same host:port as the Via, with `transport=` lowercased), so
   the trunk stays healthy. The host follows `advertised_address` when set — point
   it at the SBC FQDN for peers (Teams among them) that reject an IP in Contact.
+- **An FQDN `advertised_address` is now honored across every siphon-originated
+  (UAC) Via/From/Contact, not just IP literals.** Previously a non-IP
+  `advertised_address` (e.g. `sbc.example.org`) was collapsed to `127.0.0.1` on
+  the outbound OPTIONS keepalive/probe headers (including the Contact above), the
+  `proxy.subscribe_state` SUBSCRIBE Via/Contact, and the `proxy.send_request`
+  auto-Via, and it logged a spurious `advertised_address is not a valid IP, using
+  localhost` warning on each probe. The SIP header host now carries the advertised
+  value verbatim (RFC 3261 §20.42 permits an FQDN in the Via sent-by), while the
+  socket-source resolver still falls back to a local IP; the misleading warning is
+  downgraded to `debug`. This also fixes a latent bug where the `subscribe_state`
+  and `proxy.send_request` auto-Via sent-by was the *destination* address rather
+  than siphon's own, so a peer honoring the Via sent-by could route the response
+  away from us. A per-transport `listen.<t>.advertise` (or an IP
+  `advertised_address`) already worked and is unchanged.
 
 ### Security
 - **Bump `crossbeam-epoch` 0.9.18 → 0.9.20** to address RUSTSEC-2026-0204: an

--- a/src/script/api/proxy_utils.rs
+++ b/src/script/api/proxy_utils.rs
@@ -21,8 +21,6 @@ use crate::sip::uri::SipUri;
 use crate::transport::Transport;
 use crate::uac::UacSender;
 
-use std::net::SocketAddr;
-
 use super::reply::PyReply;
 use super::request::PyRequest;
 
@@ -366,11 +364,18 @@ impl PyProxyUtils {
             None => if scheme == "sips" { Transport::Tls } else { Transport::Udp },
         };
 
+        // Via sent-by = our advertised host (FQDN-aware) + listen port, so the
+        // peer's response comes back to us rather than the resolved destination.
+        let local_sent_by = format!(
+            "{}:{}",
+            uac_sender.via_host_for(&transport),
+            uac_sender.addr_for(&transport).port(),
+        );
         let (message, branch) = build_send_request_message(
             method,
             uri,
             transport,
-            target.address,
+            &local_sent_by,
             headers,
             body,
         )?;
@@ -529,7 +534,7 @@ fn build_send_request_message(
     method: &str,
     uri: SipUri,
     transport: Transport,
-    destination: SocketAddr,
+    local_sent_by: &str,
     headers: Option<&Bound<'_, PyDict>>,
     body: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<(SipMessage, String)> {
@@ -585,7 +590,10 @@ fn build_send_request_message(
     let auto_branch = format!("z9hG4bK-uac-py-{}", uuid::Uuid::new_v4());
     let via_value = match user_via {
         Some(via_str) => via_str,
-        None => format!("SIP/2.0/{} {};branch={}", transport, destination, auto_branch),
+        // Auto Via sent-by is *our* advertised host:port (FQDN-aware, RFC 3261
+        // §20.42) so the peer routes the response back to us — not the
+        // destination address, which was a latent bug.
+        None => format!("SIP/2.0/{} {};branch={}", transport, local_sent_by, auto_branch),
     };
     let branch = crate::sip::headers::via::Via::parse(&via_value)
         .ok()
@@ -880,8 +888,8 @@ mod tests {
         assert!(pct <= 100, "memory_used_pct returned {pct}");
     }
 
-    fn destination() -> SocketAddr {
-        "10.0.0.1:5060".parse().unwrap()
+    fn local_sent_by() -> &'static str {
+        "192.0.2.9:5060"
     }
 
     fn target_uri() -> SipUri {
@@ -910,7 +918,7 @@ mod tests {
                 "REGISTER",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 Some(body_any),
             )
@@ -963,7 +971,7 @@ mod tests {
                 "MESSAGE",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 Some(body_obj.as_any()),
             )
@@ -985,7 +993,7 @@ mod tests {
                 "OPTIONS",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 None,
             )
@@ -1014,7 +1022,7 @@ mod tests {
                 "REGISTER",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 Some(body_obj.as_any()),
             )
@@ -1042,7 +1050,7 @@ mod tests {
                 "MESSAGE",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 None,
             )
@@ -1081,7 +1089,7 @@ mod tests {
                 "MESSAGE",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 None,
             )
@@ -1106,7 +1114,7 @@ mod tests {
                 "OPTIONS",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 None,
             )
@@ -1140,7 +1148,7 @@ mod tests {
                 "MESSAGE",
                 target_uri(),
                 Transport::Udp,
-                destination(),
+                local_sent_by(),
                 Some(&headers),
                 None,
             )
@@ -1155,6 +1163,37 @@ mod tests {
             assert_eq!(
                 branch, "z9hG4bK-uac-script-supplied",
                 "returned branch must come from the user-supplied Via"
+            );
+        });
+    }
+
+    /// With no script-supplied Via, the auto Via sent-by is *our* advertised
+    /// host:port (so responses route back to us), not the resolved
+    /// destination — the latent bug this fixes.
+    #[test]
+    fn send_request_auto_via_uses_local_sent_by() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let _ = py;
+            let (message, branch) = build_send_request_message(
+                "MESSAGE",
+                target_uri(),
+                Transport::Udp,
+                local_sent_by(),
+                None,
+                None,
+            )
+            .expect("build_send_request_message");
+
+            let vias = message.headers.get_all("Via").expect("Via must be present");
+            assert_eq!(vias.len(), 1, "one Via expected, got {vias:?}");
+            assert!(
+                vias[0].contains(&format!("SIP/2.0/UDP {}", local_sent_by())),
+                "auto Via sent-by must be our advertised host:port, got {vias:?}"
+            );
+            assert!(
+                branch.starts_with("z9hG4bK-uac-py-"),
+                "auto branch must use the UAC-py prefix, got {branch}"
             );
         });
     }

--- a/src/script/api/subscribe_state.rs
+++ b/src/script/api/subscribe_state.rs
@@ -301,7 +301,11 @@ impl PySubscribeState {
         // Mint dialog identity on our side.
         let call_id = format!("py-sub-{}", Uuid::new_v4());
         let local_tag = short_uuid();
-        let local_contact_addr = uac_sender.addr_for(&transport);
+        // Advertise our own reachable host (FQDN-aware) + listen port in the
+        // Via/Contact so the notifier can route the response and any in-dialog
+        // NOTIFY back to us; addr_for only supplies the port here.
+        let local_host = uac_sender.via_host_for(&transport);
+        let local_port = uac_sender.addr_for(&transport).port();
         let local_uri_default = strip_uri_params(ruri);
 
         // Pre-extract the script-supplied header dict into a Vec so the
@@ -332,8 +336,8 @@ impl PySubscribeState {
             accept,
             target_uri,
             transport,
-            target.address,
-            local_contact_addr,
+            &local_host,
+            local_port,
             &call_id,
             &local_tag,
             &extra_headers,
@@ -987,14 +991,17 @@ fn build_outbound_subscribe(
     accept: Option<&str>,
     target_uri: Option<&str>,
     transport: Transport,
-    target_address: std::net::SocketAddr,
-    local_contact_addr: std::net::SocketAddr,
+    local_host: &str,
+    local_port: u16,
     call_id: &str,
     local_tag: &str,
     extra_headers: &[(String, String)],
 ) -> PyResult<(crate::sip::message::SipMessage, u32, Option<String>)> {
     let branch = format!("z9hG4bK-uac-py-{}", Uuid::new_v4());
-    let via = format!("SIP/2.0/{} {};branch={}", transport, target_address, branch);
+    // Via sent-by is *our* advertised host:port so the notifier routes the
+    // response back to us (RFC 3261 §18.2.1 / §20.42 — the sent-by may be an
+    // FQDN), not to the destination or a loopback fallback.
+    let via = format!("SIP/2.0/{} {}:{};branch={}", transport, local_host, local_port, branch);
     let cseq_value: u32 = 1;
     let cseq_str = format!("{cseq_value} SUBSCRIBE");
 
@@ -1012,7 +1019,7 @@ fn build_outbound_subscribe(
     // any in-dialog NOTIFY it tries to send has nowhere to go.  Derive
     // the default from siphon's listen address for the chosen transport;
     // a caller-supplied ``headers={"Contact": ...}`` replaces this below.
-    let contact_default = format_default_contact(local_contact_addr, transport);
+    let contact_default = format_default_contact(local_host, local_port, transport);
 
     let mut builder = SipMessageBuilder::new()
         .request(Method::Subscribe, ruri_parsed)
@@ -1074,7 +1081,7 @@ fn build_outbound_subscribe(
 /// Used so the SUBSCRIBE we originate carries a routable Contact, which
 /// becomes the dialog's remote target for the notifier (RFC 3261 §12.1.1
 /// / RFC 6665 §4.1.2.1).
-fn format_default_contact(addr: std::net::SocketAddr, transport: Transport) -> String {
+fn format_default_contact(host: &str, port: u16, transport: Transport) -> String {
     let transport_param = match transport {
         Transport::Udp => "",
         Transport::Tcp => ";transport=tcp",
@@ -1083,7 +1090,7 @@ fn format_default_contact(addr: std::net::SocketAddr, transport: Transport) -> S
         Transport::WebSocketSecure => ";transport=wss",
         Transport::Sctp => ";transport=sctp",
     };
-    format!("<sip:{}{}>", addr, transport_param)
+    format!("<sip:{}:{}{}>", host, port, transport_param)
 }
 
 /// Return true for SIP headers that must appear at most once per RFC 3261
@@ -1297,12 +1304,12 @@ else:
         parse_uri_standalone(ruri).expect("parse ruri")
     }
 
-    fn target_addr() -> std::net::SocketAddr {
-        "10.0.0.99:5060".parse().unwrap()
+    fn local_host() -> &'static str {
+        "172.30.0.46"
     }
 
-    fn local_addr() -> std::net::SocketAddr {
-        "172.30.0.46:5070".parse().unwrap()
+    fn local_port() -> u16 {
+        5070
     }
 
     fn collect_header<'a>(message: &'a crate::sip::message::SipMessage, name: &str) -> Vec<&'a str> {
@@ -1328,8 +1335,8 @@ else:
             Some("application/reginfo+xml"),
             None,
             Transport::Udp,
-            target_addr(),
-            local_addr(),
+            local_host(),
+            local_port(),
             "py-sub-test",
             "local-tag-1",
             &[],
@@ -1369,8 +1376,8 @@ else:
             None,
             None,
             Transport::Tcp,
-            target_addr(),
-            local_addr(),
+            local_host(),
+            local_port(),
             "py-sub-tcp",
             "local-tag-tcp",
             &[],
@@ -1400,8 +1407,8 @@ else:
             None,
             None,
             Transport::Udp,
-            target_addr(),
-            local_addr(),
+            local_host(),
+            local_port(),
             "py-sub-override",
             "local-tag-2",
             &extra,
@@ -1416,11 +1423,14 @@ else:
         );
         assert_eq!(contacts[0], "<sip:ipsmgw@ipsmgw.example.com:6060>");
 
-        // No stale default leaks onto the wire.
+        // No stale default Contact leaks onto the wire. Match the Contact
+        // form specifically (`<sip:host:port>`), not the bare host:port —
+        // the latter now legitimately appears in the Via sent-by (our own
+        // advertised address), which is a different header.
         let wire = String::from_utf8(message.to_bytes()).unwrap();
         assert!(
-            !wire.contains("172.30.0.46:5070"),
-            "default Contact host:port leaked alongside user override:\n{wire}"
+            !wire.contains("<sip:172.30.0.46:5070"),
+            "default Contact leaked alongside user override:\n{wire}"
         );
     }
 
@@ -1445,8 +1455,8 @@ else:
             Some("application/reginfo+xml"),
             None,
             Transport::Udp,
-            target_addr(),
-            local_addr(),
+            local_host(),
+            local_port(),
             "py-sub-event",
             "local-tag-3",
             &extra,
@@ -1494,8 +1504,8 @@ else:
             None,
             Some("sip:scscf.example.org;lr"),
             Transport::Udp,
-            target_addr(),
-            local_addr(),
+            local_host(),
+            local_port(),
             "py-sub-multi",
             "local-tag-4",
             &extra,
@@ -1530,8 +1540,8 @@ else:
             None,
             None,
             Transport::Udp,
-            target_addr(),
-            local_addr(),
+            local_host(),
+            local_port(),
             "py-sub-from",
             "local-tag-5",
             &extra,
@@ -1555,30 +1565,63 @@ else:
     /// supported transport — the transport param is omitted only for UDP.
     #[test]
     fn format_default_contact_per_transport() {
-        let addr: std::net::SocketAddr = "192.0.2.10:5070".parse().unwrap();
         assert_eq!(
-            format_default_contact(addr, Transport::Udp),
+            format_default_contact("192.0.2.10", 5070, Transport::Udp),
             "<sip:192.0.2.10:5070>"
         );
         assert_eq!(
-            format_default_contact(addr, Transport::Tcp),
+            format_default_contact("192.0.2.10", 5070, Transport::Tcp),
             "<sip:192.0.2.10:5070;transport=tcp>"
         );
         assert_eq!(
-            format_default_contact(addr, Transport::Tls),
+            format_default_contact("192.0.2.10", 5070, Transport::Tls),
             "<sip:192.0.2.10:5070;transport=tls>"
         );
         assert_eq!(
-            format_default_contact(addr, Transport::WebSocket),
+            format_default_contact("192.0.2.10", 5070, Transport::WebSocket),
             "<sip:192.0.2.10:5070;transport=ws>"
         );
         assert_eq!(
-            format_default_contact(addr, Transport::WebSocketSecure),
+            format_default_contact("192.0.2.10", 5070, Transport::WebSocketSecure),
             "<sip:192.0.2.10:5070;transport=wss>"
         );
         assert_eq!(
-            format_default_contact(addr, Transport::Sctp),
+            format_default_contact("192.0.2.10", 5070, Transport::Sctp),
             "<sip:192.0.2.10:5070;transport=sctp>"
         );
+    }
+
+    /// An FQDN `advertised_address` is carried verbatim into the SUBSCRIBE
+    /// Via sent-by and default Contact — the notifier must be able to reach
+    /// us for the response and any in-dialog NOTIFY (RFC 6665 §4.1.2.1).
+    #[test]
+    fn build_outbound_subscribe_advertises_fqdn_host() {
+        let ruri = "sip:alice@ims.example.org";
+        let (message, _cseq, _from) = build_outbound_subscribe(
+            ruri,
+            parse_ruri(ruri),
+            "reg",
+            3600,
+            None,
+            None,
+            Transport::Udp,
+            "sbc.example.org",
+            5060,
+            "py-sub-fqdn",
+            "local-tag-fqdn",
+            &[],
+        )
+        .expect("build SUBSCRIBE");
+
+        let vias = collect_header(&message, "Via");
+        assert_eq!(vias.len(), 1, "one Via expected, got {vias:?}");
+        assert!(
+            vias[0].contains("sbc.example.org:5060"),
+            "Via sent-by must be our advertised FQDN:port, got {}",
+            vias[0]
+        );
+        let contacts = collect_header(&message, "Contact");
+        assert_eq!(contacts.len(), 1, "one Contact expected, got {contacts:?}");
+        assert_eq!(contacts[0], "<sip:sbc.example.org:5060>");
     }
 }

--- a/src/uac/mod.rs
+++ b/src/uac/mod.rs
@@ -35,10 +35,14 @@ pub fn resolve_via_addr(
             if let Ok(ip) = adv.parse::<std::net::IpAddr>() {
                 return SocketAddr::new(ip, local_addr.port());
             }
-            warn!(
+            // Not an IP literal (e.g. an FQDN). This resolves the *socket
+            // source* address, which needs an IP; the FQDN is carried into
+            // the Via/Contact/From host separately via `resolve_via_host`.
+            debug!(
                 transport = %transport,
                 value = %adv,
-                "advertised address is not a valid IP, falling back"
+                "per-transport advertised address is not an IP literal; \
+                 using the local IP for the socket source"
             );
         }
         // Fall back to global advertised_address
@@ -47,9 +51,14 @@ pub fn resolve_via_addr(
         match host.parse::<std::net::IpAddr>() {
             Ok(ip) => SocketAddr::new(ip, local_addr.port()),
             Err(_) => {
-                warn!(
+                // FQDN (or otherwise non-IP) advertised_address. Expected and
+                // benign: the socket source falls back to localhost, while the
+                // SIP header host is taken from the advertised value via
+                // `resolve_via_host` (RFC 3261 §20.42 permits an FQDN there).
+                debug!(
                     value = %host,
-                    "global advertised_address is not a valid IP, using localhost"
+                    "advertised_address is not an IP literal; using localhost \
+                     for the socket source (the SIP header host uses the FQDN)"
                 );
                 let ip = if local_addr.is_ipv6() {
                     std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
@@ -63,9 +72,38 @@ pub fn resolve_via_addr(
         local_addr
     }
 }
+
+/// Resolve the host (IP literal or FQDN) to advertise in the Via/From/Contact
+/// of a UAC-originated request for `transport`.
+///
+/// Resolution order mirrors [`resolve_via_addr`]:
+/// 1. Per-transport advertised address
+/// 2. Global `advertised_address`
+/// 3. `local_ip_fallback()` (evaluated lazily — only when no advertised
+///    address is configured, so callers can pass a value whose computation
+///    would otherwise log)
+///
+/// Unlike [`resolve_via_addr`], this preserves an FQDN instead of collapsing
+/// it to `127.0.0.1`: RFC 3261 §20.42 permits an FQDN in the Via sent-by, and
+/// a Contact/From host must be reachable rather than loopback. The result is
+/// SIP-formatted (IPv6 addresses bracketed).
+pub fn resolve_via_host(
+    transport: &Transport,
+    advertised_addrs: &HashMap<Transport, String>,
+    advertised_address: Option<&str>,
+    local_ip_fallback: impl FnOnce() -> String,
+) -> String {
+    if let Some(advertised) = advertised_addrs.get(transport) {
+        return format_sip_host(advertised);
+    }
+    if let Some(global) = advertised_address {
+        return format_sip_host(global);
+    }
+    format_sip_host(&local_ip_fallback())
+}
 use crate::sip::builder::SipMessageBuilder;
 use crate::sip::message::{Method, SipMessage};
-use crate::sip::uri::SipUri;
+use crate::sip::uri::{format_sip_host, SipUri};
 use crate::transport::{ConnectionId, OutboundMessage, OutboundRouter, Transport};
 
 /// Result of a UAC request.
@@ -133,6 +171,21 @@ impl UacSender {
     pub fn addr_for(&self, transport: &Transport) -> SocketAddr {
         let addr = self.listen_addrs.get(transport).copied().unwrap_or(self.local_addr);
         resolve_via_addr(addr, transport, &self.advertised_addrs, self.advertised_address.as_deref())
+    }
+
+    /// Return the host string (IP literal or FQDN) to advertise in the
+    /// Via/From/Contact of a UAC-originated request for `transport`.
+    ///
+    /// Unlike [`addr_for`], this preserves an FQDN `advertised_address`
+    /// instead of collapsing it to `127.0.0.1` — pair it with
+    /// `addr_for(..).port()` for the sent-by port.
+    pub fn via_host_for(&self, transport: &Transport) -> String {
+        resolve_via_host(
+            transport,
+            &self.advertised_addrs,
+            self.advertised_address.as_deref(),
+            || self.addr_for(transport).ip().to_string(),
+        )
     }
 
     /// Send an OPTIONS request to a target address.
@@ -243,26 +296,34 @@ impl UacSender {
         // will reply to (the protected P-CSCF port); otherwise use the
         // configured per-transport address.
         let addr = source_local_addr.unwrap_or_else(|| self.addr_for(&transport));
+        // Via/From host: the exact listener IP for a captured-flow probe, else
+        // the advertised host — which may be an FQDN (RFC 3261 §20.42) rather
+        // than the loopback `addr_for` collapses an FQDN to.
+        let via_host = match source_local_addr {
+            Some(local) => format_sip_host(&local.ip().to_string()),
+            None => self.via_host_for(&transport),
+        };
         let via = format!(
             "SIP/2.0/{} {}:{};branch={}",
-            transport, addr.ip(), addr.port(), branch
+            transport, via_host, addr.port(), branch
         );
 
         let from_name = from_user.unwrap_or("siphon");
         let from_host_str = from_domain
             .map(|domain| domain.to_string())
-            .unwrap_or_else(|| addr.ip().to_string());
+            .unwrap_or_else(|| via_host.clone());
         let from_uri = format!("<sip:{from_name}@{from_host_str}>;tag=uac-{cseq}");
 
         // RFC 3261 §11.1 permits a Contact on an OPTIONS, and some peers require
         // it: Microsoft Teams Direct Routing rejects an OPTIONS that carries
         // neither Contact nor Record-Route ("Record-Route and Contact headers are
         // missing") because it uses one of them to compute the next hop. Advertise
-        // our own reachable address — same host:port as the Via — so the peer can
-        // reach us for return traffic.
+        // our own reachable address, the same host:port as the Via (so it follows
+        // the advertised address, FQDN included, rather than a loopback fallback),
+        // so the peer can reach us for return traffic.
         let contact = format!(
             "<sip:{from_name}@{}:{};transport={}>",
-            addr.ip(),
+            via_host,
             addr.port(),
             transport.to_string().to_lowercase(),
         );
@@ -1017,5 +1078,107 @@ mod tests {
         let addr: SocketAddr = "0.0.0.0:5080".parse().unwrap();
         let result = resolve_via_addr(addr, &Transport::Tcp, &HashMap::new(), Some("10.1.1.1"));
         assert_eq!(result.port(), 5080);
+    }
+
+    // --- resolve_via_host tests ---
+
+    #[test]
+    fn resolve_via_host_per_transport_wins() {
+        let mut addrs = HashMap::new();
+        addrs.insert(Transport::Udp, "203.0.113.1".to_string());
+        let result = resolve_via_host(&Transport::Udp, &addrs, Some("sbc.example.org"), || {
+            panic!("fallback must not run when an advertised address is present")
+        });
+        assert_eq!(result, "203.0.113.1");
+    }
+
+    #[test]
+    fn resolve_via_host_preserves_global_fqdn() {
+        // The whole point: an FQDN advertised_address is kept verbatim, not
+        // collapsed to an IP the way resolve_via_addr must.
+        let result = resolve_via_host(&Transport::Udp, &HashMap::new(), Some("sbc.example.org"), || {
+            panic!("fallback must not run when a global advertised address is present")
+        });
+        assert_eq!(result, "sbc.example.org");
+    }
+
+    #[test]
+    fn resolve_via_host_global_ip_literal() {
+        let result = resolve_via_host(&Transport::Udp, &HashMap::new(), Some("198.51.100.5"), || {
+            "127.0.0.1".to_string()
+        });
+        assert_eq!(result, "198.51.100.5");
+    }
+
+    #[test]
+    fn resolve_via_host_brackets_ipv6() {
+        let result = resolve_via_host(&Transport::Udp, &HashMap::new(), Some("2001:db8::1"), || {
+            "::1".to_string()
+        });
+        assert_eq!(result, "[2001:db8::1]");
+    }
+
+    #[test]
+    fn resolve_via_host_lazy_fallback_used_only_without_config() {
+        let result = resolve_via_host(&Transport::Udp, &HashMap::new(), None, || "192.0.2.7".to_string());
+        assert_eq!(result, "192.0.2.7");
+    }
+
+    /// End-to-end: a sender bound to 0.0.0.0 with an FQDN `advertised_address`
+    /// emits that FQDN in the OPTIONS Via and From — never the loopback that
+    /// the socket-source resolver falls back to.
+    #[test]
+    fn send_options_via_and_from_use_fqdn_advertised_address() {
+        let (udp_tx, udp_rx) = flume::unbounded();
+        let (tcp_tx, _tcp_rx) = flume::unbounded();
+        let (tls_tx, _tls_rx) = flume::unbounded();
+        let (ws_tx, _ws_rx) = flume::unbounded();
+        let (wss_tx, _wss_rx) = flume::unbounded();
+        let (sctp_tx, _sctp_rx) = flume::unbounded();
+        let router = Arc::new(OutboundRouter {
+            udp: udp_tx,
+            udp_by_local: std::collections::HashMap::new(),
+            tcp: tcp_tx,
+            tls: tls_tx,
+            ws: ws_tx,
+            wss: wss_tx,
+            sctp: sctp_tx,
+        });
+        let mut listen_addrs = HashMap::new();
+        listen_addrs.insert(Transport::Udp, "0.0.0.0:5060".parse().unwrap());
+        let sender = UacSender::new(
+            router,
+            "0.0.0.0:5060".parse().unwrap(),
+            listen_addrs,
+            HashMap::new(),
+            Some("sbc.example.org".to_string()),
+            None,
+            None,
+        );
+
+        let _receiver = sender.send_options(
+            "10.0.0.1:5060".parse().unwrap(),
+            Transport::Udp,
+            SipUri::new("10.0.0.1".to_string()),
+        );
+
+        let outbound = udp_rx.try_recv().unwrap();
+        let raw = String::from_utf8_lossy(&outbound.data);
+        assert!(
+            raw.contains("SIP/2.0/UDP sbc.example.org:5060"),
+            "Via must advertise the FQDN with the listen port: {raw}"
+        );
+        assert!(
+            raw.contains("sip:siphon@sbc.example.org"),
+            "From must advertise the FQDN: {raw}"
+        );
+        assert!(
+            raw.contains("Contact: <sip:siphon@sbc.example.org:5060;transport=udp>"),
+            "Contact must advertise the FQDN, not the loopback fallback: {raw}"
+        );
+        assert!(
+            !raw.contains("127.0.0.1"),
+            "must not leak loopback when an FQDN is advertised: {raw}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

With a non-IP `advertised_address` (e.g. `sbc.example.org`), siphon logged this on every keepalive/probe:

```
global advertised_address is not a valid IP, using localhost value=sbc.example.org
```

The main proxy/B2BUA datapath already handles an FQDN correctly (`DispatcherState::via_host` uses the string verbatim). But the UAC-origination paths went through `resolve_via_addr`, which returns a `SocketAddr` (IP-only) and so collapsed the FQDN to `127.0.0.1`. That silently degraded three paths and produced the bogus warning:

- **OPTIONS keepalives / gateway health probes** — Via sent-by and From host became `127.0.0.1`.
- **`proxy.subscribe_state` SUBSCRIBE** — the default Contact (the notifier's dialog remote target, RFC 6665 §4.1.2.1) became `127.0.0.1`.
- **`proxy.send_request`** — the auto-generated Via was built from the resolved destination.

While in there I found a related latent bug: the `subscribe_state` and `proxy.send_request` auto-Via **sent-by was the destination address**, not siphon's own. A peer that honors the Via sent-by (RFC 3261 §18.2.1) would route the response away from us.

## Fix

- New `resolve_via_host` / `UacSender::via_host_for`: resolve the header host as per-transport advertised → global `advertised_address` → local IP, preserving an FQDN via `format_sip_host` (RFC 3261 §20.42 permits an FQDN in the Via sent-by). IPv6 gets bracketed.
- OPTIONS, `subscribe_state`, and `proxy.send_request` now advertise our own host:port in Via/From/Contact. A captured-flow IPsec probe still pins the exact listener IP (unchanged).
- The socket-source resolver (`resolve_via_addr`) still falls back to a local IP for the actual egress/HEP source; its "not a valid IP" warning is downgraded to `debug` because that fallback is expected and benign once the header host is handled separately.
- A per-transport `listen.<t>.advertise`, or an IP `advertised_address`, already worked and is unchanged.

## Tests

- New unit tests: `resolve_via_host` (per-transport wins, global FQDN preserved, IP literal, IPv6 bracketing, lazy fallback); an end-to-end OPTIONS test asserting the FQDN in Via + From and no `127.0.0.1` leak; a `build_outbound_subscribe` FQDN Via+Contact test; a `proxy.send_request` auto-Via test.
- Tightened one existing subscribe test whose whole-wire leak-check now false-positived on the (correctly) added Via host; it asserts the default Contact form specifically.
- Full suite green (3137 passed), clippy clean under both feature configs.

## Note on the first commit

The clippy job on `main` is currently red under stable clippy 1.97 (two pre-existing lints in `engine.rs` and `timer.rs`, unrelated to this change) which would sink this PR's clippy gate too. The first commit fixes just those two so the branch is green. Happy to split it into its own PR if you'd rather land it separately.
