### PR TITLE
chore(siphon-bin): bump smpp extension to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   upward forever because TTL-expired entries leave the keyspace silently, a
   summed `LLEN` is truthful because expired keys are simply gone.
 
+### Changed
+- **Bump the `siphon-bin` SMPP extension to siphon-smpp v1.3.0**, which adds
+  Prometheus metrics for the SMPP runtime into siphon's shared `/metrics`
+  registry: `siphon_smpp_binds` (gauge, `direction`/`state`) plus
+  `siphon_smpp_pdus_total`, `siphon_smpp_throttled_total`,
+  `siphon_smpp_bind_reconnects_total`, `siphon_smpp_dispatch_errors_total`,
+  `siphon_smpp_dispatch_duration_seconds` (histogram) and
+  `siphon_smpp_bind_requests_total`. Only affects builds with `--features smpp`;
+  when the host metrics engine isn't initialised every emit path is a no-op, so
+  the dispatch hot path reads no clock and touches no metric.
+
 ### Fixed
 - **Outbound OPTIONS keepalives now carry a `Contact` header.** The UAC-side
   OPTIONS builder (NAT keepalive, gateway health probe, registrar liveness probe)

--- a/siphon-bin/Cargo.lock
+++ b/siphon-bin/Cargo.lock
@@ -14,18 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,12 +21,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -1064,10 +1046,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2289,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -2436,24 +2414,25 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rasn"
-version = "0.22.2"
+version = "0.28.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d1ed06b066a36d0492d65daaa5f40b7101c24a1228e0af2709712ef1a86e1"
+checksum = "88235e585f2f3fc26ad809c79a84dd77e6a7203eb7d12e5bcaab89fc036d3d90"
 dependencies = [
  "bitvec",
  "bitvec-nom2",
  "bytes",
+ "cfg-if",
  "chrono",
  "either",
- "hashbrown 0.14.5",
  "nom 7.1.3",
  "num-bigint",
  "num-integer",
  "num-traits",
  "once_cell",
- "rasn-derive",
+ "rasn-derive 0.28.13",
  "serde_json",
  "snafu",
+ "xml-no-std",
 ]
 
 [[package]]
@@ -2463,7 +2442,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f35fecd68ee4d5850baa37ee4520456bbae761fdd42a7fcb95701c268500a93"
 dependencies = [
  "proc-macro2",
- "rasn-derive-impl",
+ "rasn-derive-impl 0.22.2",
+ "syn",
+]
+
+[[package]]
+name = "rasn-derive"
+version = "0.28.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11dcd4dab09ceadedb3e2bedf340deb583f0e25bba9ad966b5655c2fb62b1392"
+dependencies = [
+ "proc-macro2",
+ "rasn-derive-impl 0.28.13",
  "syn",
 ]
 
@@ -2472,6 +2462,20 @@ name = "rasn-derive-impl"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355eedbab62312d9474e1c2e7963ce5fad99bded7e9abd42ae4f040762a2c5f6"
+dependencies = [
+ "either",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "rasn-derive-impl"
+version = "0.28.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f121c276d3f2fba8caabc870288de3f81abdb0bb94d5510651e58e1e00a7b9e7"
 dependencies = [
  "either",
  "itertools",
@@ -2795,6 +2799,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,9 +3027,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphon-rtp-proto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50101a2f08a8fc84d0e725827cdc814842beb151ed7d77253a49022f17b64477"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "siphon-sip"
-version = "1.0.0"
-source = "git+https://github.com/siphon-project/siphon-sip?branch=main#0746fa7d21d4dc967f697845b3b7570ad6d3abd2"
+version = "1.2.1"
+source = "git+https://github.com/siphon-project/siphon-sip?branch=main#d13e4eb144e6ad43c7196a1ce98f9c0776745eab"
 dependencies = [
  "aes",
  "arc-swap",
@@ -3027,11 +3053,12 @@ dependencies = [
  "dashmap",
  "flume",
  "futures-util",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hickory-resolver",
  "http",
  "indexmap",
  "ipnet",
+ "libc",
  "md5",
  "netlink-sys",
  "nom 8.0.0",
@@ -3043,7 +3070,7 @@ dependencies = [
  "pyo3-async-runtimes",
  "quick-xml",
  "rasn",
- "rasn-derive",
+ "rasn-derive 0.22.2",
  "redis",
  "regex",
  "reqwest",
@@ -3052,6 +3079,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.10.9",
+ "siphon-rtp-proto",
  "socket2",
  "thiserror 2.0.18",
  "tikv-jemalloc-ctl",
@@ -3071,8 +3099,8 @@ dependencies = [
 
 [[package]]
 name = "siphon-smpp"
-version = "1.2.1"
-source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.2.1#59eb5d7cf31516308cd004b3700066e9394ebe9d"
+version = "1.3.0"
+source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.3.0#482dfd8a9aada3adcb185cd619502c5a4aaff13a"
 dependencies = [
  "async-trait",
  "pyo3",
@@ -3519,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -3687,9 +3715,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3699,7 +3727,6 @@ dependencies = [
  "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -3764,12 +3791,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4257,6 +4278,12 @@ dependencies = [
  "spki",
  "tls_codec",
 ]
+
+[[package]]
+name = "xml-no-std"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
 
 [[package]]
 name = "xxhash-rust"

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -32,13 +32,13 @@ full = ["smpp", "http"]    # convenience aggregate: every extension module
 # Single-source rule: every crate here that depends on siphon-sip MUST use a
 # byte-identical git URL + ref, or cargo keys two separate `siphon-sip` sources
 # (it does NOT follow GitHub's repo-rename redirect) and the builder closures
-# fail to type-match. siphon-smpp v1.2.1 pins
+# fail to type-match. siphon-smpp v1.3.0 pins
 # `siphon-sip = { git = ".../siphon-sip", branch = "main" }`, so siphon-sip stays
 # on `branch = "main"` here too; the committed Cargo.lock pins the exact SHA for
 # reproducible builds (advance with `cargo update`). Extension crates themselves
 # are pinned to their released tags for stable, intentional bumps.
 siphon-sip = { git = "https://github.com/siphon-project/siphon-sip", branch = "main" }
-siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.2.1", optional = true }
+siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.3.0", optional = true }
 siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.1", optional = true }
 
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
Pin the optional `siphon-smpp` dependency to the **v1.3.0** tag.

## What v1.3.0 brings
SMPP observability registered into siphon's shared `/metrics` registry (no new crate dep, dispatch hot path is a no-op when the host metrics engine isn't initialised):
- `siphon_smpp_binds` (gauge, `direction`/`state`)
- `siphon_smpp_pdus_total`, `siphon_smpp_throttled_total`, `siphon_smpp_bind_reconnects_total`, `siphon_smpp_dispatch_errors_total`, `siphon_smpp_bind_requests_total`
- `siphon_smpp_dispatch_duration_seconds` (histogram)

Only affects builds with `--features smpp`.

## Changes
- `siphon-bin/Cargo.toml` — pin `siphon-smpp` v1.2.1 → v1.3.0 (single-source comment updated).
- `siphon-bin/Cargo.lock` — regenerated: `siphon-smpp` → v1.3.0 (`482dfd8`); shared `siphon-sip` `branch=main` pin advances to current main HEAD, pulling siphon-sip's newer transitive tree (rasn 0.22→0.28, quick-xml 0.37→0.41, tungstenite 0.28→0.29, +siphon-rtp-proto).
- `CHANGELOG.md` — `[Unreleased] › Changed` entry.

## Verification
- `cargo check --features full` — passes (siphon-sip + siphon-smpp v1.3.0 + siphon-http + siphon-bin all type-match; single-source unification holds).
- `cargo clippy --features full -- -D warnings` — clean.
- v1.3.0 has no `src/script` changes, so the script-facing `smpp` namespace is unchanged — no SDK mock mirror needed.