### PR TITLE
feat(rtpengine): blocking play_media(wait=True) via PlayFinished event (proto 0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Changed
+- **`rtpengine.play_media()` now blocks until the prompt finishes by default**
+  (`wait=True`), on the native `siphon-rtp` backend. `await rtpengine.play_media(...)`
+  returns only once the prompt has fully played out, so an IVR handler can
+  sequence `answer → play → echo` with no overlap; the coroutine parks while it
+  waits (no worker is held). Pass `wait=False` for fire-and-forget playback
+  (music-on-hold / background), which returns as soon as the engine accepts the
+  prompt. Backed by the new `Event::PlayFinished` completion event
+  (`siphon-rtp-proto` 0.1.2): the play accepts immediately with a `play_id` and
+  the engine reports completion asynchronously, correlated by `play_id`. A
+  configurable fallback (`media.siphon_rtp.play_timeout_ms`, default 5 min) caps
+  the wait so a lost event / dead engine can't hang the call. The rtpengine and
+  rtpproxy backends have no completion signal, so they ignore `wait` and return
+  on accept as before. Return value is now the actual played duration (or `None`
+  when the prompt was stopped / superseded before finishing, or the fallback
+  elapsed).
+
 ### Added
 - **`b2bua.terminate(call_id, reason="Normal Clearing") -> bool`** — imperative
   hangup of a B2BUA call by SIP Call-ID. Unlike `call.terminate()` (deferred

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,9 +3059,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30064e67e79f19d4a91da98932b0d572efc13e08a87f307ac82446a949aef05a"
+checksum = "16aead09194cfd48553b76bddcea284299cb6441728412e219af11cb02d98227"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.1.1"
+siphon-rtp-proto = "0.1.2"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -173,7 +173,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.1.1"
+siphon-rtp-proto = "0.1.2"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/benches/siphon_rtp_proto.rs
+++ b/benches/siphon_rtp_proto.rs
@@ -52,6 +52,7 @@ fn offer_response() -> Response {
             duration_ms: None,
             to_tag: None,
             stats: None,
+            play_id: None,
         },
     }
 }

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -1863,6 +1863,7 @@ class MockRtpEngine:
         start_ms: Optional[int] = None,
         duration_ms: Optional[int] = None,
         to_tag: Optional[str] = None,
+        wait: bool = True,
     ) -> Optional[int]:
         """Inject an audio prompt into the call.
 
@@ -1885,6 +1886,13 @@ class MockRtpEngine:
             start_ms: Offset into the file at which to start (ms).
             duration_ms: Cap on playback length (ms).
             to_tag: Optional peer tag for MPTY scoping.
+            wait: When ``True`` (default, native siphon-rtp backend), the real
+                runtime blocks until the prompt finishes playing so a script can
+                sequence a following action (e.g. ``echo()``) after it. The
+                coroutine parks while it waits. ``wait=False`` returns as soon as
+                the engine accepts the prompt (fire-and-forget). In this mock the
+                call always returns immediately (the completion event is a runtime
+                behavior); ``wait`` is recorded for assertions.
 
         Returns:
             Prompt duration in ms if rtpengine reports one (mock returns
@@ -1892,8 +1900,12 @@ class MockRtpEngine:
 
         Example::
 
-            dur = await rtpengine.play_media(call, file="/var/lib/siphon/prompts/cfu.wav")
-            await rtpengine.play_media(call, blob=tts_bytes, to_tag=peer_tag)
+            @b2bua.on_invite
+            async def on_invite(call):
+                await rtpengine.offer(call, profile="ivr")
+                call.answer(200, "OK", body=call.body, content_type="application/sdp")
+                await rtpengine.play_media(call, file="/prompts/welcome.wav")  # wait=True
+                await rtpengine.echo(call)                                     # after prompt
         """
         count = sum(1 for x in (file, blob, db_id) if x is not None)
         if count != 1:
@@ -1911,6 +1923,7 @@ class MockRtpEngine:
             "start_ms": start_ms,
             "duration_ms": duration_ms,
             "to_tag": to_tag,
+            "wait": wait,
         })
         return self._play_media_duration_ms
 

--- a/sdk/tests/test_play_media_wait.py
+++ b/sdk/tests/test_play_media_wait.py
@@ -1,0 +1,60 @@
+"""Tests for the blocking `rtpengine.play_media(wait=...)` sequencing.
+
+With `wait=True` (default) the real runtime blocks until the prompt finishes, so
+an IVR handler can `offer -> answer -> play -> echo` with no overlap. The mock
+auto-completes (blocking is a runtime behavior) but records `wait` and preserves
+call order, which is what an author test needs.
+"""
+
+import pytest
+
+from siphon_sdk.testing import SipTestHarness
+
+
+@pytest.fixture
+def harness():
+    h = SipTestHarness(local_domains=["example.com"])
+    yield h
+    h.reset()
+    h.close()
+
+
+class TestPlayMediaWait:
+    def test_play_before_echo_and_wait_defaults_true(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    await rtpengine.offer(call, profile="ivr")
+    call.answer(200, "OK", body=b"v=0\\r\\n", content_type="application/sdp")
+    await rtpengine.play_media(call, file="/prompts/welcome.wav")   # wait defaults True
+    await rtpengine.echo(call)
+"""
+        )
+        harness.send_invite(
+            ruri="sip:echo@example.com", from_uri="sip:alice@example.com"
+        )
+        # The prompt is played before echo is enabled (no overlap).
+        ops = [op for op, _ in harness.rtpengine.operations]
+        assert ops == ["offer", "play_media", "echo"]
+        play = [c for c in harness.rtpengine.media_calls if c["op"] == "play_media"][-1]
+        assert play["wait"] is True
+        assert play["file"] == "/prompts/welcome.wav"
+
+    def test_wait_false_is_recorded(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    await rtpengine.play_media(call, file="/moh.wav", wait=False)   # fire-and-forget
+"""
+        )
+        harness.send_invite(
+            ruri="sip:x@example.com", from_uri="sip:alice@example.com"
+        )
+        play = [c for c in harness.rtpengine.media_calls if c["op"] == "play_media"][-1]
+        assert play["wait"] is False

--- a/src/config.rs
+++ b/src/config.rs
@@ -1670,6 +1670,12 @@ pub struct SiphonRtpConfig {
     /// `timeout_ms` overrides it). Default: 2000.
     #[serde(default = "default_siphon_rtp_timeout_ms")]
     pub timeout_ms: u64,
+    /// Fallback cap in milliseconds for a blocking `rtpengine.play_media()` — how
+    /// long to wait for the prompt-finished event before giving up. A prompt can
+    /// be far longer than a control request, so this is separate from
+    /// `timeout_ms`. Default: 300000 (5 min).
+    #[serde(default = "default_siphon_rtp_play_timeout_ms")]
+    pub play_timeout_ms: u64,
 }
 
 impl SiphonRtpConfig {
@@ -1786,6 +1792,10 @@ fn default_rtpproxy_retries() -> u32 {
 
 fn default_siphon_rtp_timeout_ms() -> u64 {
     2000
+}
+
+fn default_siphon_rtp_play_timeout_ms() -> u64 {
+    300_000
 }
 
 /// A user-defined RTPEngine media profile with separate offer/answer NG flags.

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -4961,6 +4961,7 @@ fn build_siphon_rtp_backend(
     match crate::rtpengine::SiphonRtpClientSet::new(
         instance_tuples,
         siphon_rtp_config.control_secret.clone(),
+        siphon_rtp_config.play_timeout_ms,
         event_sender,
     ) {
         Ok(set) => {

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -21,6 +21,8 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use tracing::debug;
+
 use super::client::{PlayMediaSource, RtpEngineSet};
 use super::error::RtpEngineError;
 use super::profile::NgFlags;
@@ -79,6 +81,11 @@ impl MediaBackend {
     }
 
     /// Inject an audio prompt; returns the engine-reported duration in ms.
+    ///
+    /// `wait` (native siphon-rtp backend only) blocks until the prompt finishes
+    /// (`Event::PlayFinished`), so a script can sequence a following action after
+    /// it. The rtpengine / rtpproxy backends have no completion event, so they
+    /// ignore `wait` and return on accept (fire-and-forget) as before.
     #[allow(clippy::too_many_arguments)]
     pub async fn play_media(
         &self,
@@ -89,9 +96,13 @@ impl MediaBackend {
         start_pos_ms: Option<u64>,
         duration_ms: Option<u64>,
         to_tag: Option<&str>,
+        wait: bool,
     ) -> Result<Option<u64>, RtpEngineError> {
         match self {
             Self::RtpEngine(set) => {
+                if wait {
+                    debug!(call_id, "play_media(wait=True) ignored on rtpengine backend (no completion event); returning on accept");
+                }
                 set.play_media(
                     call_id,
                     from_tag,
@@ -113,10 +124,14 @@ impl MediaBackend {
                         start_pos_ms,
                         duration_ms,
                         to_tag,
+                        wait,
                     )
                     .await
             }
             Self::RtpProxy(client) => {
+                if wait {
+                    debug!(call_id, "play_media(wait=True) ignored on rtpproxy backend (no completion event); returning on accept");
+                }
                 client
                     .play_media(
                         call_id,
@@ -366,7 +381,7 @@ mod tests {
         // framed and sent, then no response arrived) — the reject arms below
         // return synchronously and never time out.
         let (event_tx, _event_rx) = mpsc::channel::<RtpEngineEvent>(16);
-        let set = SiphonRtpClientSet::new(vec![(dead_address(), 200, 1)], None, event_tx).unwrap();
+        let set = SiphonRtpClientSet::new(vec![(dead_address(), 200, 1)], None, 5_000, event_tx).unwrap();
         let backend = MediaBackend::SiphonRtp(set);
 
         let error = backend.echo("call-1", "tag-a", true).await.unwrap_err();

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -28,8 +28,8 @@ use std::time::Duration;
 use dashmap::DashMap;
 use futures_util::future::join_all;
 use siphon_rtp_proto::{
-    frame, CmdResult, Command, Event, PlayMediaSource as ProtoPlayMediaSource, ProfileFlags,
-    Request, Response,
+    frame, CmdResult, Command, Event, PlayEndReason, PlayMediaSource as ProtoPlayMediaSource,
+    ProfileFlags, Request, Response,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -83,16 +83,27 @@ fn proto_play_source(source: &PlayMediaSource) -> ProtoPlayMediaSource {
     }
 }
 
+/// Completion signal for a blocking `play_media(wait=True)`: how the prompt ended
+/// plus the actual played duration (from `Event::PlayFinished`).
+type PlayWaiter = oneshot::Sender<(PlayEndReason, Option<u64>)>;
+
 /// Native JSON-over-TCP control client for `siphon-rtp`.
 pub struct SiphonRtpClient {
     /// Control endpoint (`siphon-rtp --control <addr>`).
     address: SocketAddr,
     /// Per-request response timeout.
     timeout_ms: u64,
+    /// Fallback cap for a blocking `play_media(wait=True)` — how long to wait for
+    /// the `Event::PlayFinished` before giving up (a prompt can be much longer
+    /// than a control request, so this is separate from `timeout_ms`).
+    play_timeout_ms: u64,
     /// Monotonic request id allocator (starts at 1; 0 is reserved for auth).
     next_id: AtomicU64,
     /// In-flight requests awaiting a response, keyed by request id.
     pending: Arc<DashMap<u64, oneshot::Sender<CmdResult>>>,
+    /// Blocking `play_media` waiters keyed by the accept's `play_id`; resolved by
+    /// the reader when the matching `Event::PlayFinished` arrives.
+    play_pending: Arc<DashMap<u64, PlayWaiter>>,
     /// Write half of the live connection, swapped by the connection manager on
     /// (re)connect and cleared (`None`) while disconnected.
     writer: Arc<Mutex<Option<OwnedWriteHalf>>>,
@@ -122,9 +133,12 @@ impl SiphonRtpClient {
         address: SocketAddr,
         control_secret: Option<String>,
         timeout_ms: u64,
+        play_timeout_ms: u64,
         event_tx: mpsc::Sender<RtpEngineEvent>,
     ) -> Arc<Self> {
         let pending: Arc<DashMap<u64, oneshot::Sender<CmdResult>>> = Arc::new(DashMap::new());
+        let play_pending: Arc<DashMap<u64, PlayWaiter>> =
+            Arc::new(DashMap::new());
         let writer: Arc<Mutex<Option<OwnedWriteHalf>>> = Arc::new(Mutex::new(None));
         let (connected_tx, connected_rx) = watch::channel(false);
         let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>(1);
@@ -134,6 +148,7 @@ impl SiphonRtpClient {
             control_secret,
             timeout_ms,
             Arc::clone(&pending),
+            Arc::clone(&play_pending),
             Arc::clone(&writer),
             connected_tx,
             event_tx,
@@ -143,8 +158,10 @@ impl SiphonRtpClient {
         Arc::new(Self {
             address,
             timeout_ms,
+            play_timeout_ms,
             next_id: AtomicU64::new(1),
             pending,
+            play_pending,
             writer,
             connected: connected_rx,
             sessions: DashMap::new(),
@@ -283,6 +300,7 @@ impl SiphonRtpClient {
 
     /// Inject an audio prompt; returns the engine-reported duration in ms.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn play_media(
         &self,
         call_id: &str,
@@ -292,6 +310,7 @@ impl SiphonRtpClient {
         start_pos_ms: Option<u64>,
         duration_ms: Option<u64>,
         to_tag: Option<&str>,
+        wait: bool,
     ) -> Result<Option<u64>, RtpEngineError> {
         let result = self
             .request(Command::PlayMedia {
@@ -304,9 +323,57 @@ impl SiphonRtpClient {
                 to_tag: to_tag.map(str::to_string),
             })
             .await?;
-        match result {
-            CmdResult::Ok { duration_ms, .. } => Ok(duration_ms),
-            other => Err(unexpected_result("play media", other)),
+        // The accept is immediate (proto ≥0.1.2) and carries the play_id the
+        // eventual Event::PlayFinished will echo.
+        let (play_id, accept_duration) = match result {
+            CmdResult::Ok {
+                play_id,
+                duration_ms,
+                ..
+            } => (play_id, duration_ms),
+            other => return Err(unexpected_result("play media", other)),
+        };
+
+        // Fire-and-forget, or an engine that didn't assign a play_id: return on
+        // accept, exactly as before.
+        let (true, Some(play_id)) = (wait, play_id) else {
+            return Ok(accept_duration);
+        };
+
+        // Block until the prompt ends. Register the waiter keyed by play_id (the
+        // reader resolves it when PlayFinished arrives), bounded by the fallback
+        // timeout so a lost event / dead engine can't hang the call. There is a
+        // sub-millisecond race where PlayFinished could arrive before this insert
+        // (vs a seconds-long prompt) — the fallback covers that pathological case.
+        let (sender, receiver) = oneshot::channel::<(PlayEndReason, Option<u64>)>();
+        self.play_pending.insert(play_id, sender);
+        let deadline = Duration::from_millis(self.play_timeout_ms.max(1));
+        match tokio::time::timeout(deadline, receiver).await {
+            // Prompt played out in full.
+            Ok(Ok((PlayEndReason::Completed, played_ms))) => Ok(played_ms.or(accept_duration)),
+            // Ended early (stopped / superseded) — didn't play out; the script decides.
+            Ok(Ok((PlayEndReason::Stopped | PlayEndReason::Superseded, _))) => Ok(None),
+            // Engine reported an aborted playback.
+            Ok(Ok((PlayEndReason::Error, _))) => {
+                warn!(call_id, play_id, "siphon-rtp play_media aborted (engine error)");
+                Ok(None)
+            }
+            // Connection dropped (sender cleared on disconnect) — treat as not completed.
+            Ok(Err(_)) => {
+                warn!(call_id, play_id, "siphon-rtp play_media: connection lost before completion");
+                Ok(None)
+            }
+            // Fallback timeout — no PlayFinished within play_timeout_ms.
+            Err(_) => {
+                self.play_pending.remove(&play_id);
+                warn!(
+                    call_id,
+                    play_id,
+                    timeout_ms = self.play_timeout_ms,
+                    "siphon-rtp play_media: no completion within fallback timeout"
+                );
+                Ok(None)
+            }
         }
     }
 
@@ -577,6 +644,7 @@ impl SiphonRtpClientSet {
     pub fn new(
         instances: Vec<(SocketAddr, u64, u32)>,
         control_secret: Option<String>,
+        play_timeout_ms: u64,
         event_tx: mpsc::Sender<RtpEngineEvent>,
     ) -> Result<Arc<Self>, RtpEngineError> {
         if instances.is_empty() {
@@ -593,6 +661,7 @@ impl SiphonRtpClientSet {
                 *address,
                 control_secret.clone(),
                 *timeout_ms,
+                play_timeout_ms,
                 event_tx.clone(),
             ));
             running_total += weight;
@@ -689,6 +758,7 @@ impl SiphonRtpClientSet {
         start_pos_ms: Option<u64>,
         duration_ms: Option<u64>,
         to_tag: Option<&str>,
+        wait: bool,
     ) -> Result<Option<u64>, RtpEngineError> {
         self.select(call_id)
             .play_media(
@@ -699,6 +769,7 @@ impl SiphonRtpClientSet {
                 start_pos_ms,
                 duration_ms,
                 to_tag,
+                wait,
             )
             .await
     }
@@ -945,6 +1016,16 @@ fn convert_event(event: Event) -> RtpEngineEvent {
             call_id: call_id.or(conference_id),
             from_tag: Some(from_tag),
         },
+        // Intercepted by route_frame before it reaches here (resolves a blocking
+        // play_media). Mapped defensively so the match stays exhaustive and
+        // non-panicking if that ordering ever changes.
+        Event::PlayFinished {
+            call_id, from_tag, ..
+        } => RtpEngineEvent::Unknown {
+            event: "play_finished".to_string(),
+            call_id: Some(call_id),
+            from_tag: Some(from_tag),
+        },
         Event::Unknown => RtpEngineEvent::Unknown {
             event: "unknown".to_string(),
             call_id: None,
@@ -955,11 +1036,13 @@ fn convert_event(event: Event) -> RtpEngineEvent {
 
 /// Background task: maintain the control connection, route responses/events, and
 /// reconnect (with backoff + re-auth) until the client is dropped.
+#[allow(clippy::too_many_arguments)]
 async fn connection_manager(
     address: SocketAddr,
     control_secret: Option<String>,
     timeout_ms: u64,
     pending: Arc<DashMap<u64, oneshot::Sender<CmdResult>>>,
+    play_pending: Arc<DashMap<u64, PlayWaiter>>,
     writer: Arc<Mutex<Option<OwnedWriteHalf>>>,
     connected_tx: watch::Sender<bool>,
     event_tx: mpsc::Sender<RtpEngineEvent>,
@@ -1016,14 +1099,24 @@ async fn connection_manager(
         let _ = connected_tx.send(true);
         info!(%address, "siphon-rtp control connection established");
 
-        let outcome = read_loop(&mut read_half, &mut buffer, &pending, &event_tx, &mut shutdown_rx)
-            .await;
+        let outcome = read_loop(
+            &mut read_half,
+            &mut buffer,
+            &pending,
+            &play_pending,
+            &event_tx,
+            &mut shutdown_rx,
+        )
+        .await;
 
         // Connection is gone: stop accepting commands and fail every in-flight
         // request (dropping the senders makes their receivers resolve to Err).
+        // Blocking play_media waiters likewise unblock (dropped sender → Err →
+        // treated as not-completed) instead of hanging until the fallback.
         let _ = connected_tx.send(false);
         *writer.lock().await = None;
         pending.clear();
+        play_pending.clear();
 
         match outcome {
             ReadOutcome::Shutdown => return,
@@ -1051,6 +1144,7 @@ async fn read_loop(
     read_half: &mut OwnedReadHalf,
     buffer: &mut Vec<u8>,
     pending: &DashMap<u64, oneshot::Sender<CmdResult>>,
+    play_pending: &DashMap<u64, PlayWaiter>,
     event_tx: &mpsc::Sender<RtpEngineEvent>,
     shutdown_rx: &mut mpsc::Receiver<()>,
 ) -> ReadOutcome {
@@ -1061,7 +1155,7 @@ async fn read_loop(
             match frame::decode::<serde_json::Value>(buffer) {
                 Ok(Some((value, consumed))) => {
                     buffer.drain(..consumed);
-                    route_frame(value, pending, event_tx).await;
+                    route_frame(value, pending, play_pending, event_tx).await;
                 }
                 Ok(None) => break,
                 Err(error) => {
@@ -1091,10 +1185,22 @@ async fn read_loop(
 async fn route_frame(
     value: serde_json::Value,
     pending: &DashMap<u64, oneshot::Sender<CmdResult>>,
+    play_pending: &DashMap<u64, PlayWaiter>,
     event_tx: &mpsc::Sender<RtpEngineEvent>,
 ) {
     if value.get("event").is_some() {
         match serde_json::from_value::<Event>(value) {
+            Ok(Event::PlayFinished { play_id, reason, played_ms, .. }) => {
+                // Internal correlation for a blocking play_media(wait=True): hand
+                // the reason + played duration to the waiting call. No waiter
+                // means a wait=False play (or a lost accept/register race, covered
+                // by the play fallback timeout) — drop it, don't surface it as an
+                // event.
+                debug!(play_id, ?reason, played_ms, "siphon-rtp play finished");
+                if let Some((_, sender)) = play_pending.remove(&play_id) {
+                    let _ = sender.send((reason, played_ms));
+                }
+            }
             Ok(event) => {
                 let converted = convert_event(event);
                 debug!(?converted, "siphon-rtp event received");
@@ -1276,12 +1382,14 @@ mod tests {
                                 duration_ms: None,
                                 to_tag: None,
                                 stats: None,
+                                play_id: None,
                             },
                             _ => CmdResult::Ok {
                                 sdp: None,
                                 duration_ms: None,
                                 to_tag: None,
                                 stats: None,
+                                play_id: None,
                             },
                         };
                         write_frame(
@@ -1398,6 +1506,7 @@ mod tests {
                         duration_ms: None,
                         to_tag: None,
                         stats: None,
+                        play_id: None,
                     },
                 },
             )
@@ -1407,7 +1516,7 @@ mod tests {
         });
 
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         let flags = NgFlags {
             transport_protocol: Some("RTP/SAVP".into()),
             ..NgFlags::default()
@@ -1417,6 +1526,123 @@ mod tests {
         assert_eq!(client.active_sessions(), 1);
         assert_eq!(client.instance_count(), 1);
         assert_eq!(client.instance_addresses(), vec![address]);
+    }
+
+    /// Fake engine that accepts one `PlayMedia` with `play_id`, then optionally
+    /// pushes an `Event::PlayFinished` after a short delay. Returns its address.
+    async fn spawn_play_server(
+        play_id: u64,
+        finish: Option<(PlayEndReason, Option<u64>)>,
+    ) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = Vec::new();
+            let request: Request = read_frame(&mut stream, &mut buffer).await;
+            assert!(matches!(request.command, Command::PlayMedia { .. }));
+            // Accept immediately, echoing the play_id.
+            write_frame(
+                &mut stream,
+                &Response {
+                    id: request.id,
+                    result: CmdResult::Ok {
+                        sdp: None,
+                        duration_ms: None,
+                        to_tag: None,
+                        stats: None,
+                        play_id: Some(play_id),
+                    },
+                },
+            )
+            .await;
+            if let Some((reason, played_ms)) = finish {
+                // The prompt "plays", then the engine reports completion.
+                tokio::time::sleep(Duration::from_millis(30)).await;
+                write_frame(
+                    &mut stream,
+                    &Event::PlayFinished {
+                        call_id: "call-play".into(),
+                        from_tag: "tag-a".into(),
+                        to_tag: None,
+                        play_id,
+                        reason,
+                        played_ms,
+                    },
+                )
+                .await;
+            }
+            // Keep the connection open so the client doesn't see EOF.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+        address
+    }
+
+    fn play_source() -> PlayMediaSource {
+        PlayMediaSource::File("/prompts/welcome.wav".to_string())
+    }
+
+    #[tokio::test]
+    async fn play_media_wait_returns_played_ms_on_completed() {
+        // wait=True blocks until the PlayFinished(Completed) for its play_id and
+        // returns the played duration from the event (the accept carried none, so
+        // Some(1234) proves it waited for completion rather than returning early).
+        let address = spawn_play_server(7, Some((PlayEndReason::Completed, Some(1234)))).await;
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
+        let played = client
+            .play_media("call-play", "tag-a", &play_source(), None, None, None, None, true)
+            .await
+            .unwrap();
+        assert_eq!(played, Some(1234));
+    }
+
+    #[tokio::test]
+    async fn play_media_wait_returns_none_when_stopped() {
+        // Ended early (stopped / superseded) → the prompt didn't play out → None.
+        let address = spawn_play_server(8, Some((PlayEndReason::Stopped, Some(400)))).await;
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
+        let played = client
+            .play_media("call-play", "tag-a", &play_source(), None, None, None, None, true)
+            .await
+            .unwrap();
+        assert_eq!(played, None);
+    }
+
+    #[tokio::test]
+    async fn play_media_no_wait_returns_on_accept() {
+        // wait=False returns as soon as the engine accepts — it must NOT block for
+        // a completion event (the fake server never sends one).
+        let address = spawn_play_server(9, None).await;
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
+        let played = tokio::time::timeout(
+            Duration::from_millis(500),
+            client.play_media("call-play", "tag-a", &play_source(), None, None, None, None, false),
+        )
+        .await
+        .expect("play_media(wait=false) must return on accept, not block")
+        .unwrap();
+        assert_eq!(played, None);
+    }
+
+    #[tokio::test]
+    async fn play_media_wait_fallback_timeout_returns_none() {
+        // No PlayFinished ever arrives; a small play fallback timeout resolves the
+        // await to None instead of hanging the call.
+        let address = spawn_play_server(10, None).await;
+        let (event_tx, _event_rx) = channel();
+        // 100 ms play fallback so the test is fast + deterministic.
+        let client = SiphonRtpClient::new(address, None, 2000, 100, event_tx);
+        let played = tokio::time::timeout(
+            Duration::from_millis(2000),
+            client.play_media("call-play", "tag-a", &play_source(), None, None, None, None, true),
+        )
+        .await
+        .expect("play_media must give up at the fallback timeout, not hang")
+        .unwrap();
+        assert_eq!(played, None);
     }
 
     #[tokio::test]
@@ -1443,6 +1669,7 @@ mod tests {
                         duration_ms: None,
                         to_tag: None,
                         stats: None,
+                        play_id: None,
                     },
                 },
             )
@@ -1462,7 +1689,7 @@ mod tests {
         });
 
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, Some("s3cret".into()), 2000, event_tx);
+        let client = SiphonRtpClient::new(address, Some("s3cret".into()), 2000, 5_000, event_tx);
         client.ping().await.unwrap();
     }
 
@@ -1486,6 +1713,7 @@ mod tests {
                         duration_ms: None,
                         to_tag: None,
                         stats: None,
+                        play_id: None,
                     },
                 },
             )
@@ -1499,6 +1727,7 @@ mod tests {
                         duration_ms: None,
                         to_tag: None,
                         stats: None,
+                        play_id: None,
                     },
                 },
             )
@@ -1507,7 +1736,7 @@ mod tests {
         });
 
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         let flags = NgFlags::default();
         let one = client.offer("call-a", "ta", b"v=0\r\n", &flags);
         let two = client.offer("call-b", "tb", b"v=0\r\n", &flags);
@@ -1548,7 +1777,7 @@ mod tests {
         });
 
         let (event_tx, mut event_rx) = channel();
-        let _client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        let _client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
 
         match event_rx.recv().await.unwrap() {
             RtpEngineEvent::Dtmf(dtmf) => {
@@ -1586,7 +1815,7 @@ mod tests {
         });
 
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         let error = client.delete("call-x", "tag-a").await.unwrap_err();
         assert!(matches!(error, RtpEngineError::EngineError(_)));
         assert!(error.to_string().contains("no such call"));
@@ -1626,6 +1855,7 @@ mod tests {
                         duration_ms: None,
                         to_tag: None,
                         stats: None,
+                        play_id: None,
                     },
                 },
             )
@@ -1648,6 +1878,7 @@ mod tests {
                         duration_ms: None,
                         to_tag: None,
                         stats: None,
+                        play_id: None,
                     },
                 },
             )
@@ -1656,7 +1887,7 @@ mod tests {
         });
 
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         client.echo("call-echo", "tag-a", true).await.unwrap();
         client.echo("call-echo", "tag-a", false).await.unwrap();
     }
@@ -1682,6 +1913,7 @@ mod tests {
                         duration_ms: None,
                         to_tag: None,
                         stats: Some(SessionStats::default()),
+                        play_id: None,
                     },
                 },
             )
@@ -1690,7 +1922,7 @@ mod tests {
         });
 
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         let body = client
             .subscribe_answer("c", "f", "t", b"v=0\r\n", &NgFlags::default())
             .await
@@ -1724,7 +1956,7 @@ mod tests {
         });
 
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, None, 2000, event_tx);
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         // Give the manager time to see the drop and reconnect (backoff = 200ms).
         tokio::time::sleep(Duration::from_millis(500)).await;
         client.ping().await.unwrap();
@@ -1737,7 +1969,7 @@ mod tests {
         // forever or failing instantly during a transient startup window).
         let address: SocketAddr = "127.0.0.1:1".parse().unwrap();
         let (event_tx, _event_rx) = channel();
-        let client = SiphonRtpClient::new(address, None, 300, event_tx);
+        let client = SiphonRtpClient::new(address, None, 300, 5_000, event_tx);
         let error = client.ping().await.unwrap_err();
         assert!(matches!(error, RtpEngineError::Timeout { .. }));
     }
@@ -1745,7 +1977,7 @@ mod tests {
     #[test]
     fn client_set_requires_at_least_one_instance() {
         let (event_tx, _event_rx) = channel();
-        let result = SiphonRtpClientSet::new(vec![], None, event_tx);
+        let result = SiphonRtpClientSet::new(vec![], None, 5_000, event_tx);
         assert!(matches!(result, Err(RtpEngineError::Protocol(_))));
     }
 
@@ -1759,6 +1991,7 @@ mod tests {
         let set = SiphonRtpClientSet::new(
             vec![(address_one, 2000, 1), (address_two, 2000, 1)],
             None,
+            5_000,
             event_tx,
         )
         .unwrap();

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -392,11 +392,21 @@ impl PyRtpEngine {
     ///     start_ms: Offset into the file at which to start (milliseconds).
     ///     duration_ms: Cap on playback length (milliseconds).
     ///     to_tag: Optional peer tag for MPTY scoping.
+    ///     wait: When ``True`` (default), block until the prompt finishes playing
+    ///           (``await`` returns only once it has drained), so a script can
+    ///           sequence a following action — e.g. ``echo()`` — after it with no
+    ///           overlap. The coroutine parks while it waits (no worker is held).
+    ///           ``wait=False`` returns as soon as the engine accepts the prompt
+    ///           (fire-and-forget — music-on-hold / background). Native
+    ///           ``siphon-rtp`` backend only; the rtpengine / rtpproxy backends
+    ///           have no completion signal and always return on accept.
     ///
     /// Returns:
-    ///     The prompt duration in milliseconds if rtpengine reports one,
-    ///     else ``None``.
-    #[pyo3(signature = (target, file=None, blob=None, db_id=None, repeat=None, start_ms=None, duration_ms=None, to_tag=None))]
+    ///     The played duration in milliseconds if the engine reports one, else
+    ///     ``None`` (also ``None`` when the prompt was stopped / superseded before
+    ///     it finished, or the fallback timeout elapsed).
+    #[pyo3(signature = (target, file=None, blob=None, db_id=None, repeat=None, start_ms=None, duration_ms=None, to_tag=None, wait=true))]
+    #[allow(clippy::too_many_arguments)]
     fn play_media<'py>(
         &self,
         python: Python<'py>,
@@ -408,6 +418,7 @@ impl PyRtpEngine {
         start_ms: Option<u64>,
         duration_ms: Option<u64>,
         to_tag: Option<String>,
+        wait: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let source = resolve_play_media_source(file, blob, db_id)?;
 
@@ -426,6 +437,7 @@ impl PyRtpEngine {
                     start_ms,
                     duration_ms,
                     to_tag.as_deref(),
+                    wait,
                 )
                 .await
                 .map_err(|error| {

--- a/tests/integration/siphon_rtp_tests.rs
+++ b/tests/integration/siphon_rtp_tests.rs
@@ -49,12 +49,14 @@ async fn spawn_fake_siphon_rtp() -> std::net::SocketAddr {
                                 duration_ms: None,
                                 to_tag: None,
                                 stats: None,
+                                play_id: None,
                             },
                             Command::Delete { .. } => CmdResult::Ok {
                                 sdp: None,
                                 duration_ms: None,
                                 to_tag: None,
                                 stats: None,
+                                play_id: None,
                             },
                             Command::Ping => CmdResult::Pong,
                             _ => CmdResult::Error {
@@ -104,7 +106,7 @@ const INVITE_WITH_SDP: &str = concat!(
 async fn media_backend_siphon_rtp_offer_rewrites_sdp() {
     let address = spawn_fake_siphon_rtp().await;
     let (event_tx, _event_rx) = mpsc::channel(16);
-    let set = SiphonRtpClientSet::new(vec![(address, 2000, 1)], None, event_tx).unwrap();
+    let set = SiphonRtpClientSet::new(vec![(address, 2000, 1)], None, 5_000, event_tx).unwrap();
     let backend = MediaBackend::SiphonRtp(set);
 
     // Confirm the abstraction reports the native backend's shape.
@@ -213,7 +215,7 @@ async fn smoke_test_against_real_siphon_rtp() {
     // --- Native JSON-over-TCP path: SiphonRtpClient → --control ---
     let control: SocketAddr = control_addr.parse().unwrap();
     let (event_tx, _event_rx) = mpsc::channel(16);
-    let client = SiphonRtpClient::new(control, None, 2000, event_tx);
+    let client = SiphonRtpClient::new(control, None, 2000, 5_000, event_tx);
     assert!(
         wait_until(|| async { client.ping().await.is_ok() }).await,
         "siphon-rtp control listener did not become ready"


### PR DESCRIPTION
## Why

The last siphon-sip piece for dialplan-style IVR: `answer → play → echo` with no overlap. The imperative `call.answer()`/`progress()` primitives landed in #77; siphon-rtp shipped the completion event (`siphon-rtp-proto 0.1.2`, commit `49e4797`). Today `rtpengine.play_media()` returns on the accept, so `await` resolves immediately and echo starts on top of the prompt.

## What

`rtpengine.play_media()` now **blocks until the prompt finishes** by default (`wait=True`) on the native siphon-rtp backend, so:

```python
@b2bua.on_invite
async def on_invite(call):
    await rtpengine.offer(call, profile=IVR_PROFILE)
    call.answer(200, "OK", body=call.body, content_type="application/sdp")
    await rtpengine.play_media(call, file=prompt)   # parks until the prompt drains
    await rtpengine.echo(call)                       # clean prompt, THEN echo
```

`wait=False` returns on accept (fire-and-forget — music-on-hold / background). The coroutine parks while it waits, so no worker is held during a long prompt.

### How

- Proto bump `siphon-rtp-proto 0.1.1 → 0.1.2`. `Command::PlayMedia` accepts immediately with a `play_id`; the engine emits `Event::PlayFinished { play_id, reason, played_ms }` on the control event rail when the prompt drains / is stopped / superseded / aborted.
- The native client (`SiphonRtpClient`) gets a second correlation map keyed by `play_id` (parallel to its request-id `pending` map). `route_frame` intercepts `PlayFinished` and resolves the waiter; `play_media(wait=True)` registers after the accept and awaits it, bounded by a **configurable fallback** (`media.siphon_rtp.play_timeout_ms`, default 5 min) so a lost event / dead engine can't hang the call (a dropped connection also unblocks it). The return value is the actual played duration, or `None` when stopped / superseded / the fallback elapsed.
- `MediaBackend::play_media` threads `wait`; the rtpengine and rtpproxy backends have no completion event, so they ignore it and return on accept (with a `debug!`).
- `PyRtpEngine.play_media(...)` gains `wait: bool = True`.

## Tests / gates

- `cargo test`: 2856 lib + 276 integration + rest, 0 failures. New client tests (in-process fake engine): `wait=True` blocks until `Completed` and returns `played_ms`; `Stopped`/`Superseded` → `None`; the fallback timeout resolves to `None` with no hang; `wait=False` returns on accept without waiting.
- `cargo clippy --all-targets --all-features -D warnings`: clean.
- SDK `pytest`: 403 passed — new `test_play_media_wait.py` covers the `offer → answer → play → echo` order and `wait` recording; `MockRtpEngine.play_media` gained `wait` (auto-completes in the mock; blocking is a runtime behavior).

Live acceptance runs on the reference hardware against the 0.1.2 engine (prompt plays to completion with no echo underneath; a long prompt is not cut off; many concurrent IVRs stay responsive), plus the standard perf/mem baseline since a media-control path changed.
