### PR TITLE
docs(reference): auto-generated python api reference from siphon_sdk via mkdocstrings

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -11,11 +11,15 @@ on:
       - docs/**
       - mkdocs.yml
       - .github/workflows/pages.yaml
+      # The API reference is rendered from the SDK docstrings, so an SDK
+      # change can break the strict build — re-validate on those too.
+      - sdk/**
   pull_request:
     paths:
       - docs/**
       - mkdocs.yml
       - .github/workflows/pages.yaml
+      - sdk/**
   workflow_dispatch:
 
 permissions:
@@ -33,7 +37,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - run: pip install mkdocs-material
+        # `mkdocstrings[python]` renders the API reference from the siphon_sdk
+        # docstrings; `black` formats the generated signatures across lines.
+      - run: pip install mkdocs-material "mkdocstrings[python]" black
       - name: Build site (strict)
         run: mkdocs build --strict
       - name: Pin the custom domain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   queues (e.g. summing `ims_queue_*`) — where enqueue/drain counters drift
   upward forever because TTL-expired entries leave the keyspace silently, a
   summed `LLEN` is truthful because expired keys are simply gone.
+- **Public Python API reference** at
+  [siphon-sip.org/reference](https://siphon-sip.org/reference/). Every scripting
+  namespace and object (`request`, `reply`, `call`, `sdp`, the SIP value types,
+  and the `proxy`/`registrar`/`auth`/`ipsec`/`diameter`/`sbi`/`rtpengine`/… module
+  namespaces) is now rendered on the docs site straight from the `siphon-sip`
+  SDK docstrings via `mkdocstrings`, so the reference tracks the code instead of
+  drifting. The PyPI `Documentation` link now points there.
 
 ### Security
 - **Bump `crossbeam-epoch` 0.9.18 → 0.9.20** to address RUSTSEC-2026-0204: an

--- a/docs/reference/call.md
+++ b/docs/reference/call.md
@@ -1,0 +1,27 @@
+# Call
+
+The `Call` object drives a back-to-back user agent (B2BUA). Unlike the proxy
+`Request`, a `Call` owns both legs — it can dial, fork, bridge, rewrite either
+leg's URIs, and anchor media. It is passed to the `@b2bua.*` handlers.
+
+```python
+from siphon import b2bua
+
+@b2bua.on_invite
+async def bridge(call):
+    call.dial(call.ruri)
+```
+
+::: siphon_sdk.call.Call
+
+## `MediaHandle`
+
+Returned by `call.media` — controls RTP anchoring for the call.
+
+::: siphon_sdk.types.MediaHandle
+
+## `ByeInitiator`
+
+Identifies which side ended an answered call (surfaced on `@b2bua.on_bye`).
+
+::: siphon_sdk.types.ByeInitiator

--- a/docs/reference/diameter.md
+++ b/docs/reference/diameter.md
@@ -1,0 +1,31 @@
+# Diameter
+
+The `diameter` namespace exposes the IMS Diameter interfaces — Cx (HSS),
+Rx (PCRF), Sh (HSS AS), and Rf (offline charging) — plus a unified inbound
+`@diameter.on_request` hook for serving requests (RAR, PNR, ASR, …).
+
+```python
+from siphon import diameter
+
+@diameter.on_request
+async def handle(request):
+    if request.command_name == "RAR":
+        return request.answer(2001)
+    return request.reject(3002)
+```
+
+## `diameter` namespace
+
+::: siphon_sdk.mock_module.MockDiameter
+
+## `DiameterRequest`
+
+The inbound request passed to `@diameter.on_request`.
+
+::: siphon_sdk.mock_module.MockDiameterRequest
+
+## `DiameterAnswer`
+
+The value a handler returns via `request.answer(...)` / `request.reject(...)`.
+
+::: siphon_sdk.mock_module.MockDiameterAnswer

--- a/docs/reference/gateway.md
+++ b/docs/reference/gateway.md
@@ -1,0 +1,22 @@
+# Gateway
+
+The `gateway` namespace manages named groups of SIP destinations with health
+probing and pluggable load-balancing (round-robin, weighted, consistent hash).
+
+```python
+from siphon import gateway
+
+gw = gateway.select("carriers", key=request.call_id)
+if gw:
+    request.relay(gw.uri)
+```
+
+## `gateway` namespace
+
+::: siphon_sdk.mock_module.MockGateway
+
+## `Destination`
+
+A single destination returned by `gateway.select()` / `gateway.list()`.
+
+::: siphon_sdk.mock_module.MockDestination

--- a/docs/reference/ims.md
+++ b/docs/reference/ims.md
@@ -1,0 +1,63 @@
+# IMS control
+
+The namespaces that make SIPhon an IMS core: iFC evaluation (`isc`), 5G SBI /
+N5 policy authorization and Nbsf discovery (`sbi`), SIP presence (`presence`),
+lawful intercept (`li`), and the Session Recording Server hooks (`srs`).
+
+## `isc` namespace
+
+Initial Filter Criteria evaluation (3GPP TS 29.228 / IMS Service Control).
+
+::: siphon_sdk.mock_module.MockIsc
+
+## `sbi` namespace
+
+5G Service-Based Interface — N5/Npcf policy authorization plus Nbsf_Management
+PCF discovery.
+
+::: siphon_sdk.mock_module.MockSbi
+
+### `BsfError`
+
+Raised by `sbi.discover_pcf_binding(...)` when the BSF is unhealthy.
+
+::: siphon_sdk.mock_module.BsfError
+
+## `presence` namespace
+
+SIP presence document publish/lookup and subscription tracking (RFC 3856 /
+6665).
+
+::: siphon_sdk.mock_module.MockPresence
+
+## `li` namespace
+
+Lawful intercept (ETSI X1/X2/X3) and SIPREC recording triggers.
+
+::: siphon_sdk.mock_module.MockLi
+
+## `srs` namespace
+
+Session Recording Server acceptance hooks (RFC 7866 SIPREC).
+
+::: siphon_sdk.mock_module.MockSrs
+
+### `SrsSession`
+
+A completed recording session.
+
+::: siphon_sdk.srs.SrsSession
+
+### `RecordingMetadata`
+
+Parsed RFC 7866 recording metadata from a SIPREC INVITE.
+
+::: siphon_sdk.srs.RecordingMetadata
+
+### `SrsParticipant`
+
+::: siphon_sdk.srs.SrsParticipant
+
+### `SrsStreamInfo`
+
+::: siphon_sdk.srs.SrsStreamInfo

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,58 @@
+# Python API reference
+
+This section is the complete reference for the `siphon` Python module that
+SIPhon injects into your scripts at runtime — every namespace, object,
+property, and method a handler can touch.
+
+It is generated directly from the docstrings and type annotations of the
+[`siphon-sip`](https://pypi.org/project/siphon-sip/) package (import name
+`siphon_sdk`), a pure-Python mock of the `siphon` module. The mock mirrors the
+Rust engine's API one-for-one and is the single source of truth for these
+signatures, so what you read here is exactly what runs in production.
+
+The mock package doubles as a testing and authoring aid:
+
+```bash
+pip install siphon-sip
+```
+
+- **Unit-test your scripts** without the Rust binary — the
+  [test harness](testing.md) simulates incoming SIP messages and captures the
+  actions your handlers take (reply, relay, fork, reject, …) so you can assert
+  on them with pytest.
+- **Author scripts with an LLM** — every method carries rich docstrings and
+  type hints, so `pip install siphon-sip` gives a model enough context to
+  generate correct SIPhon scripts.
+
+At runtime you never construct these objects yourself; the engine hands them to
+your handlers. Import the namespaces you need:
+
+```python
+from siphon import proxy, registrar, b2bua, auth, log, cache
+from siphon import gateway, cdr, diameter, presence, li, registration
+from siphon import timer, metrics, sdp, sbi, ipsec, rtpengine, isc
+```
+
+## How this reference is organised
+
+| Page | What it covers |
+| ---- | -------------- |
+| [Request](request.md) | The inbound SIP request passed to `@proxy.on_request` handlers |
+| [Reply](reply.md) | The response object passed to `@proxy.on_reply` / `@proxy.on_failure` |
+| [Call](call.md) | The B2BUA call object and its media handle |
+| [SDP](sdp.md) | The `sdp` namespace, parsed SDP bodies, and media sections |
+| [SIP types](types.md) | `SipUri`, `Contact`, `Flow`, and the captured `Action` record |
+| [Proxy & B2BUA](proxy.md) | Routing handlers, forking, and subscription-dialog state |
+| [Registrar](registrar.md) | Location service plus outbound trunk registration |
+| [Auth & security](security.md) | Digest / IMS-AKA auth, IPsec sec-agree, STIR/SHAKEN |
+| [Media](media.md) | RTPEngine media control and the QoS SDP-to-flow helper |
+| [Gateway](gateway.md) | Health-probed destination groups and load balancing |
+| [Diameter](diameter.md) | Cx / Rx / Sh / Rf interfaces and inbound-request handling |
+| [IMS control](ims.md) | iFC evaluation, SBI/N5, presence, lawful intercept, SRS |
+| [Observability](observability.md) | Logging, cache, CDR, custom metrics, timers |
+| [Testing harness](testing.md) | The pytest harness and its result objects |
+
+!!! note "Extension namespaces"
+    The `smpp` and `http` namespaces come from the optional
+    [SMPP](https://smpp.siphon-sip.org/) and [HTTP](https://http.siphon-sip.org/)
+    addon crates and are documented on their own addon sites.

--- a/docs/reference/media.md
+++ b/docs/reference/media.md
@@ -1,0 +1,22 @@
+# Media
+
+The `rtpengine` namespace controls media anchoring and injection (announcements,
+DTMF, gating, subscriptions) via the RTPEngine / siphon-rtp NG control protocol.
+The `qos` namespace turns an SDP offer/answer pair into the `media_components`
+structure that `diameter.rx_aar` and `sbi.create_session` consume.
+
+```python
+from siphon import rtpengine
+
+@b2bua.on_invite
+async def anchor(call):
+    await rtpengine.play_media(call, file="/prompts/welcome.wav")
+```
+
+## `rtpengine` namespace
+
+::: siphon_sdk.mock_module.MockRtpEngine
+
+## `qos` namespace
+
+::: siphon_sdk.mock_module.MockQos

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -1,0 +1,51 @@
+# Observability
+
+Cross-cutting utility namespaces: structured logging (`log`), the named cache
+backends (`cache`), call detail records (`cdr`), custom Prometheus metrics
+(`metrics`), and periodic / one-shot timers (`timer`).
+
+## `log` namespace
+
+::: siphon_sdk.mock_module.MockLog
+
+## `cache` namespace
+
+Named cache backends (Redis + local LRU) from the `cache:` config list.
+
+::: siphon_sdk.mock_module.MockCache
+
+## `cdr` namespace
+
+Call detail record writing from scripts.
+
+::: siphon_sdk.mock_module.MockCdr
+
+## `metrics` namespace
+
+Custom Prometheus counters, gauges, and histograms that appear on `/metrics`.
+
+::: siphon_sdk.mock_module.MockMetrics
+
+### `Counter`
+
+::: siphon_sdk.mock_module.MockCounter
+
+### `Gauge`
+
+::: siphon_sdk.mock_module.MockGauge
+
+### `Histogram`
+
+::: siphon_sdk.mock_module.MockHistogram
+
+## `timer` namespace
+
+Periodic (`@timer.every`) and one-shot (`timer.set`) callbacks.
+
+::: siphon_sdk.mock_module.MockTimer
+
+### `TimerHandle`
+
+Returned by `timer.set(...)` — cancel a scheduled one-shot.
+
+::: siphon_sdk.mock_module.MockTimerHandle

--- a/docs/reference/proxy.md
+++ b/docs/reference/proxy.md
@@ -1,0 +1,45 @@
+# Proxy & B2BUA
+
+The `proxy` and `b2bua` namespaces register the event handlers that make
+routing decisions, plus the helpers those handlers lean on (rate limiting,
+sanity checks, ENUM lookup) and the generic SUBSCRIBE-dialog state store.
+
+```python
+from siphon import proxy, b2bua
+
+@proxy.on_request
+def route(request):
+    request.relay()
+
+@b2bua.on_invite
+async def call(call):
+    call.dial(call.ruri)
+```
+
+## `proxy` namespace
+
+::: siphon_sdk.mock_module.MockProxy
+
+## `proxy` utilities
+
+Reached as `proxy.rate_limit`, `proxy.sanity_check`, `proxy.enum_lookup`, and
+`proxy.memory_used_pct`.
+
+::: siphon_sdk.mock_module.MockProxyUtils
+
+## `b2bua` namespace
+
+::: siphon_sdk.mock_module.MockB2bua
+
+## `proxy.subscribe_state`
+
+Generic SUBSCRIBE-dialog state (RFC 6665) for any event package, with optional
+Redis-backed persistence.
+
+::: siphon_sdk.mock_module.MockSubscribeState
+
+## `SubscribeHandle`
+
+A single subscription dialog returned by `proxy.subscribe_state.create(...)`.
+
+::: siphon_sdk.mock_module.MockSubscribeHandle

--- a/docs/reference/registrar.md
+++ b/docs/reference/registrar.md
@@ -1,0 +1,27 @@
+# Registrar
+
+The `registrar` namespace is the location service: it saves contact bindings,
+looks them up, and handles the IMS implicit registration set, service routes,
+and pending/confirm flows. The `registration` namespace is the opposite
+direction — outbound REGISTER to upstream carriers and SBCs.
+
+```python
+from siphon import registrar
+
+@proxy.on_request("REGISTER")
+def register(request):
+    if auth.verify_digest(request, "example.com"):
+        registrar.save(request)   # saves contacts and sends 200 OK
+    else:
+        auth.require_www_digest(request, "example.com")
+```
+
+## `registrar` namespace
+
+::: siphon_sdk.mock_module.MockRegistrar
+
+## `registration` namespace
+
+Outbound REGISTER client for carrier / trunk registration.
+
+::: siphon_sdk.mock_module.MockRegistration

--- a/docs/reference/reply.md
+++ b/docs/reference/reply.md
@@ -1,0 +1,17 @@
+# Reply
+
+The `Reply` object wraps a SIP response. It reaches your script in a
+`@proxy.on_reply` handler (every response on a relayed transaction) and in a
+`@proxy.on_failure` handler (the best error after all branches failed).
+
+```python
+from siphon import proxy
+
+@proxy.on_reply
+def observe(request, reply):
+    if reply.status_code == 200 and request.method == "INVITE":
+        reply.set_header("X-Answered-By", "siphon")
+    reply.relay()
+```
+
+::: siphon_sdk.reply.Reply

--- a/docs/reference/request.md
+++ b/docs/reference/request.md
@@ -1,0 +1,18 @@
+# Request
+
+The `Request` object is passed to every `@proxy.on_request` handler. It gives
+read access to the parsed SIP message and methods to reply, relay, fork, and
+rewrite headers before forwarding.
+
+```python
+from siphon import proxy
+
+@proxy.on_request("INVITE")
+def route(request):
+    if request.ruri.is_local:
+        request.relay()
+    else:
+        request.reply(403, "Forbidden")
+```
+
+::: siphon_sdk.request.Request

--- a/docs/reference/sdp.md
+++ b/docs/reference/sdp.md
@@ -1,0 +1,29 @@
+# SDP
+
+The `sdp` namespace parses and rewrites SDP bodies — codec filtering, hold,
+attribute manipulation, media-section removal — then applies the result back to
+a message.
+
+```python
+from siphon import sdp
+
+s = sdp.parse(request)
+s.filter_codecs(["PCMU", "PCMA"])
+s.apply(request)
+```
+
+## `sdp` namespace
+
+::: siphon_sdk.sdp.MockSdpNamespace
+
+## Parsed SDP body
+
+Returned by `sdp.parse(...)`.
+
+::: siphon_sdk.sdp.MockSdp
+
+## Media section
+
+An `m=` section within a parsed SDP body (iterated via `sdp.media`).
+
+::: siphon_sdk.sdp.MockMediaSection

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,0 +1,75 @@
+# Auth & security
+
+Authentication and the security-agreement machinery: SIP digest and IMS-AKA
+challenges, P-CSCF IPsec sec-agree (3GPP TS 33.203 / RFC 3329), and
+STIR/SHAKEN signing and verification.
+
+```python
+from siphon import auth
+
+@proxy.on_request("INVITE")
+def route(request):
+    if not auth.verify_digest(request, "example.com"):
+        auth.require_proxy_digest(request, "example.com")
+        return
+    request.relay()
+```
+
+## `auth` namespace
+
+::: siphon_sdk.mock_module.MockAuth
+
+## `ipsec` namespace
+
+P-CSCF IPsec security association management for the sec-agree handshake.
+
+::: siphon_sdk.mock_module.MockIpsec
+
+### `SecurityOffer`
+
+A `Security-Client` offer parsed from a REGISTER (`request.parse_security_client()`).
+
+::: siphon_sdk.mock_module.MockSecurityOffer
+
+### `Transform`
+
+An operator-policy transform choice (`Transform.HmacSha1_96Null`, …).
+
+::: siphon_sdk.mock_module.MockTransform
+
+### `AuthVectorHandle`
+
+The opaque CK/IK container produced by `reply.take_av()`.
+
+::: siphon_sdk.mock_module.MockAuthVectorHandle
+
+### `PendingSA`
+
+An allocated-but-not-yet-active SA pair, returned by `ipsec.allocate(...)`.
+
+::: siphon_sdk.mock_module.MockPendingSA
+
+### `SecurityServerParams`
+
+The `Security-Server` parameters to echo back to the UE.
+
+::: siphon_sdk.mock_module.MockSecurityServerParams
+
+### `SAHandle`
+
+A read-only view of the active SA that decrypted a request
+(`request.matched_sa`).
+
+::: siphon_sdk.mock_module.MockSAHandle
+
+## `stir` namespace
+
+STIR/SHAKEN Identity-header signing and verification.
+
+::: siphon_sdk.mock_module.MockStir
+
+### `StirResult`
+
+The outcome of `stir.verify(...)`.
+
+::: siphon_sdk.mock_module.MockStirResult

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,0 +1,52 @@
+# Testing harness
+
+The `siphon_sdk.testing` module lets you unit-test SIPhon scripts with pytest,
+no Rust binary required. The harness installs the mock `siphon` module, loads
+your script, feeds it simulated SIP messages, and returns a result object that
+records what the handler did.
+
+```python
+from siphon_sdk.testing import SipTestHarness
+
+def test_register_challenges_unauthenticated():
+    harness = SipTestHarness()
+    harness.load_script("scripts/proxy_default.py")
+
+    result = harness.send_request("REGISTER", "sip:alice@example.com")
+    assert result.action == "reply"
+    assert result.status_code == 401
+```
+
+## `SipTestHarness`
+
+::: siphon_sdk.testing.SipTestHarness
+
+## `RequestResult`
+
+The result of `harness.send_request(...)`.
+
+::: siphon_sdk.testing.RequestResult
+
+## `ReplyResult`
+
+The result of feeding a response through `@proxy.on_reply`.
+
+::: siphon_sdk.testing.ReplyResult
+
+## `CallResult`
+
+The result of driving a B2BUA call.
+
+::: siphon_sdk.testing.CallResult
+
+## `MockHss`
+
+An in-process HSS stub for exercising Diameter Cx/Sh flows.
+
+::: siphon_sdk.testing.MockHss
+
+## `MockPcrf`
+
+An in-process PCRF stub for exercising Diameter Rx flows.
+
+::: siphon_sdk.testing.MockPcrf

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,0 +1,32 @@
+# SIP types
+
+Small value objects that flow through the scripting API: parsed URIs, contact
+bindings, the captured inbound flow, and the action record the test harness
+uses to report what a handler did.
+
+## `SipUri`
+
+A parsed SIP / SIPS / tel URI. Reachable via `request.ruri`, `request.from_uri`,
+`request.to_uri`, and `Contact.uri` parsing.
+
+::: siphon_sdk.types.SipUri
+
+## `Contact`
+
+A registered contact binding returned by `registrar.lookup(...)`.
+
+::: siphon_sdk.types.Contact
+
+## `Flow`
+
+An opaque view of the inbound flow captured at REGISTER time, used for
+Path-token MT routing.
+
+::: siphon_sdk.types.Flow
+
+## `Action`
+
+The record the test harness captures for each action a handler takes (reply,
+relay, fork, reject, …). Scripts do not create these; assertions read them.
+
+::: siphon_sdk.types.Action

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,22 @@ nav:
       - Media & RTP profiles: cookbook/media-rtp.md
       - Hardening & security: cookbook/security.md
       - Monitoring & observability: cookbook/monitoring.md
+  - API reference:
+      - Overview: reference/index.md
+      - Request: reference/request.md
+      - Reply: reference/reply.md
+      - Call: reference/call.md
+      - SDP: reference/sdp.md
+      - SIP types: reference/types.md
+      - Proxy & B2BUA: reference/proxy.md
+      - Registrar: reference/registrar.md
+      - Auth & security: reference/security.md
+      - Media: reference/media.md
+      - Gateway: reference/gateway.md
+      - Diameter: reference/diameter.md
+      - IMS control: reference/ims.md
+      - Observability: reference/observability.md
+      - Testing harness: reference/testing.md
   - Running in production:
       - Transports & networking: transports.md
       - Media engines (rtpengine / siphon-rtp): media-engines.md
@@ -85,3 +101,26 @@ markdown_extensions:
 
 plugins:
   - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          # `paths: [sdk]` lets griffe read `siphon_sdk` straight from the
+          # source tree — the SDK does not need to be pip-installed for the
+          # docs build.
+          paths: [sdk]
+          options:
+            docstring_style: google
+            show_source: false
+            show_root_heading: false
+            show_root_toc_entry: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            heading_level: 3
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            merge_init_into_class: false
+            docstring_section_style: table
+            filters: ["!^_"]

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/siphon-project/siphon-sip"
-Documentation = "https://github.com/siphon-project/siphon-sip/tree/main/sdk"
+Documentation = "https://siphon-sip.org/reference/"
 Repository = "https://github.com/siphon-project/siphon-sip"
 
 # Version from the repo's git tags. `root = ".."` points hatch-vcs at the repo

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -222,7 +222,8 @@ class Call:
         self._actions.append(Action(kind="reject", status_code=code, reason=reason))
 
     def answer(self, code: int, reason: str,
-               body=None, content_type: str | None = None) -> None:
+               body: Union[str, bytes, None] = None,
+               content_type: str | None = None) -> None:
         """UAS-mode answer — send a final 2xx response to the inbound
         INVITE directly, without bridging to a B-leg.
 
@@ -366,9 +367,13 @@ class Call:
             strategy: ``"parallel"`` (ring all, first answer wins) or
                       ``"sequential"`` (try in order).
             timeout: Per-branch INVITE timeout in seconds.
-            header_policy / copy / strip / translate: Same semantics as
-                :meth:`dial` — the policy applies to every branch of the
-                fork (per-branch policy is a follow-up).
+            header_policy: Header-policy preset applied to every branch of the
+                fork — same semantics as :meth:`dial` (per-branch policy is a
+                follow-up).
+            copy: Per-call header copy deltas — same semantics as :meth:`dial`.
+            strip: Per-call header strip deltas — same semantics as :meth:`dial`.
+            translate: Per-call header translation deltas — same semantics as
+                :meth:`dial`.
 
         Example::
 

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -3184,7 +3184,7 @@ class MockDiameter:
 
     # -- ISDN-AddressString helpers (3GPP TS 29.002 §17.7.8) --
 
-    def decode_isdn_address(self, value) -> str:
+    def decode_isdn_address(self, value: Union[bytes, str]) -> str:
         """Decode an ISDN-AddressString to its E.164 digit string.
 
         Accepts the raw AVP bytes (``0x91`` ToN/NPI + TBCD digits) **or** an
@@ -3289,10 +3289,10 @@ class MockDiameter:
 
     def rx_aar(self, session_id: Optional[str] = None,
                framed_ip: Optional[str] = None,
-               framed_ipv6=None,
+               framed_ipv6: Union[str, bytes, None] = None,
                media_components: Optional[list] = None,
                af_application_id: str = "IMS Services",
-               subscription_id=None) -> Optional[dict]:
+               subscription_id: Optional[tuple] = None) -> Optional[dict]:
         """Send an Rx AA-Request for QoS resource reservation.
 
         Args:
@@ -3329,7 +3329,7 @@ class MockDiameter:
     # -- Sh: HSS integration (Application Server role) --
 
     def sh_udr(self, public_identity: str,
-               data_reference,
+               data_reference: Union[int, list[int]],
                service_indication: Optional[str] = None) -> Optional[dict]:
         """Send a Sh User-Data-Request to fetch user profile data from the HSS.
 
@@ -3366,7 +3366,7 @@ class MockDiameter:
         return {"result_code": self._default_sh_result_code}
 
     def sh_snr(self, public_identity: str,
-               data_reference,
+               data_reference: Union[int, list[int]],
                subs_req_type: int,
                service_indication: Optional[str] = None) -> Optional[dict]:
         """Send a Sh Subscribe-Notifications-Request to the HSS.
@@ -5749,7 +5749,8 @@ class MockQos:
         diameter.rx_aar(framed_ip=request.source_ip, media_components=components)
     """
 
-    def media_flows_from_sdp(self, *, offer, answer, direction: str = "orig") -> list[dict]:
+    def media_flows_from_sdp(self, *, offer: Any, answer: Any,
+                             direction: str = "orig") -> list[dict]:
         """Translate an SDP offer/answer pair into a ``media_components`` list.
 
         Args:

--- a/sdk/siphon_sdk/request.py
+++ b/sdk/siphon_sdk/request.py
@@ -11,7 +11,7 @@ import ipaddress
 import uuid
 from typing import Callable, Optional, Union
 
-from siphon_sdk.types import Action, Contact, SipUri
+from siphon_sdk.types import Action, Contact, Flow, SipUri
 
 
 def _parse_uri(value: Union[str, SipUri, None]) -> Optional[SipUri]:
@@ -326,7 +326,7 @@ class Request:
         next_hop: Optional[str] = None,
         on_reply: Optional[Callable] = None,
         on_failure: Optional[Callable] = None,
-        flow=None,
+        flow: Optional[Flow] = None,
     ) -> None:
         """Forward the request to its destination.
 
@@ -664,7 +664,7 @@ class Request:
         """
         return list(getattr(self, "_reply_headers", []))
 
-    def set_body(self, body, content_type: str | None = None) -> None:
+    def set_body(self, body: Union[str, bytes], content_type: str | None = None) -> None:
         """Replace the body of the incoming request message.
 
         Args:
@@ -682,7 +682,7 @@ class Request:
             self._headers["Content-Type"] = content_type
         self._headers["Content-Length"] = str(len(body))
 
-    def set_reply_body(self, body, content_type: str) -> None:
+    def set_reply_body(self, body: Union[str, bytes], content_type: str) -> None:
         """Attach a body to the response built by :meth:`reply`.
 
         The dispatcher copies this body and sets ``Content-Type`` /


### PR DESCRIPTION
## What

Adds an auto-generated **Python API reference** to the docs site
(https://siphon-sip.org/), rendered from the `siphon-sip` SDK (`siphon_sdk`)
docstrings via `mkdocstrings`. The SDK mirrors the runtime `siphon` module
one-for-one and is already richly docstringed, so this surfaces the single
source of truth publicly instead of hand-maintaining a second copy that drifts.

## Changes

- **`mkdocs.yml`** — adds the `mkdocstrings` plugin (python handler, `paths:
  [sdk]` so griffe reads `siphon_sdk` from the source tree without installing
  it; `docstring_style: google`, `show_source: false`, separate signatures,
  signature cross-refs, `filters: ["!^_"]`). New **API reference** nav section
  (15 pages) placed after Cookbook.
- **`docs/reference/`** — one page per logical namespace/object, each an
  `mkdocstrings` injection block with a short intro (no hand-written API prose):
  `index`, `request`, `reply`, `call`, `sdp`, `types`, `proxy`, `registrar`,
  `security`, `media`, `gateway`, `diameter`, `ims`, `observability`, `testing`.
- **`.github/workflows/pages.yaml`** — the strict-build install now pulls
  `mkdocstrings[python]` + `black` (black wraps the wide Diameter/Rf/`dial`
  signatures across lines). Adds `sdk/**` to the build triggers so an SDK change
  that would break the reference re-validates the strict build.
- **`sdk/`** — backfilled a handful of missing parameter type annotations
  (`Request.relay(flow=…)`, `set_body`/`set_reply_body`, `Call.answer(body=…)`,
  `diameter.decode_isdn_address`/`rx_aar`/`sh_udr`/`sh_snr`, `qos.media_flows_from_sdp`)
  and split one combined `Args:` entry in `Call.fork`. These were the only
  griffe warnings under `--strict`; the changes are additive type hints only,
  no API or behaviour change.
- **`sdk/pyproject.toml`** — PyPI `Documentation` URL repointed from the GitHub
  source tree to https://siphon-sip.org/reference/.
- **`CHANGELOG.md`** — `[Unreleased]` entry (script-author-facing).

## Validation

- `mkdocs build --strict` passes with **zero warnings** (iterated until clean).
- Built HTML spot-checked: injection blocks render real signatures + docstrings
  (`set_ruri_user`, `fork`, `save_proxy`, `discover_pcf_binding`, `play_media`
  all present, not empty).
- SDK test suite green after the annotation changes (`371 passed`).
