### PR TITLE
feat(rtpengine): single-leg answer_local + event-context media verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   elapsed).
 
 ### Added
+- **`rtpengine.answer_local(call, profile=None, auto_reject=True)`** — single-leg
+  UAS answer for the caller's own offer, with the media engine as the far side
+  (IVR / echo / announcement server). Unlike `answer()` it takes the INVITE offer,
+  not a peer's reply: there is no far leg, so the engine picks one encodable codec
+  from the offer (RFC 3264 §6.1) and returns a real one-codec answer SDP for the
+  script to put in its own 2xx. Profile precedence matches `answer()` (explicit
+  `profile=` → the profile recorded by a matching `offer` → `rtp_passthrough`).
+  When the offer carries no codec the engine can encode, it can't be answered:
+  with `auto_reject=True` (default) and a `Call` target a deferred
+  `488 Not Acceptable Here` (RFC 3261 §13.3.1.2) is set on the call and the
+  coroutine resolves to `None`; with `auto_reject=False` (or a non-`Call` target)
+  it raises `ValueError` instead, leaving the response to the script. Native
+  `siphon-rtp` backend only (`siphon-rtp-proto` 0.1.3 `AnswerLocal`); rtpengine
+  and rtpproxy reject it.
+- **`rtpengine` media verbs now accept a `(call_id, from_tag)` tuple or a bare
+  `call_id` string** as their target, in addition to a `Request`/`Reply`/`Call`
+  object — `play_media`, `stop_media`, `play_dtmf`, `silence_media` /
+  `unsilence_media`, `block_media` / `unblock_media`, and `echo`. This lets an
+  `@rtpengine.on_dtmf` handler (which is handed `call_id` / `from_tag` strings,
+  not a SIP message) drive media directly, e.g. `await rtpengine.play_dtmf((call_id, from_tag), "1")`.
+  A bare string uses an empty from-tag (best-effort).
 - **`b2bua.terminate(call_id, reason="Normal Clearing") -> bool`** — imperative
   hangup of a B2BUA call by SIP Call-ID. Unlike `call.terminate()` (deferred
   until its own handler returns, so a no-op from an out-of-band event), this acts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,9 +3059,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16aead09194cfd48553b76bddcea284299cb6441728412e219af11cb02d98227"
+checksum = "6576cad04bc54affc3d7680517d4f75058fdaa2c55e388a99b91b05a907f5f94"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.1.2"
+siphon-rtp-proto = "0.1.3"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -173,7 +173,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.1.2"
+siphon-rtp-proto = "0.1.3"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -1736,6 +1736,33 @@ class MockCache:
 # RTPEngine namespace
 # ---------------------------------------------------------------------------
 
+def _resolve_media_target(
+    target: Any,
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve ``(call_id, from_tag)`` from a media-verb target.
+
+    Mirrors the runtime's ``resolve_call_from_tag``: a media verb may be handed
+    a SIP object (``Request``/``Reply``/``Call``), a ``(call_id, from_tag)``
+    pair, or a bare ``call_id`` string — the latter two let an
+    ``@rtpengine.on_dtmf`` handler (which receives ``call_id``/``from_tag``
+    strings) drive media without a SIP message. Tolerant of ``None`` (returns
+    ``(None, None)``) so existing ``play_media(None, …)`` unit tests keep working.
+    """
+    # Bare call_id string → empty from_tag. Checked before the pair form so a
+    # 2-char id is never misread as a pair.
+    if isinstance(target, str):
+        return target, ""
+    # (call_id, from_tag) pair of strings.
+    if (
+        isinstance(target, (tuple, list))
+        and len(target) == 2
+        and all(isinstance(item, str) for item in target)
+    ):
+        return target[0], target[1]
+    # SIP object → best-effort from its call_id / from_tag attributes.
+    return getattr(target, "call_id", None), getattr(target, "from_tag", None)
+
+
 class MockRtpEngine:
     """Mock RTPEngine namespace — records media operations for assertions.
 
@@ -1751,6 +1778,13 @@ class MockRtpEngine:
     downstream apps can unit-test MMTEL announcement flows without a live
     rtpengine. Full parameter dicts are available on ``media_calls``.
 
+    Every media verb's ``target`` accepts three forms (like the runtime's
+    ``resolve_call_from_tag``): a SIP object (``Request``/``Reply``/``Call``), a
+    ``(call_id, from_tag)`` pair, or a bare ``call_id`` string — so an
+    ``@rtpengine.on_dtmf`` handler can drive media from the ``call_id`` /
+    ``from_tag`` it was handed. The resolved ``call_id`` / ``from_tag`` are
+    recorded on each ``media_calls`` entry.
+
     Valid profiles: ``"srtp_to_rtp"``, ``"ws_to_rtp"``, ``"wss_to_rtp"``,
     ``"rtp_passthrough"``.
     """
@@ -1762,6 +1796,8 @@ class MockRtpEngine:
         """Full parameter dicts for each media-injection call."""
         self._healthy = True
         self._play_media_duration_ms: Optional[int] = None
+        self._answer_local_sdp: str = "v=0\r\nm=audio 40000 RTP/AVP 8 101\r\n"
+        self._answer_local_no_codec: bool = False
         self._subscribe_request_sdp: bytes = b""
         self._subscribe_answer_sdp: bytes = b""
         self._dtmf_handlers: list[dict[str, Any]] = []
@@ -1832,6 +1868,91 @@ class MockRtpEngine:
                 profile = "rtp_passthrough"
         self.operations.append(("answer", profile))
         return True
+
+    async def answer_local(
+        self,
+        call: Any,
+        profile: Optional[str] = None,
+        auto_reject: bool = True,
+    ) -> Optional[str]:
+        """Single-leg UAS answer — synthesise an RFC 3264 answer for the
+        caller's **own** offer, with the media engine as the far side (IVR /
+        echo / announcement server).
+
+        Unlike :meth:`answer`, this takes the offer (INVITE), not a peer's
+        reply: there is no far leg, so the engine picks one encodable codec
+        from the offer and returns the answer SDP for the script to put in its
+        own 2xx.
+
+        Profile precedence matches :meth:`answer` (explicit ``profile=`` →
+        profile recorded by a matching ``offer`` → ``"rtp_passthrough"``).
+
+        When the offer has no encodable codec (primed in tests via
+        :meth:`set_answer_local_no_codec`), the engine cannot answer:
+
+        * with ``auto_reject=True`` (default) and a ``Call`` target, a deferred
+          ``488 Not Acceptable Here`` is recorded on the call
+          (``call.reject(488, "Not Acceptable Here")``) and the coroutine
+          resolves to ``None``;
+        * with ``auto_reject=False`` (or a non-``Call`` target) it raises
+          ``ValueError`` instead.
+
+        Native ``siphon-rtp`` backend only.
+
+        Args:
+            call: A ``Call`` (B2BUA) — or ``Request`` — carrying the INVITE
+                  offer whose Call-ID / From-tag drive the single-leg answer.
+            profile: Optional explicit RTP profile name. When omitted, the
+                     profile recorded by a matching offer is used.
+            auto_reject: When ``True`` (default) and ``call`` is a ``Call``, a
+                         no-encodable-codec result records a deferred 488 and
+                         returns ``None``. When ``False`` it raises
+                         ``ValueError``.
+
+        Returns:
+            The answer SDP as ``str`` on success, or ``None`` when the offer had
+            no encodable codec and it was auto-rejected with a 488.
+
+        Example::
+
+            @b2bua.on_invite
+            async def on_invite(call):
+                sdp = await rtpengine.answer_local(call, profile="ivr")
+                if sdp is not None:
+                    call.answer(200, "OK", body=sdp, content_type="application/sdp")
+                    await rtpengine.play_media(call, file="/prompts/welcome.wav")
+        """
+        if profile is None:
+            # Mirror real behavior: recover from the last recorded offer.
+            for op, recorded in reversed(self.operations):
+                if op == "offer":
+                    profile = recorded
+                    break
+            else:
+                profile = "rtp_passthrough"
+
+        if self._answer_local_no_codec:
+            can_reject = auto_reject and hasattr(call, "reject")
+            if can_reject:
+                call.reject(488, "Not Acceptable Here")
+                self.operations.append(("answer_local", None))
+                self.media_calls.append({
+                    "op": "answer_local",
+                    "profile": profile,
+                    "auto_reject": auto_reject,
+                    "answered": False,
+                })
+                return None
+            raise ValueError("no encodable codec in offer")
+
+        self.operations.append(("answer_local", profile))
+        self.media_calls.append({
+            "op": "answer_local",
+            "profile": profile,
+            "auto_reject": auto_reject,
+            "answered": True,
+        })
+        return self._answer_local_sdp
 
     async def delete(self, request: Any) -> bool:
         """Send ``delete`` command to tear down media session.
@@ -1913,9 +2034,12 @@ class MockRtpEngine:
                 "play_media requires exactly one of file=, blob=, or db_id="
             )
         source = "file" if file is not None else "blob" if blob is not None else "db-id"
+        call_id, resolved_from_tag = _resolve_media_target(target)
         self.operations.append(("play_media", source))
         self.media_calls.append({
             "op": "play_media",
+            "call_id": call_id,
+            "from_tag": resolved_from_tag,
             "file": file,
             "blob": blob,
             "db_id": db_id,
@@ -1936,8 +2060,9 @@ class MockRtpEngine:
         Returns:
             ``True`` on success.
         """
+        call_id, from_tag = _resolve_media_target(target)
         self.operations.append(("stop_media", None))
-        self.media_calls.append({"op": "stop_media"})
+        self.media_calls.append({"op": "stop_media", "call_id": call_id, "from_tag": from_tag})
         return True
 
     async def play_dtmf(
@@ -1964,9 +2089,12 @@ class MockRtpEngine:
 
             await rtpengine.play_dtmf(call, "123#", duration_ms=100)
         """
+        call_id, resolved_from_tag = _resolve_media_target(target)
         self.operations.append(("play_dtmf", code))
         self.media_calls.append({
             "op": "play_dtmf",
+            "call_id": call_id,
+            "from_tag": resolved_from_tag,
             "code": code,
             "duration_ms": duration_ms,
             "volume_dbm0": volume_dbm0,
@@ -1980,14 +2108,16 @@ class MockRtpEngine:
 
         Pair with :meth:`unsilence_media` to restore the original stream.
         """
+        call_id, from_tag = _resolve_media_target(target)
         self.operations.append(("silence_media", None))
-        self.media_calls.append({"op": "silence_media"})
+        self.media_calls.append({"op": "silence_media", "call_id": call_id, "from_tag": from_tag})
         return True
 
     async def unsilence_media(self, target: Any) -> bool:
         """Stop replacing outgoing audio with silence (undo :meth:`silence_media`)."""
+        call_id, from_tag = _resolve_media_target(target)
         self.operations.append(("unsilence_media", None))
-        self.media_calls.append({"op": "unsilence_media"})
+        self.media_calls.append({"op": "unsilence_media", "call_id": call_id, "from_tag": from_tag})
         return True
 
     async def block_media(self, target: Any) -> bool:
@@ -1995,14 +2125,16 @@ class MockRtpEngine:
 
         Pair with :meth:`unblock_media` to resume.
         """
+        call_id, from_tag = _resolve_media_target(target)
         self.operations.append(("block_media", None))
-        self.media_calls.append({"op": "block_media"})
+        self.media_calls.append({"op": "block_media", "call_id": call_id, "from_tag": from_tag})
         return True
 
     async def unblock_media(self, target: Any) -> bool:
         """Resume forwarding the selected monologue's packets."""
+        call_id, from_tag = _resolve_media_target(target)
         self.operations.append(("unblock_media", None))
-        self.media_calls.append({"op": "unblock_media"})
+        self.media_calls.append({"op": "unblock_media", "call_id": call_id, "from_tag": from_tag})
         return True
 
     async def echo(self, target: Any, enabled: bool = True) -> bool:
@@ -2012,8 +2144,14 @@ class MockRtpEngine:
         ``enabled=False`` stops echoing. Native ``siphon-rtp`` backend only;
         DTMF and media-timeout events still fire while echoing.
         """
+        call_id, from_tag = _resolve_media_target(target)
         self.operations.append(("echo", enabled))
-        self.media_calls.append({"op": "echo", "enabled": enabled})
+        self.media_calls.append({
+            "op": "echo",
+            "enabled": enabled,
+            "call_id": call_id,
+            "from_tag": from_tag,
+        })
         return True
 
     async def subscribe_request(
@@ -2184,12 +2322,23 @@ class MockRtpEngine:
         """Configure the duration returned by :meth:`play_media` (test helper)."""
         self._play_media_duration_ms = duration_ms
 
+    def set_answer_local_sdp(self, sdp: str) -> None:
+        """Configure the answer SDP returned by :meth:`answer_local` (test helper)."""
+        self._answer_local_sdp = sdp
+
+    def set_answer_local_no_codec(self, no_codec: bool = True) -> None:
+        """Prime :meth:`answer_local` to model a no-encodable-codec offer (test
+        helper) — the next ``answer_local`` records a deferred 488 (auto-reject)
+        or raises ``ValueError`` (``auto_reject=False``)."""
+        self._answer_local_no_codec = no_codec
+
     def clear(self) -> None:
         """Clear recorded operations and registered event handlers (test helper)."""
         self.operations.clear()
         self.media_calls.clear()
         self._dtmf_handlers.clear()
         self._media_timeout_handlers.clear()
+        self._answer_local_no_codec = False
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/tests/test_rtpengine_media.py
+++ b/sdk/tests/test_rtpengine_media.py
@@ -6,8 +6,12 @@ the announcement, DTMF, and echo-test surface added for MMTEL / TAS-style script
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from siphon_sdk.call import Call
+from siphon_sdk.request import Request
 from siphon_sdk.testing import SipTestHarness
 
 
@@ -259,3 +263,107 @@ def route(request):
 """
         )
         assert harness.rtpengine.fire_media_timeout("abc", "ftag1") == 0
+
+
+class TestAnswerLocal:
+    def test_success_returns_answer_sdp(self, harness):
+        call = Call()
+        sdp = asyncio.run(harness.rtpengine.answer_local(call))
+        assert sdp == "v=0\r\nm=audio 40000 RTP/AVP 8 101\r\n"
+        # No prior offer → default profile.
+        assert ("answer_local", "rtp_passthrough") in harness.rtpengine.operations
+
+    def test_configured_answer_sdp(self, harness):
+        harness.rtpengine.set_answer_local_sdp("v=0\r\nm=audio 5004 RTP/AVP 0\r\n")
+        sdp = asyncio.run(harness.rtpengine.answer_local(Call()))
+        assert sdp == "v=0\r\nm=audio 5004 RTP/AVP 0\r\n"
+
+    def test_profile_recovered_from_offer(self, harness):
+        call = Call()
+        asyncio.run(harness.rtpengine.offer(call, profile="ivr"))
+        asyncio.run(harness.rtpengine.answer_local(call))
+        assert ("answer_local", "ivr") in harness.rtpengine.operations
+
+    def test_explicit_profile_wins(self, harness):
+        call = Call()
+        asyncio.run(harness.rtpengine.offer(call, profile="ivr"))
+        asyncio.run(harness.rtpengine.answer_local(call, profile="rtp_passthrough"))
+        assert ("answer_local", "rtp_passthrough") in harness.rtpengine.operations
+
+    def test_no_codec_auto_reject_sets_488_and_returns_none(self, harness):
+        call = Call()
+        harness.rtpengine.set_answer_local_no_codec()
+        result = asyncio.run(harness.rtpengine.answer_local(call))
+        assert result is None
+        action = call._actions[-1]
+        assert action.kind == "reject"
+        assert action.status_code == 488
+        assert action.reason == "Not Acceptable Here"
+        assert call.state == "terminated"
+
+    def test_no_codec_auto_reject_false_raises_value_error(self, harness):
+        harness.rtpengine.set_answer_local_no_codec()
+        with pytest.raises(ValueError, match="no encodable codec"):
+            asyncio.run(harness.rtpengine.answer_local(Call(), auto_reject=False))
+
+    def test_no_codec_non_call_target_raises_value_error(self, harness):
+        # A Request has no reject channel, so even auto_reject=True raises.
+        harness.rtpengine.set_answer_local_no_codec()
+        with pytest.raises(ValueError, match="no encodable codec"):
+            asyncio.run(harness.rtpengine.answer_local(Request(method="INVITE")))
+
+    def test_driven_from_on_invite_handler(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    sdp = await rtpengine.answer_local(call, profile="ivr")
+    if sdp is not None:
+        call.answer(200, "OK", body=sdp, content_type="application/sdp")
+"""
+        )
+        result = harness.send_invite(
+            ruri="sip:echo@example.com", from_uri="sip:alice@example.com"
+        )
+        assert result.action == "answer"
+        assert result.call.state == "answered"
+        assert ("answer_local", "ivr") in harness.rtpengine.operations
+
+
+class TestMediaTargetForms:
+    """Media verbs accept a SIP object, a (call_id, from_tag) pair, or a bare
+    call_id string — all resolving to the same recorded (call_id, from_tag)."""
+
+    def test_play_media_target_forms_resolve_equivalently(self, harness):
+        request = Request(method="INVITE", call_id="call-1", from_tag="ftag-1")
+        asyncio.run(harness.rtpengine.play_media(request, file="/a.wav"))
+        asyncio.run(harness.rtpengine.play_media(("call-1", "ftag-1"), file="/a.wav"))
+        asyncio.run(harness.rtpengine.play_media("call-1", file="/a.wav"))
+
+        calls = harness.rtpengine.media_calls
+        assert calls[0]["call_id"] == "call-1" and calls[0]["from_tag"] == "ftag-1"
+        assert calls[1]["call_id"] == "call-1" and calls[1]["from_tag"] == "ftag-1"
+        # Bare string → best-effort, empty from_tag.
+        assert calls[2]["call_id"] == "call-1" and calls[2]["from_tag"] == ""
+
+    def test_echo_target_forms_resolve_equivalently(self, harness):
+        request = Request(method="INVITE", call_id="call-9", from_tag="ftag-9")
+        asyncio.run(harness.rtpengine.echo(request))
+        asyncio.run(harness.rtpengine.echo(("call-9", "ftag-9")))
+        asyncio.run(harness.rtpengine.echo("call-9"))
+
+        calls = [c for c in harness.rtpengine.media_calls if c["op"] == "echo"]
+        assert calls[0]["call_id"] == "call-9" and calls[0]["from_tag"] == "ftag-9"
+        assert calls[1]["call_id"] == "call-9" and calls[1]["from_tag"] == "ftag-9"
+        assert calls[2]["call_id"] == "call-9" and calls[2]["from_tag"] == ""
+
+    def test_dtmf_from_on_dtmf_handler_shape(self, harness):
+        # The @rtpengine.on_dtmf payload is (call_id, from_tag) strings; feeding
+        # a bare call_id / pair straight into a media verb must work.
+        asyncio.run(harness.rtpengine.play_dtmf(("call-7", "ftag-7"), "1"))
+        call = harness.rtpengine.media_calls[-1]
+        assert call["op"] == "play_dtmf"
+        assert call["call_id"] == "call-7"
+        assert call["from_tag"] == "ftag-7"

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -220,6 +220,28 @@ impl MediaBackend {
         }
     }
 
+    /// Single-leg UAS answer — synthesise an RFC 3264 answer for the offerer's
+    /// SDP with the media engine as the far side (IVR / echo / announcement).
+    /// Returns the answer SDP.  Native `siphon-rtp` backend only: rtpengine and
+    /// rtpproxy have no answer-local verb, so those backends reject rather than
+    /// silently no-op.
+    pub async fn answer_local(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        offer_sdp: &str,
+        flags: &NgFlags,
+    ) -> Result<String, RtpEngineError> {
+        match self {
+            Self::SiphonRtp(client) => {
+                client.answer_local(call_id, from_tag, offer_sdp, flags).await
+            }
+            Self::RtpEngine(_) | Self::RtpProxy(_) => Err(RtpEngineError::Protocol(
+                "answer_local is only supported by the native siphon-rtp backend".to_string(),
+            )),
+        }
+    }
+
     /// Drop the selected monologue's outgoing packets entirely.
     pub async fn block_media(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
         match self {
@@ -407,6 +429,52 @@ mod tests {
         let backend = MediaBackend::RtpEngine(Arc::new(set));
 
         let error = backend.echo("call-1", "tag-a", true).await.unwrap_err();
+        assert!(matches!(error, RtpEngineError::Protocol(_)));
+        assert!(error.to_string().contains("siphon-rtp"));
+    }
+
+    #[tokio::test]
+    async fn answer_local_routes_to_siphon_rtp_backend() {
+        // Reaching the native client is proven by a Timeout (the command was
+        // framed and sent, then no response arrived) — the reject arms below
+        // return synchronously and never time out.
+        let (event_tx, _event_rx) = mpsc::channel::<RtpEngineEvent>(16);
+        let set =
+            SiphonRtpClientSet::new(vec![(dead_address(), 200, 1)], None, 5_000, event_tx).unwrap();
+        let backend = MediaBackend::SiphonRtp(set);
+
+        let error = backend
+            .answer_local("call-1", "tag-a", "v=0\r\n", &NgFlags::default())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, RtpEngineError::Timeout { .. }),
+            "expected the native client path (Timeout), got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn answer_local_rejected_on_rtpproxy_backend() {
+        let set = RtpProxyClientSet::new(vec![(dead_address(), 200, 1)], 0).await.unwrap();
+        let backend = MediaBackend::RtpProxy(set);
+
+        let error = backend
+            .answer_local("call-1", "tag-a", "v=0\r\n", &NgFlags::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RtpEngineError::Protocol(_)));
+        assert!(error.to_string().contains("siphon-rtp"));
+    }
+
+    #[tokio::test]
+    async fn answer_local_rejected_on_rtpengine_backend() {
+        let set = RtpEngineSet::new(vec![(dead_address(), 200, 1)]).await.unwrap();
+        let backend = MediaBackend::RtpEngine(Arc::new(set));
+
+        let error = backend
+            .answer_local("call-1", "tag-a", "v=0\r\n", &NgFlags::default())
+            .await
+            .unwrap_err();
         assert!(matches!(error, RtpEngineError::Protocol(_)));
         assert!(error.to_string().contains("siphon-rtp"));
     }

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -285,6 +285,36 @@ impl SiphonRtpClient {
         expect_sdp(result)
     }
 
+    /// Single-leg UAS `answer_local` — the engine *is* the far side (IVR /
+    /// echo / announcement), so there is no peer `to_tag`.  Given the offerer's
+    /// SDP, the engine synthesises an RFC 3264 answer advertising one encodable
+    /// codec and returns it.  When no offered codec is encodable in this build
+    /// the engine replies `CmdResult::Error { reason: "no-encodable-codec" }`,
+    /// surfaced here as [`RtpEngineError::EngineError`] carrying that reason.
+    ///
+    /// Bookkeeping mirrors [`Self::offer`]: a single-leg answer establishes a
+    /// session, so the call-id is tracked for active-session accounting and a
+    /// later `delete`.
+    pub async fn answer_local(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        offer_sdp: &str,
+        flags: &NgFlags,
+    ) -> Result<String, RtpEngineError> {
+        let result = self
+            .request(Command::AnswerLocal {
+                call_id: call_id.to_string(),
+                from_tag: from_tag.to_string(),
+                sdp: offer_sdp.to_string(),
+                profile: profile_flags_from_ng(flags),
+            })
+            .await?;
+        let answer_sdp = expect_sdp(result)?;
+        self.sessions.insert(call_id.to_string(), ());
+        Ok(String::from_utf8_lossy(&answer_sdp).into_owned())
+    }
+
     /// Send a `delete` to tear down a session and drop its active-session entry.
     pub async fn delete(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
         let result = self
@@ -738,6 +768,23 @@ impl SiphonRtpClientSet {
         self.select(call_id)
             .answer(call_id, from_tag, to_tag, sdp, flags)
             .await
+    }
+
+    /// Single-leg UAS `answer_local` via the affinity-bound instance, binding
+    /// call-id affinity (it establishes a session, like `offer`).
+    pub async fn answer_local(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        offer_sdp: &str,
+        flags: &NgFlags,
+    ) -> Result<String, RtpEngineError> {
+        let result = self
+            .select(call_id)
+            .answer_local(call_id, from_tag, offer_sdp, flags)
+            .await?;
+        self.bind_affinity(call_id);
+        Ok(result)
     }
 
     /// Send a `delete` and drop affinity.
@@ -1890,6 +1937,97 @@ mod tests {
         let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         client.echo("call-echo", "tag-a", true).await.unwrap();
         client.echo("call-echo", "tag-a", false).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn answer_local_returns_answer_sdp_and_records_session() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = Vec::new();
+            let request: Request = read_frame(&mut stream, &mut buffer).await;
+            match request.command {
+                Command::AnswerLocal {
+                    call_id,
+                    from_tag,
+                    profile,
+                    ..
+                } => {
+                    assert_eq!(call_id, "call-al");
+                    assert_eq!(from_tag, "tag-a");
+                    assert_eq!(profile.transport_protocol.as_deref(), Some("RTP/AVP"));
+                }
+                other => panic!("expected AnswerLocal, got {other:?}"),
+            }
+            write_frame(
+                &mut stream,
+                &Response {
+                    id: request.id,
+                    result: CmdResult::Ok {
+                        sdp: Some("v=0\r\nm=audio 40000 RTP/AVP 8 101\r\n".into()),
+                        duration_ms: None,
+                        to_tag: None,
+                        stats: None,
+                        play_id: None,
+                    },
+                },
+            )
+            .await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
+        let flags = NgFlags {
+            transport_protocol: Some("RTP/AVP".into()),
+            ..NgFlags::default()
+        };
+        let sdp = client
+            .answer_local("call-al", "tag-a", "v=0\r\n", &flags)
+            .await
+            .unwrap();
+        assert!(sdp.contains("m=audio"));
+        // Mirrors offer's bookkeeping: a single-leg answer establishes a session.
+        assert_eq!(client.active_sessions(), 1);
+    }
+
+    #[tokio::test]
+    async fn answer_local_no_encodable_codec_maps_to_engine_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = Vec::new();
+            let request: Request = read_frame(&mut stream, &mut buffer).await;
+            assert!(matches!(request.command, Command::AnswerLocal { .. }));
+            write_frame(
+                &mut stream,
+                &Response {
+                    id: request.id,
+                    result: CmdResult::Error {
+                        reason: "no-encodable-codec".into(),
+                    },
+                },
+            )
+            .await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
+        let error = client
+            .answer_local("call-al", "tag-a", "v=0\r\n", &NgFlags::default())
+            .await
+            .unwrap_err();
+        match error {
+            RtpEngineError::EngineError(reason) => assert_eq!(reason, "no-encodable-codec"),
+            other => panic!("expected EngineError(no-encodable-codec), got {other:?}"),
+        }
+        // No session recorded on failure — the SDP arm never runs.
+        assert_eq!(client.active_sessions(), 0);
     }
 
     #[tokio::test]

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -314,6 +314,18 @@ impl PyCall {
         &self.action
     }
 
+    /// Set a deferred reject action on this call — the same effect as the
+    /// Python-level `call.reject(code, reason)`, exposed so the media namespace
+    /// can apply an auto-488 after its async engine round-trip (see
+    /// `rtpengine.answer_local(auto_reject=True)`).  The dispatcher applies the
+    /// deferred [`CallAction::Reject`] when the `on_invite` handler returns.
+    pub fn set_reject(&mut self, code: u16, reason: impl Into<String>) {
+        self.action = CallAction::Reject {
+            code,
+            reason: reason.into(),
+        };
+    }
+
     /// Get the media handle (for the B2BUA core to check after script runs).
     pub fn media_handle(&self) -> &PyMediaHandle {
         &self.media_handle
@@ -1448,6 +1460,22 @@ mod tests {
             &CallAction::Reject {
                 code: 404,
                 reason: "Not Found".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn call_set_reject_sets_reject_action() {
+        // The Rust-side setter used by rtpengine.answer_local(auto_reject=True)
+        // records the same deferred CallAction::Reject as call.reject().
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.set_reject(488, "Not Acceptable Here");
+        assert_eq!(
+            call.action(),
+            &CallAction::Reject {
+                code: 488,
+                reason: "Not Acceptable Here".to_string()
             }
         );
     }

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -18,6 +18,7 @@ use tracing::{debug, warn};
 use crate::rtpengine::client::PlayMediaSource;
 use crate::rtpengine::profile::ProfileRegistry;
 use crate::rtpengine::MediaBackend;
+use crate::rtpengine::RtpEngineError;
 use crate::rtpengine::session::{MediaSession, MediaSessionStore};
 use crate::sip::message::SipMessage;
 
@@ -51,8 +52,7 @@ impl PyRtpEngine {
         target: &Bound<'py, PyAny>,
         method: &'static str,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let message = extract_message(target)?;
-        let (call_id, from_tag) = extract_delete_params(&message)?;
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
         let client = Arc::clone(&self.client);
 
         pyo3_async_runtimes::tokio::future_into_py(python, async move {
@@ -145,6 +145,52 @@ fn resolve_answer_profile(
     DEFAULT_PROFILE.to_string()
 }
 
+/// The engine's exact `CmdResult::Error` reason when the offer carries no codec
+/// this build can encode (RFC 3264 §6.1) — the signal to render a 488.
+const NO_ENCODABLE_CODEC: &str = "no-encodable-codec";
+
+/// What `answer_local` should do with the backend's [`answer_local`] result,
+/// factored out of the async closure so the mapping is unit-testable without
+/// driving the `future_into_py` awaitable.
+///
+/// [`answer_local`]: MediaBackend::answer_local
+#[derive(Debug, PartialEq, Eq)]
+enum AnswerLocalOutcome {
+    /// Engine synthesised an answer — record the session, resolve to the SDP.
+    Answered(String),
+    /// No encodable codec and the caller opted into auto-reject on a `Call` —
+    /// set a deferred 488 on the call and resolve to `None`.
+    Reject488,
+    /// No encodable codec but no auto-reject target — raise `ValueError`.
+    ValueError,
+    /// Transport / protocol / other engine error — raise `RuntimeError`.
+    RuntimeError(String),
+}
+
+/// Map an `answer_local` backend result to the Python-visible outcome.
+///
+/// `can_reject` is `true` only when the script asked for `auto_reject` *and*
+/// the target was a `Call` (the auto-488 path is defined for the B2BUA call
+/// object — a bare `Request` has no deferred-reject channel).
+fn classify_answer_local(
+    result: Result<String, RtpEngineError>,
+    can_reject: bool,
+) -> AnswerLocalOutcome {
+    match result {
+        Ok(answer_sdp) => AnswerLocalOutcome::Answered(answer_sdp),
+        Err(RtpEngineError::EngineError(reason)) if reason == NO_ENCODABLE_CODEC => {
+            if can_reject {
+                AnswerLocalOutcome::Reject488
+            } else {
+                AnswerLocalOutcome::ValueError
+            }
+        }
+        Err(error) => {
+            AnswerLocalOutcome::RuntimeError(format!("rtpengine.answer_local failed: {error}"))
+        }
+    }
+}
+
 /// Extract `Arc<Mutex<SipMessage>>` from a Python object that is either
 /// a `Request`, `Reply`, or `Call`.
 pub(super) fn extract_message(object: &Bound<'_, PyAny>) -> PyResult<Arc<Mutex<SipMessage>>> {
@@ -162,6 +208,44 @@ pub(super) fn extract_message(object: &Bound<'_, PyAny>) -> PyResult<Arc<Mutex<S
     }
     Err(pyo3::exceptions::PyTypeError::new_err(
         "expected a Request, Reply, or Call object",
+    ))
+}
+
+/// Resolve `(call_id, from_tag)` from a media-verb target.
+///
+/// Accepts three forms so the same verbs work whether the script holds a SIP
+/// object or only the identifiers an event delivered:
+///   * a `Request` / `Reply` / `Call` → today's `extract_message` +
+///     `extract_delete_params` path (behaviour preserved exactly);
+///   * a `(call_id, from_tag)` pair of strings;
+///   * a bare `call_id` string → best-effort with an empty `from_tag`.
+///
+/// The pair / bare-string forms are what let an `@rtpengine.on_dtmf` handler —
+/// which receives `call_id` / `from_tag` strings, not a SIP message — drive
+/// `play_media` / `echo` / `stop_media` / DTMF / gating directly.
+fn resolve_call_from_tag(target: &Bound<'_, PyAny>) -> PyResult<(String, String)> {
+    // SIP object → the exact path the verbs used before (Call-ID + From-tag off
+    // the message), so Request/Reply/Call callers are byte-for-byte unchanged.
+    if target.cast::<PyRequest>().is_ok()
+        || target.cast::<PyReply>().is_ok()
+        || target.cast::<PyCall>().is_ok()
+    {
+        let message = extract_message(target)?;
+        return extract_delete_params(&message);
+    }
+    // Bare `call_id` string → empty from_tag. Checked before the pair form
+    // because a Python `str` is itself a 2-sequence of 1-char strings, so a
+    // `(String, String)` extraction would misread a 2-char id as a pair.
+    if let Ok(call_id) = target.extract::<String>() {
+        return Ok((call_id, String::new()));
+    }
+    // `(call_id, from_tag)` pair of strings.
+    if let Ok((call_id, from_tag)) = target.extract::<(String, String)>() {
+        return Ok((call_id, from_tag));
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "rtpengine media verb target must be a Request/Reply/Call, a \
+         (call_id, from_tag) tuple, or a call_id string",
     ))
 }
 
@@ -321,6 +405,127 @@ impl PyRtpEngine {
         })
     }
 
+    /// Single-leg UAS answer — synthesise an RFC 3264 answer for the caller's
+    /// **own** offer, with the media engine as the far side (IVR / echo /
+    /// announcement server).  Unlike :meth:`answer`, this takes the offer
+    /// (INVITE) — not a peer's reply — because there is no far leg: the engine
+    /// picks one encodable codec from the offer and returns the answer SDP for
+    /// the script to put in its own 2xx.
+    ///
+    /// Profile precedence matches :meth:`answer`:
+    ///   1. Explicit ``profile=`` argument (script override).
+    ///   2. Profile recorded by a matching ``offer`` (looked up by Call-ID).
+    ///   3. ``DEFAULT_PROFILE`` (``rtp_passthrough``).
+    ///
+    /// When the offer carries no codec this build can encode (RFC 3264 §6.1 —
+    /// the answer must select from the offered formats), the engine cannot
+    /// answer.  With ``auto_reject=True`` (default) and a ``Call`` target, a
+    /// deferred ``488 Not Acceptable Here`` (RFC 3261 §13.3.1.2) is set on the
+    /// call and the coroutine resolves to ``None``.  With ``auto_reject=False``
+    /// (or a non-``Call`` target) it raises ``ValueError`` instead, leaving the
+    /// response to the script.
+    ///
+    /// Native ``siphon-rtp`` backend only; rtpengine and rtpproxy reject.
+    ///
+    /// Args:
+    ///     call: A ``Call`` (B2BUA) — or ``Request`` — carrying the INVITE offer
+    ///           whose Call-ID / From-tag / SDP drive the single-leg answer.
+    ///     profile: RTP profile name.  When omitted, the profile recorded by a
+    ///              matching offer is used; falls back to ``"rtp_passthrough"``.
+    ///     auto_reject: When ``True`` (default) and ``call`` is a ``Call``, a
+    ///                  no-encodable-codec engine result sets a deferred
+    ///                  ``488 Not Acceptable Here`` on the call and returns
+    ///                  ``None``.  When ``False`` it raises ``ValueError``.
+    ///
+    /// Returns:
+    ///     The answer SDP as ``str`` on success, or ``None`` when the offer had
+    ///     no encodable codec and it was auto-rejected with a 488.
+    #[pyo3(signature = (call, profile=None, auto_reject=true))]
+    fn answer_local<'py>(
+        &self,
+        python: Python<'py>,
+        call: &Bound<'py, PyAny>,
+        profile: Option<&str>,
+        auto_reject: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let message = extract_message(call)?;
+        let (call_id, from_tag, offer_sdp_bytes) = extract_offer_params(&message)?;
+        let offer_sdp = String::from_utf8_lossy(&offer_sdp_bytes).into_owned();
+
+        // Resolve the answer-side flags exactly as `answer` does (explicit
+        // profile → offer-recorded profile → default).
+        let profile_name = resolve_answer_profile(profile, &self.sessions, &call_id);
+        let entry = self.registry.get(&profile_name).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "unknown RTP profile '{profile_name}'; valid profiles: {}",
+                self.registry.profile_names().join(", ")
+            ))
+        })?;
+        let flags = entry.answer.clone();
+
+        // Capture an owned handle to the Call for the auto-488 path, cloned
+        // while the GIL is held (free-threaded `Py::clone` rule).  `None` when
+        // auto_reject is off or the target isn't a `Call` (a bare `Request` has
+        // no deferred-reject channel).  `extract_message` above already released
+        // its transient borrow of the object, so borrowing this handle later in
+        // the async block cannot alias.
+        let reject_call: Option<Py<PyCall>> = if auto_reject {
+            call.cast::<PyCall>().ok().map(|bound| bound.clone().unbind())
+        } else {
+            None
+        };
+
+        let client = Arc::clone(&self.client);
+        let sessions = Arc::clone(&self.sessions);
+        let profile_str = profile_name.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(python, async move {
+            let result = client
+                .answer_local(&call_id, &from_tag, &offer_sdp, &flags)
+                .await;
+            match classify_answer_local(result, reject_call.is_some()) {
+                AnswerLocalOutcome::Answered(answer_sdp) => {
+                    debug!(
+                        call_id = %call_id,
+                        sdp_len = answer_sdp.len(),
+                        "rtpengine.answer_local: answer SDP synthesised"
+                    );
+                    // Record the session exactly as `offer` does, so `delete`,
+                    // active-session accounting, and a later `rtpengine.answer`
+                    // profile-reuse all work.
+                    sessions.insert(MediaSession {
+                        call_id,
+                        from_tag,
+                        to_tag: None,
+                        profile: profile_str,
+                        created_at: std::time::Instant::now(),
+                    });
+                    Ok(Some(answer_sdp))
+                }
+                AnswerLocalOutcome::Reject488 => {
+                    // reject_call is Some here (can_reject implied it).
+                    if let Some(reject_call) = reject_call {
+                        Python::attach(|py| {
+                            let mut call_ref = reject_call.bind(py).borrow_mut();
+                            call_ref.set_reject(488, "Not Acceptable Here");
+                        });
+                    }
+                    debug!(
+                        call_id = %call_id,
+                        "rtpengine.answer_local: no encodable codec, deferred 488 Not Acceptable Here"
+                    );
+                    Ok(None)
+                }
+                AnswerLocalOutcome::ValueError => Err(pyo3::exceptions::PyValueError::new_err(
+                    "no encodable codec in offer",
+                )),
+                AnswerLocalOutcome::RuntimeError(message) => {
+                    Err(pyo3::exceptions::PyRuntimeError::new_err(message))
+                }
+            }
+        })
+    }
+
     /// Send an RTPEngine `delete` command to tear down the media session.
     ///
     /// Args:
@@ -422,8 +627,7 @@ impl PyRtpEngine {
     ) -> PyResult<Bound<'py, PyAny>> {
         let source = resolve_play_media_source(file, blob, db_id)?;
 
-        let message = extract_message(target)?;
-        let (call_id, from_tag) = extract_delete_params(&message)?;
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
 
         let client = Arc::clone(&self.client);
 
@@ -458,8 +662,7 @@ impl PyRtpEngine {
         python: Python<'py>,
         target: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let message = extract_message(target)?;
-        let (call_id, from_tag) = extract_delete_params(&message)?;
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
 
         let client = Arc::clone(&self.client);
 
@@ -495,8 +698,7 @@ impl PyRtpEngine {
         pause_ms: Option<u64>,
         to_tag: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let message = extract_message(target)?;
-        let (call_id, from_tag) = extract_delete_params(&message)?;
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
 
         let client = Arc::clone(&self.client);
 
@@ -582,8 +784,7 @@ impl PyRtpEngine {
         target: &Bound<'py, PyAny>,
         enabled: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let message = extract_message(target)?;
-        let (call_id, from_tag) = extract_delete_params(&message)?;
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
         let client = Arc::clone(&self.client);
 
         pyo3_async_runtimes::tokio::future_into_py(python, async move {
@@ -1310,5 +1511,100 @@ mod tests {
         let store = MediaSessionStore::new();
         let chosen = resolve_answer_profile(Some("rtp_passthrough"), &store, "no-such-call");
         assert_eq!(chosen, "rtp_passthrough");
+    }
+
+    // -- answer_local outcome classification ---------------------------------
+
+    #[test]
+    fn classify_answer_local_ok_answers() {
+        let outcome = classify_answer_local(Ok("v=0\r\nm=audio 40000 RTP/AVP 8\r\n".to_string()), true);
+        assert_eq!(
+            outcome,
+            AnswerLocalOutcome::Answered("v=0\r\nm=audio 40000 RTP/AVP 8\r\n".to_string())
+        );
+    }
+
+    #[test]
+    fn classify_answer_local_no_codec_with_call_rejects() {
+        let outcome = classify_answer_local(
+            Err(RtpEngineError::EngineError("no-encodable-codec".to_string())),
+            true,
+        );
+        assert_eq!(outcome, AnswerLocalOutcome::Reject488);
+    }
+
+    #[test]
+    fn classify_answer_local_no_codec_without_call_value_error() {
+        let outcome = classify_answer_local(
+            Err(RtpEngineError::EngineError("no-encodable-codec".to_string())),
+            false,
+        );
+        assert_eq!(outcome, AnswerLocalOutcome::ValueError);
+    }
+
+    #[test]
+    fn classify_answer_local_transport_error_is_runtime() {
+        let outcome =
+            classify_answer_local(Err(RtpEngineError::Timeout { timeout_ms: 2000 }), true);
+        match outcome {
+            AnswerLocalOutcome::RuntimeError(message) => {
+                assert!(message.contains("rtpengine.answer_local failed"));
+            }
+            other => panic!("expected RuntimeError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_answer_local_other_engine_error_is_runtime_not_reject() {
+        // A non-"no-encodable-codec" engine error is a runtime error even when a
+        // reject target is available — the auto-488 is codec-specific.
+        let outcome = classify_answer_local(
+            Err(RtpEngineError::EngineError("no such call".to_string())),
+            true,
+        );
+        assert!(matches!(outcome, AnswerLocalOutcome::RuntimeError(_)));
+    }
+
+    // -- resolve_call_from_tag: object / tuple / bare-str target forms -------
+
+    #[test]
+    fn resolve_call_from_tag_accepts_object_tuple_and_str() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            // (1) SIP object: a Call wrapping an INVITE with Call-ID + From tag.
+            let mut message = test_message(Some("application/sdp"), b"v=0\r\n");
+            message.headers.set("Call-ID", "call-xyz".to_string());
+            message
+                .headers
+                .set("From", "<sip:alice@atlanta.com>;tag=ftag-1".to_string());
+            let call = PyCall::new(
+                "id-1".to_string(),
+                Arc::new(Mutex::new(message)),
+                "10.0.0.1".to_string(),
+                "udp".to_string(),
+            );
+            let py_call = Py::new(py, call).unwrap();
+            let bound_call = py_call.bind(py).clone().into_any();
+            let (call_id, from_tag) = resolve_call_from_tag(&bound_call).unwrap();
+            assert_eq!(call_id, "call-xyz");
+            assert_eq!(from_tag, "ftag-1");
+
+            // (2) (call_id, from_tag) pair — the @rtpengine.on_dtmf shape.
+            let tuple = pyo3::types::PyTuple::new(py, ["call-xyz", "ftag-1"]).unwrap();
+            let (call_id, from_tag) = resolve_call_from_tag(tuple.as_any()).unwrap();
+            assert_eq!(call_id, "call-xyz");
+            assert_eq!(from_tag, "ftag-1");
+
+            // (3) bare call_id str → empty from_tag (best-effort).
+            let string = pyo3::types::PyString::new(py, "call-xyz");
+            let (call_id, from_tag) = resolve_call_from_tag(string.as_any()).unwrap();
+            assert_eq!(call_id, "call-xyz");
+            assert_eq!(from_tag, "");
+
+            // (4) unsupported type → TypeError.
+            let number = 42i64.into_pyobject(py).unwrap();
+            let error = resolve_call_from_tag(number.as_any()).unwrap_err();
+            assert!(error.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
+        });
     }
 }


### PR DESCRIPTION
## What

Adds `rtpengine.answer_local(call, profile=None, auto_reject=True)` and lets the media verbs be driven by raw ids from an event context. Closes two gaps a single-leg UAS (IVR / echo / announcement, where siphon terminates the call itself) hit today.

### Gap 1 — the 200 OK carried the offer, not an answer

The single-leg path answered with the rewritten *offer* SDP (`rtpengine.offer(...)` then `call.answer(200, body=call.body)`). That is offer-shaped — it lists every codec, in caller order. A caller offering one codec looks fine by luck; a real VoLTE handset offering AMR-WB/AMR/PCMU/telephone-event gets a 200 OK listing all of them, which is not a valid RFC 3264 answer, and the transcoder (which engages at answer) never engages.

`answer_local` asks the native siphon-rtp engine (new `AnswerLocal` verb, `siphon-rtp-proto` 0.1.3) to synthesise a real RFC 3264 answer: engine media address, exactly one negotiated audio codec picked from the offer honouring the profile's codec policy and constrained to a codec the engine can *encode*, plus the telephone-event PT, engaging the transcoder now. It returns the answer SDP to put in the 200.

When no offered codec is encodable, `answer_local` auto-sends `488 Not Acceptable Here` on the call's UAS transaction (RFC 3261 §13.3.1.2 / RFC 3264) and returns `None`, so a script cannot forget to answer the request. `auto_reject=False` raises `ValueError` instead for scripts that want a custom code or a fallback.

### Gap 2 — event handlers could not drive media

Every media verb resolved its target through `extract_message()`, which accepts only a `Request`/`Reply`/`Call` object. But `@rtpengine.on_dtmf` delivers `call_id`/`from_tag` as strings — no message object — so the media verbs were uncallable from the event that needs them (e.g. stop echo → play a goodbye → hang up on `#`).

`play_media`, `echo`, `stop_media`, `play_dtmf`, and the silence/block family now also accept a `(call_id, from_tag)` tuple or a bare `call_id` string:

```python
@rtpengine.on_dtmf
async def on_dtmf(call_id, from_tag, digit, *_):
    if digit == "#":
        await rtpengine.echo((call_id, from_tag), enabled=False)
        await rtpengine.play_media((call_id, from_tag), file=GOODBYE)  # wait=True
        b2bua.terminate(call_id)
```

## Changes

- `src/rtpengine/siphon_rtp.rs` — `SiphonRtpClient::answer_local` (sends `Command::AnswerLocal`, returns the answer SDP, records the session like `offer`).
- `src/rtpengine/backend.rs` — `MediaBackend::answer_local`; native siphon-rtp only, rtpengine/rtpproxy reject it (no single-leg-answer verb).
- `src/script/api/rtpengine.rs` — `answer_local` pymethod (auto-488) + `resolve_call_from_tag` swapped into the message-target media verbs.
- `src/script/api/call.rs` — `set_reject` (deferred 488, same effect as the `reject` pymethod).
- `sdk/` — `MockRtpEngine.answer_local` + tuple/bare-id targets on the mock verbs, docstrings, tests.
- `Cargo.toml` — `siphon-rtp-proto` 0.1.2 → 0.1.3.

## Testing

- `PYO3_PYTHON=python3 cargo test` — green (the single intermittent `pool_drains_asyncio_tasks_after_batch` is the known async-pool isolation flake; passes in isolation and on re-run).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cd sdk && python -m pytest tests/` — green (414 passed), including the auto-488 driven-from-`on_invite` behavioral test.

Codec selection, the one-codec answer SDP, transcoder engagement, and the no-encodable-codec rejection are validated engine-side in siphon-rtp (`answer_local` handler + `answer_codec_candidates`).
