### PR TITLE
fix(registrar): defer IPsec bindings to the SA-idle sweep on stream flow-close (stop deregistering VoLTE UEs every ECM-IDLE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Fixed
+- **Registrar liveness no longer network-deregisters an IPsec binding when its
+  stream flow closes** (RFC 5626 §4.2.2 flow recovery). A closed TCP/TLS flow
+  for an IPsec-protected UE is a recoverable flow failure, not a death signal —
+  a VoLTE UE going ECM-IDLE FINs its SIP-over-TCP flow at the radio inactivity
+  timer while it stays reachable via paging, so tearing the registration down on
+  the FIN made every idle UE uncallable. On a stream close the flow-failure path
+  now **retains** (detaches) bindings whose UE source IP still has a live XFRM
+  SA — nulling the dead `inbound_connection_id` but keeping the binding, its
+  `flow_token` and Service-Route, and emitting no `Deregistered` — and defers
+  their liveness to the SA-idle sweep (`idle_multiplier × keepalive_interval` +
+  an OPTIONS probe), which reaps only genuinely gone UEs. Non-IPsec stream
+  closes (plain TCP, WSS WebRTC) keep the immediate flow-failure deregistration
+  and network-dereg cascade unchanged. No config change.
+
 ## [1.3.0] — 2026-07-10
 
 ### Added

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1425,6 +1425,81 @@ pub(crate) async fn liveness_flow_failure_network_dereg(
     }
 }
 
+/// The set of contact URIs to **retain** (detach, not deregister) when a stream
+/// flow closes: those whose UE source IP still has a live IPsec SA.  A closed
+/// IPsec flow is a recoverable RFC 5626 §4.2.2 flow failure owned by the
+/// SA-idle sweep, not a death signal — the UE stays reachable via paging and
+/// its XFRM SA stays warm across ECM-IDLE.  A non-IPsec stream close has no SA
+/// to consult and remains an authoritative death signal (keep set excludes it).
+fn flow_close_keep_set(
+    bindings: &[(crate::registrar::Aor, crate::registrar::Contact)],
+    sa_ips: &std::collections::HashSet<std::net::IpAddr>,
+) -> std::collections::HashSet<String> {
+    bindings
+        .iter()
+        .filter(|(_, contact)| {
+            contact
+                .source_addr
+                .map(|addr| sa_ips.contains(&addr.ip()))
+                .unwrap_or(false)
+        })
+        .map(|(_, contact)| contact.uri.to_string())
+        .collect()
+}
+
+/// Handle a stream connection close under registrar liveness (RFC 5626
+/// §4.2.2).  Runs from the `server.rs` close-drain task (which has no
+/// `DispatcherState`), so it reads process globals.
+///
+/// IPsec bindings on the dead flow are **retained** (detached) and left to the
+/// SA-idle sweep ([`sweep_registrar_liveness`]), which ages them on the
+/// authoritative XFRM SA use-time plus an OPTIONS probe.  This stops a VoLTE UE
+/// from being network-deregistered on every benign ECM-IDLE transition: its
+/// SIP-over-TCP flow FINs at the radio inactivity timer, but the IMS
+/// registration must survive so an MT INVITE can page it.  Non-IPsec stream
+/// closes (plain TCP, WSS WebRTC) keep today's immediate flow-failure
+/// deregistration and cascade.
+pub(crate) async fn liveness_on_flow_close(
+    connection_id: u64,
+    dereg_mode: crate::config::LivenessDeregMode,
+) {
+    let registrar = match crate::script::api::registrar_arc() {
+        Some(registrar) => Arc::clone(registrar),
+        None => return,
+    };
+
+    // Same discriminator the SA-idle sweep uses: a UE IP with a live SA.
+    let sa_ips: std::collections::HashSet<std::net::IpAddr> = match crate::ipsec::global_manager() {
+        Some(manager) => manager
+            .liveness_snapshot()
+            .into_iter()
+            .map(|row| row.ue_addr)
+            .collect(),
+        None => std::collections::HashSet::new(),
+    };
+
+    let keep = flow_close_keep_set(&registrar.bindings_for_connection(connection_id), &sa_ips);
+    let retained = keep.len();
+    let removed = registrar.close_flow(connection_id, &keep);
+
+    if retained > 0 {
+        tracing::info!(
+            connection_id,
+            retained,
+            "registrar liveness: stream flow closed — IPsec binding(s) retained, \
+             deferring to SA-idle sweep (RFC 5626 flow recovery)"
+        );
+    }
+    if !removed.is_empty() {
+        tracing::info!(
+            connection_id,
+            removed = removed.len(),
+            "registrar liveness: flow-failure deregistration (non-IPsec stream connection closed)"
+        );
+        liveness_flow_failure_network_dereg(removed, dereg_mode).await;
+    }
+}
+
 /// Part B.4 — an abandoned UE's SA pair was just reaped from the kernel;
 /// remove the matching registrar binding(s) so the registration doesn't
 /// linger to its own `Expires`.  Runs synchronously in the sweep because the
@@ -12968,6 +13043,78 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    /// Save a stream P-CSCF cache binding directly against a bare `Registrar`,
+    /// so the flow-close decision helpers can be exercised without a running
+    /// server.  `ue_ip` is the UE source address the SA-liveness set matches on.
+    fn save_stream_binding(
+        registrar: &crate::registrar::Registrar,
+        aor: &str,
+        user: &str,
+        ue_ip: &str,
+        connection_id: u64,
+    ) {
+        registrar
+            .save_full(
+                aor,
+                SipUri::new(ue_ip.to_string()).with_user(user.to_string()),
+                3600,
+                1.0,
+                format!("call-{user}"),
+                1,
+                Some(format!("{ue_ip}:5060").parse().unwrap()),
+                Some("tcp".to_string()),
+                None,
+                None,
+                vec![],
+                crate::registrar::FlowCapture {
+                    flow_token: Some(format!("tok-{user}")),
+                    inbound_local_addr: None,
+                    inbound_connection_id: Some(connection_id),
+                },
+                Vec::new(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn flow_close_keep_set_retains_ipsec_ues() {
+        // A closed IPsec flow is a recoverable RFC 5626 flow failure: the UE's
+        // SA is still warm, so the binding must be retained (deferred to the
+        // SA-idle sweep) rather than network-deregistered on the FIN.
+        let registrar = crate::registrar::Registrar::default();
+        save_stream_binding(&registrar, "sip:alice@ims.example.com", "alice", "100.65.0.2", 7);
+        let bindings = registrar.bindings_for_connection(7);
+        assert_eq!(bindings.len(), 1);
+
+        let mut sa_ips = std::collections::HashSet::new();
+        sa_ips.insert("100.65.0.2".parse::<std::net::IpAddr>().unwrap());
+
+        let keep = flow_close_keep_set(&bindings, &sa_ips);
+        assert_eq!(keep.len(), 1);
+        assert!(keep.contains(&bindings[0].1.uri.to_string()));
+
+        // Committing the close with that keep set detaches, never deregisters.
+        assert!(registrar.close_flow(7, &keep).is_empty());
+        assert!(registrar.is_registered("sip:alice@ims.example.com"));
+    }
+
+    #[test]
+    fn flow_close_keep_set_deregs_non_ipsec() {
+        // No SA for the UE IP (plain TCP / WSS WebRTC) — the stream close stays
+        // an authoritative death signal, so nothing is retained and the binding
+        // is removed immediately.
+        let registrar = crate::registrar::Registrar::default();
+        save_stream_binding(&registrar, "sip:bob@example.com", "bob", "100.65.0.9", 9);
+        let bindings = registrar.bindings_for_connection(9);
+
+        let keep = flow_close_keep_set(&bindings, &std::collections::HashSet::new());
+        assert!(keep.is_empty());
+
+        let removed = registrar.close_flow(9, &keep);
+        assert_eq!(removed.len(), 1);
+        assert!(!registrar.is_registered("sip:bob@example.com"));
+    }
 
     #[test]
     fn advertise_supported_methods_sets_allow_when_absent() {

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -1445,7 +1445,72 @@ impl Registrar {
     /// REGISTER toward the S-CSCF under `dereg_mode: network_dereg`.  The
     /// per-AoR `service_routes` are deliberately **not** cleared here, so the
     /// caller can still resolve the upstream next hop after removal.
+    ///
+    /// Equivalent to [`close_flow`](Self::close_flow) with an empty `keep`
+    /// set — deregister every stream binding on the connection, keep nothing.
     pub fn unregister_flow_collect(&self, connection_id: u64) -> Vec<(Aor, Contact)> {
+        self.close_flow(connection_id, &std::collections::HashSet::new())
+    }
+
+    /// Read-only peek: the stream `(aor, contact)` bindings currently indexed
+    /// on `connection_id`, cloned, without mutating any store.  Lets a caller
+    /// decide which contacts to keep vs deregister — e.g. retain an IPsec
+    /// binding whose XFRM SA is still warm — *before* committing the close via
+    /// [`close_flow`](Self::close_flow).
+    ///
+    /// Empty for an unknown / transient id.  UDP contacts that happen to
+    /// collide on the id are excluded — only stream transports own a closable
+    /// socket (see [`is_stream_transport`]).
+    pub fn bindings_for_connection(&self, connection_id: u64) -> Vec<(Aor, Contact)> {
+        let aors = match self.connection_index.get(&connection_id) {
+            Some(entry) => entry.value().clone(),
+            None => return Vec::new(),
+        };
+        let mut out = Vec::new();
+        let mut seen: std::collections::HashSet<Aor> = std::collections::HashSet::new();
+        for aor in aors {
+            if !seen.insert(aor.clone()) {
+                continue;
+            }
+            if let Some(entry) = self.bindings.get(&aor) {
+                for contact in entry.value().iter() {
+                    if contact.inbound_connection_id == Some(connection_id)
+                        && is_stream_transport(contact.source_transport.as_deref())
+                    {
+                        out.push((aor.clone(), contact.clone()));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Close a dead stream connection under registrar liveness (RFC 5626
+    /// §4.2.2).  For each stream contact that arrived on `connection_id`:
+    ///
+    ///   - contact URI in `keep` → **detach**: null `inbound_connection_id`
+    ///     (the socket is dead, so a future MT send opens a fresh connection
+    ///     instead of riding a half-open one) but keep the binding, its
+    ///     `flow_token` and Service-Route, and emit no `Deregistered`.  This is
+    ///     RFC 5626 flow recovery — the flow failed but the registration
+    ///     survives.  Used for IPsec bindings whose SA is still warm: the
+    ///     SA-idle sweep (`dispatcher::sweep_registrar_liveness`) owns their
+    ///     liveness, so a benign ECM-IDLE FIN must not deregister them.
+    ///   - otherwise → **remove**: today's flow-failure dereg — drop the
+    ///     binding, prune its `flow_token`, cascade-clear orphaned AS records
+    ///     once the last UE binding is gone (TS 24.229 §5.4.2.1.2), and emit
+    ///     `Deregistered` so `@registrar.on_change` fires the terminated
+    ///     reg-event NOTIFY.
+    ///
+    /// Prunes the `connection_index` entry either way.  Returns the **removed**
+    /// bindings so the caller can run the network-dereg cascade.  A `keep` that
+    /// keeps everything is a pure detach (returns empty); an empty `keep` is
+    /// the remove-all behaviour of the former `unregister_flow_collect`.
+    pub fn close_flow(
+        &self,
+        connection_id: u64,
+        keep: &std::collections::HashSet<String>,
+    ) -> Vec<(Aor, Contact)> {
         let aors = match self.connection_index.remove(&connection_id) {
             Some((_, aors)) => aors,
             None => return Vec::new(),
@@ -1473,16 +1538,23 @@ impl Registrar {
                     // another path.  Harmless: nothing to deregister.
                     None => continue,
                 };
-                // Partition into kept vs removed so the caller gets the dropped
-                // bindings (for the network-dereg cascade), harvesting their
-                // tokens along the way.
+                // Partition into kept vs removed.  A contact on this dead flow
+                // is DETACHED (kept, id nulled) when its URI is in `keep`,
+                // otherwise REMOVED (and its token harvested for pruning).
+                // Contacts on other flows / transports are always kept.
                 let contacts = std::mem::take(entry.value_mut());
                 let before = contacts.len();
                 let mut kept = Vec::with_capacity(before);
-                for contact in contacts {
-                    let drop_contact = contact.inbound_connection_id == Some(connection_id)
+                for mut contact in contacts {
+                    let on_this_flow = contact.inbound_connection_id == Some(connection_id)
                         && is_stream_transport(contact.source_transport.as_deref());
-                    if drop_contact {
+                    if on_this_flow && keep.contains(&contact.uri.to_string()) {
+                        // Detach: the socket is gone but the registration stands
+                        // (RFC 5626 flow recovery).  A future MT send opens a
+                        // fresh connection rather than riding the half-open one.
+                        contact.inbound_connection_id = None;
+                        kept.push(contact);
+                    } else if on_this_flow {
                         if let Some(token) = &contact.flow_token {
                             tokens_to_remove.push(token.clone());
                         }
@@ -1512,8 +1584,14 @@ impl Registrar {
                 self.bindings.remove(&aor);
                 emptied_count += 1;
             }
-            self.persist_aor(&aor, stored);
+            // Only write through / announce a deregistration when a binding was
+            // actually removed or the AoR emptied.  A pure detach mutates only
+            // the process-local `inbound_connection_id` (never part of
+            // `StoredContact`), so it must NOT touch the backend or emit an
+            // event — otherwise a benign flow recovery would look like a
+            // deregistration to watchers and the backend.
             if changed || emptied {
+                self.persist_aor(&aor, stored);
                 deregistered.push(aor);
             }
         }
@@ -1940,6 +2018,250 @@ mod tests {
         );
         // Idempotent: the index entry is consumed.
         assert!(registrar.unregister_flow_collect(77).is_empty());
+    }
+
+    /// Save a P-CSCF-style cache binding: stream transport, a `flow_token`, and
+    /// a UE source IP (so the SA-liveness discriminator has an IP to match).
+    fn save_pcscf_flow(
+        registrar: &Registrar,
+        aor: &str,
+        user: &str,
+        contact_host: &str,
+        ue_ip: &str,
+        connection_id: u64,
+        flow_token: &str,
+    ) {
+        registrar
+            .save_full(
+                aor,
+                contact_uri(user, contact_host),
+                3600,
+                1.0,
+                format!("call-{user}"),
+                1,
+                Some(format!("{ue_ip}:5060").parse().unwrap()),
+                Some("tcp".to_string()),
+                None,
+                None,
+                vec![],
+                FlowCapture {
+                    flow_token: Some(flow_token.to_string()),
+                    inbound_local_addr: None,
+                    inbound_connection_id: Some(connection_id),
+                },
+                Vec::new(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn close_flow_keep_detaches_without_dereg() {
+        let registrar = Registrar::default();
+        save_pcscf_flow(
+            &registrar,
+            "sip:alice@example.com",
+            "alice",
+            "10.0.0.1",
+            "100.65.0.2",
+            7,
+            "tok-1",
+        );
+        registrar.set_service_routes("sip:alice@example.com", vec!["<sip:scscf;lr>".into()]);
+
+        // Retain everything on the flow (the UE's IPsec SA is still warm).
+        let keep: std::collections::HashSet<String> = registrar
+            .bindings_for_connection(7)
+            .into_iter()
+            .map(|(_, contact)| contact.uri.to_string())
+            .collect();
+        assert_eq!(keep.len(), 1);
+
+        let mut events = registrar.subscribe_events();
+        let removed = registrar.close_flow(7, &keep);
+
+        assert!(removed.is_empty(), "a pure detach removes nothing");
+        // Binding survives; flow_token + Service-Route intact.
+        assert!(registrar.is_registered("sip:alice@example.com"));
+        let contacts = registrar.lookup("sip:alice@example.com");
+        assert_eq!(contacts.len(), 1);
+        assert_eq!(contacts[0].flow_token.as_deref(), Some("tok-1"));
+        assert_eq!(
+            contacts[0].inbound_connection_id, None,
+            "detach nulls the dead socket id so a future MT send reconnects"
+        );
+        assert_eq!(
+            registrar.service_routes("sip:alice@example.com"),
+            vec!["<sip:scscf;lr>".to_string()]
+        );
+        // Token still resolvable — not pruned by a detach.
+        assert!(registrar.lookup_by_token("tok-1").is_some());
+        // The connection-index entry is consumed, and NO Deregistered fires.
+        assert!(registrar.bindings_for_connection(7).is_empty());
+        assert!(
+            events.try_recv().is_err(),
+            "a detach must not emit Deregistered (RFC 5626 flow recovery)"
+        );
+    }
+
+    #[test]
+    fn close_flow_no_keep_deregisters() {
+        // Regression guard: an empty `keep` is byte-for-byte the old
+        // `unregister_flow_collect` — remove, prune, emit.
+        let registrar = Registrar::default();
+        save_pcscf_flow(
+            &registrar,
+            "sip:alice@example.com",
+            "alice",
+            "10.0.0.1",
+            "100.65.0.2",
+            7,
+            "tok-1",
+        );
+
+        let mut events = registrar.subscribe_events();
+        let removed = registrar.close_flow(7, &std::collections::HashSet::new());
+
+        assert_eq!(removed.len(), 1);
+        let (aor, contact) = &removed[0];
+        assert_eq!(aor, "sip:alice@example.com");
+        assert_eq!(contact.flow_token.as_deref(), Some("tok-1"));
+        assert!(!registrar.is_registered("sip:alice@example.com"));
+        // Token pruned from the reverse index.
+        assert!(registrar.lookup_by_token("tok-1").is_none());
+        match events.try_recv() {
+            Ok(RegistrationEvent::Deregistered { aor }) => {
+                assert_eq!(aor, "sip:alice@example.com")
+            }
+            other => panic!("expected Deregistered, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn close_flow_mixed() {
+        // Two AoRs multiplexed on connection 7; keep alice, drop bob.
+        let registrar = Registrar::default();
+        save_pcscf_flow(
+            &registrar,
+            "sip:alice@example.com",
+            "alice",
+            "10.0.0.1",
+            "100.65.0.2",
+            7,
+            "tok-a",
+        );
+        save_pcscf_flow(
+            &registrar,
+            "sip:bob@example.com",
+            "bob",
+            "10.0.0.3",
+            "100.65.0.9",
+            7,
+            "tok-b",
+        );
+
+        let keep: std::collections::HashSet<String> =
+            std::iter::once(registrar.lookup("sip:alice@example.com")[0].uri.to_string()).collect();
+        let removed = registrar.close_flow(7, &keep);
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0, "sip:bob@example.com");
+        // alice detached (survives, id nulled); bob removed.
+        assert!(registrar.is_registered("sip:alice@example.com"));
+        assert_eq!(
+            registrar.lookup("sip:alice@example.com")[0].inbound_connection_id,
+            None
+        );
+        assert!(!registrar.is_registered("sip:bob@example.com"));
+    }
+
+    #[test]
+    fn bindings_for_connection_peek() {
+        let registrar = Registrar::default();
+        // A stream contact on connection 7 …
+        save_pcscf_flow(
+            &registrar,
+            "sip:alice@example.com",
+            "alice",
+            "10.0.0.1",
+            "100.65.0.2",
+            7,
+            "tok-1",
+        );
+        // … plus a UDP contact under the same AoR whose stored id collides on 7.
+        registrar
+            .save_full(
+                "sip:alice@example.com",
+                contact_uri("alice", "10.0.0.99"),
+                3600,
+                0.5,
+                "call-udp".into(),
+                1,
+                Some("100.65.0.2:5060".parse().unwrap()),
+                Some("udp".to_string()),
+                None,
+                None,
+                vec![],
+                FlowCapture {
+                    flow_token: None,
+                    inbound_local_addr: None,
+                    inbound_connection_id: Some(7),
+                },
+                Vec::new(),
+            )
+            .unwrap();
+
+        let peek = registrar.bindings_for_connection(7);
+        assert_eq!(peek.len(), 1, "UDP contact colliding on the id is excluded");
+        assert_eq!(peek[0].1.source_transport.as_deref(), Some("tcp"));
+        // Peek does not mutate: both contacts still present.
+        assert_eq!(registrar.lookup("sip:alice@example.com").len(), 2);
+        // Unknown id → empty.
+        assert!(registrar.bindings_for_connection(999).is_empty());
+    }
+
+    #[test]
+    fn detach_then_reregister_repoints() {
+        let registrar = Registrar::default();
+        save_pcscf_flow(
+            &registrar,
+            "sip:alice@example.com",
+            "alice",
+            "10.0.0.1",
+            "100.65.0.2",
+            7,
+            "tok-1",
+        );
+
+        // Detach on the dead flow (connection 7).
+        let keep: std::collections::HashSet<String> = registrar
+            .bindings_for_connection(7)
+            .into_iter()
+            .map(|(_, contact)| contact.uri.to_string())
+            .collect();
+        assert!(registrar.close_flow(7, &keep).is_empty());
+        assert!(registrar.bindings_for_connection(7).is_empty());
+
+        // Re-REGISTER of the same AoR/contact arrives on a new connection 9.
+        save_pcscf_flow(
+            &registrar,
+            "sip:alice@example.com",
+            "alice",
+            "10.0.0.1",
+            "100.65.0.2",
+            9,
+            "tok-1",
+        );
+
+        assert_eq!(
+            registrar.lookup("sip:alice@example.com")[0].inbound_connection_id,
+            Some(9),
+            "re-REGISTER re-points the binding to the live connection"
+        );
+        assert_eq!(registrar.bindings_for_connection(9).len(), 1);
+        assert!(
+            registrar.bindings_for_connection(7).is_empty(),
+            "the dead connection is not re-indexed"
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1155,29 +1155,17 @@ impl SiphonServer {
                     idle_multiplier = liveness.idle_multiplier,
                     probe_timeout_ms = liveness.probe_timeout_ms,
                     dereg_mode = ?liveness.dereg_mode,
-                    "registrar liveness ENABLED — flow-failure dereg (TCP/TLS/WS/WSS) + UDP+IPsec idle sweep active"
+                    "registrar liveness ENABLED — flow-failure dereg (non-IPsec stream) + IPsec SA-idle sweep active"
                 );
                 let dereg_mode = liveness.dereg_mode;
                 let (close_tx, close_rx) = flume::unbounded::<u64>();
                 tokio::spawn(async move {
+                    // A closed stream flow defers to the SA-idle sweep for IPsec
+                    // bindings (RFC 5626 §4.2.2 flow recovery) and only
+                    // deregisters non-IPsec bindings immediately — see
+                    // `dispatcher::liveness_on_flow_close`.
                     while let Ok(connection_id) = close_rx.recv_async().await {
-                        if let Some(registrar) = crate::script::api::registrar_arc() {
-                            let removed = registrar.unregister_flow_collect(connection_id);
-                            if !removed.is_empty() {
-                                tracing::info!(
-                                    connection_id,
-                                    removed = removed.len(),
-                                    "registrar liveness: flow-failure deregistration (stream connection closed)"
-                                );
-                                // Cascade to the registrar of record: under
-                                // network_dereg, a P-CSCF cache binding also
-                                // de-REGISTERs (Expires: 0) toward the S-CSCF.
-                                crate::dispatcher::liveness_flow_failure_network_dereg(
-                                    removed, dereg_mode,
-                                )
-                                .await;
-                            }
-                        }
+                        crate::dispatcher::liveness_on_flow_close(connection_id, dereg_mode).await;
                     }
                 });
                 Some(close_tx)


### PR DESCRIPTION
## Problem

Registrar liveness network-deregisters a VoLTE UE ~33 s after a successful
REGISTER, on every ECM-IDLE transition. The UE goes idle at the radio
inactivity timer, its SIP-over-TCP flow to the P-CSCF FINs, and the
flow-failure drain reads the closed socket as "UE gone" — dropping the local
binding **and** synthesizing an `Expires: 0` REGISTER to the S-CSCF, before the
SA-idle sweep's 90 s window ever consults the (still-warm) IPsec SA.

A UE going ECM-IDLE is normal: the EPS bearers persist, the UE keeps its IP and
TCP state, and an MT INVITE pages it back. Per RFC 5626 §4.2.2 a closed flow is
a recoverable *flow failure*, not a trigger to purge the registration of record.
Deregistering on the FIN makes an idle-but-alive UE uncallable, which is most of
the time.

## Fix

On a stream close, defer to the SA-idle sweep for IPsec bindings — the XFRM SA
use-time (kept warm by the UE's RFC 6223 keepalive across idle/paging) is the
authoritative death signal, not the FIN.

- **`Registrar::close_flow(connection_id, keep)`** — for each stream contact on
  the dead connection, a URI in `keep` is **detached** (null
  `inbound_connection_id` so a future MT send reconnects, but keep the binding,
  its `flow_token` and Service-Route, emit no `Deregistered`); every other
  contact is removed exactly as before. Backend write-through and the
  `Deregistered` event are now gated on an actual change, so a pure detach is
  invisible to watchers and the backend (`inbound_connection_id` is
  process-local, never in `StoredContact`).
- **`Registrar::bindings_for_connection(connection_id)`** — read-only peek so
  the caller can split keep-vs-remove before mutating (excludes UDP contacts
  colliding on the id).
- **`dispatcher::liveness_on_flow_close(connection_id, dereg_mode)`** — gathers
  the live-SA UE-IP set from `ipsec::global_manager().liveness_snapshot()` (the
  same discriminator the SA-idle sweep uses), retains bindings whose UE IP has a
  warm SA, removes and runs the network-dereg cascade only for non-IPsec
  closes. Decision factored into the pure `flow_close_keep_set` helper.
- `unregister_flow_collect` now delegates to `close_flow(id, &empty)` —
  behaviour-identical, regression-guarded.
- The `server.rs` close-drain task collapses to one `liveness_on_flow_close`
  call; the startup log line is reworded to match.

Non-IPsec stream closes (plain TCP, WSS WebRTC) keep today's immediate
flow-failure deregistration and cascade. No config change — reuses
`registrar.liveness.*`; the operative grace stays the sweep's
`idle_multiplier × keepalive_interval_secs` (default 90 s) plus one OPTIONS
probe, which still reaps genuinely gone UEs (airplane mode / detach).

## Tests

- Registrar: `close_flow_keep_detaches_without_dereg`,
  `close_flow_no_keep_deregisters` (regression guard for the old remove-all
  path), `close_flow_mixed`, `bindings_for_connection_peek`,
  `detach_then_reregister_repoints`.
- Dispatcher: `flow_close_keep_set_retains_ipsec_ues`,
  `flow_close_keep_set_deregs_non_ipsec`.
- clippy `--all-targets --all-features -D warnings` clean; full suite green
  (lib 2848, integration/rfc4475/proptest 3208).

Not a datapath change (control-plane liveness only), so the SIPp throughput
baseline is unaffected. Scripting API surface unchanged — no SDK update needed.
