### PR TITLE
fix(sip): Teams interop — Allow on OPTIONS keepalives + FQDN single Record-Route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the dispatch hot path reads no clock and touches no metric.
 
 ### Fixed
+- **Single Record-Route now uses the advertised host, not the bind IP.** When
+  siphon record-routes a relayed request whose inbound and outbound transport are
+  the same, the Record-Route carried the raw bind IP (and `127.0.0.1` when bound to
+  `0.0.0.0`) even with an FQDN `advertised_address` set — only the
+  transport-bridging *double* Record-Route already used the advertised address. It
+  now carries the same host:port as the Via for that transport, so an external peer
+  that rejects an IP in Record-Route (Microsoft Teams among them) can route
+  in-dialog requests back through siphon.
+- **siphon's OPTIONS keepalives now advertise an `Allow` header** listing the SIP
+  methods siphon supports (`INVITE, ACK, CANCEL, BYE, OPTIONS, INFO, UPDATE, PRACK,
+  SUBSCRIBE, NOTIFY, REFER, MESSAGE, PUBLISH`). A peer that probes the trunk with
+  OPTIONS can now discover the supported method set — Microsoft Teams Direct Routing
+  selects its call-transfer method from the SBC's advertised `Allow`, so without
+  `REFER`/`NOTIFY` here it never hands siphon a REFER even though transfer works.
 - **Outbound OPTIONS keepalives now carry a `Contact` header.** The UAC-side
   OPTIONS builder (NAT keepalive, gateway health probe, registrar liveness probe)
   emitted Via/From/To/Call-ID/CSeq only — no Contact. RFC 3261 §11.1 makes

--- a/docs/cookbook/sbc.md
+++ b/docs/cookbook/sbc.md
@@ -195,6 +195,19 @@ handshake also sends the target hostname (`sbc.example.com`) as SNI, so a
 hostname-vhost trunk front-end can route it. Server-certificate verification is
 unchanged (permissive) — this only adds the client certificate siphon presents.
 
+!!! warning "Terminate strict peers (Teams) as a B2BUA, not a plain proxy"
+    Microsoft Teams Direct Routing rejects any `Contact` or `Record-Route` whose
+    host is an IP (403 Forbidden) — it must be the SBC FQDN that matches the TLS
+    certificate. The B2BUA rewrites `Contact` to siphon's advertised address, so
+    set `advertised_address` (or the per-listener `advertise`) to that FQDN and it
+    satisfies the requirement. A **pure proxy** (`@proxy.on_request` relaying
+    INVITEs) forwards the upstream UA's `Contact` verbatim — typically a PBX's
+    private IP — which Teams refuses; RFC 3261 §16 forbids a proxy from rewriting
+    another UA's `Contact`, so this is by design, not a bug. Front Teams-facing
+    signalling with `@b2bua.on_invite`. siphon's OPTIONS keepalive and its 200 OK
+    to Teams' OPTIONS already carry the advertised FQDN in `Contact` plus an
+    `Allow` advertising the supported methods (including `REFER`/`NOTIFY`).
+
 ## See also
 
 - Real examples: [`scripts/b2bua_default.py`](https://github.com/siphon-project/siphon-sip/blob/main/scripts/b2bua_default.py), [`examples/b2bua_gateway.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/b2bua_gateway.py), [`examples/b2bua_rtpengine.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/b2bua_rtpengine.py).

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2853,7 +2853,15 @@ fn relay_request(
             core::add_record_route(&mut relayed.headers, &rr_inbound);
             core::add_record_route(&mut relayed.headers, &rr_outbound);
         } else {
-            let rr_uri = format!("sip:{}:{};transport={}", internal_host, state.local_addr.port(), transport_str.to_lowercase());
+            // Single Record-Route (inbound == outbound transport). Reuse the same
+            // sent-by as our Via — the advertised host in the normal case, or the
+            // pinned listener for IPsec/flow/send_socket egress — instead of the
+            // raw bind IP. An external peer must route in-dialog requests back
+            // through the exact host:port we advertised: Teams rejects an IP in
+            // Record-Route outright, and a P-CSCF's protected port must match or
+            // the kernel SA selector drops the in-dialog request.
+            let rr_port = via_port.unwrap_or_else(|| state.via_port(&outbound_transport));
+            let rr_uri = format!("sip:{}:{};transport={}", via_host, rr_port, transport_str.to_lowercase());
             core::add_record_route(&mut relayed.headers, &rr_uri);
         }
     }
@@ -3192,7 +3200,12 @@ fn relay_fork_branch(
             core::add_record_route(&mut relayed.headers, &rr_inbound);
             core::add_record_route(&mut relayed.headers, &rr_outbound);
         } else {
-            let rr_uri = format!("sip:{}:{};transport={}", internal_host, state.local_addr.port(), transport_str.to_lowercase());
+            // Single Record-Route (inbound == outbound transport). Reuse the same
+            // sent-by as our Via — the advertised host, or the pinned send_socket
+            // listener — instead of the raw bind IP, so an external peer can route
+            // in-dialog requests back through the exact host:port we advertised
+            // (Teams rejects an IP in Record-Route).
+            let rr_uri = format!("sip:{}:{};transport={}", via_host, via_port, transport_str.to_lowercase());
             core::add_record_route(&mut relayed.headers, &rr_uri);
         }
     }

--- a/src/sip/mod.rs
+++ b/src/sip/mod.rs
@@ -12,3 +12,13 @@ pub use parser::parse_sip_message;
 pub use builder::SipMessageBuilder;
 pub use uri::SipUri;
 pub use headers::SipHeaders;
+
+/// SIP methods siphon implements, formatted for an `Allow` header (RFC 3261
+/// §20.5). Advertised verbatim on siphon's own UA surfaces — OPTIONS responses,
+/// OPTIONS keepalives, and B2BUA responses — so peers can discover the supported
+/// method set. Microsoft Teams Direct Routing, for one, selects its call-transfer
+/// method from the SBC's advertised `Allow`: without `REFER`/`NOTIFY` here it
+/// never hands siphon a REFER, even though transfer is implemented. Keep this in
+/// sync with the methods the dispatcher/transaction layer actually handles.
+pub const SUPPORTED_METHODS: &str =
+    "INVITE, ACK, CANCEL, BYE, OPTIONS, INFO, UPDATE, PRACK, SUBSCRIBE, NOTIFY, REFER, MESSAGE, PUBLISH";

--- a/src/uac/mod.rs
+++ b/src/uac/mod.rs
@@ -337,6 +337,10 @@ impl UacSender {
             .call_id(format!("uac-keepalive-{}", uuid::Uuid::new_v4()))
             .cseq(format!("{cseq} OPTIONS"))
             .max_forwards(70)
+            // Advertise our supported methods so a peer probing us via this
+            // OPTIONS keepalive can discover the method set — e.g. Teams Direct
+            // Routing selects its transfer method from the SBC's Allow.
+            .header("Allow", crate::sip::SUPPORTED_METHODS.to_string())
             .content_length(0);
 
         if let Some(ref user_agent) = self.user_agent_header {
@@ -1179,6 +1183,14 @@ mod tests {
         assert!(
             !raw.contains("127.0.0.1"),
             "must not leak loopback when an FQDN is advertised: {raw}"
+        );
+        assert!(
+            raw.contains(&format!("Allow: {}", crate::sip::SUPPORTED_METHODS)),
+            "OPTIONS keepalive must advertise siphon's supported methods: {raw}"
+        );
+        assert!(
+            raw.contains("REFER") && raw.contains("NOTIFY"),
+            "Allow must include REFER/NOTIFY so peers discover transfer support: {raw}"
         );
     }
 }


### PR DESCRIPTION
Part 1 of 3 closing Teams Direct Routing interop gaps (follow-up to #56). This PR covers the two remaining IP-only / capability gaps on the SIP identity surface.

## What Teams needs

- The `Contact`/`Record-Route` host must be the SBC **FQDN** matching the TLS cert — an IP → 403 Forbidden.
- Teams reads the SBC's supported methods from its advertised `Allow`; without `REFER`/`NOTIFY` it never hands the SBC a REFER for transfer.

## Changes

- **Single Record-Route now follows the Via sent-by.** When siphon record-routes a relayed request whose inbound and outbound transport match, the single Record-Route carried the raw bind IP (`127.0.0.1` when bound to `0.0.0.0`), even with an FQDN `advertised_address`. Only the transport-bridging *double* Record-Route already used the advertised host. It now reuses the exact same sent-by the Via header uses for that leg — the advertised FQDN in the normal case, or the pinned listener for IPsec/flow/`send_socket` egress. That last part also fixes a latent P-CSCF bug: the old single-RR used `local_addr.port()`, not the protected listener port, so an in-dialog request could miss the kernel SA selector. Applied to both the proxy relay and fork paths.
- **`Allow` on OPTIONS keepalives.** siphon's outbound OPTIONS (NAT keepalive, gateway health probe, registrar liveness) now advertise `Allow: INVITE, ACK, CANCEL, BYE, OPTIONS, INFO, UPDATE, PRACK, SUBSCRIBE, NOTIFY, REFER, MESSAGE, PUBLISH` via a new `sip::SUPPORTED_METHODS` single source of truth (reused by the response path in the next PR).
- **Docs (#6):** a callout in the SBC cookbook — terminate Teams-facing signalling as a **B2BUA** (which rewrites Contact to the advertised FQDN); a pure proxy forwards the upstream UA's Contact verbatim (RFC 3261 §16 forbids a proxy from rewriting it), so a PBX's private IP would reach Teams and get 403.

Note: the FQDN-on-keepalive-Via/From/Contact work (gap #1) already landed on `main` separately, so it is not re-done here — its e2e test is extended with the new `Allow` assertion.

## Testing

- `cargo test` — 3169 passed, 6 ignored. `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- The keepalive FQDN + `Allow` are asserted end-to-end in `send_options_via_and_from_use_fqdn_advertised_address`.
- The single Record-Route change reuses the Via's already-computed sent-by (no new isolable logic); the dispatcher relay path has no module-level unit harness, so it is covered by the integration suite here and by the SIPp datapath baseline. Full 16-row SIPp + mem-leak baseline recommended before release-cut per project policy (datapath touch).
