### PR TITLE
build(deps): bump aes 0.9 / md5 0.8 / x509-cert 0.3 / rasn-derive 0.28 + migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   drifting. The PyPI `Documentation` link now points there.
 
 ### Changed
+- **Bump four crypto/ASN.1 dependencies to their current majors** (no behavioural
+  change; all validated against the existing known-answer vectors):
+  `aes` 0.8 → 0.9 (RustCrypto `cipher` 0.5 — `BlockEncrypt` → `BlockCipherEncrypt`,
+  `GenericArray` → `Array` in the Milenage AES-128 block op; the 3GPP TS 35.208
+  test-set KATs are byte-identical), `md5` 0.7 → 0.8 (`Context::compute` →
+  `finalize`), `x509-cert` 0.2 → 0.3 (its `Certificate` / `TbsCertificate` fields
+  became private — the STIR cert code now goes through the accessor methods and
+  `get_extension()`), and `rasn-derive` 0.22 → 0.28 to match the already-current
+  `rasn` 0.28 (the two had drifted out of lockstep). Supersedes the individual
+  Dependabot bumps.
 - **Bump the `siphon-bin` SMPP extension to siphon-smpp v1.3.0**, which adds
   Prometheus metrics for the SMPP runtime into siphon's shared `/metrics`
   registry: `siphon_smpp_binds` (gauge, `direction`/`state`) plus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,13 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -440,11 +440,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -559,6 +559,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -726,9 +732,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -748,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,12 +830,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -839,7 +856,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1472,11 +1489,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1707,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -2010,6 +2027,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,8 +2078,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2500,21 +2526,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "once_cell",
- "rasn-derive 0.28.13",
+ "rasn-derive",
  "serde_json",
  "snafu",
  "xml-no-std",
-]
-
-[[package]]
-name = "rasn-derive"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f35fecd68ee4d5850baa37ee4520456bbae761fdd42a7fcb95701c268500a93"
-dependencies = [
- "proc-macro2",
- "rasn-derive-impl 0.22.2",
- "syn",
 ]
 
 [[package]]
@@ -2524,22 +2539,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11dcd4dab09ceadedb3e2bedf340deb583f0e25bba9ad966b5655c2fb62b1392"
 dependencies = [
  "proc-macro2",
- "rasn-derive-impl 0.28.13",
+ "rasn-derive-impl",
  "syn",
-]
-
-[[package]]
-name = "rasn-derive-impl"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355eedbab62312d9474e1c2e7963ce5fad99bded7e9abd42ae4f040762a2c5f6"
-dependencies = [
- "either",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
- "uuid",
 ]
 
 [[package]]
@@ -2859,7 +2860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
  "pkcs8",
  "subtle",
@@ -3101,7 +3102,7 @@ dependencies = [
  "pyo3-async-runtimes",
  "quick-xml",
  "rasn",
- "rasn-derive 0.22.2",
+ "rasn-derive",
  "rcgen",
  "redis",
  "regex",
@@ -3211,7 +3212,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -4357,13 +4368,13 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
- "const-oid 0.9.6",
- "der",
- "spki",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
  "tls_codec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,18 +102,18 @@ clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "json", "multipart", "stream"] }
 
 # Crypto (Milenage AKA key derivation for IMS IPsec)
-aes = "0.8"
+aes = "0.9"
 
 # STIR/SHAKEN — ES256 PASSporT signing/verification (RFC 8224/8225/8226,
 # ATIS-1000074). RustCrypto, pure-Rust, no OpenSSL — fits the rustls posture.
 # ECDSA signing uses RFC 6979 deterministic nonces, so no RNG plumbing on the
 # sign path.
 p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }  # ES256 sign/verify + key load
-x509-cert = { version = "0.2", features = ["pem"] }               # cert parse, SPKI, extensions, validity
+x509-cert = { version = "0.3", features = ["pem"] }               # cert parse, SPKI, extensions, validity
 base64 = "0.22"                                                    # base64url (URL_SAFE_NO_PAD) for JWS
 
 # Utilities
-md5 = "0.7"
+md5 = "0.8"
 sha2 = "0.10"
 uuid = { version = "1.22", features = ["v4", "fast-rng"] }
 # Cryptographic randomness — used by Milenage AKA RAND generation
@@ -135,7 +135,7 @@ tower = { version = "0.5.3", features = ["util"] }
 
 # Lawful Intercept — ETSI ASN.1/BER + XML
 rasn = "0.28"
-rasn-derive = "0.22"
+rasn-derive = "0.28"
 chrono = { version = "0.4", default-features = false }
 quick-xml = { version = "0.41", features = ["serialize"] }
 

--- a/src/ipsec/milenage.rs
+++ b/src/ipsec/milenage.rs
@@ -7,8 +7,7 @@
 //! Algorithm Set: An example algorithm set for the 3GPP authentication
 //! and key generation functions f1, f1*, f2, f3, f4, f5 and f5*.
 
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::cipher::{BlockCipherEncrypt, KeyInit};
 use aes::Aes128;
 
 // ---------------------------------------------------------------------------
@@ -65,12 +64,10 @@ pub struct AkaVector {
 
 /// AES-128 encrypt a single 16-byte block.
 fn aes_encrypt(key: &[u8; 16], input: &[u8; 16]) -> [u8; 16] {
-    let cipher = Aes128::new(GenericArray::from_slice(key));
-    let mut block = *GenericArray::from_slice(input);
+    let cipher = Aes128::new(key.into());
+    let mut block = (*input).into();
     cipher.encrypt_block(&mut block);
-    let mut output = [0u8; 16];
-    output.copy_from_slice(block.as_slice());
-    output
+    block.into()
 }
 
 /// XOR two 16-byte blocks.

--- a/src/script/api/auth.rs
+++ b/src/script/api/auth.rs
@@ -1161,7 +1161,7 @@ fn md5_ha1_aka(username: &str, realm: &str, password_bytes: &[u8]) -> String {
     ctx.consume(realm.as_bytes());
     ctx.consume(b":");
     ctx.consume(password_bytes);
-    format!("{:x}", ctx.compute())
+    format!("{:x}", ctx.finalize())
 }
 
 /// Extract a named parameter from a Digest header value.

--- a/src/stir/cert.rs
+++ b/src/stir/cert.rs
@@ -39,8 +39,8 @@ pub fn parse_pem_chain(pem: &[u8]) -> Result<Vec<Certificate>, String> {
 /// Extract the ECDSA P-256 public key from a certificate's SubjectPublicKeyInfo.
 pub fn verifying_key(certificate: &Certificate) -> Result<VerifyingKey, String> {
     let point = certificate
-        .tbs_certificate
-        .subject_public_key_info
+        .tbs_certificate()
+        .subject_public_key_info()
         .subject_public_key
         .as_bytes()
         .ok_or_else(|| "subject public key is not octet-aligned".to_string())?;
@@ -75,7 +75,7 @@ pub fn validate_chain(
 
         // 1. Does any trust anchor directly sign `current`? If so, done.
         for anchor in anchors {
-            if names_equal(&anchor.tbs_certificate.subject, &current.tbs_certificate.issuer)?
+            if names_equal(anchor.tbs_certificate().subject(), current.tbs_certificate().issuer())?
                 && verify_signed_by(&current, anchor)?
             {
                 check_validity(anchor, now_unix)?;
@@ -89,8 +89,8 @@ pub fn validate_chain(
             !visited.contains(&candidate_der)
                 && is_ca(candidate)
                 && names_equal(
-                    &candidate.tbs_certificate.subject,
-                    &current.tbs_certificate.issuer,
+                    candidate.tbs_certificate().subject(),
+                    current.tbs_certificate().issuer(),
                 )
                 .unwrap_or(false)
         });
@@ -118,11 +118,10 @@ pub fn validate_chain(
 /// True when the certificate carries the RFC 8226 TNAuthList extension.
 pub fn has_tnauthlist(certificate: &Certificate) -> bool {
     certificate
-        .tbs_certificate
-        .extensions
-        .as_deref()
-        .unwrap_or(&[])
-        .iter()
+        .tbs_certificate()
+        .extensions()
+        .into_iter()
+        .flatten()
         .any(|extension| extension.extn_id.to_string() == TNAUTHLIST_OID)
 }
 
@@ -135,19 +134,19 @@ fn der_bytes(certificate: &Certificate) -> Result<Vec<u8>, String> {
 
 /// Verify that `child` was signed by `issuer`'s private key (ECDSA-P256/SHA-256).
 fn verify_signed_by(child: &Certificate, issuer: &Certificate) -> Result<bool, String> {
-    if child.signature_algorithm.oid.to_string() != ECDSA_WITH_SHA256_OID {
+    if child.signature_algorithm().oid.to_string() != ECDSA_WITH_SHA256_OID {
         return Err(format!(
             "unsupported certificate signature algorithm {} (only ecdsa-with-SHA256 in v1)",
-            child.signature_algorithm.oid
+            child.signature_algorithm().oid
         ));
     }
     let issuer_key = verifying_key(issuer)?;
     let tbs = child
-        .tbs_certificate
+        .tbs_certificate()
         .to_der()
         .map_err(|error| format!("TBSCertificate DER encode failed: {error}"))?;
     let signature_der = child
-        .signature
+        .signature()
         .as_bytes()
         .ok_or_else(|| "certificate signature is not octet-aligned".to_string())?;
     let signature = match Signature::from_der(signature_der) {
@@ -160,14 +159,14 @@ fn verify_signed_by(child: &Certificate, issuer: &Certificate) -> Result<bool, S
 /// Ensure `now_unix` falls within the certificate's validity window.
 fn check_validity(certificate: &Certificate, now_unix: i64) -> Result<(), String> {
     let not_before = certificate
-        .tbs_certificate
-        .validity
+        .tbs_certificate()
+        .validity()
         .not_before
         .to_unix_duration()
         .as_secs() as i64;
     let not_after = certificate
-        .tbs_certificate
-        .validity
+        .tbs_certificate()
+        .validity()
         .not_after
         .to_unix_duration()
         .as_secs() as i64;
@@ -182,7 +181,7 @@ fn check_validity(certificate: &Certificate, now_unix: i64) -> Result<(), String
 
 /// True when the certificate asserts CA:TRUE in basicConstraints.
 fn is_ca(certificate: &Certificate) -> bool {
-    match certificate.tbs_certificate.get::<BasicConstraints>() {
+    match certificate.tbs_certificate().get_extension::<BasicConstraints>() {
         Ok(Some((_critical, basic_constraints))) => basic_constraints.ca,
         _ => false,
     }


### PR DESCRIPTION
## What

Bumps four crypto / ASN.1 dependencies to their current majors and migrates the code. One PR because they all touch `Cargo.lock` and would otherwise serially conflict; it **supersedes the individual Dependabot PRs #64, #65, #66, #67**, which Dependabot will auto-close once this lands.

| crate | from → to | migration |
|---|---|---|
| `aes` | 0.8 → 0.9 | RustCrypto `cipher` 0.5: `BlockEncrypt` → `BlockCipherEncrypt`, `GenericArray` → `Array` in the Milenage AES-128 block op (`milenage.rs`) |
| `md5` | 0.7 → 0.8 | `Context::compute()` → `finalize()` (`auth.rs`) |
| `x509-cert` | 0.2 → 0.3 | `Certificate` / `TbsCertificate` fields are now private → accessor methods (`tbs_certificate()`, `subject()`, `issuer()`, `validity()`, `subject_public_key_info()`, `extensions()`, `signature()`), and `.get::<T>()` → `.get_extension::<T>()` (`stir/cert.rs`) |
| `rasn-derive` | 0.22 → 0.28 | version alignment only — `rasn` was already 0.28, the two had drifted out of lockstep (#64) |

No behavioural change intended.

## Validation

- **Crypto validated against known-answer vectors, not round-trips**: the Milenage f1–f5 tests run the 3GPP TS 35.208 Test Set 1 vectors and are byte-identical after the AES-0.9 block-API change; STIR cert parse/chain-validation and MD5 digest-auth tests pass unchanged.
- `cargo test --lib`: **2806 passed, 0 failed**.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.

Done in an isolated worktree off `main`.
