### PR TITLE
feat(rtpengine): rtpengine.echo() single-leg IVR echo on the native siphon-rtp backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`rtpengine.echo(target, enabled=True)`** — single-leg IVR echo on the native
+  `siphon-rtp` media backend. After offering the leg, `await rtpengine.echo(call)`
+  reflects the caller's ingress audio back to itself; `enabled=False` stops it.
+  siphon-rtp promotes the plain relay into its processing media path on enable and
+  demotes it on disable, and DTMF and media-timeout events keep firing while
+  echoing. Native `siphon-rtp` backend only: the rtpengine and rtpproxy backends
+  have no echo verb and reject the call with a clear error rather than silently
+  no-op'ing. Requires `siphon-rtp-proto` 0.1.1.
 - **`send_socket=` egress pin on `request.relay()` / `request.fork()` and
   `call.dial()` / `call.fork()`** — the operator equivalent of Kamailio's
   `force_send_socket()` / OpenSIPS' `$fs`. Selects which of siphon's own

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,9 +3059,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50101a2f08a8fc84d0e725827cdc814842beb151ed7d77253a49022f17b64477"
+checksum = "30064e67e79f19d4a91da98932b0d572efc13e08a87f307ac82446a949aef05a"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.1.0"
+siphon-rtp-proto = "0.1.1"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -173,7 +173,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.1.0"
+siphon-rtp-proto = "0.1.1"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -1705,8 +1705,8 @@ class MockRtpEngine:
         assert rtpengine.operations == [("offer", "srtp_to_rtp")]
 
     Media-injection operations (``play_media``, ``stop_media``, ``play_dtmf``,
-    ``silence_media``, ``unsilence_media``, ``block_media``, ``unblock_media``)
-    are also captured in ``operations`` as ``(name, detail_string)`` tuples so
+    ``silence_media``, ``unsilence_media``, ``block_media``, ``unblock_media``,
+    ``echo``) are also captured in ``operations`` as ``(name, detail)`` tuples so
     downstream apps can unit-test MMTEL announcement flows without a live
     rtpengine. Full parameter dicts are available on ``media_calls``.
 
@@ -1949,6 +1949,17 @@ class MockRtpEngine:
         """Resume forwarding the selected monologue's packets."""
         self.operations.append(("unblock_media", None))
         self.media_calls.append({"op": "unblock_media"})
+        return True
+
+    async def echo(self, target: Any, enabled: bool = True) -> bool:
+        """Toggle echo-test mode on a call — reflect the caller's ingress audio
+        back to itself (single-leg IVR echo).
+
+        ``enabled=False`` stops echoing. Native ``siphon-rtp`` backend only;
+        DTMF and media-timeout events still fire while echoing.
+        """
+        self.operations.append(("echo", enabled))
+        self.media_calls.append({"op": "echo", "enabled": enabled})
         return True
 
     async def subscribe_request(

--- a/sdk/tests/test_rtpengine_media.py
+++ b/sdk/tests/test_rtpengine_media.py
@@ -1,7 +1,7 @@
 """Tests for MockRtpEngine media-injection methods.
 
-Covers play_media/stop_media/play_dtmf/silence+unsilence/block+unblock — the
-announcement and DTMF surface added for MMTEL / TAS-style scripts.
+Covers play_media/stop_media/play_dtmf/silence+unsilence/block+unblock/echo —
+the announcement, DTMF, and echo-test surface added for MMTEL / TAS-style scripts.
 """
 
 from __future__ import annotations
@@ -176,6 +176,41 @@ async def route(request):
         harness.send_request("INVITE", "sip:alice@example.com")
         ops = [name for name, _ in harness.rtpengine.operations]
         assert ops == ["block_media", "unblock_media"]
+
+
+class TestEcho:
+    def test_echo_default_enabled(self, harness):
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    await rtpengine.echo(request)
+    request.reply(200, "OK")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+        assert ("echo", True) in harness.rtpengine.operations
+        call = harness.rtpengine.media_calls[-1]
+        assert call["op"] == "echo"
+        assert call["enabled"] is True
+
+    def test_echo_disabled(self, harness):
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    await rtpengine.echo(request, enabled=False)
+    request.reply(200, "OK")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+        assert ("echo", False) in harness.rtpengine.operations
+        call = harness.rtpengine.media_calls[-1]
+        assert call["enabled"] is False
 
 
 class TestClear:

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -193,6 +193,18 @@ impl MediaBackend {
         }
     }
 
+    /// Echo-test mode — reflect a leg's ingress audio back to itself (single-leg
+    /// IVR echo). Native `siphon-rtp` backend only: rtpengine and rtpproxy have
+    /// no echo verb, so those backends reject rather than silently no-op.
+    pub async fn echo(&self, call_id: &str, from_tag: &str, enabled: bool) -> Result<(), RtpEngineError> {
+        match self {
+            Self::SiphonRtp(client) => client.echo(call_id, from_tag, enabled).await,
+            Self::RtpEngine(_) | Self::RtpProxy(_) => Err(RtpEngineError::Protocol(
+                "echo is only supported by the native siphon-rtp backend".to_string(),
+            )),
+        }
+    }
+
     /// Drop the selected monologue's outgoing packets entirely.
     pub async fn block_media(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
         match self {
@@ -332,5 +344,55 @@ impl MediaBackend {
             Self::SiphonRtp(client) => client.instance_addresses(),
             Self::RtpProxy(client) => client.instance_addresses(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rtpengine::events::RtpEngineEvent;
+    use tokio::sync::mpsc;
+
+    /// A valid-but-unused loopback address; nothing listens on it. The native
+    /// client dispatches the command and times out; the other backends reject
+    /// `echo` synchronously before any I/O.
+    fn dead_address() -> SocketAddr {
+        "127.0.0.1:1".parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn echo_routes_to_siphon_rtp_backend() {
+        // Reaching the native client is proven by a Timeout (the command was
+        // framed and sent, then no response arrived) — the reject arms below
+        // return synchronously and never time out.
+        let (event_tx, _event_rx) = mpsc::channel::<RtpEngineEvent>(16);
+        let set = SiphonRtpClientSet::new(vec![(dead_address(), 200, 1)], None, event_tx).unwrap();
+        let backend = MediaBackend::SiphonRtp(set);
+
+        let error = backend.echo("call-1", "tag-a", true).await.unwrap_err();
+        assert!(
+            matches!(error, RtpEngineError::Timeout { .. }),
+            "expected the native client path (Timeout), got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn echo_rejected_on_rtpproxy_backend() {
+        let set = RtpProxyClientSet::new(vec![(dead_address(), 200, 1)], 0).await.unwrap();
+        let backend = MediaBackend::RtpProxy(set);
+
+        let error = backend.echo("call-1", "tag-a", true).await.unwrap_err();
+        assert!(matches!(error, RtpEngineError::Protocol(_)));
+        assert!(error.to_string().contains("siphon-rtp"));
+    }
+
+    #[tokio::test]
+    async fn echo_rejected_on_rtpengine_backend() {
+        let set = RtpEngineSet::new(vec![(dead_address(), 200, 1)]).await.unwrap();
+        let backend = MediaBackend::RtpEngine(Arc::new(set));
+
+        let error = backend.echo("call-1", "tag-a", true).await.unwrap_err();
+        assert!(matches!(error, RtpEngineError::Protocol(_)));
+        assert!(error.to_string().contains("siphon-rtp"));
     }
 }

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -67,6 +67,10 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         direction: flags.direction.clone(),
         record_call: flags.record_call,
         record_path: flags.record_path.clone(),
+        // Proto fields siphon's NgFlags has no source for (address_family,
+        // ws_uri, received_from, rtcp_mux). Default them: each carries
+        // skip_serializing_if, so the emitted wire form is unchanged.
+        ..ProfileFlags::default()
     }
 }
 
@@ -369,6 +373,27 @@ impl SiphonRtpClient {
         )
     }
 
+    /// Echo-test mode: the engine reflects a leg's ingress audio back to itself
+    /// (single-leg IVR echo). `enabled=false` stops it. siphon-rtp promotes a
+    /// plain relay to a processing MediaCall automatically; DTMF and
+    /// media-timeout events still fire while echoing.
+    pub async fn echo(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        enabled: bool,
+    ) -> Result<(), RtpEngineError> {
+        expect_ok(
+            self.request(Command::Echo {
+                call_id: call_id.to_string(),
+                from_tag: from_tag.to_string(),
+                to_tag: None,
+                enabled,
+            })
+            .await?,
+        )
+    }
+
     /// Drop the selected monologue's outgoing packets entirely.
     pub async fn block_media(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
         expect_ok(
@@ -492,9 +517,10 @@ impl SiphonRtpClient {
         match self.request(Command::Ping).await? {
             CmdResult::Pong => Ok(()),
             CmdResult::Error { reason } => Err(RtpEngineError::EngineError(reason)),
-            CmdResult::Ok { .. } => Err(RtpEngineError::Protocol(
-                "expected 'pong', got 'ok'".to_string(),
-            )),
+            other => Err(RtpEngineError::Protocol(format!(
+                "expected 'pong', got '{}'",
+                result_kind(&other)
+            ))),
         }
     }
 
@@ -713,6 +739,16 @@ impl SiphonRtpClientSet {
         self.select(call_id).unsilence_media(call_id, from_tag).await
     }
 
+    /// Toggle echo-test mode on the affinity-bound instance.
+    pub async fn echo(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        enabled: bool,
+    ) -> Result<(), RtpEngineError> {
+        self.select(call_id).echo(call_id, from_tag, enabled).await
+    }
+
     /// Block egress on the affinity-bound instance.
     pub async fn block_media(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
         self.select(call_id).block_media(call_id, from_tag).await
@@ -837,13 +873,37 @@ fn unexpected_result(context: &str, result: CmdResult) -> RtpEngineError {
         CmdResult::Ok { .. } => {
             RtpEngineError::Protocol(format!("unexpected 'ok' response to {context}"))
         }
+        // Results for cluster/stats/query commands siphon never issues on this
+        // control connection (List/Statistics/Load/NodeInfo/Checkpoint). Seeing
+        // one is a protocol violation, not a stub — treat it as such.
+        other => RtpEngineError::Protocol(format!(
+            "unexpected '{}' response to {context}",
+            result_kind(&other)
+        )),
+    }
+}
+
+/// A short, stable tag for a [`CmdResult`] variant, for error messages.
+fn result_kind(result: &CmdResult) -> &'static str {
+    match result {
+        CmdResult::Ok { .. } => "ok",
+        CmdResult::Error { .. } => "error",
+        CmdResult::Pong => "pong",
+        CmdResult::List { .. } => "list",
+        CmdResult::Statistics { .. } => "statistics",
+        CmdResult::Load { .. } => "load",
+        CmdResult::NodeInfo { .. } => "node_info",
+        CmdResult::Checkpoint { .. } => "checkpoint",
     }
 }
 
 /// Convert a proto [`Event`] to siphon's [`RtpEngineEvent`].
 ///
 /// `Event::Dtmf` is a field-for-field twin of [`DtmfEvent`]; `MediaTimeout`
-/// maps to the dedicated variant; anything else becomes `Unknown`.
+/// maps to the dedicated variant. The conference/quality events
+/// (`ActiveSpeaker`, `CallQuality`) are not modelled by a typed handler yet, so
+/// they surface through `Unknown` (logged, not dropped) carrying their stream
+/// identifiers — a typed Python handler is a follow-up.
 fn convert_event(event: Event) -> RtpEngineEvent {
     match event {
         Event::Dtmf {
@@ -866,6 +926,24 @@ fn convert_event(event: Event) -> RtpEngineEvent {
         Event::MediaTimeout { call_id, from_tag } => RtpEngineEvent::MediaTimeout {
             call_id,
             from_tag,
+        },
+        Event::ActiveSpeaker {
+            conference_id,
+            from_tag,
+        } => RtpEngineEvent::Unknown {
+            event: "active_speaker".to_string(),
+            call_id: Some(conference_id),
+            from_tag,
+        },
+        Event::CallQuality {
+            conference_id,
+            call_id,
+            from_tag,
+            ..
+        } => RtpEngineEvent::Unknown {
+            event: "call_quality".to_string(),
+            call_id: call_id.or(conference_id),
+            from_tag: Some(from_tag),
         },
         Event::Unknown => RtpEngineEvent::Unknown {
             event: "unknown".to_string(),
@@ -1083,9 +1161,10 @@ async fn authenticate(
                                 CmdResult::Error { reason } => {
                                     Err(RtpEngineError::EngineError(reason))
                                 }
-                                CmdResult::Pong => Err(RtpEngineError::Protocol(
-                                    "unexpected 'pong' for authenticate".to_string(),
-                                )),
+                                other => Err(RtpEngineError::Protocol(format!(
+                                    "unexpected '{}' response for authenticate",
+                                    result_kind(&other)
+                                ))),
                             };
                         }
                     }
@@ -1511,6 +1590,75 @@ mod tests {
         let error = client.delete("call-x", "tag-a").await.unwrap_err();
         assert!(matches!(error, RtpEngineError::EngineError(_)));
         assert!(error.to_string().contains("no such call"));
+    }
+
+    #[tokio::test]
+    async fn echo_frames_command_with_enabled_flag() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = Vec::new();
+
+            // First call: echo(enabled=true).
+            let request: Request = read_frame(&mut stream, &mut buffer).await;
+            match request.command {
+                Command::Echo {
+                    call_id,
+                    from_tag,
+                    to_tag,
+                    enabled,
+                } => {
+                    assert_eq!(call_id, "call-echo");
+                    assert_eq!(from_tag, "tag-a");
+                    assert_eq!(to_tag, None);
+                    assert!(enabled, "enabled=true must serialize as true");
+                }
+                other => panic!("expected Echo, got {other:?}"),
+            }
+            write_frame(
+                &mut stream,
+                &Response {
+                    id: request.id,
+                    result: CmdResult::Ok {
+                        sdp: None,
+                        duration_ms: None,
+                        to_tag: None,
+                        stats: None,
+                    },
+                },
+            )
+            .await;
+
+            // Second call on the same persistent connection: echo(enabled=false).
+            let request: Request = read_frame(&mut stream, &mut buffer).await;
+            match request.command {
+                Command::Echo { enabled, .. } => {
+                    assert!(!enabled, "enabled=false must serialize as false");
+                }
+                other => panic!("expected Echo, got {other:?}"),
+            }
+            write_frame(
+                &mut stream,
+                &Response {
+                    id: request.id,
+                    result: CmdResult::Ok {
+                        sdp: None,
+                        duration_ms: None,
+                        to_tag: None,
+                        stats: None,
+                    },
+                },
+            )
+            .await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        client.echo("call-echo", "tag-a", true).await.unwrap();
+        client.echo("call-echo", "tag-a", false).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -554,6 +554,37 @@ impl PyRtpEngine {
         self.simple_media_command(python, target, "unblock_media")
     }
 
+    /// Enable/disable echo-test mode on a call — reflect the caller's ingress
+    /// audio back to itself (single-leg IVR echo). ``enabled=False`` stops
+    /// echoing. Native ``siphon-rtp`` backend only; DTMF and media-timeout
+    /// events still fire while echoing.
+    ///
+    /// Args:
+    ///     target: A Request, Reply, or Call whose Call-ID / From-tag select
+    ///         the leg to echo (the same message the offer used).
+    ///     enabled: True to start echoing (default), False to stop.
+    #[pyo3(signature = (target, enabled=true))]
+    fn echo<'py>(
+        &self,
+        python: Python<'py>,
+        target: &Bound<'py, PyAny>,
+        enabled: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let message = extract_message(target)?;
+        let (call_id, from_tag) = extract_delete_params(&message)?;
+        let client = Arc::clone(&self.client);
+
+        pyo3_async_runtimes::tokio::future_into_py(python, async move {
+            client.echo(&call_id, &from_tag, enabled).await.map_err(|error| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "rtpengine.echo failed: {error}"
+                ))
+            })?;
+            debug!(call_id = %call_id, enabled, "rtpengine echo");
+            Ok(true)
+        })
+    }
+
     /// Send a `subscribe request` — create a new subscription to an existing
     /// call's media.
     ///


### PR DESCRIPTION
## What

Adds `rtpengine.echo(target, enabled=True)` to the scripting API: single-leg IVR echo on the native `siphon-rtp` media backend. After offering a leg, `await rtpengine.echo(call)` reflects the caller's ingress audio back to itself; `enabled=False` stops it. siphon-rtp promotes the plain relay into its processing media path on enable and demotes it on disable, and DTMF / media-timeout events keep firing while echoing.

`echo` was the one missing verb: offer/answer/delete/play/stop/silence/block/subscribe/ping were already wired across all three layers, but a single-leg echo had no way to loop the caller's audio back. Ownership is why a script-side socket to `--control` can't substitute: siphon-rtp keys call ownership to the control connection, and the backend uses one persistent connection, so echo has to ride that same connection (`rtpengine.echo()`), not a side socket.

## Layers

Echo is native-only, so three small additions plus the version bump:

1. **Native client** (`src/rtpengine/siphon_rtp.rs`) — `SiphonRtpClient::echo` frames `Command::Echo { call_id, from_tag, to_tag: None, enabled }`; `SiphonRtpClientSet::echo` delegates via affinity `select()`.
2. **Backend dispatcher** (`src/rtpengine/backend.rs`) — `MediaBackend::echo` routes to the siphon-rtp client. rtpengine and rtpproxy have no echo verb, so those backends reject with a clear `Protocol` error rather than silently no-op'ing.
3. **Python API** (`src/script/api/rtpengine.rs`) — `echo(target, enabled=True)` resolves `(call_id, from_tag)` from the same message the offer used and calls the backend.
4. **SDK mock** (`sdk/siphon_sdk/mock_module.py`) — matching `MockRtpEngine.echo` stub recording `("echo", enabled)`.

## Proto bump (0.1.0 -> 0.1.1)

`Command::Echo` only exists in `siphon-rtp-proto` 0.1.1, so the pin moves from 0.1.0 to 0.1.1. That release also carries the accumulated conference/quality/cluster surface, so a few pre-existing match sites needed to absorb the additive variants (unrelated to echo, but exposed by the bump):

- `ProfileFlags` gained `address_family` / `ws_uri` / `received_from` / `rtcp_mux`; `profile_flags_from_ng` defaults them (each is `skip_serializing_if`, so the emitted wire form is byte-identical).
- New `CmdResult` variants (`list`/`statistics`/`load`/`node_info`/`checkpoint`) are answers to commands siphon never issues on this connection; they map to a `Protocol` error via a small `result_kind()` helper.
- New `Event` variants (`ActiveSpeaker`, `CallQuality`) surface through the existing `RtpEngineEvent::Unknown` logging path carrying their stream identifiers (not dropped). A typed Python handler for those is a follow-up.

## Tests

- **client** — `echo_frames_command_with_enabled_flag`: drives a fake control server, asserts `Command::Echo` fields for both `enabled=true` and `false` on the persistent connection.
- **dispatcher** — `SiphonRtp` routes into the native client (proven by the client timing out against a dead address, which only the siphon-rtp arm does); `RtpEngine` / `RtpProxy` return the unsupported `Protocol` error, no panic.
- **SDK** — `TestEcho` covers default-enabled and `enabled=False`.

Full suite green: `cargo clippy --all-targets --all-features -D warnings` clean, `cargo test` 2841 lib + all integration harnesses (0 failures), SDK pytest 393 passed.

## Notes

- No SIP datapath touched, so the 16-row SIPp CPS / memory-leak baseline is not meaningfully affected (release-cut gate).
- Consumer switch in apps/sbc (`media.backend: siphon-rtp` + `await rtpengine.echo(call)` replacing the hand-rolled JSON-socket echo) is a separate change on that side.
