### PR TITLE
fix(b2bua,proxy): Teams interop — OPTIONS-200 capability response + truthful Allow on responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the dispatch hot path reads no clock and touches no metric.
 
 ### Fixed
+- **OPTIONS 200 and B2BUA responses now advertise `Contact` + `Allow`.** A 2xx
+  answer to an inbound OPTIONS (RFC 3261 §11.2 capability response) carried no
+  `Contact` and no `Allow`. siphon now adds a `Contact` at its advertised sent-by
+  for the transport the OPTIONS arrived on — so a peer that rejects an OPTIONS
+  answer with neither `Contact` nor `Record-Route` (Microsoft Teams Direct Routing)
+  accepts it — and an `Allow` listing the methods siphon supports. On the B2BUA
+  response path the B-leg's `Allow` is stripped (its capabilities are not siphon's
+  to relay) and replaced with siphon's own, so a peer that selects its call-transfer
+  method from the SBC's `Allow` (Teams does) sees `REFER`/`NOTIFY`. Both are added
+  only when absent, so a script-set `Contact`/`Allow` still wins.
 - **Single Record-Route now uses the advertised host, not the bind IP.** When
   siphon record-routes a relayed request whose inbound and outbound transport are
   the same, the Record-Route carried the raw bind IP (and `127.0.0.1` when bound to

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2383,6 +2383,20 @@ fn handle_request(
                 response.body = body_bytes.clone();
             }
 
+            // RFC 3261 §11.2 — make a 2xx OPTIONS a proper capability response: a
+            // Contact (Microsoft Teams Direct Routing rejects an OPTIONS answer
+            // carrying neither Contact nor Record-Route) plus an Allow advertising
+            // siphon's supported methods (peers read transfer capability from it).
+            // Both are added only when absent, so a script-set header still wins.
+            if method == "OPTIONS" && (200..300).contains(code) {
+                augment_options_response(
+                    &mut response,
+                    &state.via_host(&inbound.transport),
+                    state.via_port(&inbound.transport),
+                    inbound.transport,
+                );
+            }
+
             // RFC 3262 — script asked for a reliable provisional. Only valid for
             // 101..199 INVITE responses, and only when the UAC advertised 100rel.
             // We attach Require: 100rel + a fresh RSeq, then arm a retransmit
@@ -5460,13 +5474,50 @@ fn parse_translate_op_name(name: &str) -> Option<crate::b2bua::header_policy::Tr
     }
 }
 
+/// Set `Allow` (RFC 3261 §20.5) to the methods siphon supports, but only when the
+/// header is absent — never overwrite a caller/script-set `Allow`. Used on
+/// siphon's own UA surfaces (OPTIONS 2xx responses, B2BUA responses) so a peer can
+/// discover the supported method set, including REFER/NOTIFY for transfer.
+fn advertise_supported_methods(headers: &mut SipHeaders) {
+    if !headers.has("Allow") {
+        headers.set("Allow", crate::sip::SUPPORTED_METHODS.to_string());
+    }
+}
+
+/// Turn a 2xx OPTIONS into a proper capability response (RFC 3261 §11.2): add a
+/// `Contact` at the advertised sent-by and advertise the supported methods via
+/// `Allow`. Both are added only when absent, so a script-set `Contact`/`Allow`
+/// wins. `via_host`/`via_port` are the advertised sent-by for the transport the
+/// OPTIONS arrived on; some peers (Microsoft Teams Direct Routing) reject an
+/// OPTIONS answer that carries neither `Contact` nor `Record-Route`.
+fn augment_options_response(
+    response: &mut SipMessage,
+    via_host: &str,
+    via_port: u16,
+    transport: Transport,
+) {
+    if !response.headers.has("Contact") {
+        response.headers.set(
+            "Contact",
+            format!(
+                "<sip:{}:{};transport={}>",
+                via_host,
+                via_port,
+                transport.to_string().to_lowercase()
+            ),
+        );
+    }
+    advertise_supported_methods(&mut response.headers);
+}
+
 /// Sanitize a B2BUA response before forwarding it to the A-leg.
 ///
 /// A proper B2BUA terminates and regenerates the dialog, so B-leg-specific
 /// headers must not leak to the A-leg. This function:
 /// - Replaces Contact with siphon's own address (critical for dialog routing)
 /// - Strips User-Agent (UAC header — not for responses), sets Server
-/// - Removes Allow, Allow-Events, Supported, Require
+/// - Strips the B-leg's Allow-Events/Supported/Require, and replaces Allow with
+///   siphon's own supported methods (a B2BUA is a UA in its own right)
 /// - Strips B-leg-specific P-Asserted-Identity, P-Charging-Vector
 fn sanitize_b2bua_response(
     response: &mut SipMessage,
@@ -5531,6 +5582,15 @@ fn sanitize_b2bua_response(
         server_header: state.server_header.as_deref(),
     };
     crate::b2bua::header_policy::apply_to_response(response, &policy, &ctx);
+
+    // Advertise siphon's own supported methods. The policy above strips the
+    // B-leg's Allow (a B2BUA terminates the dialog, so the B-leg's capabilities
+    // are not siphon's to relay); replace it with what siphon actually implements
+    // as a UA, so a peer that reads transfer capability from the Allow sees
+    // REFER/NOTIFY — Microsoft Teams Direct Routing selects its transfer method
+    // this way, and without it never hands siphon a REFER. Gated on absence so a
+    // script `call.set_header("Allow", …)` (policy precedence 1) still wins.
+    advertise_supported_methods(&mut response.headers);
 
     // Sanitize SDP: mask B-leg identity in o= and s= lines, and rewrite
     // the o= address to our advertised address for topology hiding.
@@ -12901,6 +12961,60 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    #[test]
+    fn advertise_supported_methods_sets_allow_when_absent() {
+        let mut headers = SipHeaders::new();
+        advertise_supported_methods(&mut headers);
+        let allow = headers.get("Allow").expect("Allow must be set");
+        assert_eq!(allow, crate::sip::SUPPORTED_METHODS);
+        // The whole point: peers read transfer capability from here.
+        assert!(allow.contains("REFER") && allow.contains("NOTIFY"));
+    }
+
+    #[test]
+    fn advertise_supported_methods_preserves_existing_allow() {
+        let mut headers = SipHeaders::new();
+        headers.set("Allow", "INVITE, ACK, BYE".to_string());
+        advertise_supported_methods(&mut headers);
+        assert_eq!(headers.get("Allow").unwrap(), "INVITE, ACK, BYE");
+    }
+
+    #[test]
+    fn augment_options_response_adds_contact_and_allow() {
+        let mut response = SipMessageBuilder::new()
+            .response(200, "OK".to_string())
+            .build()
+            .unwrap();
+        augment_options_response(&mut response, "sbc.example.org", 5061, Transport::Tls);
+        assert_eq!(
+            response.headers.get("Contact").unwrap(),
+            "<sip:sbc.example.org:5061;transport=tls>"
+        );
+        assert_eq!(
+            response.headers.get("Allow").unwrap(),
+            crate::sip::SUPPORTED_METHODS
+        );
+    }
+
+    #[test]
+    fn augment_options_response_preserves_script_contact() {
+        let mut response = SipMessageBuilder::new()
+            .response(200, "OK".to_string())
+            .contact("<sip:custom@host:5060>".to_string())
+            .build()
+            .unwrap();
+        augment_options_response(&mut response, "sbc.example.org", 5061, Transport::Udp);
+        // Script-set Contact must not be clobbered; Allow is still advertised.
+        assert_eq!(
+            response.headers.get("Contact").unwrap(),
+            "<sip:custom@host:5060>"
+        );
+        assert_eq!(
+            response.headers.get("Allow").unwrap(),
+            crate::sip::SUPPORTED_METHODS
+        );
+    }
 
     #[test]
     fn b_leg_contact_default_is_userless() {


### PR DESCRIPTION
Part 2 of 3 closing Teams Direct Routing interop gaps (after #68). This one makes siphon's own response surfaces advertise capabilities properly.

## What Teams needs

- A 2xx to OPTIONS must carry a `Contact` (Teams rejects an OPTIONS answer with neither `Contact` nor `Record-Route`).
- Teams selects its call-transfer method from the SBC's advertised `Allow`; without `REFER`/`NOTIFY` it never hands the SBC a REFER, even though siphon implements transfer.

## Changes

- **OPTIONS 200 capability response (#2 + #4).** In the reply path, a 2xx answer to an inbound OPTIONS now gets a `Contact` at siphon's advertised sent-by (for the transport the OPTIONS arrived on) plus an `Allow` listing supported methods. Both only when absent, so a script `set_reply_header` wins. Localized to the reply handler — the other ~60 `build_response` callers are untouched.
- **Truthful `Allow` on B2BUA responses (#4).** The transparent policy strips the B-leg's `Allow` (a B2BUA terminates the dialog, so the B-leg's capabilities aren't siphon's to relay); siphon now synthesizes its own `Allow` after the policy runs, so the 200 OK relayed to Teams advertises `REFER`/`NOTIFY`. Gated on absence so a `call.set_header("Allow", …)` (policy precedence 1) still wins.
- New `sip::SUPPORTED_METHODS` (added in #68) is the single source of truth, applied via two small pure helpers `advertise_supported_methods` / `augment_options_response`.

## Deferred: per-gateway Allow subset

You asked for an optional per-gateway subset ("advertise fewer methods to this peer for some scenarios"). I did **not** wire it here: at the response-building points there's no clean association to "which gateway is this response going to" without threading gateway context through, and per the plan I won't ship a half-wired knob. The natural home for a per-peer subset is the egress side (the OPTIONS keepalive prober / B2BUA dial, which know the destination) — noting it as a follow-up rather than bolting a dangling config field on now. The default truthful `Allow` (the "must send it") is fully delivered.

## Testing

- `cargo test` — 3173 passed, 6 ignored. `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- The Contact/Allow logic is extracted into pure helpers and unit-tested directly (adds when absent incl. REFER/NOTIFY; never clobbers a script-set Contact/Allow) — no `DispatcherState` needed. Full SIPp + mem-leak baseline recommended before release-cut per policy (response-path touch).
