### PR TITLE
fix(rtpengine): adopt siphon-rtp-proto 0.1.1, unbreak fuzz CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Changed
+- **Bump `siphon-rtp-proto` 0.1.0 → 0.1.1** for the native `media.backend:
+  siphon-rtp` control path. 0.1.1 widens the wire contract — `ProfileFlags`
+  gains `address_family` (v4/v6 far-leg interworking), `received_from` (the
+  post-NAT source gate), `rtcp_mux` (an rtcp-mux override) and `ws_uri`
+  (audio-stream WebSocket bridge); `CmdResult` gains the cluster/HA answers
+  `List`/`Statistics`/`Load`/`NodeInfo`/`Checkpoint`; and `Event` gains
+  `ActiveSpeaker` (conference floor change) and `CallQuality` (periodic per-leg
+  RTCP/MOS estimate). siphon does not drive the new engine knobs yet, so the
+  serialized control frames are byte-identical to before (the new `ProfileFlags`
+  fields stay unset); the new engine events surface through the existing
+  unhandled-event path (logged at `debug`) until dedicated
+  `@rtpengine.on_active_speaker` / `on_call_quality` hooks land. Experimental
+  backend only — the rtpengine NG backend is unaffected. This also restores the
+  fuzz CI job, which re-resolves its dependencies and had begun pulling the newer
+  `siphon-rtp-proto` against the older match arms.
+
 ## [1.3.0] — 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,9 +3059,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50101a2f08a8fc84d0e725827cdc814842beb151ed7d77253a49022f17b64477"
+checksum = "30064e67e79f19d4a91da98932b0d572efc13e08a87f307ac82446a949aef05a"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.1.0"
+siphon-rtp-proto = "0.1.1"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -173,7 +173,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.1.0"
+siphon-rtp-proto = "0.1.1"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -53,10 +53,17 @@ const READ_CHUNK: usize = 8192;
 
 /// Convert siphon's [`NgFlags`] to the proto [`ProfileFlags`] (its JSON twin).
 ///
-/// A field-for-field copy — the two structs carry identical media-handling
-/// semantics; only the wire encoding (JSON vs bencode) differs.  A free
-/// function rather than a `From` impl because both `From` and `ProfileFlags`
-/// are foreign to this crate (orphan rule).
+/// A field-for-field copy of the flags siphon models — the two structs carry
+/// identical media-handling semantics; only the wire encoding (JSON vs bencode)
+/// differs.  A free function rather than a `From` impl because both `From` and
+/// `ProfileFlags` are foreign to this crate (orphan rule).
+///
+/// `ProfileFlags` also carries engine knobs that siphon's `NgFlags` does not
+/// model (`address_family`, `received_from`, `rtcp_mux`, `ws_uri` — v4/v6
+/// interworking, the post-NAT source gate, the rtcp-mux override, and the
+/// audio-stream WebSocket URI).  They are left at their defaults (unset), so the
+/// serialized frame is byte-identical to before — siphon does not drive them
+/// yet.  When siphon gains config/script surface for one, map it here.
 pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
     ProfileFlags {
         transport_protocol: flags.transport_protocol.clone(),
@@ -67,6 +74,7 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         direction: flags.direction.clone(),
         record_call: flags.record_call,
         record_path: flags.record_path.clone(),
+        ..Default::default()
     }
 }
 
@@ -491,10 +499,7 @@ impl SiphonRtpClient {
     pub async fn ping(&self) -> Result<(), RtpEngineError> {
         match self.request(Command::Ping).await? {
             CmdResult::Pong => Ok(()),
-            CmdResult::Error { reason } => Err(RtpEngineError::EngineError(reason)),
-            CmdResult::Ok { .. } => Err(RtpEngineError::Protocol(
-                "expected 'pong', got 'ok'".to_string(),
-            )),
+            other => Err(unexpected_result("ping", other)),
         }
     }
 
@@ -828,22 +833,30 @@ fn expect_ok(result: CmdResult) -> Result<(), RtpEngineError> {
 }
 
 /// Map a non-`Ok` result to the appropriate [`RtpEngineError`].
+///
+/// An engine `Error` becomes an [`RtpEngineError::EngineError`]; any other
+/// variant is a protocol violation for the command that was sent (siphon only
+/// issues commands whose success answer is `Ok`/`Pong`, never `List`,
+/// `Statistics`, `Load`, `NodeInfo` or `Checkpoint`), so the catch-all names the
+/// offending result for the log without re-enumerating the proto enum — which
+/// keeps this arm stable when siphon-rtp-proto adds further cluster/HA results.
 fn unexpected_result(context: &str, result: CmdResult) -> RtpEngineError {
     match result {
         CmdResult::Error { reason } => RtpEngineError::EngineError(reason),
-        CmdResult::Pong => {
-            RtpEngineError::Protocol(format!("unexpected 'pong' response to {context}"))
-        }
-        CmdResult::Ok { .. } => {
-            RtpEngineError::Protocol(format!("unexpected 'ok' response to {context}"))
-        }
+        other => RtpEngineError::Protocol(format!("unexpected {other:?} response to {context}")),
     }
 }
 
 /// Convert a proto [`Event`] to siphon's [`RtpEngineEvent`].
 ///
-/// `Event::Dtmf` is a field-for-field twin of [`DtmfEvent`]; `MediaTimeout`
-/// maps to the dedicated variant; anything else becomes `Unknown`.
+/// `Event::Dtmf` is a field-for-field twin of [`DtmfEvent`]; `MediaTimeout` maps
+/// to the dedicated variant.  `ActiveSpeaker` (conference floor change) and
+/// `CallQuality` (periodic per-leg RTCP/MOS estimate) have no dedicated script
+/// hook yet, so they surface as `Unknown` under their own event name — logged at
+/// `debug` by the dispatcher, never silently dropped (a dedicated
+/// `@rtpengine.on_active_speaker` / `on_call_quality` hook is a follow-up).  The
+/// match stays exhaustive so a future siphon-rtp-proto bump surfaces any new
+/// event here instead of being swallowed.
 fn convert_event(event: Event) -> RtpEngineEvent {
     match event {
         Event::Dtmf {
@@ -866,6 +879,23 @@ fn convert_event(event: Event) -> RtpEngineEvent {
         Event::MediaTimeout { call_id, from_tag } => RtpEngineEvent::MediaTimeout {
             call_id,
             from_tag,
+        },
+        Event::ActiveSpeaker {
+            conference_id,
+            from_tag,
+        } => RtpEngineEvent::Unknown {
+            event: "active_speaker".to_string(),
+            call_id: Some(conference_id),
+            from_tag,
+        },
+        Event::CallQuality {
+            conference_id,
+            call_id,
+            ..
+        } => RtpEngineEvent::Unknown {
+            event: "call_quality".to_string(),
+            call_id: conference_id.or(call_id),
+            from_tag: None,
         },
         Event::Unknown => RtpEngineEvent::Unknown {
             event: "unknown".to_string(),
@@ -1080,12 +1110,7 @@ async fn authenticate(
                             )?;
                             return match response.result {
                                 CmdResult::Ok { .. } => Ok(()),
-                                CmdResult::Error { reason } => {
-                                    Err(RtpEngineError::EngineError(reason))
-                                }
-                                CmdResult::Pong => Err(RtpEngineError::Protocol(
-                                    "unexpected 'pong' for authenticate".to_string(),
-                                )),
+                                other => Err(unexpected_result("authenticate", other)),
                             };
                         }
                     }


### PR DESCRIPTION
## Why

`siphon-rtp-proto 0.1.1` was published to crates.io, and the `fuzz` CI job — which re-resolves its dependencies on every run (no `--locked`) — began pulling it against siphon's older match arms, so the fuzz build stopped compiling:

```
error[E0004]: non-exhaustive patterns: CmdResult::List/Statistics/Load +2 not covered
error[E0063]: missing fields address_family, received_from, rtcp_mux +1 in ProfileFlags
error[E0004]: non-exhaustive patterns: siphon_rtp_proto::Event::ActiveSpeaker/CallQuality not covered
```

The main workspace pins `siphon-rtp-proto 0.1.0` in `Cargo.lock`, so real builds, the test suite, and the just-shipped **1.3.0** release were all unaffected — only the un-pinned fuzz job saw it. This bumps siphon to 0.1.1 deliberately and adapts the `media.backend: siphon-rtp` control path (experimental) to the widened wire contract.

## What 0.1.1 adds, and how it's handled

All changes are confined to `src/rtpengine/siphon_rtp.rs` (the native JSON-over-TCP control client):

- **`ProfileFlags` +4 fields** (`address_family`, `received_from`, `rtcp_mux`, `ws_uri`). siphon's `NgFlags` doesn't model these engine knobs, so `profile_flags_from_ng` leaves them at `Default` (unset) — the serialized frame stays byte-identical, and there's no half-wired config surface. When siphon grows a knob for one, it maps here.
- **`CmdResult` +5 variants** (`List`/`Statistics`/`Load`/`NodeInfo`/`Checkpoint` — cluster/HA answers). siphon never issues the commands that produce them, so receiving one is a protocol violation: `unexpected_result` now names the offending result via a catch-all, and `ping`/`authenticate` route non-`Ok`/`Pong` results through it. The catch-all also means future cluster/HA results won't re-break the client build.
- **`Event` +2 variants** (`ActiveSpeaker`, `CallQuality`). No dedicated script hook exists yet, so `convert_event` surfaces them as `RtpEngineEvent::Unknown` under their own event name — logged at `debug` by the dispatcher, never silently dropped. The match stays **exhaustive** so a future proto bump surfaces new events here rather than swallowing them. Dedicated `@rtpengine.on_active_speaker` / `on_call_quality` hooks are a follow-up (same shape as `on_media_timeout`).

## Validation

- `cargo test` — 3200 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo build --manifest-path fuzz/Cargo.toml` — compiles siphon-sip against 0.1.1 (the case CI was failing on)

## Note on recurrence

The fuzz job re-resolves without `--locked` (cargo-fuzz's `run` doesn't accept it), so a future breaking `siphon-rtp-proto 0.1.x` could break fuzz again the same way. A durable fix is an exact pin (`=0.1.x`) or teaching the fuzz job to build against a committed lock; deferred here since it's a dependency-policy call.