### PR TITLE
feat(b2bua): imperative call.answer() + call.progress() for dialplan-style media sequencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   unknown or already gone, so an IVR racing a caller-initiated BYE is a clean
   no-op. The BYE carries an RFC 3326 `Reason: Q.850;cause=16` header with the
   supplied text.
+- **`call.progress(code, reason, body=None, content_type=None)`** — imperative
+  UAS provisional (18x) for a B2BUA call: send a `183 Session Progress` with
+  early-media SDP, or a `180 Ringing`, immediately from a handler, without
+  answering the call. An 18x with SDP opens an early dialog and carries the same
+  UAS To-tag `call.answer()` uses. The handler must still `answer()` / `dial()` /
+  `reject()` for a final response.
+
+### Changed
+- **`call.answer()` now sends the final 2xx immediately** instead of deferring it
+  to when the handler returns. This lets an `async` `@b2bua.on_invite` answer and
+  then keep working — e.g. `await rtpengine.play_media(...)` a prompt to
+  completion, then `await rtpengine.echo(...)` — without the awaited media
+  delaying the 200 OK (the old deferred behavior held the answer until the whole
+  coroutine finished, so a prompt played *before* the caller was answered). The
+  method stays synchronous (no `await`), and the answer is confirmed with the
+  A-leg dialog To-tag as before. Existing answer-then-return scripts are
+  unaffected; there is no separate `answer_now()`.
 
 ### Fixed
 - **UAS-mode `call.answer()` now emits a To-tag** (RFC 3261 §12.1.1). A B2BUA

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -226,8 +226,13 @@ class Call:
     def answer(self, code: int, reason: str,
                body: Union[str, bytes, None] = None,
                content_type: str | None = None) -> None:
-        """UAS-mode answer — send a final 2xx response to the inbound
-        INVITE directly, without bridging to a B-leg.
+        """UAS-mode answer — send a final 2xx response to the inbound INVITE
+        **immediately**, without bridging to a B-leg.
+
+        The response goes on the wire the moment this is called (not deferred to
+        when the handler returns), so an ``async`` handler can answer and then
+        keep working — e.g. play a prompt to completion before starting echo —
+        without delaying the 200 OK. Synchronous; no ``await`` needed.
 
         Args:
             code: Final 2xx status code (200, 202, etc.).
@@ -237,7 +242,12 @@ class Call:
 
         Example::
 
-            call.answer(200, "OK", body=sdp_bytes, content_type="application/sdp")
+            @b2bua.on_invite
+            async def on_invite(call):
+                await rtpengine.offer(call, profile="ivr")
+                call.answer(200, "OK", body=call.body, content_type="application/sdp")
+                await rtpengine.play_media(call, file=prompt)   # 200 already sent
+                await rtpengine.echo(call)
         """
         if not 200 <= code < 300:
             raise ValueError(
@@ -249,6 +259,38 @@ class Call:
         self._state = "answered"
         self._actions.append(Action(
             kind="answer",
+            status_code=code,
+            reason=reason,
+            extras={"body": body, "content_type": content_type},
+        ))
+
+    def progress(self, code: int, reason: str = "Ringing",
+                 body: Union[str, bytes, None] = None,
+                 content_type: str | None = None) -> None:
+        """UAS-mode provisional — send a 1xx response to the inbound INVITE
+        **immediately** (e.g. ``183 Session Progress`` with early-media SDP, or
+        ``180 Ringing``). Does not answer the call: the handler must still
+        ``answer()`` / ``dial()`` / ``reject()`` for a final response.
+
+        Args:
+            code: Provisional status code (must be 1xx; 100 carries no To-tag).
+            reason: Reason phrase.
+            body: Optional response body (``bytes`` or ``str``) — early-media SDP.
+            content_type: Content-Type for the body (e.g. ``"application/sdp"``).
+
+        Example::
+
+            call.progress(183, "Session Progress", body=sdp, content_type="application/sdp")
+        """
+        if not 100 <= code < 200:
+            raise ValueError(
+                f"call.progress() requires a 1xx status code (got {code}); "
+                f"use call.answer() for the final response"
+            )
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        self._actions.append(Action(
+            kind="progress",
             status_code=code,
             reason=reason,
             extras={"body": body, "content_type": content_type},

--- a/sdk/tests/test_call_answer_progress.py
+++ b/sdk/tests/test_call_answer_progress.py
@@ -1,0 +1,83 @@
+"""Tests for imperative UAS ``call.answer()`` and ``call.progress()``.
+
+``answer()`` sends the final 2xx the moment it's called (not deferred to when
+the handler returns), so an async handler can answer and then keep working —
+play a prompt to completion, then start echo — without delaying the 200.
+``progress()`` sends a 1xx (early media / ringback) without answering.
+"""
+
+import pytest
+
+from siphon_sdk.call import Call
+from siphon_sdk.testing import SipTestHarness
+
+
+class TestCallAnswerProgress:
+    def test_answer_records_and_marks_answered(self):
+        call = Call()
+        call.answer(200, "OK", body="v=0\r\n", content_type="application/sdp")
+        assert call.state == "answered"
+        action = call._actions[-1]
+        assert action.kind == "answer"
+        assert action.status_code == 200
+        assert action.extras["body"] == b"v=0\r\n"
+        assert action.extras["content_type"] == "application/sdp"
+
+    def test_answer_rejects_non_2xx(self):
+        call = Call()
+        with pytest.raises(ValueError):
+            call.answer(183, "Session Progress")
+
+    def test_progress_records_provisional_without_answering(self):
+        call = Call()
+        call.progress(183, "Session Progress", body=b"v=0\r\n",
+                      content_type="application/sdp")
+        # A provisional does NOT answer the call.
+        assert call.state != "answered"
+        action = call._actions[-1]
+        assert action.kind == "progress"
+        assert action.status_code == 183
+        assert action.extras["body"] == b"v=0\r\n"
+
+    def test_progress_rejects_non_1xx(self):
+        call = Call()
+        with pytest.raises(ValueError):
+            call.progress(200, "OK")
+
+
+@pytest.fixture
+def harness():
+    h = SipTestHarness(local_domains=["example.com"])
+    yield h
+    h.reset()
+    h.close()
+
+
+class TestIvrSequencing:
+    def test_answer_then_play_then_echo(self, harness):
+        # The dialplan-style IVR shape: offer -> answer NOW -> play to
+        # completion -> echo. The await on play parks the coroutine; the answer
+        # is already on the wire.
+        harness.load_source(
+            """
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    await rtpengine.offer(call, profile="ivr")
+    call.answer(200, "OK", body=b"v=0\\r\\n", content_type="application/sdp")
+    await rtpengine.play_media(call, file="/prompts/welcome.wav")
+    await rtpengine.echo(call)
+"""
+        )
+        result = harness.send_invite(
+            ruri="sip:echo@example.com", from_uri="sip:alice@example.com"
+        )
+        # The call was answered (last Call action), and stays answered.
+        assert result.action == "answer"
+        assert result.call.state == "answered"
+        # Media ran: offer, then the prompt, then echo — all after the answer.
+        ops = [op for op, _ in harness.rtpengine.operations]
+        assert "offer" in ops
+        assert "play_media" in ops
+        assert "echo" in ops

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -582,6 +582,11 @@ pub struct CallActor {
     pub created_at: std::time::Instant,
     /// Original A-leg INVITE message (for script handler reconstruction).
     pub a_leg_invite: Option<Arc<Mutex<SipMessage>>>,
+    /// Local (listener) address the A-leg INVITE arrived on. Captured at INVITE
+    /// so an imperative `call.answer()` / `call.progress()` sends the UAS
+    /// response back out the same listener (source-socket parity with the
+    /// inbound-driven send path on a multi-homed host).
+    pub a_leg_local_addr: Option<std::net::SocketAddr>,
     /// RFC 4028 session timer state (set after 200 OK negotiation).
     pub session_timer: Option<SessionTimerState>,
     /// Per-call session timer override from Python script.
@@ -664,6 +669,7 @@ impl CallActor {
             winner: None,
             created_at: std::time::Instant::now(),
             a_leg_invite: None,
+            a_leg_local_addr: None,
             session_timer: None,
             session_timer_override: None,
             transfer: None,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -8300,6 +8300,10 @@ fn handle_b2bua_invite(
         // call's life) so the reliable-1xx strip gate can't be defeated by the
         // script mutating the shared INVITE for B-leg header shaping.
         call.a_leg_supports_100rel = a_leg_supports_100rel;
+        // Listener the INVITE arrived on, so an imperative call.answer() /
+        // call.progress() (which has no `inbound` in scope) sends the UAS
+        // response back out the same socket.
+        call.a_leg_local_addr = Some(inbound.local_addr);
     }
     state.call_event_receivers.insert(call_id.clone(), event_rx);
 
@@ -8535,46 +8539,13 @@ fn handle_b2bua_invite(
         CallAction::RejectRefer { code, reason } => {
             debug!(call_id = %call_id, code, reason = %reason, "B2BUA: RejectRefer during INVITE (no-op)");
         }
-        CallAction::Answer { code, reason, body, content_type } => {
-            debug!(call_id = %call_id, code, "B2BUA: UAS-mode answer");
-            // RFC 3261 §12.1.1: a 2xx to a dialog-creating INVITE MUST carry a
-            // To-tag, and for a UAS-mode B2BUA answer it must be the A-leg
-            // dialog's local_tag — otherwise a later siphon-originated in-dialog
-            // BYE (b2bua.terminate / session-timer expiry) carries a From-tag the
-            // caller never saw and is 481-rejected. build_response copies the
-            // INVITE's tagless To verbatim, so inject the tag here.
-            let mut reply_headers: Vec<(crate::script::api::request::ReplyHeaderOp, String, String)> =
-                Vec::new();
-            if (200..300).contains(&code) {
-                if let Some(to_value) = message_guard.headers.to() {
-                    if !to_value.contains(";tag=") {
-                        if let Some(local_tag) = state
-                            .call_actors
-                            .get_call(&call_id)
-                            .map(|call| call.a_leg.dialog.local_tag.clone())
-                        {
-                            reply_headers.push((
-                                crate::script::api::request::ReplyHeaderOp::Replace,
-                                "To".to_string(),
-                                crate::b2bua::actor::ensure_tag(to_value, Some(&local_tag)),
-                            ));
-                        }
-                    }
-                }
-            }
-            let mut response = build_response(
-                &message_guard, code, &reason, state.server_header.as_deref(), &reply_headers,
-            );
-            if let Some(body_bytes) = body {
-                if let Some(ct) = content_type {
-                    response.headers.set("Content-Type", ct);
-                }
-                response.headers.set("Content-Length", body_bytes.len().to_string());
-                response.body = body_bytes;
-            }
-            send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
-            // Actor stays alive — the A-leg dialog is now confirmed and the
-            // @b2bua.on_bye handler takes over when the UAC BYEs.
+        CallAction::Answered => {
+            // The script called call.answer() imperatively — the 2xx has already
+            // been sent (see b2bua_answer_call). This marker only tells the
+            // dispatcher the actor was answered so the CallAction::None arm above
+            // doesn't remove_call() it as a silent drop. The A-leg dialog is
+            // confirmed and @b2bua.on_bye takes over when the UAC BYEs.
+            debug!(call_id = %call_id, "B2BUA: UAS-mode answer already sent (imperative)");
         }
     }
 }
@@ -12038,6 +12009,114 @@ pub fn b2bua_terminate_call(sip_call_id: &str, reason: Option<&str>) -> bool {
     )
 }
 
+/// Build and send a UAS response (final 2xx or provisional 1xx) for a B2BUA call
+/// from an imperative `call.answer()` / `call.progress()`.
+///
+/// Unlike the bridged path, the script owns the A-leg dialog and answers it
+/// directly. The response is built from `invite` (the A-leg INVITE, passed from
+/// the `PyCall` because `a_leg_invite` isn't stored on the actor until after the
+/// handler returns) and sent out the listener the INVITE arrived on. For any
+/// code > 100 the To header is tagged with the A-leg dialog's `local_tag`
+/// (RFC 3261 §12.1.1 — a dialog-creating 2xx and an early-dialog 18x both need
+/// it, and it's what makes a later siphon-originated in-dialog BYE match the
+/// caller instead of being 481-rejected).
+///
+/// `final_response` marks the call `Answered` and stamps the CDR answer time.
+/// Returns `false` (never panics) if the call is gone or the dispatcher isn't
+/// running.
+fn b2bua_send_uas_response(
+    internal_call_id: &str,
+    invite: &SipMessage,
+    code: u16,
+    reason: &str,
+    body: Option<Vec<u8>>,
+    content_type: Option<&str>,
+    final_response: bool,
+) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let state = &control.state;
+    let (transport, remote_addr, connection_id, local_addr, local_tag) =
+        match state.call_actors.get_call(internal_call_id) {
+            Some(call) => (
+                call.a_leg.transport.transport,
+                call.a_leg.transport.remote_addr,
+                call.a_leg.transport.connection_id,
+                call.a_leg_local_addr,
+                call.a_leg.dialog.local_tag.clone(),
+            ),
+            None => return false,
+        };
+    // The send path may spawn (TCP/TLS connect) and the caller may be on a
+    // non-tokio thread (async-pool asyncio loop), so establish the runtime.
+    let _enter = control.runtime.enter();
+
+    // RFC 3261 §12.1.1: tag the To header with the A-leg dialog local_tag for any
+    // dialog-establishing response (2xx) or early-dialog provisional (18x).
+    let mut reply_headers: Vec<(crate::script::api::request::ReplyHeaderOp, String, String)> =
+        Vec::new();
+    if code > 100 {
+        if let Some(to_value) = invite.headers.to() {
+            if !to_value.contains(";tag=") {
+                reply_headers.push((
+                    crate::script::api::request::ReplyHeaderOp::Replace,
+                    "To".to_string(),
+                    crate::b2bua::actor::ensure_tag(to_value, Some(&local_tag)),
+                ));
+            }
+        }
+    }
+
+    let mut response =
+        build_response(invite, code, reason, state.server_header.as_deref(), &reply_headers);
+    if let Some(body_bytes) = body {
+        if let Some(ct) = content_type {
+            response.headers.set("Content-Type", ct.to_string());
+        }
+        response.headers.set("Content-Length", body_bytes.len().to_string());
+        response.body = body_bytes;
+    }
+    send_message_from(response, transport, remote_addr, connection_id, local_addr, state);
+
+    if final_response {
+        // Confirm the A-leg dialog and mark the CDR answered (tracked at INVITE
+        // by cdr_track_b2bua_start) so a later BYE/terminate CDR shows duration.
+        state.call_actors.set_state(internal_call_id, CallState::Answered);
+        if crate::cdr::auto_emit_enabled() {
+            cdr_mark_answer(state, internal_call_id, code);
+        }
+    }
+    true
+}
+
+/// Imperatively send the final 2xx for a UAS-mode B2BUA call (`call.answer()`).
+/// `code` must be 2xx. Returns `false` if the call is gone / dispatcher down.
+pub fn b2bua_answer_call(
+    internal_call_id: &str,
+    invite: &SipMessage,
+    code: u16,
+    reason: &str,
+    body: Option<Vec<u8>>,
+    content_type: Option<&str>,
+) -> bool {
+    b2bua_send_uas_response(internal_call_id, invite, code, reason, body, content_type, true)
+}
+
+/// Imperatively send a provisional (1xx) for a UAS-mode B2BUA call
+/// (`call.progress()`) — e.g. a 183 with early-media SDP. Does not answer the
+/// call. Returns `false` if the call is gone / dispatcher down.
+pub fn b2bua_progress_call(
+    internal_call_id: &str,
+    invite: &SipMessage,
+    code: u16,
+    reason: &str,
+    body: Option<Vec<u8>>,
+    content_type: Option<&str>,
+) -> bool {
+    b2bua_send_uas_response(internal_call_id, invite, code, reason, body, content_type, false)
+}
+
 /// Arm the RFC 3262 §3 retransmit task for a reliable provisional response.
 ///
 /// Stores a [`ReliableProvisional`] entry in the dispatcher state under
@@ -13264,6 +13343,27 @@ mod tests {
             "does-not-exist@nowhere",
             Some("Normal Clearing")
         ));
+    }
+
+    #[test]
+    fn b2bua_answer_and_progress_unknown_id_is_false_no_panic() {
+        // Imperative call.answer()/progress() against an unknown call (and no
+        // running dispatcher in the test binary) is a clean no-op — returns
+        // false, never panics.
+        let raw = concat!(
+            "INVITE sip:echo@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1\r\n",
+            "From: <sip:alice@example.com>;tag=a\r\n",
+            "To: <sip:echo@example.com>\r\n",
+            "Call-ID: unknown-ivr@example.com\r\n",
+            "CSeq: 1 INVITE\r\n",
+            "Max-Forwards: 70\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        );
+        let invite = parse_sip_message(raw).expect("test fixture must parse").1;
+        assert!(!b2bua_answer_call("nope", &invite, 200, "OK", None, None));
+        assert!(!b2bua_progress_call("nope", &invite, 183, "Session Progress", None, None));
     }
 
     /// Save a stream P-CSCF cache binding directly against a bare `Registrar`,

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -72,16 +72,11 @@ pub enum CallAction {
     AcceptRefer,
     /// Reject a REFER with a status code.
     RejectRefer { code: u16, reason: String },
-    /// UAS-mode answer — siphon sends the final response to the A-leg
-    /// INVITE directly instead of bridging to a B-leg.  ``code`` must
-    /// be 2xx.  ``body`` is an optional answer body (SDP for audio,
-    /// could also be XML for future simservs-Ut responses).
-    Answer {
-        code: u16,
-        reason: String,
-        body: Option<Vec<u8>>,
-        content_type: Option<String>,
-    },
+    /// UAS-mode answer already sent imperatively by `call.answer()` — the final
+    /// 2xx went on the wire during the handler (see `dispatcher::b2bua_answer_call`).
+    /// This marker only tells the dispatcher the call was answered so it keeps
+    /// the actor alive instead of removing it as a silent (no-action) drop.
+    Answered,
 }
 
 /// Which side initiated a BYE.
@@ -327,6 +322,17 @@ impl PyCall {
     /// Get the underlying SIP message.
     pub fn message(&self) -> Arc<Mutex<SipMessage>> {
         Arc::clone(&self.message)
+    }
+
+    /// Lock and clone the A-leg INVITE — the source for an imperative
+    /// `answer()` / `progress()` UAS response. The dispatcher can't read the
+    /// INVITE off the actor during `on_invite` (it's stored only after the
+    /// handler returns), so the `PyCall` supplies it.
+    fn locked_invite(&self) -> PyResult<SipMessage> {
+        let guard = self.message.lock().map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+        })?;
+        Ok(guard.clone())
     }
 
     /// Update the call state (called by the B2BUA core).
@@ -861,8 +867,25 @@ impl PyCall {
     }
 
     /// UAS-mode answer — send a final 2xx response to the A-leg INVITE
-    /// directly instead of bridging to a B-leg.  Useful for MRF /
-    /// announcement servers that own the dialog themselves.
+    /// **immediately**, instead of bridging to a B-leg. Useful for MRF /
+    /// announcement / echo / IVR servers that own the dialog themselves.
+    ///
+    /// The response goes on the wire the moment this is called (not deferred to
+    /// when the handler returns), so an `async` handler can answer and then keep
+    /// working — e.g. play a prompt to completion before starting echo —
+    /// without delaying the 200 OK:
+    ///
+    /// ```python,ignore
+    /// @b2bua.on_invite
+    /// async def on_invite(call):
+    ///     await rtpengine.offer(call, profile="ivr")
+    ///     call.answer(200, "OK", body=call.body, content_type="application/sdp")
+    ///     await rtpengine.play_media(call, file=prompt)   # 200 already sent
+    ///     await rtpengine.echo(call)
+    /// ```
+    ///
+    /// Synchronous — no `await` needed (the send is a queue push). The A-leg
+    /// dialog is confirmed and `@b2bua.on_bye` takes over when the UAC BYEs.
     ///
     /// Args:
     ///     code: Final response status (must be 2xx).
@@ -888,12 +911,60 @@ impl PyCall {
             None => None,
         };
 
-        self.action = CallAction::Answer {
-            code,
-            reason: reason.to_string(),
-            body: body_bytes,
-            content_type: content_type.map(|s| s.to_string()),
+        let invite = self.locked_invite()?;
+        let sent = crate::dispatcher::b2bua_answer_call(
+            &self.id, &invite, code, reason, body_bytes, content_type,
+        );
+        if !sent {
+            tracing::error!(call_id = %self.id, "call.answer(): no live B2BUA call to answer");
+        }
+        // Marker so the dispatcher keeps the actor alive after the handler
+        // returns (the 2xx has already been sent by b2bua_answer_call).
+        self.action = CallAction::Answered;
+        Ok(())
+    }
+
+    /// UAS-mode provisional — send a 1xx response to the A-leg INVITE
+    /// **immediately** (e.g. a ``183 Session Progress`` with early-media SDP, or
+    /// ``180 Ringing``). Does not answer the call: the handler must still
+    /// ``answer()`` / ``dial()`` / ``reject()`` to reach a final response.
+    ///
+    /// Like ``answer()``, the response goes on the wire the moment this is
+    /// called, so a script can send ringback / an announcement as early media
+    /// and then ``answer()`` later. An 18x with SDP opens an early dialog and
+    /// carries the same UAS To-tag ``answer()`` will use.
+    ///
+    /// Args:
+    ///     code: Provisional status (must be 1xx; 100 sends no To-tag).
+    ///     reason: Reason phrase (e.g. ``"Session Progress"``).
+    ///     body: Optional response body (``bytes`` or ``str``) — early-media SDP.
+    ///     content_type: Content-Type for the body (e.g. ``"application/sdp"``).
+    #[pyo3(signature = (code, reason="Ringing", body=None, content_type=None))]
+    fn progress(
+        &mut self,
+        code: u16,
+        reason: &str,
+        body: Option<&Bound<'_, PyAny>>,
+        content_type: Option<&str>,
+    ) -> PyResult<()> {
+        if !(100..200).contains(&code) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "call.progress() requires a 1xx status code (got {code}); use call.answer() for the final response"
+            )));
+        }
+
+        let body_bytes = match body {
+            Some(obj) => Some(super::request::extract_body_bytes(obj)?),
+            None => None,
         };
+
+        let invite = self.locked_invite()?;
+        let sent = crate::dispatcher::b2bua_progress_call(
+            &self.id, &invite, code, reason, body_bytes, content_type,
+        );
+        if !sent {
+            tracing::error!(call_id = %self.id, "call.progress(): no live B2BUA call");
+        }
         Ok(())
     }
 

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -526,6 +526,36 @@ fn uas_single_leg_call_is_resolvable_by_sip_call_id_for_terminate() {
     assert!(store.find_by_sip_call_id("not-a-call@test").is_none());
 }
 
+#[test]
+fn uas_imperative_answer_marks_answered_and_keeps_actor_alive() {
+    // call.answer() sends the 2xx imperatively then marks the call Answered via
+    // CallAction::Answered so the dispatcher keeps the actor alive (instead of
+    // removing it as a no-action silent drop). Model that at the store level:
+    // set_state(Answered) leaves the actor resolvable, and the A-leg dialog
+    // carries the local_tag the 2xx To header is stamped with.
+    let store = CallActorStore::new();
+    let sip_call_id = "ivr-answer@test";
+    let call_id = store.create_call(make_a_leg(sip_call_id));
+
+    let local_tag = {
+        let call = store.get_call(&call_id).unwrap();
+        assert_eq!(call.state, CallState::Calling);
+        assert!(!call.a_leg.dialog.local_tag.is_empty());
+        call.a_leg.dialog.local_tag.clone()
+    };
+
+    store.set_state(&call_id, CallState::Answered);
+
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(call.state, CallState::Answered);
+    // Still a single-leg UAS call; the actor persists so @b2bua.on_bye /
+    // b2bua.terminate can reach it, and the dialog tag is stable.
+    assert!(call.winner.is_none());
+    assert_eq!(call.a_leg.dialog.local_tag, local_tag);
+    drop(call);
+    assert_eq!(store.count(), 1);
+}
+
 // ---------------------------------------------------------------------------
 // B2BUA CANCEL: A-leg CANCEL → cancel B-legs
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
> Stacked on #76 (reuses the `B2BUA_CONTROL` dispatcher handle). Base is `feat/b2bua-terminate`; it retargets to `main` when #76 merges.

## Why

Dialplan-style media sequencing for the SBC echo/IVR route: `answer(); play(); echo();` — answer the call, play a prompt **to completion**, *then* start echo, no overlap. The `await` on `play_media()` is already non-blocking (the coroutine parks on its async-pool driver loop; the siphon-rtp side defers the play response, landed as `dd1fb16`). The siphon-sip blocker was that **dialog transitions are deferred**: `call.answer()` set `CallAction::Answer`, applied only when the async handler *returns* (the dispatcher runs the whole coroutine, then applies the action). So `await play()` inside `on_invite` delayed the 200 OK by the whole prompt length — today's echo only "works" because `on_invite` returns immediately after a fire-and-forget play, which is exactly why the prompt overlaps the echo.

## What

- **`call.answer()` is now imperative** — it sends the final 2xx the moment it's called (not deferred to handler-return), and stays synchronous (no `await`). An async `@b2bua.on_invite` can answer and keep working:
  ```python
  @b2bua.on_invite
  async def on_invite(call):
      await rtpengine.offer(call, profile=IVR_PROFILE)
      call.answer(200, "OK", body=call.body, content_type="application/sdp")  # sent now
      await rtpengine.play_media(call, file=prompt)                            # parks; 200 already out
      await rtpengine.echo(call)                                              # clean prompt, THEN echo
  ```
  Decided against a separate `answer_now()`: the deferral was an artifact of the `CallAction` model, not a feature, and no shipped script (`scripts/`, `examples/`) calls `call.answer()` today, so two near-identical methods would be permanent API debt. Answer-then-return scripts are unaffected.
- **`call.progress(code, reason, body=None, content_type=None)`** — new imperative UAS provisional (183 with early-media SDP, or 180). Opens an early dialog with the same To-tag `answer()` uses; the handler must still reach a final response.

### How

- New `dispatcher::b2bua_send_uas_response` + `b2bua_answer_call` / `b2bua_progress_call`, reached from `PyCall` via the `B2BUA_CONTROL` handle from #76 (so the send works from the async-pool driver thread). The RFC 3261 §12.1.1 To-tag logic from #76 moves here and is shared by answer + progress.
- The deferred `CallAction::Answer` variant is replaced by a unit `CallAction::Answered` marker whose apply-arm is a **no-op** — it exists only to stop the `CallAction::None` arm from `remove_call`-ing the actor (silent drop) after a UAS answer. `a_leg_invite` isn't stored on the actor until after the handler, so the send builds the 200 from the `PyCall`'s own INVITE; a new `CallActor.a_leg_local_addr` (captured at INVITE) makes the response leave the same listener.
- A 2xx also marks the CDR answered (`cdr_mark_answer`), so the #76 terminate/BYE CDR shows answered+duration.

This does not touch the threading/non-blocking model — the `await play` parking is the existing async pool + siphon-rtp's job.

## Tests / gates

- `cargo test`: 2852 lib + 275 integration + rest, 0 failures (new: answer/progress unknown-id → false; UAS answered actor stays alive with a stable dialog tag). One unrelated real-socket `udp_roundtrip` flake passes in isolation.
- `cargo clippy --all-targets --all-features -D warnings`: clean.
- SDK `pytest`: green — new `test_call_answer_progress.py` covers the `offer → answer → play → echo` sequencing via the harness plus direct `answer`/`progress` recording; `MockCall.answer` docstring refreshed, `MockCall.progress` added.

Wire-level acceptance (200 on the wire before the handler returns, no dup 200; 183 with SDP; the prompt plays to completion with no echo underneath, then echo; concurrent IVRs stay responsive) runs on the reference hardware, together with the perf/mem baseline.
