### PR TITLE
fix(gateway): honor Retry-After on 503, stop counting 503 probes as healthy (teams datacenter failover)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,29 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   OPTIONS can now discover the supported method set — Microsoft Teams Direct Routing
   selects its call-transfer method from the SBC's advertised `Allow`, so without
   `REFER`/`NOTIFY` here it never hands siphon a REFER even though transfer works.
+- **Gateway health prober now fails a `503`, and honors `Retry-After`, for
+  Teams Direct Routing datacenter failover.** The OPTIONS prober counted *any*
+  response as a successful probe, so a destination answering `503 Service
+  Unavailable` was recorded healthy and stayed selectable. A `503` is now
+  treated as a probe failure. When it carries a `Retry-After` (RFC 3261 §20.33)
+  the destination is marked down immediately and held down for at least that
+  cooldown (a new `down_until` deadline on `Destination`); a later successful
+  probe does not flip it healthy again before the cooldown elapses. This is the
+  Microsoft Teams Direct Routing overload contract: a datacenter that sheds load
+  with `503 + Retry-After` is taken out of selection, and the next call's
+  `gateway.select()` routes to the next healthy datacenter (an operator override
+  via `gateway.mark_up()` clears the cooldown). Other answered codes
+  (`500`/`502`/`504` and any non-`503`) still count as healthy, since a peer that
+  answers is reachable and OPTIONS is not a real call; only `503` carries the
+  "stop sending me traffic" semantics. Within-call re-selection across gateway
+  destinations on a live `503` is unchanged (sequential fork still iterates the
+  script-supplied target list); marking down affects subsequent calls.
+- **Outbound REGISTER honors a `Retry-After` on the failure response.** A
+  carrier or Teams registrar that rejects a REGISTER with `503 + Retry-After`
+  now schedules the next registration attempt at the server-supplied cooldown
+  instead of the local exponential backoff (the backoff state still advances, so
+  a later failure without `Retry-After` resumes where it left off). The existing
+  re-resolve-to-a-different-IP-on-failure behavior is unchanged.
 - **Outbound OPTIONS keepalives now carry a `Contact` header.** The UAC-side
   OPTIONS builder (NAT keepalive, gateway health probe, registrar liveness probe)
   emitted Via/From/To/Call-ID/CSeq only — no Contact. RFC 3261 §11.1 makes

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -9075,6 +9075,12 @@ fn handle_registrant_response(
     let is_aka =
         registrant.auth_mode(&aor) == Some(crate::registrant::AuthMode::Aka);
 
+    // A carrier / Teams Direct Routing registrar that rejects with a Retry-After
+    // (RFC 3261 §20.33) is telling us exactly when to re-REGISTER — thread it
+    // into the failure handler so it schedules the next attempt at that cooldown
+    // instead of the local exponential backoff.
+    let retry_after = crate::sip::headers::retry_after::parse_retry_after(&message.headers);
+
     match status_code {
         200 => {
             // Parse granted expires: top-level Expires header first,
@@ -9136,7 +9142,7 @@ fn handle_registrant_response(
                 Some(raw) => raw.clone(),
                 None => {
                     warn!(aor = %aor, status_code, "registrant: {status_code} without {header_name}");
-                    registrant.handle_failure(&aor, status_code);
+                    registrant.handle_failure(&aor, status_code, retry_after);
                     return;
                 }
             };
@@ -9148,7 +9154,7 @@ fn handle_registrant_response(
                 // send so the kernel encrypts the protected REGISTER — both run
                 // ordered inside one spawned task (TS 33.203 §7.4).
                 if is_aka && registrant.is_ipsec_entry(&aor) {
-                    handle_registrant_ipsec_challenge(registrant, message, &aor, &challenge, status_code, state);
+                    handle_registrant_ipsec_challenge(registrant, message, &aor, &challenge, status_code, retry_after, state);
                     return;
                 }
 
@@ -9179,15 +9185,15 @@ fn handle_registrant_response(
                     let data = bytes::Bytes::from(retry_message.to_bytes());
                     send_outbound(data, transport, destination, crate::transport::ConnectionId::default(), state);
                 } else {
-                    registrant.handle_failure(&aor, status_code);
+                    registrant.handle_failure(&aor, status_code, retry_after);
                 }
             } else {
                 warn!(aor = %aor, "failed to parse digest challenge from {header_name}");
-                registrant.handle_failure(&aor, status_code);
+                registrant.handle_failure(&aor, status_code, retry_after);
             }
         }
         _ => {
-            registrant.handle_failure(&aor, status_code);
+            registrant.handle_failure(&aor, status_code, retry_after);
         }
     }
 }
@@ -9206,6 +9212,7 @@ fn handle_registrant_ipsec_challenge(
     aor: &str,
     challenge: &crate::auth::DigestChallenge,
     status_code: u16,
+    retry_after: Option<std::time::Duration>,
     state: &DispatcherState,
 ) {
     match message.headers.get("Security-Server").cloned() {
@@ -9213,13 +9220,13 @@ fn handle_registrant_ipsec_challenge(
             Some(server) => registrant.store_security_server(aor, &server, &server_raw),
             None => {
                 warn!(aor = %aor, "IPsec UE: unparseable Security-Server, failing registration");
-                registrant.handle_failure(aor, status_code);
+                registrant.handle_failure(aor, status_code, retry_after);
                 return;
             }
         },
         None => {
             warn!(aor = %aor, "IPsec UE: 401 without Security-Server, failing registration");
-            registrant.handle_failure(aor, status_code);
+            registrant.handle_failure(aor, status_code, retry_after);
             return;
         }
     }
@@ -9238,7 +9245,7 @@ fn handle_registrant_ipsec_challenge(
     let (retry_message, destination, transport) = match built {
         Some((retry_message, _branch, destination, transport)) => (retry_message, destination, transport),
         None => {
-            registrant.handle_failure(aor, status_code);
+            registrant.handle_failure(aor, status_code, retry_after);
             return;
         }
     };
@@ -9259,7 +9266,7 @@ fn handle_registrant_ipsec_challenge(
         Some(manager) => manager,
         None => {
             warn!(aor = %aor, "IPsec UE: no IpsecManager configured, failing registration");
-            registrant.handle_failure(aor, status_code);
+            registrant.handle_failure(aor, status_code, retry_after);
             return;
         }
     };
@@ -9275,7 +9282,7 @@ fn handle_registrant_ipsec_challenge(
             Some(sa) => sa,
             None => {
                 warn!(aor = %aor_task, "IPsec UE: missing CK/IK or Security-Server, protected REGISTER not sent");
-                registrant_task.handle_failure(&aor_task, 0);
+                registrant_task.handle_failure(&aor_task, 0, None);
                 return;
             }
         };
@@ -9289,7 +9296,7 @@ fn handle_registrant_ipsec_challenge(
         let _ = ipsec_manager.delete_sa_pair(&ue_addr, ue_port_c).await;
         if let Err(error) = ipsec_manager.create_ue_sa_pair(sa).await {
             warn!(aor = %aor_task, %error, "IPsec UE: SA install failed, protected REGISTER not sent");
-            registrant_task.handle_failure(&aor_task, 0);
+            registrant_task.handle_failure(&aor_task, 0, None);
             return;
         }
         let outbound_message = crate::transport::OutboundMessage {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -16,7 +16,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
@@ -86,6 +86,12 @@ pub struct Destination {
     healthy: AtomicBool,
     /// Consecutive failure count.
     failures: AtomicU32,
+    /// Cooldown deadline. When set and not yet elapsed, the health prober must
+    /// not flip this destination back to healthy — used to honor a `503`
+    /// `Retry-After` (RFC 3261 §20.33 / Teams Direct Routing datacenter
+    /// failover): a peer that answered "come back in N seconds" stays out of
+    /// selection for at least that long even if a later probe succeeds.
+    down_until: std::sync::Mutex<Option<Instant>>,
 }
 
 impl Destination {
@@ -106,6 +112,7 @@ impl Destination {
             attrs: HashMap::new(),
             healthy: AtomicBool::new(true),
             failures: AtomicU32::new(0),
+            down_until: std::sync::Mutex::new(None),
         }
     }
 
@@ -136,10 +143,55 @@ impl Destination {
     pub fn mark_up(&self) {
         self.healthy.store(true, Ordering::Relaxed);
         self.failures.store(0, Ordering::Relaxed);
+        // Explicit operator override clears any Retry-After cooldown.
+        *self
+            .down_until
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     }
 
     pub fn mark_down(&self) {
         self.healthy.store(false, Ordering::Relaxed);
+    }
+
+    /// Mark down and hold down until at least `until`.
+    ///
+    /// Sets `healthy=false` (so `select()` skips it immediately) and arms the
+    /// cooldown so the prober will not auto-recover it before `until`. Honors a
+    /// `503` `Retry-After`. A later, longer cooldown extends the window; a
+    /// shorter one never shrinks a still-pending one.
+    pub fn mark_down_until(&self, until: Instant) {
+        self.healthy.store(false, Ordering::Relaxed);
+        let mut guard = self
+            .down_until
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = Some(match *guard {
+            Some(existing) if existing > until => existing,
+            _ => until,
+        });
+    }
+
+    /// Whether a `Retry-After` cooldown is still in effect.
+    ///
+    /// Side effect: clears an elapsed deadline so it is only paid once. Called
+    /// off the hot path (only the prober), so the `Mutex` is fine — selection
+    /// stays a lock-free atomic load via `is_healthy()`, which reads `false`
+    /// for the whole cooldown because `mark_down_until` cleared the flag and
+    /// only a gated `record_success` (or a manual `mark_up`) can set it again.
+    pub fn in_cooldown(&self) -> bool {
+        let mut guard = self
+            .down_until
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match *guard {
+            Some(until) if Instant::now() < until => true,
+            Some(_) => {
+                *guard = None;
+                false
+            }
+            None => false,
+        }
     }
 
     fn record_failure(&self) -> u32 {
@@ -590,46 +642,118 @@ async fn probe_destination(
 
     let result = tokio::time::timeout(Duration::from_secs(5), receiver).await;
 
-    match result {
-        Ok(Ok(crate::uac::UacResult::Response(_))) => {
-            if !dest.is_healthy() {
-                info!(uri = %dest.uri, "destination recovered");
-            }
-            dest.record_success();
-        }
-        _ => {
-            let count = dest.record_failure();
-            debug!(
-                uri = %dest.uri,
-                failures = count,
-                "destination probe failed"
-            );
-            if count >= failure_threshold {
-                if dest.is_healthy() {
-                    warn!(uri = %dest.uri, "marking destination down after {count} failures");
-                }
-                dest.mark_down();
+    // A `Response(_)` means the peer answered; a timeout / transport error is a
+    // hard failure. The health verdict on a response is not "any answer = up":
+    // see `apply_probe_response`.
+    let response = match result {
+        Ok(Ok(crate::uac::UacResult::Response(response))) => Some(response),
+        _ => None,
+    };
+    apply_probe_response(dest, response.as_deref(), failure_threshold);
+}
 
-                // Re-resolve DNS to try a different IP on next probe
-                if let Some(ref address_str) = dest.address_str {
-                    use std::net::ToSocketAddrs;
-                    if let Ok(mut addrs) = address_str.to_socket_addrs() {
-                        let old = dest.address();
-                        // Pick a different address than the current one if available
-                        let new_addr = addrs.find(|a| *a != old)
-                            .or_else(|| address_str.to_socket_addrs().ok()?.next());
-                        if let Some(new_addr) = new_addr {
-                            if new_addr != old {
-                                info!(
-                                    uri = %dest.uri,
-                                    old = %old,
-                                    new = %new_addr,
-                                    "re-resolved destination to different IP"
-                                );
-                                dest.set_address(new_addr);
-                            }
-                        }
-                    }
+/// Update a destination's health from a completed probe.
+///
+/// `response` is `Some` when the peer answered, `None` on timeout / transport
+/// error. Split out from `probe_destination` (which owns the transport) so the
+/// health logic is unit-testable without a live UAC.
+///
+/// Health verdict on a response:
+/// - **`503 Service Unavailable`** (RFC 3261 §21.5.4) is NOT healthy. A `503`
+///   is an explicit "I am temporarily unable to serve this request", which is
+///   exactly what an overloaded Microsoft Teams Direct Routing datacenter
+///   returns (with `Retry-After`) to steer the SBC to the next datacenter. So a
+///   `503` counts as a probe failure, and a `Retry-After` on it pins the
+///   destination down for at least that cooldown.
+/// - **`500` / `502` / `504`** (and any other non-`503` response) still count
+///   as healthy: the peer answered, so it is reachable — it is erroring on this
+///   particular transaction, not shedding load, and OPTIONS is not a real call
+///   anyway. Only `503` carries the "stop sending me traffic" semantics.
+/// - Defensively, a `Retry-After` on ANY response also triggers the cooldown —
+///   a peer that says "retry later" should be believed regardless of code.
+fn apply_probe_response(
+    dest: &Destination,
+    response: Option<&crate::sip::message::SipMessage>,
+    failure_threshold: u32,
+) {
+    let Some(response) = response else {
+        record_probe_failure(dest, failure_threshold, None);
+        return;
+    };
+
+    let status = response.status_code().unwrap_or(0);
+    let cooldown = crate::sip::headers::retry_after::parse_retry_after(&response.headers);
+
+    if status == 503 || cooldown.is_some() {
+        record_probe_failure(dest, failure_threshold, cooldown);
+        return;
+    }
+
+    // Healthy answer. If a prior Retry-After cooldown is still pending, a good
+    // probe does not clear it early — the peer told us to wait.
+    if dest.in_cooldown() {
+        debug!(
+            uri = %dest.uri,
+            "probe answered but destination still in Retry-After cooldown"
+        );
+        return;
+    }
+    if !dest.is_healthy() {
+        info!(uri = %dest.uri, "destination recovered");
+    }
+    dest.record_success();
+}
+
+/// Record a probe failure and, past threshold (or on an explicit `Retry-After`
+/// cooldown), mark the destination down and try a different resolved IP next
+/// probe.
+fn record_probe_failure(dest: &Destination, failure_threshold: u32, cooldown: Option<Duration>) {
+    let count = dest.record_failure();
+    debug!(
+        uri = %dest.uri,
+        failures = count,
+        cooldown_secs = cooldown.map(|c| c.as_secs()),
+        "destination probe failed"
+    );
+
+    // A Retry-After is an explicit directive — honor it immediately, without
+    // waiting for the consecutive-failure threshold. Otherwise fall back to the
+    // usual threshold gate.
+    if cooldown.is_none() && count < failure_threshold {
+        return;
+    }
+
+    if dest.is_healthy() {
+        warn!(
+            uri = %dest.uri,
+            failures = count,
+            cooldown_secs = cooldown.map(|c| c.as_secs()),
+            "marking destination down"
+        );
+    }
+    match cooldown {
+        Some(cooldown) => dest.mark_down_until(Instant::now() + cooldown),
+        None => dest.mark_down(),
+    }
+
+    // Re-resolve DNS to try a different IP on next probe.
+    if let Some(ref address_str) = dest.address_str {
+        use std::net::ToSocketAddrs;
+        if let Ok(mut addrs) = address_str.to_socket_addrs() {
+            let old = dest.address();
+            // Pick a different address than the current one if available.
+            let new_addr = addrs
+                .find(|a| *a != old)
+                .or_else(|| address_str.to_socket_addrs().ok()?.next());
+            if let Some(new_addr) = new_addr {
+                if new_addr != old {
+                    info!(
+                        uri = %dest.uri,
+                        old = %old,
+                        new = %new_addr,
+                        "re-resolved destination to different IP"
+                    );
+                    dest.set_address(new_addr);
                 }
             }
         }
@@ -1705,5 +1829,132 @@ mod tests {
         group.all_destinations()[0].set_address("203.0.113.7:5060".parse().unwrap());
         group.refresh_member_ips();
         assert!(group.contains_source("203.0.113.7".parse().unwrap()));
+    }
+
+    // --- Probe health verdict (apply_probe_response) ---
+
+    fn make_response(status: u16, retry_after: Option<&str>) -> crate::sip::message::SipMessage {
+        use crate::sip::message::{SipMessage, StartLine, StatusLine, Version};
+        let mut headers = crate::sip::headers::SipHeaders::new();
+        if let Some(value) = retry_after {
+            headers.set("Retry-After", value.to_string());
+        }
+        SipMessage {
+            start_line: StartLine::Response(StatusLine {
+                version: Version::sip_2_0(),
+                status_code: status,
+                reason_phrase: "Test".to_string(),
+            }),
+            headers,
+            body: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn probe_200_keeps_healthy() {
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        let response = make_response(200, None);
+        apply_probe_response(&dest, Some(&response), 3);
+        assert!(dest.is_healthy());
+    }
+
+    #[test]
+    fn probe_500_502_504_still_healthy() {
+        // An answering peer is reachable — only 503 sheds load.
+        for status in [500u16, 502, 504] {
+            let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+            let response = make_response(status, None);
+            apply_probe_response(&dest, Some(&response), 3);
+            assert!(dest.is_healthy(), "status {status} should stay healthy");
+        }
+    }
+
+    #[test]
+    fn probe_503_without_retry_after_fails_and_marks_down_at_threshold() {
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        // First two 503s: below threshold, not yet down.
+        apply_probe_response(&dest, Some(&make_response(503, None)), 3);
+        assert!(dest.is_healthy());
+        apply_probe_response(&dest, Some(&make_response(503, None)), 3);
+        assert!(dest.is_healthy());
+        // Third 503 reaches the threshold: down.
+        apply_probe_response(&dest, Some(&make_response(503, None)), 3);
+        assert!(!dest.is_healthy());
+    }
+
+    #[test]
+    fn probe_503_with_retry_after_marks_down_immediately_and_holds_cooldown() {
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        // A single 503 + Retry-After marks down at once, without the threshold.
+        apply_probe_response(&dest, Some(&make_response(503, Some("30"))), 3);
+        assert!(!dest.is_healthy(), "503+Retry-After must mark down immediately");
+        assert!(dest.in_cooldown(), "cooldown must be armed");
+
+        // A healthy probe DURING the cooldown does not recover it.
+        apply_probe_response(&dest, Some(&make_response(200, None)), 3);
+        assert!(!dest.is_healthy(), "must stay down while cooling down");
+        assert!(dest.in_cooldown());
+    }
+
+    #[test]
+    fn cooldown_elapses_then_healthy_probe_recovers() {
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        // Arm a very short cooldown directly (seconds granularity in the wire
+        // header would make this test slow).
+        dest.mark_down_until(Instant::now() + Duration::from_millis(40));
+        assert!(!dest.is_healthy());
+        assert!(dest.in_cooldown());
+
+        // Healthy probe while cooling: no recovery.
+        apply_probe_response(&dest, Some(&make_response(200, None)), 3);
+        assert!(!dest.is_healthy());
+
+        std::thread::sleep(Duration::from_millis(70));
+        assert!(!dest.in_cooldown(), "cooldown should have elapsed");
+
+        // Now a healthy probe recovers it.
+        apply_probe_response(&dest, Some(&make_response(200, None)), 3);
+        assert!(dest.is_healthy(), "should recover after cooldown elapses");
+    }
+
+    #[test]
+    fn retry_after_on_non_503_response_also_cools_down() {
+        // Defensive: believe an explicit Retry-After regardless of status code.
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        apply_probe_response(&dest, Some(&make_response(486, Some("15"))), 3);
+        assert!(!dest.is_healthy());
+        assert!(dest.in_cooldown());
+    }
+
+    #[test]
+    fn probe_timeout_marks_down_at_threshold() {
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        for _ in 0..3 {
+            apply_probe_response(&dest, None, 3);
+        }
+        assert!(!dest.is_healthy());
+    }
+
+    #[test]
+    fn mark_up_clears_cooldown() {
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        dest.mark_down_until(Instant::now() + Duration::from_secs(60));
+        assert!(dest.in_cooldown());
+        dest.mark_up();
+        assert!(dest.is_healthy());
+        assert!(!dest.in_cooldown(), "operator mark_up clears the cooldown");
+    }
+
+    #[test]
+    fn mark_down_until_never_shrinks_pending_cooldown() {
+        let dest = make_dest("sip:gw1.example.com", 5060, 1, 1);
+        let long = Instant::now() + Duration::from_secs(120);
+        dest.mark_down_until(long);
+        // A shorter cooldown must not shorten the still-pending long one.
+        dest.mark_down_until(Instant::now() + Duration::from_secs(5));
+        assert!(dest.in_cooldown());
+        // Still down after the short window would have elapsed is implied by the
+        // long deadline; we just assert it is still cooling.
+        assert!(!dest.is_healthy());
     }
 }

--- a/src/registrant/mod.rs
+++ b/src/registrant/mod.rs
@@ -1084,25 +1084,38 @@ impl RegistrantManager {
     }
 
     /// Handle a failure response (non-401/407, or auth failed twice).
-    pub fn handle_failure(&self, aor: &str, status_code: u16) {
+    ///
+    /// `retry_after` carries the response's `Retry-After` header (RFC 3261
+    /// §20.33) when present: a carrier / Teams Direct Routing registrar that
+    /// answers `503` with `Retry-After` is telling us exactly when to come back,
+    /// so we schedule the next attempt at that cooldown instead of the local
+    /// exponential backoff. The backoff state is still advanced so that if the
+    /// registrar stops sending `Retry-After` we resume climbing from where we
+    /// were rather than resetting.
+    pub fn handle_failure(&self, aor: &str, status_code: u16, retry_after: Option<Duration>) {
         if let Some(mut entry) = self.entries.get_mut(aor) {
             entry.state = RegistrantState::Failed;
             entry.failure_count += 1;
             entry.expires_at = None;
 
-            // Exponential backoff capped at max_retry_interval
+            // Exponential backoff capped at max_retry_interval.
             let backoff = std::cmp::min(
                 entry.backoff * 2,
                 self.max_retry_interval,
             );
             entry.backoff = backoff;
-            entry.next_attempt = Instant::now() + backoff;
+
+            // A server-supplied Retry-After wins over local backoff — honor the
+            // registrar's explicit cooldown directive.
+            let retry_in = retry_after.unwrap_or(backoff);
+            entry.next_attempt = Instant::now() + retry_in;
 
             warn!(
                 aor = %entry.aor,
                 status_code,
                 failures = entry.failure_count,
-                retry_in = ?backoff,
+                retry_in = ?retry_in,
+                retry_after = ?retry_after,
                 "registration failed"
             );
 
@@ -1287,7 +1300,7 @@ pub async fn registration_loop(
                 let timed_out = manager.entries_timed_out();
                 for aor in &timed_out {
                     warn!(aor = %aor, "REGISTER transaction timed out — no response received");
-                    manager.handle_failure(aor, 0);
+                    manager.handle_failure(aor, 0, None);
                 }
 
                 let due = manager.entries_due();
@@ -1329,7 +1342,7 @@ pub async fn registration_loop(
                         debug!(aor = %aor, branch = %branch, "sending REGISTER");
                         if let Err(error) = outbound.send(outbound_message) {
                             warn!(aor = %aor, %error, "failed to send REGISTER");
-                            manager.handle_failure(&aor, 0);
+                            manager.handle_failure(&aor, 0, None);
                         }
                     }
                 }
@@ -1650,7 +1663,7 @@ mod tests {
         let manager = make_manager();
         manager.add(make_entry("sip:alice@carrier.com"));
 
-        manager.handle_failure("sip:alice@carrier.com", 403);
+        manager.handle_failure("sip:alice@carrier.com", 403, None);
 
         assert_eq!(
             manager.state("sip:alice@carrier.com"),
@@ -1663,12 +1676,75 @@ mod tests {
     }
 
     #[test]
+    fn retry_after_overrides_backoff() {
+        let manager = make_manager();
+        manager.add(make_entry("sip:alice@carrier.com"));
+
+        // Local backoff after one failure would be ~10s (5s initial doubled).
+        // A registrar Retry-After of 120s must win, pushing next_attempt out far
+        // beyond the backoff.
+        let before = Instant::now();
+        manager.handle_failure(
+            "sip:alice@carrier.com",
+            503,
+            Some(Duration::from_secs(120)),
+        );
+
+        let next_attempt = manager
+            .entries
+            .get("sip:alice@carrier.com")
+            .unwrap()
+            .next_attempt;
+        assert!(
+            next_attempt >= before + Duration::from_secs(60),
+            "Retry-After should schedule far past the ~10s local backoff"
+        );
+    }
+
+    #[test]
+    fn retry_after_honored_even_when_shorter_than_backoff() {
+        let manager = make_manager();
+        manager.add(make_entry("sip:alice@carrier.com"));
+
+        // A Retry-After shorter than the local backoff is still honored — the
+        // registrar's explicit directive wins in both directions.
+        let before = Instant::now();
+        manager.handle_failure("sip:alice@carrier.com", 503, Some(Duration::from_secs(1)));
+
+        let next_attempt = manager
+            .entries
+            .get("sip:alice@carrier.com")
+            .unwrap()
+            .next_attempt;
+        assert!(
+            next_attempt <= before + Duration::from_secs(3),
+            "Retry-After=1s should win over the ~10s backoff"
+        );
+    }
+
+    #[test]
+    fn backoff_still_advances_under_retry_after() {
+        // Retry-After schedules the next attempt, but the backoff state keeps
+        // climbing so a later failure without Retry-After resumes correctly.
+        let manager = make_manager();
+        manager.add(make_entry("sip:alice@carrier.com"));
+
+        manager.handle_failure("sip:alice@carrier.com", 503, Some(Duration::from_secs(30)));
+        let backoff = manager
+            .entries
+            .get("sip:alice@carrier.com")
+            .unwrap()
+            .backoff;
+        assert_eq!(backoff, Duration::from_secs(10)); // 5s doubled
+    }
+
+    #[test]
     fn backoff_increases_on_repeated_failures() {
         let manager = make_manager();
         manager.add(make_entry("sip:alice@carrier.com"));
 
         // First failure
-        manager.handle_failure("sip:alice@carrier.com", 503);
+        manager.handle_failure("sip:alice@carrier.com", 503, None);
         let backoff_1 = manager
             .entries
             .get("sip:alice@carrier.com")
@@ -1683,7 +1759,7 @@ mod tests {
             .next_attempt = Instant::now();
 
         // Second failure
-        manager.handle_failure("sip:alice@carrier.com", 503);
+        manager.handle_failure("sip:alice@carrier.com", 503, None);
         let backoff_2 = manager
             .entries
             .get("sip:alice@carrier.com")
@@ -1705,7 +1781,7 @@ mod tests {
 
         // Fail many times
         for _ in 0..20 {
-            manager.handle_failure("sip:alice@carrier.com", 503);
+            manager.handle_failure("sip:alice@carrier.com", 503, None);
         }
 
         let backoff = manager
@@ -1722,8 +1798,8 @@ mod tests {
         manager.add(make_entry("sip:alice@carrier.com"));
 
         // Fail a few times
-        manager.handle_failure("sip:alice@carrier.com", 503);
-        manager.handle_failure("sip:alice@carrier.com", 503);
+        manager.handle_failure("sip:alice@carrier.com", 503, None);
+        manager.handle_failure("sip:alice@carrier.com", 503, None);
 
         // Then succeed
         manager.handle_success("sip:alice@carrier.com", 3600);
@@ -1919,7 +1995,7 @@ mod tests {
         let mut receiver = manager.subscribe_events();
         manager.add(make_entry("sip:alice@carrier.com"));
 
-        manager.handle_failure("sip:alice@carrier.com", 503);
+        manager.handle_failure("sip:alice@carrier.com", 503, None);
 
         let event = receiver.try_recv().unwrap();
         assert!(matches!(event, RegistrantEvent::Failed { ref aor, status_code: 503 } if aor == "sip:alice@carrier.com"));

--- a/src/sip/headers/mod.rs
+++ b/src/sip/headers/mod.rs
@@ -6,6 +6,7 @@ pub mod route;
 pub mod session_timer;
 pub mod rseq;
 pub mod charging;
+pub mod retry_after;
 
 use indexmap::IndexMap;
 use std::sync::Arc;

--- a/src/sip/headers/retry_after.rs
+++ b/src/sip/headers/retry_after.rs
@@ -1,0 +1,136 @@
+//! RFC 3261 §20.33 `Retry-After` header parsing.
+//!
+//! Wire format:
+//!   Retry-After = delta-seconds [ comment ] *( SEMI retry-param )
+//!
+//! e.g. `Retry-After: 18`, `Retry-After: 120 (I'm in a meeting)`,
+//! `Retry-After: 30;duration=600`.
+//!
+//! Only the leading `delta-seconds` integer is meaningful for backoff /
+//! failover decisions, so we parse that and ignore any trailing comment and
+//! parameters. Unlike HTTP (RFC 7231 §7.1.3), SIP `Retry-After` is never an
+//! HTTP-date, so an `HTTP-date`-shaped value (`Mon, 01 Jan 2035 ...`) simply
+//! has no leading digits and yields `None`.
+
+use std::time::Duration;
+
+/// Parse a `Retry-After` header value into a cooldown `Duration`.
+///
+/// Reads the leading `delta-seconds` integer (RFC 3261 §20.33) and returns it
+/// as a `Duration`; any trailing comment `(...)` and `;param`s are ignored.
+/// Returns `None` when the value has no leading integer (absent header,
+/// garbage, or an HTTP-date form) or overflows `u64` seconds.
+///
+/// Examples:
+///   "18"                -> Some(18s)
+///   "120 (I'm busy)"    -> Some(120s)
+///   "30;duration=600"   -> Some(30s)
+///   "Mon, 01 Jan ..."   -> None
+///   "garbage"           -> None
+pub fn parse(value: &str) -> Option<Duration> {
+    let digits: String = value
+        .trim_start()
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    // Overflow (an absurdly long digit run) parses to None rather than panicking.
+    digits.parse::<u64>().ok().map(Duration::from_secs)
+}
+
+/// Extract and parse the `Retry-After` header from a message's headers.
+pub fn parse_retry_after(headers: &super::SipHeaders) -> Option<Duration> {
+    headers.get("Retry-After").and_then(|value| parse(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_plain_seconds() {
+        assert_eq!(parse("18"), Some(Duration::from_secs(18)));
+    }
+
+    #[test]
+    fn parse_zero() {
+        assert_eq!(parse("0"), Some(Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn parse_with_comment() {
+        assert_eq!(parse("120 (I'm busy)"), Some(Duration::from_secs(120)));
+    }
+
+    #[test]
+    fn parse_with_comment_no_space() {
+        assert_eq!(parse("30(back soon)"), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn parse_with_param() {
+        assert_eq!(parse("30;duration=600"), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn parse_with_comment_and_param() {
+        assert_eq!(
+            parse("300 (maintenance);duration=3600"),
+            Some(Duration::from_secs(300))
+        );
+    }
+
+    #[test]
+    fn parse_leading_whitespace() {
+        assert_eq!(parse("   45"), Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn parse_large_value() {
+        assert_eq!(parse("86400"), Some(Duration::from_secs(86400)));
+    }
+
+    #[test]
+    fn reject_http_date_form() {
+        // SIP Retry-After is never an HTTP-date; it has no leading digits.
+        assert_eq!(parse("Mon, 01 Jan 2035 12:00:00 GMT"), None);
+    }
+
+    #[test]
+    fn reject_garbage() {
+        assert_eq!(parse("garbage"), None);
+    }
+
+    #[test]
+    fn reject_empty() {
+        assert_eq!(parse(""), None);
+        assert_eq!(parse("   "), None);
+    }
+
+    #[test]
+    fn reject_leading_sign() {
+        // A signed value has no leading ASCII digit.
+        assert_eq!(parse("-5"), None);
+    }
+
+    #[test]
+    fn overflow_yields_none() {
+        // Too many digits to fit u64 seconds — graceful None, no panic.
+        assert_eq!(parse("999999999999999999999999999999"), None);
+    }
+
+    #[test]
+    fn extract_from_headers() {
+        let mut headers = super::super::SipHeaders::new();
+        headers.set("Retry-After", "30;duration=600".to_string());
+        assert_eq!(parse_retry_after(&headers), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn extract_absent_header() {
+        let headers = super::super::SipHeaders::new();
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+}


### PR DESCRIPTION
## Problem

Microsoft Teams Direct Routing sheds load by answering `503 Service Unavailable` with a `Retry-After` from an overloaded datacenter, expecting the SBC to stop selecting that datacenter and fail over to the next one. siphon did none of this. Worse, the gateway OPTIONS health prober counted *any* response as a successful probe, so a destination answering `503` was recorded healthy and stayed selectable. The outbound REGISTER client also ignored `Retry-After` and always applied local exponential backoff.

## Change

1. **Retry-After parser** (`src/sip/headers/retry_after.rs`, new). Small unit-tested helper: parses the leading `delta-seconds` integer per RFC 3261 §20.33, ignores the optional `(comment)` and `;params`, returns `Option<Duration>`. HTTP-date form and garbage return `None`.

2. **Gateway prober** (`src/gateway/mod.rs`). The prober now binds the response and reads its status code. A `503` no longer records success; it falls into the failure path. When the `503` carries a `Retry-After`, the destination is marked down immediately (without waiting for the failure threshold) and held down for at least that cooldown via a new `down_until` deadline on `Destination`; a later successful probe does not flip it healthy again until the cooldown elapses. `500`/`502`/`504` (and any other answered non-`503` code) still count as healthy, since a peer that answers is reachable and OPTIONS is not a real call. Only `503` carries the "stop sending me traffic" semantics; the decision is documented in a code comment. An operator `gateway.mark_up()` clears the cooldown. The health verdict is split into a pure `apply_probe_response` helper so it is unit-testable without a live UAC.

3. **Registrant** (`src/registrant/mod.rs`, `src/dispatcher.rs`). `handle_failure` now takes the response's `Retry-After` (`Option<Duration>`), plumbed from `handle_registrant_response` / `handle_registrant_ipsec_challenge` where the REGISTER failure response is handled. When present, it schedules `next_attempt` at the server cooldown instead of the exponential backoff; the backoff state still advances so a later failure without `Retry-After` resumes correctly. The re-resolve-to-a-different-IP-on-failure behavior is unchanged. Transport-level failures (timeout, send error) pass `None`.

## Call-path failover (investigated)

Marking a destination down (`is_healthy() == false`) is sufficient for the next call's `gateway.select()` to route around it: `select()` filters candidates on `is_healthy()` and it is the only selection path. So for subsequent calls, the mark-down in change (2) is the whole fix.

There is one gap, called out as a follow-up rather than half-wired: there is no automatic *within-call* re-selection across gateway destinations. Sequential `request.fork()` / `call.fork()` iterate the fixed target list the script passed and never re-select from the group or mark a destination down on a live `503`/timeout. A per-call `503` on the first destination is not auto-failed-over inside the same call attempt today; that would be a separate change (either an engine-side fork-from-group primitive or driving it from the `on_failure` callback).

## Testing done

- `PYO3_PYTHON=python3 cargo clippy --all-targets --all-features -- -D warnings` clean.
- `PYO3_PYTHON=python3 cargo test` green: 3196 passed, 6 ignored.
- New unit tests:
  - Retry-After parser (15): `18` -> 18s, `120 (I'm busy)` -> 120s, `30;duration=600` -> 30s, comment+param, leading whitespace, HTTP-date -> None, garbage/empty/signed -> None, u64 overflow -> None, header extraction.
  - Gateway prober (9): `200` stays healthy; `500`/`502`/`504` stay healthy; `503` without Retry-After marks down only at threshold; `503`+Retry-After marks down immediately and holds the cooldown against a healthy probe; cooldown elapses then a healthy probe recovers; Retry-After on a non-`503` also cools down; timeout marks down at threshold; `mark_up` clears the cooldown; a shorter cooldown never shrinks a pending longer one.
  - Registrant (3): Retry-After overrides backoff; Retry-After honored even when shorter than backoff; backoff state still advances under Retry-After.
