### PR TITLE
feat(b2bua): imperative terminate(call_id) for event-driven hangup (+ RFC 3261 §12.1.1 UAS 2xx To-tag fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,36 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **`b2bua.terminate(call_id, reason="Normal Clearing") -> bool`** — imperative
+  hangup of a B2BUA call by SIP Call-ID. Unlike `call.terminate()` (deferred
+  until its own handler returns, so a no-op from an out-of-band event), this acts
+  immediately and reads shared Rust dialog state, so it works from an
+  `@rtpengine.on_dtmf` / `@rtpengine.on_media_timeout` callback, a timer, or a
+  normal handler, and needs no stashed `call` object (cross-worker safe). Sends
+  an in-dialog BYE to every leg (a single-leg UAS/IVR call gets just the caller
+  leg) and runs the full teardown — Rf ACR-STOP, CDR, SIPREC stop, media
+  release, dialog cleanup. Returns `False` (never raises) when the Call-ID is
+  unknown or already gone, so an IVR racing a caller-initiated BYE is a clean
+  no-op. The BYE carries an RFC 3326 `Reason: Q.850;cause=16` header with the
+  supplied text.
+
 ### Fixed
+- **UAS-mode `call.answer()` now emits a To-tag** (RFC 3261 §12.1.1). A B2BUA
+  script that answers an INVITE directly (`call.answer(200, ...)` — MRF /
+  announcement / echo / IVR) previously sent a 2xx whose To header was copied
+  verbatim from the tagless INVITE, so the caller's dialog had no remote tag. The
+  2xx now carries the A-leg dialog's local tag, which also makes a
+  siphon-originated in-dialog BYE (from `b2bua.terminate` or session-timer
+  expiry) match the caller's dialog instead of being rejected `481`. Bridged
+  (`call.dial()`) calls are unchanged.
+- **Session-timer expiry (RFC 4028) now completes the call teardown.** Tearing a
+  call down on session-timer expiry previously BYE'd both legs but skipped the
+  Rf ACR-STOP, the CDR, and the SIPREC stop that an inbound BYE performs, leaking
+  those per-call records. It now runs through the same full-teardown funnel as an
+  inbound BYE and the new `b2bua.terminate`, and the BYE carries an RFC 3326
+  `Reason: Q.850;cause=102` (recovery on timer expiry) header.
+
 - **Registrar liveness no longer network-deregisters an IPsec binding when its
   stream flow closes** (RFC 5626 §4.2.2 flow recovery). A closed TCP/TLS flow
   for an IPsec-protected UE is a recoverable flow failure, not a death signal —

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -572,7 +572,48 @@ class MockB2bua:
         - ``@b2bua.on_bye`` — call ended
         - ``@b2bua.on_refer`` — call transfer (RFC 3515)
         - ``@b2bua.on_cancel`` — unanswered call cancelled (RFC 3261 §9)
+
+    Imperative:
+        - ``b2bua.terminate(call_id)`` — end a call by SIP Call-ID from any
+          context (records onto ``terminates`` for test assertions)
     """
+
+    def __init__(self) -> None:
+        # Records b2bua.terminate(...) calls for test assertions.
+        self.terminates: list[dict] = []
+
+    def clear(self) -> None:
+        """Reset recorded imperative calls (called by ``reset()``)."""
+        self.terminates.clear()
+
+    def terminate(self, call_id: str, reason: str = "Normal Clearing") -> bool:
+        """Imperatively end a B2BUA call by its SIP Call-ID.
+
+        Unlike ``call.terminate()`` (deferred until its handler returns), this
+        acts immediately and is keyed by SIP Call-ID, so it works from an
+        out-of-band event callback (``@rtpengine.on_dtmf``,
+        ``@rtpengine.on_media_timeout``), a timer, or a normal handler.
+
+        Args:
+            call_id: the SIP Call-ID of the call to end.
+            reason: free-text hangup reason (RFC 3326 ``Reason`` on the BYE).
+
+        Returns:
+            bool: True if a matching call was found and torn down, False if the
+            Call-ID is unknown / already gone. Never raises.
+
+        In the mock, records ``{"call_id", "reason"}`` on ``terminates`` and
+        returns True. Inspect via ``siphon.get_b2bua().terminates``.
+
+        Usage::
+
+            @rtpengine.on_dtmf
+            def on_ivr_dtmf(call_id, from_tag, digit, duration_ms, volume):
+                if digit == "#":
+                    b2bua.terminate(call_id)
+        """
+        self.terminates.append({"call_id": call_id, "reason": reason})
+        return True
 
     @staticmethod
     def on_invite(fn: Callable) -> Callable:
@@ -6060,6 +6101,7 @@ def reset() -> None:
     _proxy._utils._sanity_check_pass = True
     _proxy._utils._enum_results.clear()
     _proxy._utils._memory_pct = 25
+    _b2bua.clear()
 
 
 def get_registry() -> _HandlerRegistry:
@@ -6080,6 +6122,11 @@ def get_http() -> MockHttp:
 def get_proxy() -> MockProxy:
     """Access the mock proxy singleton."""
     return _proxy
+
+
+def get_b2bua() -> MockB2bua:
+    """Access the mock b2bua singleton (test helper) — inspect ``.terminates``."""
+    return _b2bua
 
 
 def get_registrar() -> MockRegistrar:

--- a/sdk/siphon_sdk/testing.py
+++ b/sdk/siphon_sdk/testing.py
@@ -250,6 +250,11 @@ class SipTestHarness:
         return mock_module._proxy
 
     @property
+    def b2bua(self) -> mock_module.MockB2bua:
+        """Access the mock b2bua namespace to inspect ``terminates``."""
+        return mock_module._b2bua
+
+    @property
     def presence(self) -> mock_module.MockPresence:
         """Access the mock presence store."""
         return mock_module._presence

--- a/sdk/tests/test_b2bua_terminate.py
+++ b/sdk/tests/test_b2bua_terminate.py
@@ -1,0 +1,76 @@
+"""Tests for the imperative b2bua.terminate(call_id) hangup.
+
+Unlike call.terminate() (deferred until its own handler returns), b2bua.terminate
+acts immediately and is keyed by SIP Call-ID, so it works from an out-of-band
+event callback like @rtpengine.on_dtmf — the echo/IVR '#' hangup case.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from siphon_sdk.testing import SipTestHarness
+
+
+@pytest.fixture
+def harness():
+    h = SipTestHarness(local_domains=["example.com"])
+    yield h
+    h.reset()
+    h.close()
+
+
+class TestB2buaTerminate:
+    def test_records_call_id_and_reason(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_invite
+def on_invite(call):
+    b2bua.terminate(call.call_id, reason="IVR done")
+"""
+        )
+        # Call it directly on the namespace too (the mock returns True).
+        import siphon
+
+        assert siphon.b2bua.terminate("ivr@example.com") is True
+        assert harness.b2bua.terminates[-1] == {
+            "call_id": "ivr@example.com",
+            "reason": "Normal Clearing",
+        }
+
+    def test_terminate_from_on_dtmf_end_digit(self, harness):
+        # The real echo/IVR shape: '#' in an @rtpengine.on_dtmf handler hangs the
+        # call up by call-id, with no stashed `call` object (cross-worker safe).
+        harness.load_source(
+            """
+from siphon import rtpengine, b2bua
+
+END_DIGIT = "#"
+
+@rtpengine.on_dtmf
+def on_ivr_dtmf(call_id, from_tag, digit, duration_ms, volume):
+    if digit == END_DIGIT:
+        b2bua.terminate(call_id)
+"""
+        )
+
+        # A non-end digit does not terminate.
+        harness.rtpengine.fire_dtmf("call-abc@example.com", "ft", "5")
+        assert harness.b2bua.terminates == []
+
+        # The end digit terminates by call-id.
+        fired = harness.rtpengine.fire_dtmf("call-abc@example.com", "ft", "#")
+        assert fired == 1
+        assert harness.b2bua.terminates == [
+            {"call_id": "call-abc@example.com", "reason": "Normal Clearing"}
+        ]
+
+    def test_reset_clears_recorded_terminates(self, harness):
+        import siphon
+
+        siphon.b2bua.terminate("x@example.com")
+        assert harness.b2bua.terminates
+        harness.reset()
+        assert harness.b2bua.terminates == []

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -578,6 +578,14 @@ pub async fn run(
     let _ = drain.transaction_manager.set(Arc::clone(&state.transaction_manager));
     let _ = drain.call_actors.set(Arc::clone(&state.call_actors));
 
+    // Publish a handle to the running dispatcher + its tokio runtime so the
+    // imperative `b2bua.terminate` script API can tear a call down by SIP
+    // Call-ID from any thread (event callbacks, timers). First writer wins.
+    let _ = B2BUA_CONTROL.set(B2buaControlHandle {
+        state: Arc::clone(&state),
+        runtime: tokio::runtime::Handle::current(),
+    });
+
     // Install the rf_sessions lookup so the CDR Python API can
     // auto-stamp `rf_session_id` / `rf_result_code` on every CDR
     // emitted while an Rf session is active for the SIP dialog.
@@ -6996,10 +7004,29 @@ fn spawn_rf_b2bua_start(
 /// completes so script-driven `cdr.write()` calls still see the
 /// rf_session for auto-stamping.  See [`spawn_rf_proxy_stop_if_tracked`]
 /// for the full rationale.
+/// Derive a Diameter Q.850 cause code from an RFC 3326 `Reason:` header, if
+/// present. The `cause=` parameter is interpreted as a SIP status code and
+/// mapped via [`crate::diameter::rf::sip_status_to_cause_code`] — the historical
+/// B2BUA BYE behaviour, kept identical when [`spawn_rf_b2bua_stop`] moved from
+/// taking the BYE message to taking the pre-derived cause.
+fn parse_reason_cause(message: &SipMessage) -> Option<i32> {
+    message
+        .headers
+        .get("Reason")
+        .and_then(|r| {
+            r.split(';')
+                .filter_map(|p| p.trim().strip_prefix("cause="))
+                .next()
+                .and_then(|v| v.split_whitespace().next())
+                .and_then(|v| v.parse::<u16>().ok())
+        })
+        .and_then(crate::diameter::rf::sip_status_to_cause_code)
+}
+
 fn spawn_rf_b2bua_stop(
     state: &DispatcherState,
     internal_call_id: &str,
-    bye: &SipMessage,
+    cause_code: Option<i32>,
 ) {
     let charger = match state.rf_charger.as_ref() {
         Some(c) if c.auto_emit_b2bua() => Arc::clone(c),
@@ -7010,17 +7037,6 @@ fn spawn_rf_b2bua_stop(
         return;
     }
 
-    let cause_code = bye
-        .headers
-        .get("Reason")
-        .and_then(|r| {
-            r.split(';')
-                .filter_map(|p| p.trim().strip_prefix("cause="))
-                .next()
-                .and_then(|v| v.split_whitespace().next())
-                .and_then(|v| v.parse::<u16>().ok())
-        })
-        .and_then(crate::diameter::rf::sip_status_to_cause_code);
     let response_timestamp = std::time::SystemTime::now();
 
     let rf_sessions = Arc::clone(&state.rf_sessions);
@@ -8521,8 +8537,33 @@ fn handle_b2bua_invite(
         }
         CallAction::Answer { code, reason, body, content_type } => {
             debug!(call_id = %call_id, code, "B2BUA: UAS-mode answer");
+            // RFC 3261 §12.1.1: a 2xx to a dialog-creating INVITE MUST carry a
+            // To-tag, and for a UAS-mode B2BUA answer it must be the A-leg
+            // dialog's local_tag — otherwise a later siphon-originated in-dialog
+            // BYE (b2bua.terminate / session-timer expiry) carries a From-tag the
+            // caller never saw and is 481-rejected. build_response copies the
+            // INVITE's tagless To verbatim, so inject the tag here.
+            let mut reply_headers: Vec<(crate::script::api::request::ReplyHeaderOp, String, String)> =
+                Vec::new();
+            if (200..300).contains(&code) {
+                if let Some(to_value) = message_guard.headers.to() {
+                    if !to_value.contains(";tag=") {
+                        if let Some(local_tag) = state
+                            .call_actors
+                            .get_call(&call_id)
+                            .map(|call| call.a_leg.dialog.local_tag.clone())
+                        {
+                            reply_headers.push((
+                                crate::script::api::request::ReplyHeaderOp::Replace,
+                                "To".to_string(),
+                                crate::b2bua::actor::ensure_tag(to_value, Some(&local_tag)),
+                            ));
+                        }
+                    }
+                }
+            }
             let mut response = build_response(
-                &message_guard, code, &reason, state.server_header.as_deref(), &[],
+                &message_guard, code, &reason, state.server_header.as_deref(), &reply_headers,
             );
             if let Some(body_bytes) = body {
                 if let Some(ct) = content_type {
@@ -11522,7 +11563,7 @@ fn handle_b2bua_bye(
     // 200 OK is sent so the accounting record reflects the moment the
     // proxy committed to tearing the call down; the SIP path is
     // unaffected (spawn is fire-and-forget per §6.5).
-    spawn_rf_b2bua_stop(state, &call_id, &message);
+    spawn_rf_b2bua_stop(state, &call_id, parse_reason_cause(&message));
 
     // CDR: write the call record on BYE (cdr.auto_emit). `from_a_leg` gives the
     // disconnecting side (caller vs callee).
@@ -11614,32 +11655,7 @@ fn handle_b2bua_bye(
     }
 
     // SIPREC: stop any active recording sessions for this call.
-    // First, collect RTPEngine subscribe info before stop_recording cleans up sessions.
-    let siprec_infos = state.recording_manager.active_session_infos(&call_id);
-    let bye_messages = state.recording_manager.stop_recording(&call_id, state.local_addr);
-    for (bye_msg, destination, transport) in bye_messages {
-        let data = Bytes::from(bye_msg.to_bytes());
-        let target = RelayTarget {
-            address: destination,
-            transport: Some(transport),
-            server_name: None,
-        };
-        send_to_target(data, &target, transport, ConnectionId::default(), None, state);
-    }
-    // RTPEngine unsubscribe: stop media forking for each recording session.
-    if let Some(ref rtpengine_set) = state.rtpengine_set {
-        for (original_call_id, original_from_tag, original_to_tag) in siprec_infos {
-            let set = Arc::clone(rtpengine_set);
-            tokio::spawn(async move {
-                if let Err(error) = set.unsubscribe(&original_call_id, &original_from_tag, &original_to_tag).await {
-                    warn!(
-                        call_id = %original_call_id,
-                        "SIPREC: RTPEngine unsubscribe failed: {error}"
-                    );
-                }
-            });
-        }
-    }
+    b2bua_stop_siprec(&call_id, state);
 
     state.call_actors.set_state(&call_id, CallState::Terminated);
     // remove_call sends Shutdown to any remaining actors, cleans up registry,
@@ -11822,21 +11838,107 @@ fn b2bua_send_refresh_reinvite(call_id: &str, state: &DispatcherState) {
     }
 }
 
-/// Terminate a call due to session timer expiry — send BYE to both legs.
-fn b2bua_session_timer_terminate(call_id: &str, state: &DispatcherState) {
-    let (a_leg, winner_b_leg, sip_call_id) = match state.call_actors.get_call(call_id) {
+/// Stop and tear down any SIPREC recording sessions for a B2BUA call: send the
+/// SRC-side BYE to each SRS and unsubscribe the RTPEngine media fork. Shared by
+/// the inbound-BYE teardown ([`handle_b2bua_bye`]) and the framework-initiated
+/// teardown ([`b2bua_terminate_call_inner`]).
+fn b2bua_stop_siprec(internal_call_id: &str, state: &DispatcherState) {
+    // Collect RTPEngine subscribe info before stop_recording cleans up sessions.
+    let siprec_infos = state.recording_manager.active_session_infos(internal_call_id);
+    let bye_messages = state
+        .recording_manager
+        .stop_recording(internal_call_id, state.local_addr);
+    for (bye_msg, destination, transport) in bye_messages {
+        let data = Bytes::from(bye_msg.to_bytes());
+        let target = RelayTarget {
+            address: destination,
+            transport: Some(transport),
+            server_name: None,
+        };
+        send_to_target(data, &target, transport, ConnectionId::default(), None, state);
+    }
+    // RTPEngine unsubscribe: stop media forking for each recording session.
+    if let Some(ref rtpengine_set) = state.rtpengine_set {
+        for (original_call_id, original_from_tag, original_to_tag) in siprec_infos {
+            let set = Arc::clone(rtpengine_set);
+            tokio::spawn(async move {
+                if let Err(error) = set
+                    .unsubscribe(&original_call_id, &original_from_tag, &original_to_tag)
+                    .await
+                {
+                    warn!(
+                        call_id = %original_call_id,
+                        "SIPREC: RTPEngine unsubscribe failed: {error}"
+                    );
+                }
+            });
+        }
+    }
+}
+
+/// Build an RFC 3326 `Reason:` header value for a graceful, script-initiated
+/// call teardown. Q.850 cause 16 = normal call clearing; the script-supplied
+/// text rides along in `text=` (embedded quotes stripped so the header stays
+/// well-formed).
+fn format_normal_clearing_reason(reason: &str) -> String {
+    let text = reason.replace('"', "");
+    format!("Q.850;cause=16;text=\"{text}\"")
+}
+
+/// Full B2BUA call teardown initiated by the framework — session-timer expiry or
+/// an imperative `b2bua.terminate` — NOT by an inbound BYE. Sends an in-dialog
+/// BYE to BOTH legs from stored dialog state (a single-leg UAS call degrades to
+/// just the A-leg), emits Rf ACR-STOP + a CDR + stops SIPREC (matching the
+/// inbound-BYE teardown in [`handle_b2bua_bye`] so those per-call stores drain
+/// here too), tears down media, and removes all dialog/registry state.
+///
+/// `reason_header` is a full RFC 3326 `Reason:` value added to each BYE and
+/// recorded as the CDR `sip_reason`. `disconnect_initiator` is the CDR
+/// disconnecting side (`"b2bua"` for a script terminate, `"timeout"` for
+/// session-timer expiry). Returns `true` if the call existed.
+fn b2bua_terminate_call_inner(
+    internal_call_id: &str,
+    reason_header: Option<&str>,
+    disconnect_initiator: &str,
+    state: &DispatcherState,
+) -> bool {
+    let (a_leg, winner_b_leg, sip_call_id) = match state.call_actors.get_call(internal_call_id) {
         Some(call) => {
             let b_leg = call.winner.and_then(|i| call.b_legs.get(i).cloned());
             (call.a_leg.clone(), b_leg, call.a_leg.dialog.call_id.clone())
         }
-        None => return,
+        None => return false,
     };
 
-    // Build BYE for each leg using the shared build_b2bua_bye helper.
+    // Rf ACR-STOP (TS 32.299 §6.2.2). A framework-initiated teardown maps to the
+    // Diameter "normal" cause (None → 0); the RFC 3326 Reason on the BYE is
+    // informational only here (its Q.850 cause is not a SIP status).
+    spawn_rf_b2bua_stop(state, internal_call_id, None);
+
+    // CDR (cdr.auto_emit): write the record with the framework as the
+    // disconnecting side and the Reason header as sip_reason.
+    if crate::cdr::auto_emit_enabled() {
+        cdr_finalize(
+            state,
+            internal_call_id,
+            disconnect_initiator,
+            None,
+            reason_header.map(|r| r.to_string()),
+        );
+    }
+
+    // Build + send BYE to each leg using the shared build_b2bua_bye helper.
     // Destination derived from the dialog route set (RFC 3261 §12.2.1.1) — see
-    // resolve_in_dialog_destination for why the cached transport.remote_addr
-    // is wrong for routes that don't match the original INVITE next-hop.
-    if let Some(bye_msg) = build_b2bua_bye(&a_leg, state) {
+    // resolve_in_dialog_destination for why the cached transport.remote_addr is
+    // wrong for routes that don't match the original INVITE next-hop.
+    let build_bye = |leg: &Leg| -> Option<SipMessage> {
+        let mut bye = build_b2bua_bye(leg, state)?;
+        if let Some(reason) = reason_header {
+            bye.headers.add("Reason", reason.to_string());
+        }
+        Some(bye)
+    };
+    if let Some(bye_msg) = build_bye(&a_leg) {
         let (destination, transport) = resolve_in_dialog_destination(
             &a_leg.dialog.route_set,
             state,
@@ -11846,7 +11948,7 @@ fn b2bua_session_timer_terminate(call_id: &str, state: &DispatcherState) {
         send_message(bye_msg, transport, destination, a_leg.transport.connection_id, state);
     }
     if let Some(b_leg) = &winner_b_leg {
-        if let Some(bye_msg) = build_b2bua_bye(b_leg, state) {
+        if let Some(bye_msg) = build_bye(b_leg) {
             let (destination, transport) = resolve_in_dialog_destination(
                 &b_leg.dialog.route_set,
                 state,
@@ -11857,7 +11959,7 @@ fn b2bua_session_timer_terminate(call_id: &str, state: &DispatcherState) {
         }
     }
 
-    // Safety-net RTPEngine cleanup
+    // Safety-net RTPEngine cleanup.
     if let (Some(rtpengine_set), Some(media_sessions)) =
         (&state.rtpengine_set, &state.rtpengine_sessions)
     {
@@ -11871,10 +11973,69 @@ fn b2bua_session_timer_terminate(call_id: &str, state: &DispatcherState) {
         }
     }
 
-    state.call_actors.set_state(call_id, CallState::Terminated);
-    state.call_actors.remove_call(call_id);
-    state.call_event_receivers.remove(call_id);
+    // SIPREC: stop any active recording sessions for this call.
+    b2bua_stop_siprec(internal_call_id, state);
+
+    state.call_actors.set_state(internal_call_id, CallState::Terminated);
+    // remove_call sends Shutdown to any remaining actors, cleans up registry,
+    // and moves re-INVITE tracking entries to the zombie map.
+    state.call_actors.remove_call(internal_call_id);
+    state.call_event_receivers.remove(internal_call_id);
     schedule_zombie_reinvite_cleanup(&state.call_actors);
+    true
+}
+
+/// Terminate a call due to session timer expiry (RFC 4028) — BYE both legs and
+/// run the full framework teardown (Rf ACR-STOP + CDR + SIPREC + media), the
+/// same funnel the imperative `b2bua.terminate` uses.
+fn b2bua_session_timer_terminate(call_id: &str, state: &DispatcherState) {
+    // Q.850 cause 102 = "recovery on timer expiry".
+    b2bua_terminate_call_inner(
+        call_id,
+        Some("Q.850;cause=102;text=\"Session timer expired\""),
+        "timeout",
+        state,
+    );
+}
+
+/// Handle to the running dispatcher, published once at startup so imperative
+/// script APIs (e.g. `b2bua.terminate`) can reach dialog state and the tokio
+/// runtime from any thread — an event-callback driver, a timer, or an async-pool
+/// loop, none of which are tokio workers.
+struct B2buaControlHandle {
+    state: Arc<DispatcherState>,
+    runtime: tokio::runtime::Handle,
+}
+
+static B2BUA_CONTROL: std::sync::OnceLock<B2buaControlHandle> = std::sync::OnceLock::new();
+
+/// Imperatively tear down a B2BUA call identified by its SIP Call-ID, sending a
+/// BYE to every leg and running the full teardown ([`b2bua_terminate_call_inner`]).
+///
+/// Safe to call from any thread/context (event callbacks like `@rtpengine.on_dtmf`,
+/// timers, async handlers) — unlike the deferred `call.terminate()`, which only
+/// applies when its own handler returns. Returns `false` (never panics) when the
+/// call-id is unknown / already gone or the dispatcher is not running, so an IVR
+/// that races a caller-initiated BYE is a clean no-op.
+pub fn b2bua_terminate_call(sip_call_id: &str, reason: Option<&str>) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let Some(internal_call_id) = control.state.call_actors.find_by_sip_call_id(sip_call_id) else {
+        return false;
+    };
+    // The caller may be on a thread with no tokio context (async-pool asyncio
+    // loop, rtpengine event driver); enter the runtime so the teardown's
+    // tokio::spawn calls (RTPEngine delete, Rf ACR-STOP, SIPREC unsubscribe) are
+    // valid.
+    let _enter = control.runtime.enter();
+    let reason_header = reason.map(format_normal_clearing_reason);
+    b2bua_terminate_call_inner(
+        &internal_call_id,
+        reason_header.as_deref(),
+        "b2bua",
+        &control.state,
+    )
 }
 
 /// Arm the RFC 3262 §3 retransmit task for a reliable provisional response.
@@ -13043,6 +13204,67 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    // -----------------------------------------------------------------------
+    // Imperative B2BUA terminate helpers (b2bua.terminate / session timer)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_normal_clearing_reason_is_q850_cause_16() {
+        assert_eq!(
+            format_normal_clearing_reason("Normal Clearing"),
+            "Q.850;cause=16;text=\"Normal Clearing\"",
+        );
+        // Embedded quotes are stripped so the header stays well-formed.
+        assert_eq!(
+            format_normal_clearing_reason("say \"hi\""),
+            "Q.850;cause=16;text=\"say hi\"",
+        );
+    }
+
+    #[test]
+    fn parse_reason_cause_maps_sip_status_or_none() {
+        // Build a BYE with an optional RFC 3326 Reason header via the parser
+        // (the builder setters take String; raw parse matches the other fixtures).
+        fn bye_with_reason(reason: Option<&str>) -> SipMessage {
+            let mut raw = String::from("BYE sip:b@host SIP/2.0\r\n");
+            raw.push_str("Via: SIP/2.0/UDP host:5060;branch=z9hG4bK1\r\n");
+            raw.push_str("From: <sip:a@host>;tag=a\r\n");
+            raw.push_str("To: <sip:b@host>;tag=b\r\n");
+            raw.push_str("Call-ID: c@host\r\n");
+            raw.push_str("CSeq: 1 BYE\r\n");
+            if let Some(value) = reason {
+                raw.push_str(&format!("Reason: {value}\r\n"));
+            }
+            raw.push_str("Content-Length: 0\r\n\r\n");
+            parse_sip_message(&raw).expect("test fixture must parse").1
+        }
+
+        // SIP;cause=<status> maps via sip_status_to_cause_code.
+        assert_eq!(
+            parse_reason_cause(&bye_with_reason(Some("SIP;cause=486;text=\"Busy Here\""))),
+            crate::diameter::rf::sip_status_to_cause_code(486),
+        );
+        // No Reason header → None.
+        assert_eq!(parse_reason_cause(&bye_with_reason(None)), None);
+        // Reason without a cause= param → None.
+        assert_eq!(
+            parse_reason_cause(&bye_with_reason(Some("SIP;text=\"no cause\""))),
+            None,
+        );
+    }
+
+    #[test]
+    fn b2bua_terminate_call_unknown_id_is_false_no_panic() {
+        // Unknown SIP Call-ID (and no running dispatcher in the test binary) is a
+        // clean no-op — never panics, returns false — so an IVR racing a
+        // caller-initiated BYE degrades gracefully.
+        assert!(!b2bua_terminate_call("does-not-exist@nowhere", None));
+        assert!(!b2bua_terminate_call(
+            "does-not-exist@nowhere",
+            Some("Normal Clearing")
+        ));
+    }
 
     /// Save a stream P-CSCF cache binding directly against a bare `Registrar`,
     /// so the flow-close decision helpers can be exercised without a running

--- a/src/script/api/b2bua.rs
+++ b/src/script/api/b2bua.rs
@@ -1,0 +1,46 @@
+//! PyO3 `b2bua` control namespace — imperative B2BUA call operations that act
+//! immediately rather than via a deferred [`CallAction`](super::call::CallAction).
+//!
+//! Injected as `siphon.b2bua._control` at startup; the pure-Python
+//! `_B2buaNamespace` forwards `b2bua.terminate(...)` to it. Stateless — it
+//! reaches the running dispatcher through a process-global handle, so it works
+//! from any context (event callbacks like `@rtpengine.on_dtmf`, timers, async
+//! handlers) where the deferred `call.terminate()` is a silent no-op.
+
+use pyo3::prelude::*;
+
+/// Stateless imperative B2BUA control namespace (`siphon.b2bua._control`).
+#[pyclass(name = "B2buaControl")]
+pub struct PyB2buaControl;
+
+impl Default for PyB2buaControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PyB2buaControl {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[pymethods]
+impl PyB2buaControl {
+    /// Imperatively end a B2BUA call by its SIP Call-ID, sending an in-dialog
+    /// BYE to every leg **now** (not deferred until a handler returns, the way
+    /// `call.terminate()` is).
+    ///
+    /// Keyed by SIP Call-ID and backed by shared Rust dialog state, so it is
+    /// cross-worker safe and works from an event callback (`@rtpengine.on_dtmf`,
+    /// `@rtpengine.on_media_timeout`), a timer, or a normal handler — none of
+    /// which give `call.terminate()` a handler-return to act on.
+    ///
+    /// Returns True if a matching call was found and torn down, False if the
+    /// Call-ID is unknown / already gone (e.g. the caller hung up first) — never
+    /// raises, so racing a caller-initiated BYE is a clean no-op.
+    #[pyo3(signature = (call_id, reason="Normal Clearing"))]
+    fn terminate(&self, call_id: &str, reason: &str) -> bool {
+        crate::dispatcher::b2bua_terminate_call(call_id, Some(reason))
+    }
+}

--- a/src/script/api/mod.rs
+++ b/src/script/api/mod.rs
@@ -7,6 +7,7 @@
 //! write into; the Rust engine reads it after script execution.
 
 pub mod auth;
+pub mod b2bua;
 pub mod cache;
 pub mod call;
 pub mod cdr;
@@ -125,6 +126,10 @@ static ISC_SINGLETON: OnceLock<Py<PyAny>> = OnceLock::new();
 static SBI_SINGLETON: OnceLock<Py<PyAny>> = OnceLock::new();
 
 static TIMER_SINGLETON: OnceLock<Py<PyAny>> = OnceLock::new();
+
+/// Stateless imperative B2BUA control singleton (`b2bua._control`) — always
+/// available, backs `b2bua.terminate()`.
+static B2BUA_CONTROL_SINGLETON: OnceLock<Py<PyAny>> = OnceLock::new();
 
 static SUBSCRIBE_STATE_SINGLETON: OnceLock<Py<PyAny>> = OnceLock::new();
 
@@ -395,6 +400,18 @@ pub fn set_sdp_singleton(python: Python<'_>) -> Result<()> {
     Ok(())
 }
 
+/// Store the B2BUA control singleton for injection as `b2bua._control`.
+///
+/// Always called at startup — stateless, reaches the dispatcher via a global
+/// handle; `b2bua.terminate()` returns False before the dispatcher is running.
+pub fn set_b2bua_control_singleton(python: Python<'_>) -> Result<()> {
+    let control_py: Py<PyAny> = Py::new(python, b2bua::PyB2buaControl::new())
+        .map_err(|error| SiphonError::Script(format!("Py::new(b2bua control): {error}")))?
+        .into_any();
+    let _ = B2BUA_CONTROL_SINGLETON.set(control_py);
+    Ok(())
+}
+
 /// Store the QoS namespace singleton for injection into the siphon module.
 ///
 /// Always available — stateless SDP→IPFilterRule helper, no config needed.
@@ -638,6 +655,19 @@ pub fn install_siphon_module(python: Python<'_>) -> Result<()> {
             .map_err(|error| {
                 SiphonError::Script(format!("setattr proxy.subscribe_state: {error}"))
             })?;
+    }
+
+    // Inject the imperative B2BUA control onto the b2bua namespace as
+    // `_control` (mirrors `proxy._utils`).  Always available — the pure-Python
+    // `_B2buaNamespace.terminate` forwards to it; unconditional so a script that
+    // imported `b2bua` before the singleton was wired still resolves it.
+    if let Some(b2bua_control_py) = B2BUA_CONTROL_SINGLETON.get() {
+        let b2bua_ns = module
+            .getattr("b2bua")
+            .map_err(|error| SiphonError::Script(format!("getattr b2bua: {error}")))?;
+        b2bua_ns
+            .setattr("_control", b2bua_control_py.bind(python))
+            .map_err(|error| SiphonError::Script(format!("setattr b2bua._control: {error}")))?;
     }
 
     // Inject optional RTPEngine singleton (only when media.rtpengine is configured).

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -152,6 +152,45 @@ class _ProxyNamespace:
 class _B2buaNamespace:
     """Namespace for B2BUA call event handlers."""
 
+    def __init__(self):
+        # Replaced at startup by the Rust-backed B2buaControl
+        # (set_b2bua_control_singleton / install_siphon_module).  None until
+        # then, so terminate() is a graceful no-op in bare-Python contexts.
+        self._control = None
+
+    def terminate(self, call_id, reason="Normal Clearing"):
+        """Imperatively end a B2BUA call by its SIP Call-ID, sending an in-dialog
+        BYE to every leg immediately.
+
+        Unlike ``call.terminate()`` (which only applies when *its own* handler
+        returns), this acts now and is keyed by SIP Call-ID against shared Rust
+        dialog state — so it works from an out-of-band event callback
+        (``@rtpengine.on_dtmf``, ``@rtpengine.on_media_timeout``), a timer, or a
+        normal handler, and is cross-worker safe (no reliance on a stashed
+        ``call`` object).
+
+        Args:
+            call_id: the SIP Call-ID of the call to end (e.g. the ``call_id``
+                delivered to an ``@rtpengine.on_dtmf`` handler).
+            reason: free-text hangup reason, carried as an RFC 3326
+                ``Reason: Q.850;cause=16`` header on the BYE and into the CDR.
+
+        Returns:
+            bool: True if a matching call was found and torn down, False if the
+            Call-ID is unknown / already gone (e.g. the caller hung up first).
+            Never raises — racing a caller-initiated BYE is a clean no-op.
+
+        Usage:
+            @rtpengine.on_dtmf
+            def on_ivr_dtmf(call_id, from_tag, digit, duration_ms, volume):
+                if digit == "#":
+                    b2bua.terminate(call_id)
+        """
+        control = object.__getattribute__(self, "__dict__").get("_control")
+        if control is None:
+            return False
+        return control.terminate(call_id, reason)
+
     @staticmethod
     def on_invite(fn):
         """Register handler for new INVITE (new call)."""

--- a/src/server.rs
+++ b/src/server.rs
@@ -587,6 +587,15 @@ impl SiphonServer {
             }
         });
 
+        // --- Initialize imperative B2BUA control for Python scripts ---
+        // Backs b2bua.terminate() — always available, reaches the dispatcher via
+        // a global handle set once run() starts.
+        pyo3::Python::attach(|python| {
+            if let Err(error) = crate::script::api::set_b2bua_control_singleton(python) {
+                error!("failed to store b2bua control singleton: {error}");
+            }
+        });
+
         // --- Initialize ISC namespace before script load ---
         // Must be registered before ScriptEngine::new() so that
         // install_siphon_module() can inject the Rust-backed isc instance

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -493,6 +493,40 @@ fn b2bua_bye_from_b_leg_bridges_to_a_leg() {
 }
 
 // ---------------------------------------------------------------------------
+// B2BUA imperative terminate (b2bua.terminate) — UAS single-leg precondition
+// ---------------------------------------------------------------------------
+
+#[test]
+fn uas_single_leg_call_is_resolvable_by_sip_call_id_for_terminate() {
+    // A UAS-mode IVR/echo call (call.answer, no dial) has only an A-leg — no
+    // B-leg, no winner. b2bua.terminate(call_id) resolves the SIP Call-ID
+    // (which is what @rtpengine.on_dtmf carries) to the internal call, then
+    // BYEs every present leg; "both legs" degrades to just the A-leg here.
+    let store = CallActorStore::new();
+    let sip_call_id = "ivr-echo@test";
+    let call_id = store.create_call(make_a_leg(sip_call_id));
+
+    // The SIP Call-ID resolves to the internal call id.
+    assert_eq!(store.find_by_sip_call_id(sip_call_id), Some(call_id.clone()));
+
+    let call = store.get_call(&call_id).unwrap();
+    // Single-leg UAS call: no B-leg / winner.
+    assert!(call.winner.is_none());
+    assert!(call.b_legs.is_empty());
+    // The A-leg dialog carries the local_tag that the UAS 200 OK put in its To
+    // header (Change A), so a siphon-originated BYE's From-tag matches the
+    // caller's dialog. build_b2bua_bye reads exactly this local_tag +
+    // remote_tag, so both must be present for the BYE to be accepted (not 481).
+    assert!(!call.a_leg.dialog.local_tag.is_empty());
+    assert_eq!(call.a_leg.dialog.remote_tag.as_deref(), Some("alice-tag"));
+    drop(call);
+
+    // An unknown SIP Call-ID does not resolve — the imperative terminate returns
+    // false (clean no-op) for it.
+    assert!(store.find_by_sip_call_id("not-a-call@test").is_none());
+}
+
+// ---------------------------------------------------------------------------
 // B2BUA CANCEL: A-leg CANCEL → cancel B-legs
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

RTT's SBC echo/IVR route detects a `#` keypress in an `@rtpengine.on_dtmf` handler and wants to hang up, but nothing happens (the caller has to hang up manually ~6 s later). `call.terminate()` is **deferred** — it sets `CallAction::Terminate`, which the dispatcher only applies when *that call's own handler returns*. From an out-of-band event callback there is no handler return, and the stashed `call` object is cross-worker detached, so it's a silent no-op. Imperative media commands (`rtpengine.delete`, keyed by call-id) already work from an event, so the media tears down but the SIP dialog never does.

## What

**`b2bua.terminate(call_id, reason="Normal Clearing") -> bool`** — imperative hangup by SIP Call-ID that acts immediately and reads shared Rust dialog state, so it works from `@rtpengine.on_dtmf` / `@rtpengine.on_media_timeout`, a timer, or a normal handler, with no stashed `call` object (cross-worker safe). Sends an in-dialog BYE to every leg (a single-leg UAS/IVR call gets just the caller leg) and runs the full teardown — Rf ACR-STOP, CDR, SIPREC stop, media release, dialog cleanup. Returns `False` (never raises) when the Call-ID is unknown/already gone, so an IVR racing a caller BYE is a clean no-op. The BYE carries an RFC 3326 `Reason: Q.850;cause=16` header.

### Root-cause fix the ticket didn't mention (RFC 3261 §12.1.1)

A UAS-mode `call.answer()` (MRF / announcement / echo / IVR — the script owns the dialog) was sending a **tagless 2xx**: `build_response` copies the tagless INVITE To header verbatim, so the caller's dialog had no remote tag while the A-leg dialog `local_tag` was an unrelated generated value. A siphon-originated BYE toward the caller would then carry a From-tag the caller never saw and be **481-rejected** — so exposing `terminate` alone could not clear the IVR call. The 2xx now carries the A-leg dialog's `local_tag`, which is both spec-compliant and makes the BYE match. Bridged (`call.dial()`) calls are unchanged.

### Session-timer teardown unified

Extracted one `b2bua_terminate_call_inner` funnel used by both the new terminate and session-timer expiry (RFC 4028). Expiry previously BYE'd both legs but skipped the Rf ACR-STOP / CDR / SIPREC stop an inbound BYE performs, leaking those per-call records; it now runs the full teardown too, with a `Reason: Q.850;cause=102` header.

## Tests / gates

- `cargo test`: 2851 lib + 275 integration + rest, 0 failures (new: `format_normal_clearing_reason`, `parse_reason_cause`, `b2bua_terminate_call` unknown→false, UAS single-leg resolvable-by-call-id).
- `cargo clippy --all-targets --all-features -D warnings`: clean.
- SDK `pytest`: 29 passed (new `test_b2bua_terminate.py` covers the `#`-from-`on_dtmf` shape; SDK mock `MockB2bua.terminate` mirrors the runtime API).

The wire-level acceptance (dial the echo route, press `#`, confirm siphon sends a BYE the caller answers 200 not 481, call clears immediately) plus the 16-row SIPp baseline + mem-leak run on the reference hardware, since a BYE datapath is touched.
