### PR TITLE
feat(script): whole-URI setters (set_from_uri/set_to_uri/set_contact_uri) + set_contact_user on request and call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **Whole-URI setters `set_from_uri` / `set_to_uri` / `set_contact_uri`, plus
+  `set_contact_user`, on both `request` (proxy) and `call` (B2BUA).** The
+  whole-URI form of the existing `set_*_user` / `set_*_host` setters: replace the
+  entire URI inside the header's angle brackets — scheme, user, host, port and
+  URI params — in one call, preserving the display name and the dialog-critical
+  From/To tag (unlike a raw `set_header("From", "<sip:…>")`, which drops the
+  tag). `set_contact_user` rewrites only the Contact userpart (empty string
+  clears it). On the B2BUA these mutate the outbound B-leg: `set_from_uri` /
+  `set_to_uri` also pin the host (same topology-hiding opt-out as
+  `set_from_host` / `set_to_host`); `set_contact_user` injects a userpart into
+  siphon's advertised Contact while keeping its host:port (so in-dialog routing
+  is unchanged and the userpart rides along — for a downstream that keys a
+  tenant/extension off the Contact userpart, the way it does for a REGISTER
+  Contact), and `set_contact_uri` replaces the whole Contact for edge/GRUU
+  deployments that front siphon. The B-leg Contact stays userless by default
+  (RFC 3261 §8.1.1.8 puts no identity in the Contact userpart); these are opt-in.
 - **`cache.list_len(name, key)` and `cache.list_len_sum(name, prefix)`.** Two
   async cache-namespace methods for Redis-backed lists. `list_len` returns a
   single list's length (`LLEN`, `0` for a missing key). `list_len_sum` returns

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -71,6 +71,8 @@ class Call:
         self._media = MediaHandle()
         self._refer_to = refer_to
         self._refer_replaces = refer_replaces
+        self._contact_user_override: Optional[str] = None
+        self._contact_override: Optional[str] = None
 
     # -- Properties ------------------------------------------------------------
 
@@ -609,6 +611,86 @@ class Call:
         """
         if self._to_uri is not None:
             self._to_uri.host = value
+
+    def set_from_uri(self, value: str) -> None:
+        """Replace the entire From header URI on the B-leg INVITE.
+
+        The whole-URI form of :meth:`set_from_user` / :meth:`set_from_host` —
+        rewrites scheme, user, host, port and URI params in one call while
+        preserving the display name and From-tag. The host is also pinned (the
+        B-leg builder would otherwise rewrite it to the advertised address for
+        topology hiding — same opt-out as :meth:`set_from_host`). Must be called
+        before :meth:`dial`.
+
+        Args:
+            value: New From URI, e.g.
+                ``"sip:+31123@tenant.example.com:5060;transport=tcp"``.
+
+        Example::
+
+            @b2bua.on_invite
+            async def on_invite(call):
+                call.set_from_uri("sip:1001@tenant.example.com:5060")
+                call.dial("sip:gw@carrier.example.com")
+        """
+        self._from_uri = _parse_uri(value)
+
+    def set_to_uri(self, value: str) -> None:
+        """Replace the entire To header URI on the B-leg INVITE.
+
+        The whole-URI form of :meth:`set_to_user` / :meth:`set_to_host`,
+        preserving the display name and any To-tag. The host is also pinned
+        (same opt-out as :meth:`set_to_host`). Must be called before
+        :meth:`dial`.
+
+        Args:
+            value: New To URI, e.g.
+                ``"sip:5112@ims.mnc088.mcc204.3gppnetwork.org"``.
+        """
+        self._to_uri = _parse_uri(value)
+
+    def set_contact_user(self, value: str) -> None:
+        """Inject a userpart into the B-leg Contact URI, keeping siphon's
+        advertised host:port.
+
+        The B2BUA advertises its own address as the Contact so in-dialog
+        requests (BYE, re-INVITE) route back through siphon; by default that
+        Contact is userless (RFC 3261 §8.1.1.8 puts no identity in the Contact
+        userpart). ``set_contact_user()`` adds a userpart while leaving the
+        host:port untouched, so in-dialog routing still works and the userpart
+        rides along — e.g. a downstream that keys a tenant/extension off the
+        Contact userpart, the way it does for a REGISTER Contact.
+
+        Pass an empty string to force a userless Contact. Must be called before
+        :meth:`dial`.
+
+        Args:
+            value: Contact userpart (e.g. the extension).
+
+        Example::
+
+            @b2bua.on_invite
+            async def on_invite(call):
+                call.set_contact_user(call.from_uri.user)
+                call.dial("sip:gw@carrier.example.com")
+        """
+        self._contact_user_override = value
+
+    def set_contact_uri(self, value: str) -> None:
+        """Replace the entire B-leg Contact URI — a full override of siphon's
+        advertised Contact.
+
+        Power tool for edge deployments that front siphon (GRUU, edge SBC).
+        Overriding the host/port moves the in-dialog anchor off siphon, so the
+        deployment must route the far side's in-dialog requests back to siphon
+        or the dialog breaks. Takes precedence over :meth:`set_contact_user`.
+        ``value`` is a bare URI (no angle brackets). Must be called before
+        :meth:`dial`.
+
+        Args:
+            value: Full Contact URI, e.g. ``"sip:gruu-token@edge.example.com:5060"``.
+        """
+        self._contact_override = value
 
     # -- Header access ---------------------------------------------------------
 

--- a/sdk/siphon_sdk/request.py
+++ b/sdk/siphon_sdk/request.py
@@ -881,6 +881,31 @@ class Request:
         """
         self.set_header("To-Display", display_name)
 
+    def set_from_uri(self, value: str) -> None:
+        """Replace the whole From header URI, preserving the display name and
+        From-tag.
+
+        The whole-URI form of :meth:`set_from_user`. The tag survives — unlike a
+        raw ``set_header("From", "<sip:...>")``, which drops the mandatory
+        From-tag.
+
+        Args:
+            value: New From URI (e.g. ``"sip:+3120@tenant.example.com:5070"``).
+        """
+        self._from_uri = _parse_uri(value)
+
+    def set_to_uri(self, value: str) -> None:
+        """Replace the whole To header URI, preserving the display name and any
+        To-tag.
+
+        The whole-URI form of :meth:`set_to_user`. The tag survives — unlike a
+        raw ``set_header("To", "<sip:...>")``.
+
+        Args:
+            value: New To URI (e.g. ``"sip:5112@ims.example.org"``).
+        """
+        self._to_uri = _parse_uri(value)
+
     def add_path(self, uri: str) -> None:
         """Prepend a ``Path`` header (P-CSCF registration path).
 
@@ -931,6 +956,49 @@ class Request:
         contact = self.get_header("Contact")
         if contact and ";alias" not in contact:
             self.set_header("Contact", f"{contact};alias")
+
+    def set_contact_uri(self, value: str) -> None:
+        """Replace the whole Contact header URI, preserving the display name and
+        any Contact header params (q/expires/…).
+
+        In a proxy the Contact is the UA's in-dialog target: rewriting it changes
+        where mid-dialog requests (BYE, re-INVITE) are routed. Fine when the new
+        target is meaningful downstream; a footgun otherwise.
+
+        Args:
+            value: New Contact URI (e.g. ``"sip:bob@192.0.2.9:5080;transport=tcp"``).
+        """
+        contact = self.get_header("Contact")
+        if contact is None:
+            return
+        display = contact.split("<", 1)[0] if "<" in contact else ""
+        suffix = ">" + contact.split(">", 1)[1] if ">" in contact else ">"
+        self.set_header("Contact", f"{display}<{value}{suffix}")
+
+    def set_contact_user(self, value: str) -> None:
+        """Rewrite only the userpart of the Contact header URI, leaving the
+        host/port/params intact. An empty string clears the userpart.
+
+        Args:
+            value: New Contact userpart (e.g. an extension), or ``""`` to clear.
+        """
+        contact = self.get_header("Contact")
+        if contact is None:
+            return
+        if "<" in contact and ">" in contact:
+            prefix = contact.split("<", 1)[0] + "<"
+            inner = contact.split("<", 1)[1].split(">", 1)[0]
+            suffix = ">" + contact.split(">", 1)[1]
+        else:
+            prefix = ""
+            inner = contact
+            suffix = ""
+        scheme_sep = inner.find(":")
+        scheme = inner[: scheme_sep + 1] if scheme_sep != -1 else ""
+        body = inner[scheme_sep + 1 :] if scheme_sep != -1 else inner
+        hostpart = body.split("@", 1)[1] if "@" in body else body
+        new_inner = f"{scheme}{value}@{hostpart}" if value else f"{scheme}{hostpart}"
+        self.set_header("Contact", f"{prefix}{new_inner}{suffix}")
 
     # -- NAT fixup -------------------------------------------------------------
 

--- a/sdk/tests/test_uri_setters.py
+++ b/sdk/tests/test_uri_setters.py
@@ -1,0 +1,97 @@
+"""
+Tests for the whole-URI setters — ``set_from_uri`` / ``set_to_uri`` /
+``set_contact_uri`` (and ``set_contact_user``) — on both the proxy ``Request``
+and the B2BUA ``Call``.
+"""
+
+from siphon_sdk.call import Call
+from siphon_sdk.request import Request
+
+
+class TestRequestUriSetters:
+    def test_set_from_uri_replaces_uri(self):
+        request = Request(from_uri="sip:alice@atlanta.com")
+        request.set_from_uri("sip:+3120@tenant.example.com:5070")
+        assert request.from_uri.user == "+3120"
+        assert request.from_uri.host == "tenant.example.com"
+        assert request.from_uri.port == 5070
+
+    def test_set_to_uri_replaces_uri(self):
+        request = Request(to_uri="sip:bob@biloxi.com")
+        request.set_to_uri("sip:5112@ims.example.org")
+        assert request.to_uri.user == "5112"
+        assert request.to_uri.host == "ims.example.org"
+
+    def test_set_contact_uri_replaces_contact(self):
+        request = Request()
+        request.set_header("Contact", "<sip:alice@10.0.0.1:5060>")
+        request.set_contact_uri("sip:bob@192.0.2.9:5080;transport=tcp")
+        contact = request.get_header("Contact")
+        assert "bob@192.0.2.9:5080" in contact
+        assert "transport=tcp" in contact
+        assert "10.0.0.1" not in contact
+
+    def test_set_contact_uri_preserves_header_params(self):
+        request = Request()
+        request.set_header("Contact", "<sip:alice@10.0.0.1:5060>;expires=600")
+        request.set_contact_uri("sip:bob@192.0.2.9:5080")
+        contact = request.get_header("Contact")
+        assert "bob@192.0.2.9:5080" in contact
+        assert ";expires=600" in contact
+
+    def test_set_contact_user_rewrites_userpart_only(self):
+        request = Request()
+        request.set_header("Contact", "<sip:alice@10.0.0.1:5060;transport=tcp>")
+        request.set_contact_user("1001")
+        contact = request.get_header("Contact")
+        assert "1001@10.0.0.1:5060" in contact
+        assert "transport=tcp" in contact
+        assert "alice@" not in contact
+
+    def test_set_contact_user_empty_clears_userpart(self):
+        request = Request()
+        request.set_header("Contact", "<sip:alice@10.0.0.1:5060>")
+        request.set_contact_user("")
+        contact = request.get_header("Contact")
+        assert "10.0.0.1:5060" in contact
+        assert "alice" not in contact
+        assert "@" not in contact
+
+    def test_set_contact_uri_noop_without_contact(self):
+        request = Request()
+        request.set_contact_uri("sip:bob@192.0.2.9")
+        assert request.get_header("Contact") is None
+
+
+class TestCallUriSetters:
+    def test_set_from_uri_replaces_uri(self):
+        call = Call(from_uri="sip:alice@atlanta.com")
+        call.set_from_uri("sip:1001@tenant.example.com:5060")
+        assert call.from_uri.user == "1001"
+        assert call.from_uri.host == "tenant.example.com"
+
+    def test_set_to_uri_replaces_uri(self):
+        call = Call(to_uri="sip:bob@example.com")
+        call.set_to_uri("sip:5112@ims.example.org")
+        assert call.to_uri.user == "5112"
+        assert call.to_uri.host == "ims.example.org"
+
+    def test_set_contact_user_records_override(self):
+        call = Call()
+        assert call._contact_user_override is None
+        call.set_contact_user("1001")
+        assert call._contact_user_override == "1001"
+
+    def test_set_contact_uri_records_override(self):
+        call = Call()
+        assert call._contact_override is None
+        call.set_contact_uri("sip:gruu-token@edge.example.com:5060")
+        assert call._contact_override == "sip:gruu-token@edge.example.com:5060"
+
+    def test_set_contact_user_from_from_uri(self):
+        # The motivating case: carry the caller's extension into the B-leg
+        # Contact userpart so a downstream that keys on "extension in Contact"
+        # matches the INVITE the way it matches the REGISTER.
+        call = Call(from_uri="sip:1001@tenant.example.com")
+        call.set_contact_user(call.from_uri.user)
+        assert call._contact_user_override == "1001"

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -606,6 +606,17 @@ pub struct CallActor {
     /// Script-pinned B-leg To URI host (`call.set_to_host()`). When set, the
     /// B-leg INVITE To host is rewritten to this instead of the dial-target host.
     pub to_host_override: Option<String>,
+    /// Script-pinned B-leg Contact userpart (`call.set_contact_user()`). When
+    /// set, the B-leg Contact becomes `<sip:user@advertised-host:port;transport>`
+    /// instead of the default userless anchor. siphon still receives in-dialog
+    /// requests (host:port unchanged) — the userpart just rides along.
+    pub contact_user_override: Option<String>,
+    /// Script-pinned B-leg Contact URI (`call.set_contact_uri()`). Full override
+    /// of siphon's advertised Contact — the power tool for edge deployments that
+    /// front siphon (GRUU, edge SBC). Overriding the host/port here moves the
+    /// in-dialog anchor off siphon, so the deployment must route it back or the
+    /// dialog breaks. Takes precedence over `contact_user_override`.
+    pub contact_override: Option<String>,
     /// Pre-built ACK for the winning B-leg, deferred until A-leg ACKs (late ACK pattern).
     /// Contains (ACK message, transport, destination address).
     pub pending_b_leg_ack: Option<(SipMessage, crate::transport::Transport, std::net::SocketAddr)>,
@@ -662,6 +673,8 @@ impl CallActor {
             preserve_call_id: false,
             from_host_override: None,
             to_host_override: None,
+            contact_user_override: None,
+            contact_override: None,
             pending_b_leg_ack: None,
             resolved_header_policy: None,
             a_leg_supports_100rel: false,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -8006,12 +8006,14 @@ fn handle_b2bua_invite(
         policy_input,
         from_host_override,
         to_host_override,
+        contact_user_override,
+        contact_override,
     ) = Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {
             Ok(obj) => obj,
             Err(error) => {
                 error!("failed to create PyCall: {error}");
-                return (CallAction::None, None, None, false, false, None, None, None);
+                return (CallAction::None, None, None, false, false, None, None, None, None, None);
             }
         };
 
@@ -8025,7 +8027,7 @@ fn handle_b2bua_invite(
                             return (CallAction::Reject {
                                 code: 500,
                                 reason: "Script Error".to_string(),
-                            }, None, None, false, false, None, None, None);
+                            }, None, None, false, false, None, None, None, None, None);
                         }
                     }
                 }
@@ -8034,7 +8036,7 @@ fn handle_b2bua_invite(
                     return (CallAction::Reject {
                         code: 500,
                         reason: "Script Error".to_string(),
-                    }, None, None, false, false, None, None, None);
+                    }, None, None, false, false, None, None, None, None, None);
                 }
             }
         }
@@ -8048,7 +8050,9 @@ fn handle_b2bua_invite(
         let policy_input = borrowed.header_policy_input().cloned();
         let from_host_ovr = borrowed.from_host_override().map(String::from);
         let to_host_ovr = borrowed.to_host_override().map(String::from);
-        (action, timer_override, credentials, li_record, preserve_cid, policy_input, from_host_ovr, to_host_ovr)
+        let contact_user_ovr = borrowed.contact_user_override().map(String::from);
+        let contact_ovr = borrowed.contact_override().map(String::from);
+        (action, timer_override, credentials, li_record, preserve_cid, policy_input, from_host_ovr, to_host_ovr, contact_user_ovr, contact_ovr)
     });
 
     // Store the A-leg INVITE for later use by on_answer/on_failure/on_bye handlers
@@ -8102,6 +8106,8 @@ fn handle_b2bua_invite(
         || resolved_policy.is_some()
         || from_host_override.is_some()
         || to_host_override.is_some()
+        || contact_user_override.is_some()
+        || contact_override.is_some()
     {
         if let Some(mut call) = state.call_actors.get_call_mut(&call_id) {
             if let Some(override_config) = timer_override {
@@ -8122,6 +8128,12 @@ fn handle_b2bua_invite(
             }
             if to_host_override.is_some() {
                 call.to_host_override = to_host_override;
+            }
+            if contact_user_override.is_some() {
+                call.contact_user_override = contact_user_override;
+            }
+            if contact_override.is_some() {
+                call.contact_override = contact_override;
             }
         }
     }
@@ -8208,6 +8220,43 @@ fn handle_b2bua_invite(
             // Actor stays alive — the A-leg dialog is now confirmed and the
             // @b2bua.on_bye handler takes over when the UAC BYEs.
         }
+    }
+}
+
+/// Build the B-leg Contact header value.
+///
+/// Default is siphon's own userless address `<sip:host:port;transport=…>` — RFC
+/// 3261 §8.1.1.8 puts no identity in the Contact userpart, and siphon's address
+/// is all that's needed as the §12.2.1.1 in-dialog remote target. A script may
+/// override it via `call.set_contact_user()` (inject a userpart, keep siphon's
+/// host:port — in-dialog routing intact) or `call.set_contact_uri()` (replace
+/// the whole URI — edge/GRUU deployments that front siphon). The full-URI
+/// override wins over the userpart one; an empty userpart override collapses to
+/// the userless default.
+fn build_b_leg_contact(
+    host: &str,
+    port: u16,
+    transport: Transport,
+    contact_user_override: Option<&str>,
+    contact_override: Option<&str>,
+) -> String {
+    if let Some(uri) = contact_override {
+        format!("<{uri}>")
+    } else if let Some(user) = contact_user_override.filter(|user| !user.is_empty()) {
+        format!(
+            "<sip:{}@{}:{};transport={}>",
+            user,
+            host,
+            port,
+            transport.to_string().to_lowercase(),
+        )
+    } else {
+        format!(
+            "<sip:{}:{};transport={}>",
+            host,
+            port,
+            transport.to_string().to_lowercase(),
+        )
     }
 }
 
@@ -8324,6 +8373,8 @@ fn b2bua_send_b_leg_invite(
         a_leg_from_tag,
         from_host_override,
         to_host_override,
+        contact_user_override,
+        contact_override,
     ) = match state.call_actors.get_call(call_id) {
         Some(c) => (
             c.session_timer_override.clone(),
@@ -8332,8 +8383,10 @@ fn b2bua_send_b_leg_invite(
             c.a_leg.dialog.remote_tag.clone().unwrap_or_default(),
             c.from_host_override.clone(),
             c.to_host_override.clone(),
+            c.contact_user_override.clone(),
+            c.contact_override.clone(),
         ),
-        None => (None, false, String::new(), String::new(), None, None),
+        None => (None, false, String::new(), String::new(), None, None, None, None),
     };
 
     let b_leg_call_id = if preserve_call_id {
@@ -8380,13 +8433,25 @@ fn b2bua_send_b_leg_invite(
     // Set Contact to siphon's own address so in-dialog requests route through us.
     // via_host()/via_port() apply advertised_address fallback and substitute the
     // sanitized local_addr when the bind is 0.0.0.0/[::] — never leak unspecified.
+    //
+    // The Contact is userless by default (RFC 3261 §8.1.1.8 puts no identity in
+    // the Contact userpart; siphon's own address is all that's needed for the
+    // §12.2.1.1 in-dialog remote target). A script may override it:
+    //   set_contact_user() → keep our host:port, inject a userpart (safe — we
+    //     still receive in-dialog requests, the userpart just rides along, e.g.
+    //     for a downstream that keys a tenant/extension off the Contact user);
+    //   set_contact_uri()  → replace the whole URI (edge/GRUU deployments that
+    //     front siphon — the deployment owns routing the in-dialog target back).
     let b_contact_host = state.via_host(&outbound_transport);
     let b_contact_port = state.via_port(&outbound_transport);
-    b_leg_invite.headers.set("Contact", format!(
-        "<sip:{}:{};transport={}>",
-        b_contact_host, b_contact_port,
-        outbound_transport.to_string().to_lowercase(),
-    ));
+    let b_contact_value = build_b_leg_contact(
+        &b_contact_host,
+        b_contact_port,
+        outbound_transport,
+        contact_user_override.as_deref(),
+        contact_override.as_deref(),
+    );
+    b_leg_invite.headers.set("Contact", b_contact_value.clone());
 
     // User-Agent rewrite is policy-managed (see `transparent-b2bua@2026`
     // → User-Agent: Rewrite(ReplaceWithUserAgentHeader)).  Topology-hiding
@@ -8480,12 +8545,9 @@ fn b2bua_send_b_leg_invite(
         b_leg_invite.headers.set("Content-Length", b_leg_invite.body.len().to_string());
     }
 
-    // Register B-leg with call manager
-    let b_contact_value = format!(
-        "<sip:{}:{};transport={}>",
-        b_contact_host, b_contact_port,
-        outbound_transport.to_string().to_lowercase(),
-    );
+    // Register B-leg with call manager (Contact built above; local_contact must
+    // match the wire Contact so siphon's own mid-dialog requests advertise the
+    // same address the callee will target).
     let mut b_leg = Leg::new_b_leg(
         b_leg_call_id,
         b_leg_from_tag,
@@ -12629,6 +12691,42 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    #[test]
+    fn b_leg_contact_default_is_userless() {
+        // RFC 3261 §8.1.1.8 — no identity in the Contact userpart by default.
+        let contact = build_b_leg_contact("proxy.example.com", 5060, Transport::Udp, None, None);
+        assert_eq!(contact, "<sip:proxy.example.com:5060;transport=udp>");
+    }
+
+    #[test]
+    fn b_leg_contact_user_override_keeps_host_port() {
+        // set_contact_user() injects a userpart, siphon's host:port unchanged.
+        let contact =
+            build_b_leg_contact("proxy.example.com", 5060, Transport::Tcp, Some("1001"), None);
+        assert_eq!(contact, "<sip:1001@proxy.example.com:5060;transport=tcp>");
+    }
+
+    #[test]
+    fn b_leg_contact_empty_user_override_collapses_to_userless() {
+        // set_contact_user("") explicitly forces the userless form.
+        let contact =
+            build_b_leg_contact("proxy.example.com", 5060, Transport::Udp, Some(""), None);
+        assert_eq!(contact, "<sip:proxy.example.com:5060;transport=udp>");
+    }
+
+    #[test]
+    fn b_leg_contact_full_uri_override_wins_over_user() {
+        // set_contact_uri() takes precedence over set_contact_user().
+        let contact = build_b_leg_contact(
+            "proxy.example.com",
+            5060,
+            Transport::Udp,
+            Some("1001"),
+            Some("sip:gruu@edge.example.com:5080"),
+        );
+        assert_eq!(contact, "<sip:gruu@edge.example.com:5080>");
+    }
 
     #[test]
     fn collect_route_set_splits_lines_and_top_level_commas() {

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -183,6 +183,11 @@ pub struct PyCall {
     /// When set, pin the B-leg To URI host to this value instead of the
     /// dial-target host. Set via `set_to_host()`.
     to_host_override: Option<String>,
+    /// When set, inject this userpart into the B-leg Contact URI (keeping
+    /// siphon's advertised host:port). Set via `set_contact_user()`.
+    contact_user_override: Option<String>,
+    /// When set, replace the whole B-leg Contact URI. Set via `set_contact_uri()`.
+    contact_override: Option<String>,
     /// Per-call header policy input captured from `call.dial(header_policy=…, …)`
     /// or `call.fork(…)`.  The dispatcher resolves `policy_name` against
     /// the preset registry and applies deltas to produce a
@@ -209,6 +214,39 @@ pub struct HeaderPolicyInput {
     pub deltas_translate: Vec<(String, String)>,
 }
 
+/// Replace the URI inside a From/To/Contact header value while preserving the
+/// display-name and header params (tag/q/expires/…). Returns the parsed host of
+/// the new URI so B2BUA callers can pin the matching `*_host_override` (the
+/// B-leg builder rewrites the host otherwise). A no-op when the header is
+/// absent; the parsed host is still returned so the override is set either way.
+fn replace_header_uri(
+    message: &mut SipMessage,
+    primary: &str,
+    alias: &str,
+    new_uri: &str,
+) -> PyResult<String> {
+    let parsed = crate::sip::parser::parse_uri_standalone(new_uri).map_err(|error| {
+        pyo3::exceptions::PyValueError::new_err(format!("invalid SIP URI: {error}"))
+    })?;
+    let host = parsed.host.clone();
+    let raw = message
+        .headers
+        .get(primary)
+        .or_else(|| message.headers.get(alias))
+        .cloned();
+    if let Some(raw) = raw {
+        let mut nameaddr =
+            crate::sip::headers::nameaddr::NameAddr::parse(&raw).map_err(|error| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "cannot parse {primary} header: {error}"
+                ))
+            })?;
+        nameaddr.uri = parsed;
+        message.headers.set(primary, nameaddr.to_string());
+    }
+    Ok(host)
+}
+
 impl PyCall {
     pub fn new(
         id: String,
@@ -232,6 +270,8 @@ impl PyCall {
             preserve_call_id_flag: false,
             from_host_override: None,
             to_host_override: None,
+            contact_user_override: None,
+            contact_override: None,
             header_policy_input: None,
         }
     }
@@ -536,6 +576,20 @@ impl PyCall {
     /// it replaces the dial-target rewrite of the To URI host.
     pub fn to_host_override(&self) -> Option<&str> {
         self.to_host_override.as_deref()
+    }
+
+    /// Script-set B-leg Contact userpart, if `set_contact_user()` was called.
+    /// Read by the dispatcher when building the B-leg Contact — injected into
+    /// the URI while siphon's advertised host:port is preserved.
+    pub fn contact_user_override(&self) -> Option<&str> {
+        self.contact_user_override.as_deref()
+    }
+
+    /// Script-set B-leg Contact URI, if `set_contact_uri()` was called — a full
+    /// override of siphon's advertised Contact. Takes precedence over
+    /// `contact_user_override()`.
+    pub fn contact_override(&self) -> Option<&str> {
+        self.contact_override.as_deref()
     }
 
     /// Set the Refer-To information (called by B2BUA core before firing on_refer).
@@ -1149,6 +1203,87 @@ impl PyCall {
         Ok(())
     }
 
+    /// Replace the entire From header URI on the B-leg INVITE — scheme, user,
+    /// host, port and URI params — in one call, preserving the display name and
+    /// From-tag.
+    ///
+    /// The whole-URI form of [`set_from_user`]/[`set_from_host`]. The host is
+    /// also pinned (the B-leg builder would otherwise rewrite it to the
+    /// advertised address for topology hiding — same opt-out as
+    /// [`set_from_host`]). Must be called before [`dial`].
+    ///
+    /// Usage in Python:
+    ///   call.set_from_uri("sip:+31123@tenant.example.com:5060;transport=tcp")
+    fn set_from_uri(&mut self, uri: &str) -> PyResult<()> {
+        let host = {
+            let mut message = self.message.lock().map_err(|error| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+            })?;
+            replace_header_uri(&mut message, "From", "f", uri)?
+        };
+        self.from_host_override = Some(host);
+        Ok(())
+    }
+
+    /// Replace the entire To header URI on the B-leg INVITE — scheme, user,
+    /// host, port and URI params — preserving the display name and any To-tag.
+    ///
+    /// The whole-URI form of [`set_to_user`]/[`set_to_host`]. The host is also
+    /// pinned (the B-leg builder would otherwise rewrite it to the dial-target
+    /// host — same opt-out as [`set_to_host`]). Must be called before [`dial`].
+    ///
+    /// Usage in Python:
+    ///   call.set_to_uri("sip:5112@ims.mnc088.mcc204.3gppnetwork.org")
+    fn set_to_uri(&mut self, uri: &str) -> PyResult<()> {
+        let host = {
+            let mut message = self.message.lock().map_err(|error| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+            })?;
+            replace_header_uri(&mut message, "To", "t", uri)?
+        };
+        self.to_host_override = Some(host);
+        Ok(())
+    }
+
+    /// Inject a userpart into the B-leg Contact URI, keeping siphon's advertised
+    /// host:port (and transport).
+    ///
+    /// The B2BUA advertises its own address as the Contact so in-dialog requests
+    /// (BYE, re-INVITE) route back through siphon. By default that Contact is
+    /// userless — `set_contact_user()` adds a userpart while leaving the
+    /// host:port untouched, so in-dialog routing still works and the userpart
+    /// rides along (e.g. a downstream that keys a tenant/extension off the
+    /// Contact userpart, the way it does for a REGISTER Contact).
+    ///
+    /// Pass an empty string to force a userless Contact even when transparent
+    /// carry-through would otherwise apply. Must be called before [`dial`].
+    ///
+    /// Usage in Python:
+    ///   call.set_contact_user(extension)
+    fn set_contact_user(&mut self, user: &str) -> PyResult<()> {
+        self.contact_user_override = Some(user.to_string());
+        Ok(())
+    }
+
+    /// Replace the entire B-leg Contact URI — a full override of siphon's
+    /// advertised Contact.
+    ///
+    /// Power tool for edge deployments that front siphon (GRUU, edge SBC).
+    /// Overriding the host/port moves the in-dialog anchor off siphon, so the
+    /// deployment must route the far side's in-dialog requests back to siphon or
+    /// the dialog breaks. Takes precedence over [`set_contact_user`]. `uri` is a
+    /// bare URI (no angle brackets). Must be called before [`dial`].
+    ///
+    /// Usage in Python:
+    ///   call.set_contact_uri("sip:gruu-token@edge.example.com:5060")
+    fn set_contact_uri(&mut self, uri: &str) -> PyResult<()> {
+        crate::sip::parser::parse_uri_standalone(uri).map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid SIP URI: {error}"))
+        })?;
+        self.contact_override = Some(uri.to_string());
+        Ok(())
+    }
+
     /// Copy the A-leg Call-ID to the B-leg instead of generating a new one.
     ///
     /// By default the B2BUA generates a fresh Call-ID for each B-leg to fully
@@ -1559,6 +1694,76 @@ mod tests {
         let call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
         assert_eq!(call.from_host_override(), None);
         assert_eq!(call.to_host_override(), None);
+    }
+
+    #[test]
+    fn call_set_from_uri_replaces_uri_and_pins_host() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message.clone(), "10.0.0.1".to_string(), "udp".to_string());
+        call.set_from_uri("sip:1001@tenant.example.com:5070;transport=tcp").unwrap();
+        let msg = message.lock().unwrap();
+        let from = msg.headers.get("From").unwrap();
+        assert!(from.contains("1001@tenant.example.com:5070"), "user+host+port: {from}");
+        assert!(from.contains("transport=tcp"), "uri params preserved: {from}");
+        assert!(from.contains(";tag=abc"), "From tag preserved: {from}");
+        assert!(!from.contains("atlanta.com"), "old host gone: {from}");
+        drop(msg);
+        // Host is pinned so the B-leg builder's topology-hiding rewrite honours it.
+        assert_eq!(call.from_host_override(), Some("tenant.example.com"));
+    }
+
+    #[test]
+    fn call_set_to_uri_replaces_uri_and_pins_host() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message.clone(), "10.0.0.1".to_string(), "udp".to_string());
+        call.set_to_uri("sip:5112@ims.example.org").unwrap();
+        let msg = message.lock().unwrap();
+        let to = msg.headers.get("To").unwrap();
+        assert!(to.contains("5112@ims.example.org"), "user+host: {to}");
+        assert!(!to.contains("example.com"), "old host gone: {to}");
+        assert!(!to.contains(";tag="), "initial INVITE To must not gain a tag: {to}");
+        drop(msg);
+        assert_eq!(call.to_host_override(), Some("ims.example.org"));
+    }
+
+    #[test]
+    fn call_set_to_uri_preserves_display_and_tag() {
+        let mut invite = make_invite();
+        invite.headers.set("To", "\"Bob\" <sip:bob@example.com>;tag=remote".to_string());
+        let message = Arc::new(Mutex::new(invite));
+        let mut call = PyCall::new("test-id".to_string(), message.clone(), "10.0.0.1".to_string(), "udp".to_string());
+        call.set_to_uri("sip:5112@ims.example.org").unwrap();
+        let msg = message.lock().unwrap();
+        let to = msg.headers.get("To").unwrap();
+        assert!(to.contains("\"Bob\""), "display preserved: {to}");
+        assert!(to.contains("5112@ims.example.org"), "uri replaced: {to}");
+        assert!(to.contains(";tag=remote"), "tag preserved: {to}");
+    }
+
+    #[test]
+    fn call_set_contact_user_sets_override() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        assert_eq!(call.contact_user_override(), None);
+        call.set_contact_user("1001").unwrap();
+        assert_eq!(call.contact_user_override(), Some("1001"));
+    }
+
+    #[test]
+    fn call_set_contact_uri_sets_override() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        assert_eq!(call.contact_override(), None);
+        call.set_contact_uri("sip:gruu-token@edge.example.com:5060").unwrap();
+        assert_eq!(call.contact_override(), Some("sip:gruu-token@edge.example.com:5060"));
+    }
+
+    #[test]
+    fn call_set_contact_uri_rejects_invalid() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        assert!(call.set_contact_uri("not-a-uri").is_err());
+        assert_eq!(call.contact_override(), None);
     }
 
     #[test]

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -1239,6 +1239,39 @@ impl PyRequest {
         rewrite_display_name(&mut message, "To", display_name)
     }
 
+    /// Replace the whole From header URI (scheme/user/host/port/params) in one
+    /// call, preserving the display name and From-tag. The tag survives — unlike
+    /// a raw `set_header("From", "<sip:…>")`, which drops the mandatory From-tag.
+    fn set_from_uri(&self, uri: &str) -> PyResult<()> {
+        let mut message = self.lock_mut()?;
+        rewrite_header_uri(&mut message, "From", "f", uri)
+    }
+
+    /// Replace the whole To header URI, preserving the display name and any
+    /// To-tag. The tag survives — unlike a raw `set_header("To", "<sip:…>")`.
+    fn set_to_uri(&self, uri: &str) -> PyResult<()> {
+        let mut message = self.lock_mut()?;
+        rewrite_header_uri(&mut message, "To", "t", uri)
+    }
+
+    /// Replace the whole Contact header URI, preserving the display name and any
+    /// Contact params (q/expires/…).
+    ///
+    /// In a proxy the Contact is the UA's in-dialog target: rewriting it changes
+    /// where mid-dialog requests (BYE, re-INVITE) are routed. Fine when the new
+    /// target is meaningful downstream; a footgun otherwise.
+    fn set_contact_uri(&self, uri: &str) -> PyResult<()> {
+        let mut message = self.lock_mut()?;
+        rewrite_header_uri(&mut message, "Contact", "m", uri)
+    }
+
+    /// Rewrite only the userpart of the Contact header URI, leaving host/port/
+    /// params intact. An empty string clears the userpart.
+    fn set_contact_user(&self, user: &str) -> PyResult<()> {
+        let mut message = self.lock_mut()?;
+        rewrite_header_uri_user(&mut message, "Contact", "m", user)
+    }
+
     /// Append `;alias` parameter to the Contact URI for NAT traversal.
     fn add_contact_alias(&self) -> PyResult<()> {
         let mut message = self.lock_mut()?;
@@ -1534,6 +1567,60 @@ fn rewrite_display_name(
             nameaddr.display_name = Some(display_name.to_string());
             message.headers.set(header_name, nameaddr.to_string());
         }
+    }
+    Ok(())
+}
+
+/// Replace the whole URI inside a From/To/Contact header value while preserving
+/// the display-name and header params (tag/q/expires/…). No-op when the header
+/// is absent. `alias` is the RFC 3261 §7.3.3 compact form (`f`/`t`/`m`).
+fn rewrite_header_uri(
+    message: &mut SipMessage,
+    primary: &str,
+    alias: &str,
+    new_uri: &str,
+) -> PyResult<()> {
+    let raw = message
+        .headers
+        .get(primary)
+        .or_else(|| message.headers.get(alias))
+        .cloned();
+    if let Some(raw) = raw {
+        let mut nameaddr = NameAddr::parse(&raw).map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!("cannot parse {primary} header: {error}"))
+        })?;
+        nameaddr.uri = parse_uri_standalone(new_uri).map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid SIP URI: {error}"))
+        })?;
+        message.headers.set(primary, nameaddr.to_string());
+    }
+    Ok(())
+}
+
+/// Rewrite only the userpart of the URI inside a From/To/Contact header value,
+/// preserving everything else (host/port/params, display-name, header params).
+/// An empty `user` clears the userpart. No-op when the header is absent.
+fn rewrite_header_uri_user(
+    message: &mut SipMessage,
+    primary: &str,
+    alias: &str,
+    user: &str,
+) -> PyResult<()> {
+    let raw = message
+        .headers
+        .get(primary)
+        .or_else(|| message.headers.get(alias))
+        .cloned();
+    if let Some(raw) = raw {
+        let mut nameaddr = NameAddr::parse(&raw).map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!("cannot parse {primary} header: {error}"))
+        })?;
+        nameaddr.uri.user = if user.is_empty() {
+            None
+        } else {
+            Some(user.to_string())
+        };
+        message.headers.set(primary, nameaddr.to_string());
     }
     Ok(())
 }
@@ -2274,6 +2361,67 @@ mod tests {
         request.add_contact_alias().unwrap();
         let contact = request.get_header("Contact").unwrap().unwrap();
         assert!(contact.contains(";alias"));
+    }
+
+    #[test]
+    fn set_from_uri_replaces_uri_preserves_display_and_tag() {
+        let request = make_request();
+        request.set_from_uri("sip:+3120@tenant.example.com:5070;transport=tcp").unwrap();
+        let from = request.get_header("From").unwrap().unwrap();
+        assert!(from.contains("\"Alice\""), "display preserved: {from}");
+        assert!(from.contains("+3120@tenant.example.com:5070"), "uri replaced: {from}");
+        assert!(from.contains("transport=tcp"), "uri params preserved: {from}");
+        assert!(from.contains(";tag=1928301774"), "From tag preserved: {from}");
+        assert!(!from.contains("atlanta.com"), "old host gone: {from}");
+    }
+
+    #[test]
+    fn set_to_uri_replaces_uri_preserves_display() {
+        let request = make_request();
+        request.set_to_uri("sip:5112@ims.example.org").unwrap();
+        let to = request.get_header("To").unwrap().unwrap();
+        assert!(to.contains("\"Bob\""), "display preserved: {to}");
+        assert!(to.contains("5112@ims.example.org"), "uri replaced: {to}");
+        assert!(!to.contains("biloxi.com"), "old host gone: {to}");
+    }
+
+    #[test]
+    fn set_contact_uri_replaces_contact() {
+        let request = make_request();
+        request.set_header("Contact", "<sip:alice@10.0.0.1:5060>").unwrap();
+        request.set_contact_uri("sip:bob@192.0.2.9:5080;transport=tcp").unwrap();
+        let contact = request.get_header("Contact").unwrap().unwrap();
+        assert!(contact.contains("bob@192.0.2.9:5080"), "contact replaced: {contact}");
+        assert!(contact.contains("transport=tcp"), "params preserved: {contact}");
+        assert!(!contact.contains("10.0.0.1"), "old contact gone: {contact}");
+    }
+
+    #[test]
+    fn set_contact_user_rewrites_userpart_only() {
+        let request = make_request();
+        request.set_header("Contact", "<sip:alice@10.0.0.1:5060;transport=tcp>").unwrap();
+        request.set_contact_user("1001").unwrap();
+        let contact = request.get_header("Contact").unwrap().unwrap();
+        assert!(contact.contains("1001@10.0.0.1:5060"), "user rewritten, host/port kept: {contact}");
+        assert!(contact.contains("transport=tcp"), "uri params kept: {contact}");
+        assert!(!contact.contains("alice@"), "old user gone: {contact}");
+    }
+
+    #[test]
+    fn set_contact_user_empty_clears_userpart() {
+        let request = make_request();
+        request.set_header("Contact", "<sip:alice@10.0.0.1:5060>").unwrap();
+        request.set_contact_user("").unwrap();
+        let contact = request.get_header("Contact").unwrap().unwrap();
+        assert!(contact.contains("10.0.0.1:5060"), "host:port kept: {contact}");
+        assert!(!contact.contains("alice"), "user cleared: {contact}");
+        assert!(!contact.contains('@'), "no dangling @ once userpart cleared: {contact}");
+    }
+
+    #[test]
+    fn set_from_uri_rejects_invalid() {
+        let request = make_request();
+        assert!(request.set_from_uri("not-a-uri").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds whole-URI setters `set_from_uri`, `set_to_uri`, `set_contact_uri` (plus `set_contact_user`) to **both** the proxy `request` and the B2BUA `call`. These are the whole-URI form of the existing `set_*_user` / `set_*_host` setters: replace the entire URI inside the header's angle brackets (scheme, user, host, port, URI params) in one call, while preserving the display name and the dialog-critical From/To **tag** — unlike a raw `set_header("From", "<sip:…>")`, which silently drops the mandatory tag. `set_contact_user` rewrites only the Contact userpart (empty string clears it).

## Why

The B2BUA emits a **userless** Contact on its outbound legs (`<sip:host:port;transport=…>`). A downstream that keys a tenant/extension off the **Contact userpart** works fine for a REGISTER (the UE's Contact carries the extension) but has nothing to match on for the B2BUA's INVITE. There was no script hook to set it: `call.set_header("Contact", …)` doesn't stick because the leg builder regenerates the Contact after the script runs (same reason `set_from_host` / `set_to_host` had to exist).

## Behaviour

- **Proxy** — plain header rewrites; From/To/Contact are pass-through, so `set_contact_uri` on a proxy retargets in-dialog requests (documented footgun).
- **B2BUA** — the setters mutate the outbound B-leg. `set_from_uri` / `set_to_uri` also pin the host (same topology-hiding opt-out as `set_from_host` / `set_to_host`). `set_contact_user` injects a userpart while keeping siphon's host:port, so in-dialog routing is unchanged and the userpart just rides along. `set_contact_uri` replaces the whole Contact for edge/GRUU deployments that front siphon (`contact_uri` wins over `contact_user`).
- **Default is unchanged.** The B-leg Contact stays userless. RFC 3261 §8.1.1.8 puts no identity in the Contact userpart, and siphon's own address is all that's needed as the §12.2.1.1 in-dialog remote target — so carrying an identity there is a deliberate opt-in, not a new default. Zero wire-behaviour change, zero test churn for existing deployments.

## Tests

- Rust unit tests: `build_b_leg_contact` precedence/format (dispatcher), the `call` setters (message mutation + host-override pinning + override storage + invalid-URI rejection), the `request` setters (URI replace preserving display/tag, Contact userpart rewrite/clear).
- SDK mock mirrored (`request.py`, `call.py`) + `sdk/tests/test_uri_setters.py` (12 tests).
- Full suite green: `cargo test --all-targets` 3142 passed / 3 ignored; clippy clean; SDK 383 passed.
