### PR TITLE
feat(transport): send_socket egress pin (force_send_socket equivalent) for relay/fork/dial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`send_socket=` egress pin on `request.relay()` / `request.fork()` and
+  `call.dial()` / `call.fork()`** — the operator equivalent of Kamailio's
+  `force_send_socket()` / OpenSIPS' `$fs`. Selects which of siphon's own
+  configured listeners a relayed or dialed request leaves from on a multi-homed
+  host (`send_socket="udp:10.0.0.1:5060"`), and advertises that listener's
+  address in the outgoing Via so the response returns to the same socket. UDP
+  pins the exact `(ip, port)` listener; TCP/TLS bind the source IP with an
+  ephemeral source port (the source is now part of the connection-pool key, so a
+  source-bound and a default connection to the same peer stay distinct). The pin
+  is validated for format at the scripting API (a malformed spec raises
+  `ValueError`); a well-formed spec that names no configured listener is logged
+  and falls back to default routing rather than dropping the request. It is
+  ignored when a captured `flow=` is set (the flow already pins egress) and when
+  its transport doesn't match the routed transport. Per-listener UDP egress
+  channels are now enabled whenever the host has more than one UDP listener (they
+  were previously only enabled under IPsec); a single-listener deployment keeps
+  the existing fast path unchanged.
 - **`cache.list_len(name, key)` and `cache.list_len_sum(name, prefix)`.** Two
   async cache-namespace methods for Redis-backed lists. `list_len` returns a
   single list's length (`LLEN`, `0` for a missing key). `list_len_sum` returns

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -278,6 +278,58 @@ A few properties worth knowing:
 
 ---
 
+## Choosing the egress socket (`send_socket`)
+
+On a multi-homed host — several listeners across interfaces — routing usually
+picks the outbound transport, but not *which local socket* the request leaves
+from. `send_socket=` pins it, the way Kamailio's `force_send_socket()` and
+OpenSIPS' `$fs` do. It takes a `"<transport>:<ip>:<port>"` string naming one of
+siphon's **own** configured listeners:
+
+```python
+# Proxy — relay this trunk call out of the carrier-facing NIC.
+request.relay("sip:carrier.example.net", send_socket="udp:203.0.113.10:5060")
+
+# Proxy — fork; the pin applies to every branch.
+request.fork(contacts, send_socket="udp:10.0.0.1:5060")
+
+# B2BUA — dial the B-leg out of a specific interface.
+call.dial("sip:bob@10.0.0.2:5060", send_socket="tcp:10.0.0.1:5060")
+```
+
+What it does:
+
+- **Advertises the right Via.** The outgoing Via sent-by is the selected
+  listener's advertised address (its `advertise:`, else its bound IP) with the
+  listener's port, so the peer's response comes back to the same socket. This is
+  the correctness reason to use `send_socket` instead of hand-rolling a Via
+  rewrite — get the sent-by wrong and the response lands on the wrong listener
+  (or nowhere).
+- **UDP** pins the exact `(ip, port)` listener socket as the egress.
+- **TCP/TLS** bind the source **IP** (interface); the source *port* stays
+  ephemeral, because binding a listen port for an outbound connection collides on
+  the 4-tuple in `TIME_WAIT`. Source-bound and default connections to the same
+  peer are pooled separately, so they never reuse each other.
+
+Rules and fall-backs:
+
+- A **malformed** spec raises `ValueError` at the scripting API (immediate, so
+  you catch typos in tests).
+- A **well-formed but unknown** socket (no such listener) is logged and the
+  request falls back to default routing — it is never dropped.
+- Ignored when a captured **`flow=`** is set (the flow already pins egress), and
+  when its **transport doesn't match** the routed transport (logged).
+- WS/WSS callees can't be dialed (client-initiated); reach them with `flow=`, not
+  `send_socket`.
+
+!!! note "Multi-homed UDP fast path"
+    Per-listener UDP egress is enabled automatically once the host has more than
+    one UDP listener (or IPsec is configured). A single-UDP-listener deployment
+    keeps the original zero-overhead send path — `send_socket` only has real work
+    to do when there's more than one socket to choose between.
+
+---
+
 ## NAT traversal for clients
 
 Subscribers behind home NAT advertise unroutable private addresses in their Via

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -11,7 +11,7 @@ import uuid
 from typing import Optional, Union
 
 from siphon_sdk.types import Action, Contact, Flow, MediaHandle, SipUri
-from siphon_sdk.request import _parse_uri
+from siphon_sdk.request import _parse_uri, _validate_send_socket
 
 
 class Call:
@@ -262,6 +262,7 @@ class Call:
         strip: Optional[list[str]] = None,
         translate: Optional[list[tuple[str, str]]] = None,
         route: Optional[list[str]] = None,
+        send_socket: Optional[str] = None,
     ) -> None:
         """Dial a single B-leg target.
 
@@ -304,6 +305,16 @@ class Call:
                 originating S-CSCF (RFC 3608).  Each entry is a full route
                 value, e.g. ``"<sip:scscf.ims.example.com:6060;lr>"`` — pass
                 the list returned by ``registration.service_route(impu)``.
+            send_socket: Optional egress socket pin
+                (``"<transport>:<ip>:<port>"``, e.g. ``"udp:10.0.0.1:5060"``)
+                — the operator equivalent of Kamailio's ``force_send_socket()``.
+                Selects which of siphon's own configured listeners the B-leg
+                INVITE leaves from on a multi-homed host; the B-leg Via
+                advertises that listener's address.  UDP pins the exact
+                ``(ip, port)`` listener; TCP/TLS bind the source IP with an
+                ephemeral port.  Ignored when ``flow`` is set (the flow already
+                pins egress), and when its transport doesn't match the B-leg
+                transport.  A malformed spec raises ``ValueError``.
 
         Example::
 
@@ -329,6 +340,7 @@ class Call:
                       "P-Asserted-Identity", "Reason"],
             )
         """
+        _validate_send_socket(send_socket)
         self._actions.append(Action(
             kind="dial",
             targets=[uri],
@@ -341,6 +353,7 @@ class Call:
                 "strip": strip or [],
                 "translate": translate or [],
                 "route": route or [],
+                "send_socket": send_socket,
             },
         ))
 
@@ -353,6 +366,7 @@ class Call:
         copy: Optional[list[str]] = None,
         strip: Optional[list[str]] = None,
         translate: Optional[list[tuple[str, str]]] = None,
+        send_socket: Optional[str] = None,
     ) -> None:
         """Fork to multiple B-leg targets.
 
@@ -369,6 +383,9 @@ class Call:
             header_policy / copy / strip / translate: Same semantics as
                 :meth:`dial` — the policy applies to every branch of the
                 fork (per-branch policy is a follow-up).
+            send_socket: Optional egress socket pin applied to every branch
+                (same ``"<transport>:<ip>:<port>"`` form as :meth:`dial`).  A
+                per-branch captured flow still takes precedence for that branch.
 
         Example::
 
@@ -376,6 +393,7 @@ class Call:
             # Pass Contact objects so WebSocket callees route over their flow.
             call.fork(contacts, strategy="parallel", timeout=30)
         """
+        _validate_send_socket(send_socket)
         uris = [t.uri if isinstance(t, Contact) else str(t) for t in targets]
         self._actions.append(Action(
             kind="fork",
@@ -387,6 +405,7 @@ class Call:
                 "copy": copy or [],
                 "strip": strip or [],
                 "translate": translate or [],
+                "send_socket": send_socket,
             },
         ))
 

--- a/sdk/siphon_sdk/request.py
+++ b/sdk/siphon_sdk/request.py
@@ -13,6 +13,40 @@ from typing import Callable, Optional, Union
 
 from siphon_sdk.types import Action, Contact, SipUri
 
+_SEND_SOCKET_TRANSPORTS = {"udp", "tcp", "tls", "ws", "wss", "sctp"}
+
+
+def _validate_send_socket(spec: Optional[str]) -> None:
+    """Format-validate a ``send_socket=`` spec, mirroring the Rust engine.
+
+    Raises ``ValueError`` on a malformed spec (the real engine rejects it the
+    same way).  Existence as a real configured listener is a runtime concern,
+    not checked here.
+    """
+    if spec is None:
+        return
+    scheme, sep, addr = spec.partition(":")
+    if not sep or scheme.lower() not in _SEND_SOCKET_TRANSPORTS:
+        raise ValueError(
+            f"send_socket {spec!r} must be '<transport>:<ip>:<port>' "
+            f"(e.g. 'udp:10.0.0.1:5060'); transport one of "
+            f"{sorted(_SEND_SOCKET_TRANSPORTS)}"
+        )
+    host, colon, port = addr.rpartition(":")
+    if not colon or not host:
+        raise ValueError(
+            f"send_socket {spec!r}: missing '<ip>:<port>' after the transport"
+        )
+    try:
+        int(port)
+    except ValueError:
+        raise ValueError(f"send_socket {spec!r}: port {port!r} is not an integer") from None
+    # Validate the IP literal (strip IPv6 brackets).
+    try:
+        ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        raise ValueError(f"send_socket {spec!r}: {host!r} is not a valid IP address") from None
+
 
 def _parse_uri(value: Union[str, SipUri, None]) -> Optional[SipUri]:
     """Parse a string into a SipUri, or pass through if already one."""
@@ -327,6 +361,7 @@ class Request:
         on_reply: Optional[Callable] = None,
         on_failure: Optional[Callable] = None,
         flow=None,
+        send_socket: Optional[str] = None,
     ) -> None:
         """Forward the request to its destination.
 
@@ -344,19 +379,38 @@ class Request:
                   — load-bearing for P-CSCF MT routing where the UE's
                   Contact URI is unreachable (NAT, IPSec).
                   Ignores ``next_hop`` when set.
+            send_socket: Optional egress socket pin
+                  (``"<transport>:<ip>:<port>"``, e.g. ``"udp:10.0.0.1:5060"``)
+                  — the operator equivalent of Kamailio's
+                  ``force_send_socket()``.  Selects which of siphon's own
+                  configured listeners the request leaves from on a multi-homed
+                  host.  The outgoing Via advertises that listener's address so
+                  the response comes back to the same socket.  UDP pins the
+                  exact ``(ip, port)`` listener; TCP/TLS bind the source IP with
+                  an ephemeral port.  Ignored when ``flow`` is set (the flow
+                  already pins egress), and when its transport doesn't match the
+                  routed transport.  A malformed spec raises ``ValueError``; a
+                  well-formed spec that names no configured listener is logged
+                  and falls back to default routing (never dropped).
 
         Example::
 
             request.relay()                           # default routing
             request.relay("sip:proxy@10.0.0.2:5060")  # explicit next-hop
             request.relay(on_reply=my_reply_handler)   # per-relay callback
+            request.relay(send_socket="udp:10.0.0.1:5060")  # pin egress NIC
             # Path-token MT routing:
             binding = registrar.lookup_by_token(token)
             request.relay(flow=binding.flow)
         """
+        _validate_send_socket(send_socket)
         extras: Optional[dict] = None
-        if flow is not None:
-            extras = {"flow": flow}
+        if flow is not None or send_socket is not None:
+            extras = {}
+            if flow is not None:
+                extras["flow"] = flow
+            if send_socket is not None:
+                extras["send_socket"] = send_socket
         self._actions.append(Action(
             kind="relay",
             next_hop=next_hop,
@@ -371,6 +425,7 @@ class Request:
         self,
         targets: list[Union[str, Contact]],
         strategy: str = "parallel",
+        send_socket: Optional[str] = None,
     ) -> None:
         """Fork the request to multiple targets.
 
@@ -383,6 +438,10 @@ class Request:
                 contacts fall back to URI routing.
             strategy: ``"parallel"`` (all at once, first 2xx wins) or
                       ``"sequential"`` (try in q-value order, next on failure).
+            send_socket: Optional egress socket pin applied to every branch
+                      (same ``"<transport>:<ip>:<port>"`` form as
+                      :meth:`relay`).  A per-branch captured flow still takes
+                      precedence over it for that branch.
 
         Example::
 
@@ -390,7 +449,9 @@ class Request:
             # Pass Contact objects so a WebSocket UE routes over its flow.
             request.fork(contacts)
             request.fork(["sip:a@host", "sip:b@host"], strategy="sequential")
+            request.fork(contacts, send_socket="udp:10.0.0.1:5060")
         """
+        _validate_send_socket(send_socket)
         uris = [t.uri if isinstance(t, Contact) else str(t) for t in targets]
         self._actions.append(Action(
             kind="fork",
@@ -398,6 +459,7 @@ class Request:
             strategy=strategy,
             headers_set=dict(self._pending_headers()),
             headers_removed=list(self._pending_removed()),
+            extras={"send_socket": send_socket} if send_socket is not None else None,
         ))
 
     def record_route(self) -> None:

--- a/sdk/tests/test_call_dial.py
+++ b/sdk/tests/test_call_dial.py
@@ -4,6 +4,8 @@ R-URI construction from the wire-routing destination (IMS BGCF / I-CSCF
 edge case).
 """
 
+import pytest
+
 from siphon_sdk.call import Call
 
 
@@ -80,3 +82,23 @@ class TestCallDial:
         assert action.extras["copy"] == []
         assert action.extras["strip"] == []
         assert action.extras["translate"] == []
+        assert action.extras["send_socket"] is None
+
+    def test_dial_send_socket_pin(self):
+        # Force-send-socket egress pin (multi-homed host).
+        call = Call()
+        call.dial("sip:bob@10.0.0.2:5060", send_socket="udp:10.0.0.1:5060")
+        action = call._actions[0]
+        assert action.extras["send_socket"] == "udp:10.0.0.1:5060"
+
+    def test_dial_send_socket_malformed_raises(self):
+        call = Call()
+        with pytest.raises(ValueError):
+            call.dial("sip:bob@10.0.0.2:5060", send_socket="10.0.0.1:5060")
+        with pytest.raises(ValueError):
+            call.dial("sip:bob@10.0.0.2:5060", send_socket="udp:not-an-addr")
+        with pytest.raises(ValueError):
+            call.dial("sip:bob@10.0.0.2:5060", send_socket="pigeon:10.0.0.1:5060")
+        # A well-formed IPv6 pin is accepted.
+        call.dial("sip:bob@10.0.0.2:5060", send_socket="tls:[2001:db8::1]:5061")
+        assert call._actions[-1].extras["send_socket"] == "tls:[2001:db8::1]:5061"

--- a/sdk/tests/test_send_socket.py
+++ b/sdk/tests/test_send_socket.py
@@ -1,0 +1,52 @@
+"""
+Tests for the ``send_socket=`` egress pin on ``request.relay`` / ``request.fork``
+(the operator equivalent of Kamailio's ``force_send_socket()``).
+"""
+
+import pytest
+
+from siphon_sdk.request import Request
+
+
+def _request():
+    return Request(method="INVITE", ruri="sip:bob@example.com")
+
+
+class TestRelaySendSocket:
+    def test_relay_send_socket_pin(self):
+        request = _request()
+        request.relay(send_socket="udp:10.0.0.1:5060")
+        action = request._actions[0]
+        assert action.kind == "relay"
+        assert action.extras["send_socket"] == "udp:10.0.0.1:5060"
+
+    def test_relay_without_send_socket_leaves_extras_none(self):
+        request = _request()
+        request.relay()
+        assert request._actions[0].extras is None
+
+    def test_relay_send_socket_malformed_raises(self):
+        request = _request()
+        with pytest.raises(ValueError):
+            request.relay(send_socket="10.0.0.1:5060")       # no transport
+        with pytest.raises(ValueError):
+            request.relay(send_socket="udp:garbage")          # bad addr
+        with pytest.raises(ValueError):
+            request.relay(send_socket="smoke:10.0.0.1:5060")  # bad transport
+
+    def test_fork_send_socket_pin(self):
+        request = _request()
+        request.fork(["sip:a@host", "sip:b@host"], send_socket="tcp:10.0.0.1:5060")
+        action = request._actions[0]
+        assert action.kind == "fork"
+        assert action.extras["send_socket"] == "tcp:10.0.0.1:5060"
+
+    def test_fork_send_socket_malformed_raises(self):
+        request = _request()
+        with pytest.raises(ValueError):
+            request.fork(["sip:a@host"], send_socket="not-a-socket")
+
+    def test_ipv6_send_socket_accepted(self):
+        request = _request()
+        request.relay(send_socket="tls:[2001:db8::1]:5061")
+        assert request._actions[0].extras["send_socket"] == "tls:[2001:db8::1]:5061"

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -90,6 +90,11 @@ struct DispatcherState {
     /// Per-transport listen address for HEP capture (so TLS responses report
     /// port 5061, not the UDP/TCP port 5060).
     listen_addrs: std::collections::HashMap<Transport, SocketAddr>,
+    /// Every configured listener (transport + bound addr + advertised host).
+    /// Backs `send_socket=` egress resolution — a script may only pin a source
+    /// socket siphon is actually listening on, and the advertised host for the
+    /// outgoing Via comes from the matched listener.
+    listener_registry: crate::transport::ListenerRegistry,
     /// Server header value injected into locally-generated responses.
     server_header: Option<String>,
     /// User-Agent header value for outbound requests (UAC, registrant).
@@ -304,6 +309,39 @@ impl DispatcherState {
             .unwrap_or(self.local_addr.port())
     }
 
+    /// Resolve a script `send_socket=` spec against the configured listeners.
+    ///
+    /// Returns `Some(SendSocket)` only when the spec is well-formed AND names a
+    /// socket siphon is actually listening on.  A malformed spec can't reach
+    /// here (the script API rejects it with `ValueError`); a well-formed spec
+    /// that doesn't match any listener warns and returns `None`, so the caller
+    /// falls back to default routing rather than dropping the request —
+    /// silently dropping would violate the "always answer" invariant, and an
+    /// operator typo shouldn't blackhole calls.
+    fn resolve_send_socket(
+        &self,
+        spec: Option<&str>,
+    ) -> Option<crate::transport::SendSocket> {
+        let spec = spec?;
+        match crate::transport::parse_send_socket(spec) {
+            Ok((transport, addr)) => {
+                let resolved = self.listener_registry.resolve(transport, addr);
+                if resolved.is_none() {
+                    warn!(
+                        send_socket = %spec,
+                        "send_socket names no configured listener — falling back to default routing"
+                    );
+                }
+                resolved
+            }
+            Err(error) => {
+                // Should be unreachable (validated at the API), but never panic.
+                warn!(send_socket = %spec, "ignoring malformed send_socket: {error}");
+                None
+            }
+        }
+    }
+
     /// Resolve the header policy for a B2BUA call.  Returns the per-call
     /// policy when the script attached one via `call.dial(header_policy=…)`,
     /// otherwise the configured default.
@@ -360,6 +398,7 @@ pub async fn run(
     local_addr: SocketAddr,
     listen_addrs: std::collections::HashMap<Transport, SocketAddr>,
     advertised_addrs: std::collections::HashMap<Transport, String>,
+    listener_registry: crate::transport::ListenerRegistry,
     hep_sender: Option<Arc<HepSender>>,
     uac_sender: Arc<UacSender>,
     connection_pool: Arc<ConnectionPool>,
@@ -489,6 +528,7 @@ pub async fn run(
         local_addr: via_addr,
         advertised_addrs: merged_advertised,
         listen_addrs,
+        listener_registry,
         server_header,
         user_agent_header,
         transaction_timeout,
@@ -2457,13 +2497,14 @@ fn handle_request(
             }
 
         }
-        RequestAction::Relay { next_hop, flow } => {
+        RequestAction::Relay { next_hop, flow, send_socket } => {
             // RFC 3261 §16.2: a stateful proxy SHOULD send 100 Trying
             // immediately upon receiving an INVITE to stop UAC retransmissions.
             if method == "INVITE" {
                 let trying = build_response(&message_guard, 100, "Trying", state.server_header.as_deref(), &[]);
                 send_message_from(trying, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
             }
+            let send_socket = state.resolve_send_socket(send_socket.as_deref());
             relay_request(
                 &message_guard,
                 next_hop.as_deref(),
@@ -2476,9 +2517,10 @@ fn handle_request(
                 send_via_transport.as_deref(),
                 send_via_target.as_deref(),
                 flow.as_ref(),
+                send_socket.as_ref(),
             );
         }
-        RequestAction::Fork { targets, flows, strategy } => {
+        RequestAction::Fork { targets, flows, strategy, send_socket } => {
             if targets.is_empty() {
                 warn!("fork with empty targets list");
                 let response = build_response(&message_guard, 500, "No Targets", state.server_header.as_deref(), &[]);
@@ -2492,6 +2534,7 @@ fn handle_request(
                     "sequential" => crate::proxy::fork::ForkStrategy::Sequential,
                     _ => crate::proxy::fork::ForkStrategy::Parallel,
                 };
+                let send_socket = state.resolve_send_socket(send_socket.as_deref());
                 relay_fork_request(
                     &message_guard,
                     targets,
@@ -2501,6 +2544,7 @@ fn handle_request(
                     &inbound,
                     server_key.as_ref(),
                     state,
+                    send_socket.as_ref(),
                 );
             }
         }
@@ -2555,6 +2599,7 @@ fn relay_request(
     send_via_transport: Option<&str>,
     send_via_target: Option<&str>,
     flow: Option<&crate::script::api::registrar::PyFlow>,
+    send_socket: Option<&crate::transport::SendSocket>,
 ) {
     // Two ways to know where this request is going:
     //   a) flow=Some — use the captured inbound flow directly,
@@ -2725,6 +2770,28 @@ fn relay_request(
         _ => None,
     };
 
+    // Resolve the script `send_socket=` egress pin against the *final*
+    // outbound transport (the IPsec block above may have re-pinned it).  It
+    // applies only when: there is no captured flow (a flow already pins the
+    // egress listener), IPsec has not claimed the source (the kernel XFRM
+    // selector must win), and its transport matches the outbound transport.
+    // A transport mismatch is an operator config error — warn and ignore it
+    // rather than egress on the wrong socket.
+    let send_socket = match send_socket {
+        _ if flow.is_some() || ipsec_source.is_some() => None,
+        Some(pin) if pin.transport == outbound_transport => Some(pin),
+        Some(pin) => {
+            warn!(
+                send_socket = %pin.addr,
+                requested_transport = %pin.transport,
+                outbound_transport = %outbound_transport,
+                "send_socket transport does not match the outbound transport — ignoring the egress pin"
+            );
+            None
+        }
+        None => None,
+    };
+
     // Add our Via — use the outbound transport for the Via header.
     // If force_send_via set a target, use it as the Via sent-by address.
     let transport_str = format!("{}", outbound_transport);
@@ -2742,6 +2809,12 @@ fn relay_request(
         // on the Via we advertise, otherwise the kernel selector
         // doesn't match and the response is silently dropped.
         (local.ip().to_string(), Some(local.port()))
+    } else if let Some(pin) = send_socket {
+        // Script send_socket= egress pin: advertise the selected listener's
+        // sent-by (its configured advertise host, else the bound IP) with the
+        // listener's port, so the peer's response comes back to this socket.
+        let (host, port) = pin.via_sent_by();
+        (format_sip_host(&host), Some(port))
     } else if let Some(target_str) = send_via_target {
         // Parse "host:port" or just "host"
         if let Some((host, port_str)) = target_str.rsplit_once(':') {
@@ -2891,7 +2964,14 @@ fn relay_request(
             transport: Some(outbound_transport),
             server_name: None,
         };
-        send_to_target(data, &target, inbound.transport, inbound.connection_id, state)
+        send_to_target(
+            data,
+            &target,
+            inbound.transport,
+            inbound.connection_id,
+            send_socket.map(|pin| pin.addr),
+            state,
+        )
     };
     // Patch the session's ClientBranch via the locally-held `Arc` we got
     // back from `session_store.insert(...)` rather than re-looking up
@@ -2929,6 +3009,7 @@ fn relay_fork_request(
     inbound: &InboundMessage,
     server_key: Option<&TransactionKey>,
     state: &DispatcherState,
+    send_socket: Option<&crate::transport::SendSocket>,
 ) {
     use crate::proxy::fork::ForkAggregator;
 
@@ -2955,7 +3036,7 @@ fn relay_fork_request(
         None => {
             // Fall back to single-target relay if no server transaction —
             // carry the first branch's flow so a single WS contact still routes.
-            relay_request(message, targets.first().map(|s| s.as_str()), record_routed, inbound, None, state, None, None, None, None, flows.first().and_then(|f| f.as_ref()));
+            relay_request(message, targets.first().map(|s| s.as_str()), record_routed, inbound, None, state, None, None, None, None, flows.first().and_then(|f| f.as_ref()), send_socket);
             return;
         }
     };
@@ -2971,6 +3052,7 @@ fn relay_fork_request(
     );
     session.fork_aggregator = Some(Arc::clone(&aggregator));
     session.fork_flows = flows.to_vec();
+    session.fork_send_socket = send_socket.cloned();
 
     // Determine which branches to start now
     let branches_to_start: Vec<usize> = match strategy {
@@ -2998,6 +3080,7 @@ fn relay_fork_request(
             &session_arc,
             &aggregator,
             flows.get(branch_index).and_then(|f| f.as_ref()),
+            send_socket,
             state,
         );
     }
@@ -3017,6 +3100,7 @@ fn relay_fork_branch(
     session_arc: &Arc<RwLock<ProxySession>>,
     aggregator: &Arc<std::sync::Mutex<crate::proxy::fork::ForkAggregator>>,
     flow: Option<&crate::script::api::registrar::PyFlow>,
+    send_socket: Option<&crate::transport::SendSocket>,
     state: &DispatcherState,
 ) {
     // Resolve the branch destination + transport: over the captured inbound flow
@@ -3059,12 +3143,40 @@ fn relay_fork_branch(
         return; // caller handles the error for the whole fork
     }
 
+    // A script send_socket= egress pin applies to this branch only when it has
+    // no captured flow (a flow already pins egress) and its transport matches
+    // the branch's outbound transport.  When it applies, the Via sent-by is the
+    // pinned listener's advertised address so the branch's response comes back
+    // to that socket.
+    let send_socket = match send_socket {
+        _ if flow.is_some() => None,
+        Some(pin) if pin.transport == outbound_transport => Some(pin),
+        Some(pin) => {
+            warn!(
+                send_socket = %pin.addr,
+                requested_transport = %pin.transport,
+                outbound_transport = %outbound_transport,
+                branch = branch_index,
+                "fork: send_socket transport does not match the branch transport — ignoring"
+            );
+            None
+        }
+        None => None,
+    };
+
     let transport_str = format!("{}", outbound_transport);
+    let (via_host, via_port) = match send_socket {
+        Some(pin) => {
+            let (host, port) = pin.via_sent_by();
+            (format_sip_host(&host), port)
+        }
+        None => (state.via_host(&outbound_transport), state.via_port(&outbound_transport)),
+    };
     let branch = core::add_via(
         &mut relayed.headers,
         &transport_str,
-        &state.via_host(&outbound_transport),
-        Some(state.via_port(&outbound_transport)),
+        &via_host,
+        Some(via_port),
     );
 
     if record_routed {
@@ -3162,7 +3274,7 @@ fn relay_fork_branch(
         cid
     } else {
         let relay_target = RelayTarget { address: destination, transport: Some(outbound_transport), server_name: None };
-        send_to_target(data, &relay_target, inbound.transport, inbound.connection_id, state)
+        send_to_target(data, &relay_target, inbound.transport, inbound.connection_id, send_socket.map(|pin| pin.addr), state)
     };
 
     debug!(
@@ -3299,7 +3411,7 @@ fn handle_response(
                                     transport: Some(transport),
                                     server_name: None,
                                 };
-                                send_to_target(data, &target, transport, ConnectionId::default(), state);
+                                send_to_target(data, &target, transport, ConnectionId::default(), None, state);
                             }
                         } else if status_code >= 300 {
                             state.recording_manager.handle_failure(&session_id, status_code);
@@ -3579,6 +3691,7 @@ fn handle_response(
                             &RelayTarget { address: cb.destination, transport: Some(cb.transport), server_name: None },
                             cb.transport,
                             cb.connection_id,
+                            None,
                             state,
                         );
                         info!(
@@ -4358,10 +4471,16 @@ fn send_to_target(
     target: &RelayTarget,
     fallback_transport: Transport,
     fallback_connection_id: ConnectionId,
+    send_source: Option<SocketAddr>,
     state: &DispatcherState,
 ) -> ConnectionId {
     let transport = target.transport.unwrap_or(fallback_transport);
     let destination = target.address;
+    // A script `send_socket=` egress pin translated to a bind address:
+    // - UDP pins the exact `(ip, port)` listener socket (`source_local_addr`).
+    // - TCP/TLS bind the source *IP* with an ephemeral port (`port 0`) — the
+    //   listen port would collide on the 4-tuple in `TIME_WAIT`.
+    let send_bind_stream = send_source.map(|addr| SocketAddr::new(addr.ip(), 0));
 
     // HEP capture — outbound (sent to network)
     if let Some(ref hep) = state.hep_sender {
@@ -4379,10 +4498,14 @@ fn send_to_target(
             // never matches and the packet is silently dropped.
             let pool = Arc::clone(&state.connection_pool);
             let data_clone = data;
-            let ipsec_source = crate::script::api::ipsec::outbound_local_addr_for(destination);
+            // IPsec's fixed-port source wins over a script send_socket pin (the
+            // kernel XFRM selector requires it); otherwise use the pin's
+            // interface IP with an ephemeral source port.
+            let source = crate::script::api::ipsec::outbound_local_addr_for(destination)
+                .or(send_bind_stream);
             let connect_result = tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
-                    match ipsec_source {
+                    match source {
                         Some(source) => pool.send_tcp_from(source, destination, data_clone).await,
                         None => pool.send_tcp(destination, data_clone).await,
                     }
@@ -4416,6 +4539,40 @@ fn send_to_target(
             }
         }
         Transport::Tls => {
+            // Script send_socket= egress pin over TLS: open (or reuse) a
+            // source-bound pool connection.  The pool keys on the bind address,
+            // so this stays distinct from a default-source connection to the
+            // same peer.  We bypass the generic `reuse` below because that
+            // ignores the source — reusing a connection off the wrong interface
+            // would violate the operator's egress pin.
+            if let Some(bind) = send_bind_stream {
+                let pool = Arc::clone(&state.connection_pool);
+                let server_name = target.server_name.clone();
+                let data_clone = data;
+                return match tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(pool.send_tls_from(
+                        bind,
+                        destination,
+                        server_name.as_deref(),
+                        data_clone,
+                    ))
+                }) {
+                    Ok(connection_id) => {
+                        debug!(
+                            destination = %destination,
+                            connection_id = ?connection_id,
+                            bind = %bind,
+                            "relayed via source-bound TLS pool (send_socket)"
+                        );
+                        connection_id
+                    }
+                    Err(error) => {
+                        error!(destination = %destination, "source-bound TLS pool send failed: {error}");
+                        ConnectionId::default()
+                    }
+                };
+            }
+
             // TLS connection reuse: find an existing inbound (or pool-created
             // outbound) TLS connection to the destination (like OpenSIPS
             // connection reuse).  `reuse` tries an exact SocketAddr match, then
@@ -4530,8 +4687,11 @@ fn send_to_target(
             // Returns `None` for non-IPsec deployments and ordinary
             // (non-UE) destinations — i.e. zero impact on the hot
             // path when no IpsecManager is wired.
+            // IPsec auto-source wins over a script send_socket pin (kernel XFRM
+            // selector); otherwise the pin selects the exact `(ip, port)` UDP
+            // listener socket to egress from (routed via `udp_by_local`).
             let source_local_addr =
-                crate::script::api::ipsec::outbound_local_addr_for(destination);
+                crate::script::api::ipsec::outbound_local_addr_for(destination).or(send_source);
             let outbound_message = OutboundMessage {
                 connection_id: fallback_connection_id,
                 transport,
@@ -5857,7 +6017,7 @@ fn send_b2bua_to_bleg(
         transport: Some(transport),
         server_name: None,
     };
-    send_to_target(data, &target, transport, ConnectionId::default(), state);
+    send_to_target(data, &target, transport, ConnectionId::default(), None, state);
 }
 
 /// Create Rust-backed auth, registrar, log, and proxy utility singletons
@@ -6921,7 +7081,7 @@ fn start_next_fork_branch(
     server_key: &TransactionKey,
     state: &DispatcherState,
 ) {
-    let (original_request, record_routed, source_addr, connection_id, transport, agg, branch_flow) = {
+    let (original_request, record_routed, source_addr, connection_id, transport, agg, branch_flow, send_socket) = {
         let session = match session_arc.read() {
             Ok(s) => s,
             Err(_) => return,
@@ -6934,6 +7094,7 @@ fn start_next_fork_branch(
             session.transport,
             session.fork_aggregator.clone(),
             session.fork_flows.get(next_index).cloned().flatten(),
+            session.fork_send_socket.clone(),
         )
     };
 
@@ -6968,6 +7129,7 @@ fn start_next_fork_branch(
             session_arc,
             &agg,
             branch_flow.as_ref(),
+            send_socket.as_ref(),
             state,
         );
     }
@@ -7181,6 +7343,7 @@ fn handle_ack_via_session(
                 &target,
                 client_branch.transport,
                 ack_connection_id,
+                None,
                 state,
             );
         }
@@ -8144,7 +8307,7 @@ fn handle_b2bua_invite(
             state.call_actors.remove_call(&call_id);
             state.call_event_receivers.remove(&call_id);
         }
-        CallAction::Dial { target, next_hop, flow, route, timeout } => {
+        CallAction::Dial { target, next_hop, flow, route, send_socket, timeout } => {
             debug!(
                 call_id = %call_id,
                 target = %target,
@@ -8153,20 +8316,23 @@ fn handle_b2bua_invite(
                 routes = route.len(),
                 "B2BUA: dialling B-leg",
             );
+            let send_socket = state.resolve_send_socket(send_socket.as_deref());
             b2bua_send_b_leg_invite(
                 &call_id,
                 &target,
                 next_hop.as_deref(),
                 flow.as_ref(),
                 &route,
+                send_socket.as_ref(),
                 &message_guard,
                 &inbound,
                 state,
             );
             set_b2bua_answer_deadline(&call_id, timeout, state);
         }
-        CallAction::Fork { targets, flows, strategy: _, timeout } => {
+        CallAction::Fork { targets, flows, strategy: _, send_socket, timeout } => {
             debug!(call_id = %call_id, targets = ?targets, "B2BUA: forking B-legs");
+            let send_socket = state.resolve_send_socket(send_socket.as_deref());
             for (index, target) in targets.iter().enumerate() {
                 b2bua_send_b_leg_invite(
                     &call_id,
@@ -8174,6 +8340,7 @@ fn handle_b2bua_invite(
                     None,
                     flows.get(index).and_then(|f| f.as_ref()),
                     &[],
+                    send_socket.as_ref(),
                     &message_guard,
                     &inbound,
                     state,
@@ -8218,12 +8385,14 @@ fn handle_b2bua_invite(
 /// wire destination instead of `target_uri` — IMS edge use-case where the
 /// R-URI must carry the canonical home-domain IMPU but the message has to
 /// be routed via a fixed next-hop (BGCF, I-CSCF, outbound proxy, …).
+#[allow(clippy::too_many_arguments)]
 fn b2bua_send_b_leg_invite(
     call_id: &str,
     target_uri: &str,
     next_hop: Option<&str>,
     flow: Option<&crate::script::api::registrar::PyFlow>,
     b_leg_route: &[String],
+    send_socket: Option<&crate::transport::SendSocket>,
     original_request: &SipMessage,
     _inbound: &InboundMessage,
     state: &DispatcherState,
@@ -8263,13 +8432,41 @@ fn b2bua_send_b_leg_invite(
         (relay_target.address, relay_target.transport.unwrap_or(Transport::Udp))
     };
 
+    // A script send_socket= egress pin applies to the B-leg only when it has no
+    // captured flow (a flow already pins egress) and its transport matches the
+    // B-leg's outbound transport.  When it applies, the B-leg Via sent-by is the
+    // pinned listener's advertised address so the callee's response comes back
+    // to that socket.
+    let send_socket = match send_socket {
+        _ if flow.is_some() => None,
+        Some(pin) if pin.transport == outbound_transport => Some(pin),
+        Some(pin) => {
+            warn!(
+                call_id = %call_id,
+                send_socket = %pin.addr,
+                requested_transport = %pin.transport,
+                outbound_transport = %outbound_transport,
+                "B2BUA: send_socket transport does not match the B-leg transport — ignoring"
+            );
+            None
+        }
+        None => None,
+    };
+
     // Build a new INVITE for the B-leg
     let branch = TransactionKey::generate_branch();
+    let (via_host, via_port) = match send_socket {
+        Some(pin) => {
+            let (host, port) = pin.via_sent_by();
+            (format_sip_host(&host), port)
+        }
+        None => (state.via_host(&outbound_transport), state.via_port(&outbound_transport)),
+    };
     let via_value = format!(
         "SIP/2.0/{} {}:{};branch={}",
         outbound_transport,
-        state.via_host(&outbound_transport),
-        state.via_port(&outbound_transport),
+        via_host,
+        via_port,
         branch,
     );
 
@@ -8539,7 +8736,7 @@ fn b2bua_send_b_leg_invite(
         }
     } else {
         let relay_target = RelayTarget { address: destination, transport: Some(outbound_transport), server_name: None };
-        send_to_target(data, &relay_target, outbound_transport, ConnectionId::default(), state);
+        send_to_target(data, &relay_target, outbound_transport, ConnectionId::default(), send_socket.map(|pin| pin.addr), state);
     }
 
     // Persist the fully hygiene-processed B-leg INVITE on the leg.
@@ -10227,7 +10424,7 @@ fn handle_b2bua_response(
                         transport: Some(transport),
                         server_name: None,
                     };
-                    send_to_target(data, &target, transport, ConnectionId::default(), state);
+                    send_to_target(data, &target, transport, ConnectionId::default(), None, state);
                 }
             }
         }
@@ -10462,7 +10659,7 @@ fn handle_b2bua_response(
                                 }
 
                                 let data = Bytes::from(retry.to_bytes());
-                                send_to_target(data, &relay_target, transport, reuse_connection_id, state);
+                                send_to_target(data, &relay_target, transport, reuse_connection_id, None, state);
                             }
                             return; // don't forward 422 to A-leg or fire on_failure
                         }
@@ -10732,7 +10929,7 @@ fn handle_b2bua_response(
                                 }
 
                                 let data = Bytes::from(retry.to_bytes());
-                                send_to_target(data, &relay_target, transport, reuse_connection_id, state);
+                                send_to_target(data, &relay_target, transport, reuse_connection_id, None, state);
                             }
                             return; // don't forward 401/407 to A-leg or fire on_failure
                         }
@@ -11210,7 +11407,7 @@ fn handle_b2bua_bye(
             transport: Some(transport),
             server_name: None,
         };
-        send_to_target(data, &target, transport, ConnectionId::default(), state);
+        send_to_target(data, &target, transport, ConnectionId::default(), None, state);
     }
     // RTPEngine unsubscribe: stop media forking for each recording session.
     if let Some(ref rtpengine_set) = state.rtpengine_set {

--- a/src/proxy/session.rs
+++ b/src/proxy/session.rs
@@ -76,6 +76,11 @@ pub struct ProxySession {
     /// branches started after the first.  `PyFlow` is plain data (no
     /// `Py<PyAny>`), so cloning it off the dispatcher thread is sound.
     pub fork_flows: Vec<Option<crate::script::api::registrar::PyFlow>>,
+    /// Script `send_socket=` egress pin for the whole fork, stored so sequential
+    /// forking (`start_next_fork_branch`) applies the same source-socket pin to
+    /// branches started after the first.  `SendSocket` is plain data (no
+    /// `Py<PyAny>`), so cloning it off the dispatcher thread is sound.
+    pub fork_send_socket: Option<crate::transport::SendSocket>,
     /// Maps client transaction key → branch index in the ForkAggregator.
     pub branch_index_map: HashMap<TransactionKey, usize>,
     /// Whether `record_route()` was called by the script.
@@ -115,6 +120,7 @@ impl ProxySession {
             client_branches: HashMap::new(),
             fork_aggregator: None,
             fork_flows: Vec::new(),
+            fork_send_socket: None,
             branch_index_map: HashMap::new(),
             source_addr,
             inbound_local_addr,

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -42,6 +42,12 @@ pub enum CallAction {
         /// Service-Route on MO calls so they traverse the originating S-CSCF
         /// (RFC 3608). Each entry is a full route value, e.g. `<sip:scscf;lr>`.
         route: Vec<String>,
+        /// Force-send-socket egress pin (`send_socket="udp:10.0.0.1:5060"`).
+        /// Selects which configured listener the B-leg INVITE leaves from on a
+        /// multi-homed host.  Validated for format at API-call time; resolved
+        /// against the configured listeners in the dispatcher.  Ignored when
+        /// `flow` is set (the flow already pins the egress listener).
+        send_socket: Option<String>,
         timeout: u32,
     },
     /// Fork to multiple targets.
@@ -54,6 +60,10 @@ pub enum CallAction {
         targets: Vec<String>,
         flows: Vec<Option<super::registrar::PyFlow>>,
         strategy: String,
+        /// Force-send-socket egress pin applied to every B-leg branch (see
+        /// [`CallAction::Dial::send_socket`]).  A per-branch flow still takes
+        /// precedence over it for that branch.
+        send_socket: Option<String>,
         timeout: u32,
     },
     /// Terminate the call (BYE both legs).
@@ -861,7 +871,8 @@ impl PyCall {
     ///         copy=["X-Operator-Tag"],
     ///         strip=["History-Info"],
     ///     )
-    #[pyo3(signature = (uri, timeout=30, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new()))]
+    #[pyo3(signature = (uri, timeout=30, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new(), send_socket=None))]
+    #[allow(clippy::too_many_arguments)]
     fn dial(
         &mut self,
         uri: &str,
@@ -873,15 +884,19 @@ impl PyCall {
         strip: Vec<String>,
         translate: Vec<(String, String)>,
         route: Vec<String>,
-    ) {
+        send_socket: Option<String>,
+    ) -> PyResult<()> {
+        super::request::validate_send_socket(send_socket.as_deref())?;
         self.action = CallAction::Dial {
             target: uri.to_string(),
             next_hop: next_hop.map(String::from),
             flow,
             route,
+            send_socket,
             timeout,
         };
         self.update_header_policy_input(header_policy, copy, strip, translate);
+        Ok(())
     }
 
     /// Fork to multiple targets.
@@ -892,7 +907,8 @@ impl PyCall {
     /// connection reuse, mandatory for WebSocket callees (RFC 7118 §5 / RFC
     /// 5626 §5.3).  `header_policy` / `copy` / `strip` / `translate` apply to
     /// every branch — per-branch policy is a follow-up enhancement.
-    #[pyo3(signature = (targets, strategy="parallel", timeout=30, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new()))]
+    #[pyo3(signature = (targets, strategy="parallel", timeout=30, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), send_socket=None))]
+    #[allow(clippy::too_many_arguments)]
     fn fork(
         &mut self,
         targets: Vec<Bound<'_, PyAny>>,
@@ -902,7 +918,9 @@ impl PyCall {
         copy: Vec<String>,
         strip: Vec<String>,
         translate: Vec<(String, String)>,
+        send_socket: Option<String>,
     ) -> PyResult<()> {
+        super::request::validate_send_socket(send_socket.as_deref())?;
         let mut target_uris: Vec<String> = Vec::with_capacity(targets.len());
         let mut flows: Vec<Option<super::registrar::PyFlow>> = Vec::with_capacity(targets.len());
         for item in targets {
@@ -919,6 +937,7 @@ impl PyCall {
             targets: target_uris,
             flows,
             strategy: strategy.to_string(),
+            send_socket,
             timeout,
         };
         self.update_header_policy_input(header_policy, copy, strip, translate);
@@ -1231,7 +1250,7 @@ mod tests {
     fn call_dial() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        call.dial("sip:bob@10.0.0.2:5060", 30, None, None, None, vec![], vec![], vec![], vec![]);
+        call.dial("sip:bob@10.0.0.2:5060", 30, None, None, None, vec![], vec![], vec![], vec![], None).unwrap();
         assert_eq!(
             call.action(),
             &CallAction::Dial {
@@ -1239,6 +1258,7 @@ mod tests {
                 next_hop: None,
                 flow: None,
                 route: vec![],
+                send_socket: None,
                 timeout: 30,
             }
         );
@@ -1260,7 +1280,8 @@ mod tests {
             vec![],
             vec![],
             vec!["<sip:scscf.ims.mnc01.mcc001.3gppnetwork.org:6060;lr>".to_string()],
-        );
+            None,
+        ).unwrap();
         match call.action() {
             CallAction::Dial { route, .. } => {
                 assert_eq!(route, &vec!["<sip:scscf.ims.mnc01.mcc001.3gppnetwork.org:6060;lr>".to_string()]);
@@ -1283,7 +1304,8 @@ mod tests {
             vec![],
             vec![],
             vec![],
-        );
+            None,
+        ).unwrap();
         assert_eq!(
             call.action(),
             &CallAction::Dial {
@@ -1291,6 +1313,7 @@ mod tests {
                 next_hop: Some("sip:172.16.0.111:4060".to_string()),
                 flow: None,
                 route: vec![],
+                send_socket: None,
                 timeout: 30,
             }
         );
@@ -1310,7 +1333,8 @@ mod tests {
             vec!["History-Info".to_string()],
             vec![("Diversion".to_string(), "rfc7044".to_string())],
             vec![],
-        );
+            None,
+        ).unwrap();
         let input = call.header_policy_input().expect("policy input must be captured");
         assert_eq!(input.policy_name.as_deref(), Some("ims-trust-domain-boundary@2026"));
         assert_eq!(input.deltas_copy, vec!["X-Operator-Tag".to_string()]);
@@ -1319,6 +1343,35 @@ mod tests {
             input.deltas_translate,
             vec![("Diversion".to_string(), "rfc7044".to_string())]
         );
+    }
+
+    #[test]
+    fn call_dial_with_send_socket() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.dial(
+            "sip:bob@10.0.0.2:5060", 30, None, None, None,
+            vec![], vec![], vec![], vec![],
+            Some("udp:10.0.0.1:5060".to_string()),
+        ).unwrap();
+        match call.action() {
+            CallAction::Dial { send_socket, .. } => {
+                assert_eq!(send_socket.as_deref(), Some("udp:10.0.0.1:5060"));
+            }
+            other => panic!("expected Dial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn call_dial_rejects_malformed_send_socket() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        let result = call.dial(
+            "sip:bob@10.0.0.2:5060", 30, None, None, None,
+            vec![], vec![], vec![], vec![],
+            Some("not-a-socket".to_string()),
+        );
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1331,13 +1384,14 @@ mod tests {
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.2").into_any(),
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.3").into_any(),
             ];
-            call.fork(targets, "parallel", 30, None, vec![], vec![], vec![]).unwrap();
+            call.fork(targets, "parallel", 30, None, vec![], vec![], vec![], None).unwrap();
             assert_eq!(
                 call.action(),
                 &CallAction::Fork {
                     targets: vec!["sip:bob@10.0.0.2".to_string(), "sip:bob@10.0.0.3".to_string()],
                     flows: vec![None, None],
                     strategy: "parallel".to_string(),
+                    send_socket: None,
                     timeout: 30,
                 }
             );
@@ -1354,7 +1408,7 @@ mod tests {
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.2").into_any(),
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.3").into_any(),
             ];
-            call.fork(targets, "parallel", 30, Some("sip-trunk-edge@2026"), vec![], vec!["X-Internal-Tag".to_string()], vec![]).unwrap();
+            call.fork(targets, "parallel", 30, Some("sip-trunk-edge@2026"), vec![], vec!["X-Internal-Tag".to_string()], vec![], None).unwrap();
             let input = call.header_policy_input().expect("policy input must be captured");
             assert_eq!(input.policy_name.as_deref(), Some("sip-trunk-edge@2026"));
             assert_eq!(input.deltas_strip, vec!["X-Internal-Tag".to_string()]);

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -99,6 +99,11 @@ pub enum RequestAction {
     Relay {
         next_hop: Option<String>,
         flow: Option<super::registrar::PyFlow>,
+        /// Force-send-socket egress pin (`send_socket="udp:10.0.0.1:5060"`).
+        /// Validated for format at API-call time; resolved against the
+        /// configured listeners in the dispatcher.  Ignored when `flow` is set
+        /// (the flow already pins the egress listener).
+        send_socket: Option<String>,
     },
     /// Fork to multiple targets.
     ///
@@ -111,7 +116,24 @@ pub enum RequestAction {
         targets: Vec<String>,
         flows: Vec<Option<super::registrar::PyFlow>>,
         strategy: String,
+        /// Force-send-socket egress pin applied to every branch (see
+        /// [`RequestAction::Relay::send_socket`]).  A per-branch flow (`flows[i]`)
+        /// still takes precedence over it for that branch.
+        send_socket: Option<String>,
     },
+}
+
+/// Format-validate a `send_socket=` argument, raising a Python `ValueError`
+/// with a helpful message on a malformed spec.  Existence as a real configured
+/// listener is checked later, in the dispatcher, against the `ListenerRegistry`
+/// (an unknown-but-well-formed socket warns and falls back to default routing
+/// rather than dropping the request).
+pub(crate) fn validate_send_socket(send_socket: Option<&str>) -> PyResult<()> {
+    if let Some(spec) = send_socket {
+        crate::transport::parse_send_socket(spec)
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
+    }
+    Ok(())
 }
 
 /// Python-visible SIP request object.
@@ -840,17 +862,20 @@ impl PyRequest {
     /// Optional callbacks:
     /// - `on_reply`: called with `(request, reply)` when a response arrives
     /// - `on_failure`: called with `(request, code, reason)` on error response
-    #[pyo3(signature = (next_hop=None, on_reply=None, on_failure=None, flow=None))]
+    #[pyo3(signature = (next_hop=None, on_reply=None, on_failure=None, flow=None, send_socket=None))]
     fn relay(
         &mut self,
         next_hop: Option<String>,
         on_reply: Option<Py<PyAny>>,
         on_failure: Option<Py<PyAny>>,
         flow: Option<super::registrar::PyFlow>,
-    ) {
+        send_socket: Option<String>,
+    ) -> PyResult<()> {
+        validate_send_socket(send_socket.as_deref())?;
         self.on_reply_callback = on_reply;
         self.on_failure_callback = on_failure;
-        self.action = RequestAction::Relay { next_hop, flow };
+        self.action = RequestAction::Relay { next_hop, flow, send_socket };
+        Ok(())
     }
 
     /// Fork to multiple targets.
@@ -861,8 +886,14 @@ impl PyRequest {
     /// captured inbound flow — RFC 5626 §5.3 connection reuse, mandatory for
     /// WebSocket UEs (RFC 7118 §5).  Bare strings (and non-local contacts) are
     /// DNS-resolved as before.
-    #[pyo3(signature = (targets, strategy="parallel"))]
-    fn fork(&mut self, targets: Vec<Bound<'_, PyAny>>, strategy: &str) -> PyResult<()> {
+    #[pyo3(signature = (targets, strategy="parallel", send_socket=None))]
+    fn fork(
+        &mut self,
+        targets: Vec<Bound<'_, PyAny>>,
+        strategy: &str,
+        send_socket: Option<String>,
+    ) -> PyResult<()> {
+        validate_send_socket(send_socket.as_deref())?;
         let mut target_uris: Vec<String> = Vec::with_capacity(targets.len());
         let mut flows: Vec<Option<super::registrar::PyFlow>> = Vec::with_capacity(targets.len());
         for item in targets {
@@ -880,6 +911,7 @@ impl PyRequest {
             targets: target_uris,
             flows,
             strategy: strategy.to_string(),
+            send_socket,
         };
         Ok(())
     }
@@ -1722,22 +1754,23 @@ mod tests {
     #[test]
     fn relay_sets_action() {
         let mut request = make_request();
-        request.relay(None, None, None, None);
+        request.relay(None, None, None, None, None).unwrap();
         assert_eq!(
             *request.action(),
-            RequestAction::Relay { next_hop: None, flow: None }
+            RequestAction::Relay { next_hop: None, flow: None, send_socket: None }
         );
     }
 
     #[test]
     fn relay_with_next_hop() {
         let mut request = make_request();
-        request.relay(Some("sip:proxy@next.com:5060".to_string()), None, None, None);
+        request.relay(Some("sip:proxy@next.com:5060".to_string()), None, None, None, None).unwrap();
         assert_eq!(
             *request.action(),
             RequestAction::Relay {
                 next_hop: Some("sip:proxy@next.com:5060".to_string()),
                 flow: None,
+                send_socket: None,
             }
         );
     }
@@ -1755,12 +1788,13 @@ mod tests {
             local_addr: "127.0.0.1:5066".parse().unwrap(),
             connection_id: 0xabcdef,
         };
-        request.relay(None, None, None, Some(flow.clone()));
+        request.relay(None, None, None, Some(flow.clone()), None).unwrap();
         assert_eq!(
             *request.action(),
             RequestAction::Relay {
                 next_hop: None,
                 flow: Some(flow),
+                send_socket: None,
             }
         );
     }
@@ -1784,9 +1818,10 @@ mod tests {
             None,
             None,
             Some(flow.clone()),
-        );
+            None,
+        ).unwrap();
         match request.action() {
-            RequestAction::Relay { next_hop, flow: action_flow } => {
+            RequestAction::Relay { next_hop, flow: action_flow, .. } => {
                 assert_eq!(next_hop.as_deref(), Some("sip:ignored@example.com"));
                 assert_eq!(action_flow.as_ref(), Some(&flow));
             }
@@ -1835,6 +1870,60 @@ mod tests {
     }
 
     #[test]
+    fn relay_with_send_socket_stores_spec() {
+        let mut request = make_request();
+        request
+            .relay(None, None, None, None, Some("udp:10.0.0.1:5060".to_string()))
+            .unwrap();
+        assert_eq!(
+            *request.action(),
+            RequestAction::Relay {
+                next_hop: None,
+                flow: None,
+                send_socket: Some("udp:10.0.0.1:5060".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn relay_with_malformed_send_socket_raises() {
+        // Format is validated at the API so a script author gets an immediate
+        // ValueError rather than a silently-ignored egress pin.
+        let mut request = make_request();
+        assert!(request.relay(None, None, None, None, Some("10.0.0.1:5060".to_string())).is_err());
+        assert!(request.relay(None, None, None, None, Some("udp:nonsense".to_string())).is_err());
+        assert!(request.relay(None, None, None, None, Some("pigeon:10.0.0.1:5060".to_string())).is_err());
+        // A well-formed spec is accepted here (existence is checked later, in
+        // the dispatcher, against the configured listeners).
+        assert!(request.relay(None, None, None, None, Some("tls:[2001:db8::1]:5061".to_string())).is_ok());
+    }
+
+    #[test]
+    fn fork_with_send_socket_stores_spec() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let mut request = make_request();
+            let targets: Vec<Bound<'_, PyAny>> = vec![
+                pyo3::types::PyString::new(py, "sip:a@host").into_any(),
+            ];
+            request
+                .fork(targets, "parallel", Some("tcp:10.0.0.1:5060".to_string()))
+                .unwrap();
+            match request.action() {
+                RequestAction::Fork { send_socket, .. } => {
+                    assert_eq!(send_socket.as_deref(), Some("tcp:10.0.0.1:5060"));
+                }
+                other => panic!("expected Fork, got {other:?}"),
+            }
+
+            let targets: Vec<Bound<'_, PyAny>> = vec![
+                pyo3::types::PyString::new(py, "sip:a@host").into_any(),
+            ];
+            assert!(request.fork(targets, "parallel", Some("bad-spec".to_string())).is_err());
+        });
+    }
+
+    #[test]
     fn fork_sets_action() {
         pyo3::Python::initialize();
         pyo3::Python::attach(|py| {
@@ -1843,13 +1932,14 @@ mod tests {
                 pyo3::types::PyString::new(py, "sip:a@host").into_any(),
                 pyo3::types::PyString::new(py, "sip:b@host").into_any(),
             ];
-            request.fork(targets, "sequential").unwrap();
+            request.fork(targets, "sequential", None).unwrap();
             assert_eq!(
                 *request.action(),
                 RequestAction::Fork {
                     targets: vec!["sip:a@host".to_string(), "sip:b@host".to_string()],
                     flows: vec![None, None],
                     strategy: "sequential".to_string(),
+                    send_socket: None,
                 }
             );
         });

--- a/src/script/api/timer.rs
+++ b/src/script/api/timer.rs
@@ -221,7 +221,7 @@ impl PyTimerHandle {
     }
 
     fn __repr__(&self) -> String {
-        format!("TimerHandle(key={:?})", &self.key)
+        format!("TimerHandle(key={:?})", self.key)
     }
 }
 

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -799,7 +799,7 @@ fn extract_handlers(
         let metadata: Option<Bound<'_, PyAny>> = item
             .get_item(4)
             .ok()
-            .and_then(|v: Bound<'_, PyAny>| if v.is_none() { None } else { Some(v) });
+            .filter(|v: &Bound<'_, PyAny>| !v.is_none());
 
         let kind = match kind_str.as_str() {
             "proxy.on_request" => HandlerKind::ProxyRequest(filter),
@@ -1555,6 +1555,7 @@ def new_call(call):
                     next_hop: None,
                     flow: None,
                     route: vec![],
+                    send_socket: None,
                     timeout: 30,
                 }
             );

--- a/src/server.rs
+++ b/src/server.rs
@@ -1047,8 +1047,16 @@ impl SiphonServer {
         > = std::collections::HashMap::new();
         let mut udp_default: Option<flume::Sender<transport::OutboundMessage>> = None;
         let ipsec_enabled = config.ipsec.is_some();
+        // Populate the per-listener UDP channel map when IPsec is enabled OR the
+        // host is multi-homed (more than one UDP listener).  A single-listener
+        // deployment — the README perf baseline — keeps `udp_by_local` empty so
+        // `OutboundRouter::send` stays on the branch-predicted fast path (no
+        // per-message HashMap lookup).  Multi-homing is what makes a script
+        // `send_socket=` egress pin meaningful, and it also covers
+        // IPsec-protected replies (TS 33.203 §7.4).
+        let per_listener_udp = ipsec_enabled || udp_listener_channels.len() > 1;
         for (addr, (tx, _)) in udp_listener_channels.iter() {
-            if ipsec_enabled {
+            if per_listener_udp {
                 udp_by_local.insert(*addr, tx.clone());
             }
             if udp_default.is_none() {
@@ -1071,6 +1079,11 @@ impl SiphonServer {
         let mut first_listen_addr: Option<std::net::SocketAddr> = None;
         let mut listen_addrs = std::collections::HashMap::new();
         let mut advertised_addrs: std::collections::HashMap<transport::Transport, String> = std::collections::HashMap::new();
+        // Every configured listener (transport + bound addr + advertised host),
+        // for `send_socket=` egress resolution.  Unlike `listen_addrs` (first
+        // per transport), this keeps the FULL multi-homed set across transports.
+        let mut listener_registry_entries: Vec<(transport::Transport, std::net::SocketAddr, Option<String>)> =
+            Vec::new();
 
         // DSCP → TOS byte resolution helper.
         // Per-entry overrides the global listen.dscp (default CS3 = 24 → TOS 96).
@@ -1093,6 +1106,7 @@ impl SiphonServer {
             if let Some(adv) = entry.advertise() {
                 advertised_addrs.entry(transport::Transport::Udp).or_insert_with(|| adv.to_string());
             }
+            listener_registry_entries.push((transport::Transport::Udp, addr, entry.advertise().map(str::to_string)));
             let tos = resolve_tos(entry);
             info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting UDP transport");
             // Use this listener's dedicated outbound channel (TS 33.203
@@ -1190,6 +1204,7 @@ impl SiphonServer {
             if let Some(adv) = entry.advertise() {
                 advertised_addrs.entry(transport::Transport::Tcp).or_insert_with(|| adv.to_string());
             }
+            listener_registry_entries.push((transport::Transport::Tcp, addr, entry.advertise().map(str::to_string)));
             let tos = resolve_tos(entry);
             tcp_entries.push((addr, tos, entry.dscp().or(global_dscp)));
         }
@@ -1291,6 +1306,7 @@ impl SiphonServer {
                 if let Some(adv) = entry.advertise() {
                     advertised_addrs.entry(transport::Transport::Tls).or_insert_with(|| adv.to_string());
                 }
+                listener_registry_entries.push((transport::Transport::Tls, addr, entry.advertise().map(str::to_string)));
                 let tos = resolve_tos(entry);
                 info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting TLS transport");
                 transport::tls::listen(addr, tls_config, inbound_tx.clone(), tls_outbound_rx.clone(), Arc::clone(&tls_connection_map), Arc::clone(&transport_acl), stream_connections.clone(), tos, Some(Arc::clone(&connection_pool)), crlf_pong_tracker.clone(), connection_close_tx.clone()).await;
@@ -1311,6 +1327,7 @@ impl SiphonServer {
             if let Some(adv) = entry.advertise() {
                 advertised_addrs.entry(transport::Transport::WebSocket).or_insert_with(|| adv.to_string());
             }
+            listener_registry_entries.push((transport::Transport::WebSocket, addr, entry.advertise().map(str::to_string)));
             let tos = resolve_tos(entry);
             info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting WS transport");
             transport::ws::listen(addr, inbound_tx.clone(), ws_outbound_rx.clone(), Arc::clone(&ws_connection_map), Arc::clone(&transport_acl), stream_connections.clone(), tos, connection_close_tx.clone()).await;
@@ -1331,6 +1348,7 @@ impl SiphonServer {
                 if let Some(adv) = entry.advertise() {
                     advertised_addrs.entry(transport::Transport::WebSocketSecure).or_insert_with(|| adv.to_string());
                 }
+                listener_registry_entries.push((transport::Transport::WebSocketSecure, addr, entry.advertise().map(str::to_string)));
                 let tos = resolve_tos(entry);
                 info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting WSS transport");
                 transport::ws::listen_secure(addr, tls_config, inbound_tx.clone(), wss_outbound_rx.clone(), Arc::clone(&wss_connection_map), Arc::clone(&transport_acl), stream_connections.clone(), tos, connection_close_tx.clone()).await;
@@ -1353,6 +1371,7 @@ impl SiphonServer {
                 if let Some(adv) = entry.advertise() {
                     advertised_addrs.entry(transport::Transport::Sctp).or_insert_with(|| adv.to_string());
                 }
+                listener_registry_entries.push((transport::Transport::Sctp, addr, entry.advertise().map(str::to_string)));
                 let tos = resolve_tos(entry);
                 info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting SCTP transport");
                 transport::sctp::listen(addr, inbound_tx.clone(), sctp_outbound_rx.clone(), Arc::clone(&sctp_connection_map), Arc::clone(&transport_acl), tos).await;
@@ -1850,6 +1869,7 @@ impl SiphonServer {
             local_addr,
             listen_addrs,
             advertised_addrs,
+            transport::ListenerRegistry::from_entries(listener_registry_entries),
             hep_sender,
             uac_sender,
             connection_pool,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -128,6 +128,129 @@ impl std::fmt::Display for Transport {
     }
 }
 
+impl Transport {
+    /// Parse a SIP transport scheme token (`"udp"`, `"tcp"`, `"tls"`, `"ws"`,
+    /// `"wss"`, `"sctp"`, case-insensitive) into a [`Transport`].  Returns
+    /// `None` for an unrecognized scheme.
+    pub fn from_scheme(scheme: &str) -> Option<Transport> {
+        match scheme.to_ascii_lowercase().as_str() {
+            "udp" => Some(Transport::Udp),
+            "tcp" => Some(Transport::Tcp),
+            "tls" => Some(Transport::Tls),
+            "ws" => Some(Transport::WebSocket),
+            "wss" => Some(Transport::WebSocketSecure),
+            "sctp" => Some(Transport::Sctp),
+            _ => None,
+        }
+    }
+}
+
+/// A script-requested egress socket ("force send socket") — the operator
+/// equivalent of Kamailio's `force_send_socket()` / OpenSIPS' `$fs`.  Selects
+/// which of siphon's *own* configured listeners a relayed / dialed request
+/// leaves from, on a multi-homed host.  Resolved from a `send_socket=` string
+/// (e.g. `"udp:10.0.0.1:5060"`) against the [`ListenerRegistry`], so it always
+/// names a real listener and carries that listener's advertised address for
+/// the outgoing Via (so responses come back to the same socket).
+///
+/// Source-socket selection is transport-specific:
+/// - **UDP** pins the exact `(ip, port)` listener socket as the egress
+///   ([`OutboundMessage::source_local_addr`] → `udp_by_local`).
+/// - **TCP/TLS** bind the egress socket's *source IP* (interface); the source
+///   port stays ephemeral, because binding the listen port for an outbound
+///   connection collides on the 4-tuple in `TIME_WAIT` (`EADDRNOTAVAIL`).
+#[derive(Debug, Clone)]
+pub struct SendSocket {
+    /// The transport of the selected listener.
+    pub transport: Transport,
+    /// The listener's bound socket address.
+    pub addr: SocketAddr,
+    /// The listener's advertised host (from `listen: { advertise: ... }`),
+    /// used as the outgoing Via sent-by host when set.
+    pub advertise: Option<String>,
+}
+
+impl SendSocket {
+    /// The Via sent-by `(host, port)` this egress socket should advertise.
+    /// Prefers the configured advertised host (external reachability behind
+    /// NAT / a load balancer); falls back to the bound IP literal.  The port
+    /// is always the listener's bound port so a response reaches this socket.
+    pub fn via_sent_by(&self) -> (String, u16) {
+        let host = self
+            .advertise
+            .clone()
+            .unwrap_or_else(|| self.addr.ip().to_string());
+        (host, self.addr.port())
+    }
+}
+
+/// Parse a `send_socket=` spec string of the form `"<scheme>:<ip>:<port>"`
+/// (e.g. `"udp:10.0.0.1:5060"`, `"tls:[2001:db8::1]:5061"`) into its
+/// `(transport, addr)` parts.  Validates *format only* — existence as a real
+/// listener is checked separately against the [`ListenerRegistry`].
+///
+/// Returns a human-readable error string suitable for surfacing to a script
+/// author as a `ValueError`.
+pub fn parse_send_socket(spec: &str) -> Result<(Transport, SocketAddr), String> {
+    let (scheme, addr_part) = spec.split_once(':').ok_or_else(|| {
+        format!("send_socket '{spec}' must be '<transport>:<ip>:<port>' (e.g. 'udp:10.0.0.1:5060')")
+    })?;
+    let transport = Transport::from_scheme(scheme).ok_or_else(|| {
+        format!("send_socket '{spec}': unknown transport '{scheme}' (use udp/tcp/tls/ws/wss/sctp)")
+    })?;
+    let addr: SocketAddr = addr_part
+        .parse()
+        .map_err(|error| format!("send_socket '{spec}': invalid '<ip>:<port>' address: {error}"))?;
+    Ok((transport, addr))
+}
+
+/// Registry of every configured listener (`transport` + bound address +
+/// advertised host), built once at startup.  Backs `send_socket=` resolution:
+/// a script may only egress from a socket siphon is actually listening on, and
+/// the advertised host it should put in the outgoing Via comes from here too.
+///
+/// This is distinct from [`OutboundRouter::udp_by_local`] (which holds only the
+/// per-listener UDP *channels*) and from the per-transport `listen_addrs` map
+/// (which keeps only the first listener of each transport): multi-homed
+/// `send_socket` needs the *full* set across every transport.
+#[derive(Debug, Default, Clone)]
+pub struct ListenerRegistry {
+    entries: Arc<std::collections::HashMap<(Transport, SocketAddr), Option<String>>>,
+}
+
+impl ListenerRegistry {
+    /// Build from `(transport, bound_addr, advertise)` triples.
+    pub fn from_entries(
+        entries: impl IntoIterator<Item = (Transport, SocketAddr, Option<String>)>,
+    ) -> Self {
+        let map = entries
+            .into_iter()
+            .map(|(transport, addr, advertise)| ((transport, addr), advertise))
+            .collect();
+        Self { entries: Arc::new(map) }
+    }
+
+    /// Resolve a parsed `(transport, addr)` to a [`SendSocket`] iff a listener
+    /// with exactly that transport+address is configured.  Returns `None` for
+    /// an address siphon is not listening on (the caller should then warn and
+    /// fall back to default routing rather than drop the request).
+    pub fn resolve(&self, transport: Transport, addr: SocketAddr) -> Option<SendSocket> {
+        self.entries
+            .get(&(transport, addr))
+            .map(|advertise| SendSocket { transport, addr, advertise: advertise.clone() })
+    }
+
+    /// Number of registered listeners (diagnostics / tests).
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether no listeners are registered (test fixtures).
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 /// A message to be sent outbound on a specific connection.
 #[derive(Debug)]
 pub struct OutboundMessage {
@@ -603,5 +726,118 @@ mod tests {
             registry.get(&addr("10.0.0.5:50000")),
             Some((Transport::WebSocket, ConnectionId(4))),
         );
+    }
+
+    #[test]
+    fn transport_from_scheme_roundtrips() {
+        assert_eq!(Transport::from_scheme("udp"), Some(Transport::Udp));
+        assert_eq!(Transport::from_scheme("TCP"), Some(Transport::Tcp));
+        assert_eq!(Transport::from_scheme("Tls"), Some(Transport::Tls));
+        assert_eq!(Transport::from_scheme("ws"), Some(Transport::WebSocket));
+        assert_eq!(Transport::from_scheme("wss"), Some(Transport::WebSocketSecure));
+        assert_eq!(Transport::from_scheme("sctp"), Some(Transport::Sctp));
+        assert_eq!(Transport::from_scheme("carrier-pigeon"), None);
+    }
+
+    #[test]
+    fn parse_send_socket_valid_forms() {
+        let (transport, addr) = parse_send_socket("udp:10.0.0.1:5060").unwrap();
+        assert_eq!(transport, Transport::Udp);
+        assert_eq!(addr, "10.0.0.1:5060".parse().unwrap());
+
+        let (transport, addr) = parse_send_socket("tls:[2001:db8::1]:5061").unwrap();
+        assert_eq!(transport, Transport::Tls);
+        assert_eq!(addr, "[2001:db8::1]:5061".parse().unwrap());
+    }
+
+    #[test]
+    fn parse_send_socket_rejects_malformed() {
+        assert!(parse_send_socket("10.0.0.1:5060").is_err()); // no scheme
+        assert!(parse_send_socket("udp:not-an-addr").is_err()); // bad addr
+        assert!(parse_send_socket("udp:10.0.0.1").is_err()); // missing port
+        assert!(parse_send_socket("smoke-signal:10.0.0.1:5060").is_err()); // bad scheme
+    }
+
+    #[test]
+    fn outbound_router_routes_udp_by_source_local_addr() {
+        // The UDP egress mechanism `send_socket=` relies on: when a message
+        // carries `source_local_addr = Some(addr)` and a per-listener channel
+        // is registered for `addr`, it must be delivered to *that* listener's
+        // channel — not the default.  A message with no (or an unknown) source
+        // falls back to the default channel.
+        let default = flume::unbounded::<OutboundMessage>();
+        let listener_a = flume::unbounded::<OutboundMessage>();
+        let listener_b = flume::unbounded::<OutboundMessage>();
+        let addr_a = addr("10.0.0.1:5060");
+        let addr_b = addr("192.168.1.1:5060");
+
+        let mut udp_by_local = std::collections::HashMap::new();
+        udp_by_local.insert(addr_a, listener_a.0.clone());
+        udp_by_local.insert(addr_b, listener_b.0.clone());
+
+        let (dummy, _) = flume::unbounded();
+        let router = OutboundRouter {
+            udp: default.0.clone(),
+            udp_by_local,
+            tcp: dummy.clone(),
+            tls: dummy.clone(),
+            ws: dummy.clone(),
+            wss: dummy.clone(),
+            sctp: dummy,
+        };
+
+        let make = |source: Option<SocketAddr>| OutboundMessage {
+            connection_id: ConnectionId(0),
+            transport: Transport::Udp,
+            destination: addr("203.0.113.1:5060"),
+            data: Bytes::from_static(b"PING"),
+            source_local_addr: source,
+            server_name: None,
+        };
+
+        // Pinned to listener A → lands on A's channel.
+        router.send(make(Some(addr_a))).unwrap();
+        assert_eq!(listener_a.1.try_recv().unwrap().source_local_addr, Some(addr_a));
+        assert!(listener_b.1.try_recv().is_err());
+        assert!(default.1.try_recv().is_err());
+
+        // Pinned to listener B → lands on B's channel.
+        router.send(make(Some(addr_b))).unwrap();
+        assert_eq!(listener_b.1.try_recv().unwrap().source_local_addr, Some(addr_b));
+
+        // No source → default channel.
+        router.send(make(None)).unwrap();
+        assert!(default.1.try_recv().is_ok());
+
+        // Unknown source (not a registered listener) → default channel.
+        router.send(make(Some(addr("172.16.0.1:5060")))).unwrap();
+        assert!(default.1.try_recv().is_ok());
+    }
+
+    #[test]
+    fn listener_registry_resolves_only_configured_sockets() {
+        let registry = ListenerRegistry::from_entries([
+            (Transport::Udp, addr("10.0.0.1:5060"), Some("sip.example.com".to_string())),
+            (Transport::Udp, addr("192.168.1.1:5060"), None),
+            (Transport::Tcp, addr("10.0.0.1:5060"), None),
+        ]);
+        assert_eq!(registry.len(), 3);
+
+        // Exact transport+addr match resolves, carrying the advertised host.
+        let resolved = registry.resolve(Transport::Udp, addr("10.0.0.1:5060")).unwrap();
+        assert_eq!(resolved.transport, Transport::Udp);
+        assert_eq!(resolved.addr, addr("10.0.0.1:5060"));
+        assert_eq!(resolved.via_sent_by(), ("sip.example.com".to_string(), 5060));
+
+        // No advertise → Via host falls back to the bound IP literal.
+        let plain = registry.resolve(Transport::Udp, addr("192.168.1.1:5060")).unwrap();
+        assert_eq!(plain.via_sent_by(), ("192.168.1.1".to_string(), 5060));
+
+        // Same address, different transport is a distinct listener.
+        assert!(registry.resolve(Transport::Tcp, addr("10.0.0.1:5060")).is_some());
+        assert!(registry.resolve(Transport::Tls, addr("10.0.0.1:5060")).is_none());
+
+        // An address siphon isn't listening on does not resolve.
+        assert!(registry.resolve(Transport::Udp, addr("172.16.0.1:5060")).is_none());
     }
 }

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -49,11 +49,21 @@ const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// a process abort.
 const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Key for a pooled connection: destination address + transport type.
+/// Key for a pooled connection: destination address + transport type + the
+/// requested local *bind* address.
+///
+/// The bind address is part of the key so connections with different source
+/// endpoints to the same destination stay distinct.  Without it, a
+/// source-bound send (ESP-over-TCP IPsec, or a script `send_socket=` egress
+/// pin) and an ephemeral send to the same destination would collide on one
+/// pooled connection — reusing the wrong source, or hitting `EADDRNOTAVAIL`
+/// when a rebind conflicts on the 4-tuple.  `None` means "no explicit bind"
+/// (the OS picks the source — the default TLS outbound path).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct PoolKey {
     destination: SocketAddr,
     transport: Transport,
+    bind: Option<SocketAddr>,
 }
 
 /// A pooled outbound connection.
@@ -310,14 +320,16 @@ impl ConnectionPool {
     /// §7.2) requires src=`pcscf_port_c`, dst=`ue_port_us`, and an
     /// ephemerally-bound socket would never match.
     ///
-    /// Same pooling semantics as `send_tcp` — but **destinations
-    /// reached this way must always use the same source**.  The pool
-    /// keys connections by destination only, so mixing source-bound
-    /// and ephemeral connections to the same destination would either
-    /// reuse the wrong one or hit `EADDRNOTAVAIL` on rebind.  In
-    /// practice IPsec destinations are exclusively source-bound and
-    /// non-IPsec destinations are exclusively ephemeral; no mixing
-    /// occurs at runtime.
+    /// Same pooling semantics as `send_tcp` — and the requested `source`
+    /// is part of the pool key ([`PoolKey::bind`]), so a source-bound
+    /// connection and an ephemeral one to the same destination are kept
+    /// distinct: they never reuse each other or collide on rebind.  Two
+    /// sends that request the *same* `source` to the same destination do
+    /// share a pooled connection (correct — same 4-tuple source).
+    ///
+    /// Used for ESP-over-TCP IPsec (a fixed `pcscf_addr:pcscf_port_c`
+    /// source) and for a script `send_socket=` egress pin (a chosen
+    /// interface IP with an ephemeral port).
     pub async fn send_tcp_from(
         &self,
         source: SocketAddr,
@@ -336,6 +348,7 @@ impl ConnectionPool {
         let key = PoolKey {
             destination,
             transport: Transport::Tcp,
+            bind: Some(bind_addr),
         };
 
         // Fast path: reuse a live pooled connection without taking the
@@ -620,9 +633,38 @@ impl ConnectionPool {
         server_name: Option<&str>,
         data: Bytes,
     ) -> Result<ConnectionId, std::io::Error> {
+        self.send_tls_inner(None, destination, server_name, data).await
+    }
+
+    /// Send over TLS, binding the outbound socket's source to `bind_addr`
+    /// (a script `send_socket=` egress pin selecting a specific local
+    /// interface).  The source is part of the pool key, so a source-bound
+    /// TLS connection stays distinct from a default (OS-picked-source) one to
+    /// the same destination.  Pass `bind_addr` with port `0` to keep the
+    /// source port ephemeral (binding the TLS listen port for an outbound
+    /// connection collides on the 4-tuple in `TIME_WAIT`).
+    pub async fn send_tls_from(
+        &self,
+        bind_addr: SocketAddr,
+        destination: SocketAddr,
+        server_name: Option<&str>,
+        data: Bytes,
+    ) -> Result<ConnectionId, std::io::Error> {
+        self.send_tls_inner(Some(bind_addr), destination, server_name, data)
+            .await
+    }
+
+    async fn send_tls_inner(
+        &self,
+        bind_addr: Option<SocketAddr>,
+        destination: SocketAddr,
+        server_name: Option<&str>,
+        data: Bytes,
+    ) -> Result<ConnectionId, std::io::Error> {
         let key = PoolKey {
             destination,
             transport: Transport::Tls,
+            bind: bind_addr,
         };
 
         // Try existing connection first
@@ -638,18 +680,37 @@ impl ConnectionPool {
         }
 
         // Create new TCP connection, then wrap with TLS handshake.
-        // Unlike TCP pool connections we do NOT bind to a specific local port —
-        // the TLS listen port (5061) is for inbound only; outbound uses ephemeral.
+        // The default outbound path does NOT bind a specific local port — the
+        // TLS listen port (5061) is for inbound only; outbound uses ephemeral.
+        // A `send_socket=` egress pin (`bind_addr = Some`) binds the chosen
+        // interface IP (ephemeral port) so traffic leaves the intended NIC.
         //
         // Fail-fast on both the TCP connect and the TLS handshake: an
         // unreachable or silently-dropping peer would otherwise block the
         // calling worker indefinitely (same wedge class as the TCP path).
-        let tcp_stream = match tokio::time::timeout(
-            self.connect_timeout,
-            tokio::net::TcpStream::connect(destination),
-        )
-        .await
-        {
+        let connect_future = async {
+            match bind_addr {
+                Some(source) => {
+                    let socket = if destination.is_ipv6() {
+                        tokio::net::TcpSocket::new_v6()?
+                    } else {
+                        tokio::net::TcpSocket::new_v4()?
+                    };
+                    socket.set_reuseaddr(true)?;
+                    socket.set_reuseport(true)?;
+                    if let Some(tos) = self.tos {
+                        socket2::SockRef::from(&socket).set_tos_v4(tos)?;
+                    }
+                    socket.bind(source).map_err(|error| {
+                        warn!(bind_addr = %source, destination = %destination, "pool: TLS bind to requested source failed: {error}");
+                        error
+                    })?;
+                    socket.connect(destination).await
+                }
+                None => tokio::net::TcpStream::connect(destination).await,
+            }
+        };
+        let tcp_stream = match tokio::time::timeout(self.connect_timeout, connect_future).await {
             Ok(result) => result?,
             Err(_) => {
                 warn!(destination = %destination, timeout = ?self.connect_timeout, "pool: TLS TCP connect timed out");


### PR DESCRIPTION
## What

Adds a `send_socket=` egress pin to `request.relay()`, `request.fork()`, `call.dial()`, and `call.fork()` — the operator equivalent of Kamailio's `force_send_socket()` / OpenSIPS' `$fs`. On a multi-homed host it selects **which of siphon's own configured listeners** a relayed or dialed request leaves from:

```python
request.relay("sip:carrier.example.net", send_socket="udp:203.0.113.10:5060")
request.fork(contacts, send_socket="udp:10.0.0.1:5060")
call.dial("sip:bob@10.0.0.2:5060", send_socket="tcp:10.0.0.1:5060")
```

The spec is `"<transport>:<ip>:<port>"` naming a real listener, so the outgoing **Via** advertises that listener's address (its `advertise:`, else its bound IP) with the listener's port — the response returns to the same socket. That Via correctness is the reason to use this instead of hand-rolling a Via rewrite.

## How

- **Transport** (`transport/mod.rs`): `parse_send_socket`, a `SendSocket` type, and a `ListenerRegistry` built from *all* configured listeners (not the first-per-transport map `listen_addrs` keeps).
- **UDP** pins the exact `(ip, port)` listener socket via `OutboundMessage.source_local_addr` → `udp_by_local`. That per-listener channel map is now populated whenever there is **more than one UDP listener** (previously IPsec-only); a single-listener deployment keeps `udp_by_local` empty and stays on the existing branch-predicted fast path, so the perf baseline is structurally unchanged.
- **TCP/TLS** bind the source **IP** with an ephemeral source port (binding the listen port for an outbound connection collides on the 4-tuple in `TIME_WAIT`). The requested bind is now part of `PoolKey`, so a source-bound and a default connection to the same peer are pooled separately and never reuse each other. Adds `ConnectionPool::send_tls_from`.
- **Dispatcher**: threaded through `relay_request`, `send_to_target`, the fork branch, and the B2BUA B-leg builder, driving both the Via sent-by and the actual egress source. Sequential-fork continuation reuses the pin via a new `ProxySession.fork_send_socket` field.

Precedence / fallbacks:
- A captured `flow=` and an IPsec-installed source both take precedence over the pin (the kernel XFRM selector must win).
- A transport mismatch (pin transport ≠ routed transport) is logged and ignored.
- A malformed spec raises `ValueError` at the scripting API; a well-formed spec that names no configured listener is logged and falls back to default routing — never dropped.
- WS/WSS callees are client-initiated and can't be dialed; reach them with `flow=`, not `send_socket`.

## SDK / docs / changelog

- SDK mock mirrored (`request.py` / `call.py`) with docstrings + the same format validation, plus tests.
- `docs/transports.md` gains a "Choosing the egress socket (`send_socket`)" section.
- `CHANGELOG.md` `[Unreleased]` entry.

## Tests

- `cargo test`: 2776 lib + 274 integration, 0 failed. `cargo clippy --all-targets --all-features -- -D warnings` clean. SDK pytest green.
- New coverage: the parser, `ListenerRegistry` resolution, the `OutboundRouter` source-routing that UDP egress relies on, `PoolKey` distinctness, and API validation/storage on all four entry points.
- Also fixes two pre-existing clippy lints (`timer.rs`, `engine.rs`) surfaced by a newer clippy — needed for a green clippy gate on this branch.

## Not yet run

The 16-row SIPp perf + mem-leak baseline on reference hardware (single-listener hot path is unchanged by design, but it's the before-merge gate), and a live multi-homed egress smoke.

## Note

Touches `sdk/siphon_sdk/request.py` + `call.py`, which also change in the docs-reference branch (#58) — expect a trivial conflict for whichever merges second.
