### PR TITLE
docs(changelog): promote [Unreleased] to [1.3.0], backfill [1.2.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-07-10
+
 ### Added
 - **`send_socket=` egress pin on `request.relay()` / `request.fork()` and
   `call.dial()` / `call.fork()`** — the operator equivalent of Kamailio's
@@ -160,6 +162,8 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   advertised, and the choice flipped between restarts. The default is now the
   first `listen.udp` listener in configuration order, matching the advertised Via
   sent-by. Single-listener and IPsec deployments are unaffected.
+
+## [1.2.1] — 2026-07-09
 
 ### Security
 - **Bump `crossbeam-epoch` 0.9.18 → 0.9.20** to address RUSTSEC-2026-0204: an


### PR DESCRIPTION
Promotes the accumulated `[Unreleased]` entries to `## [1.3.0] — 2026-07-10` ahead of cutting v1.3.0.

The `[Unreleased]` changes since v1.2.1 are all additive (new scripting-API surface: `send_socket=` egress pin, whole-URI setters, `cache.list_len`/`list_len_sum`; plus the Teams-interop fixes and the crypto/ASN.1 major bumps), so this is a minor bump.

Also backfills a `## [1.2.1] — 2026-07-09` section for the `crossbeam-epoch` 0.9.20 (RUSTSEC-2026-0204) bump that actually shipped in v1.2.1 — it had been left stranded under `[Unreleased]`, which would have misattributed it to 1.3.0.