### PR TITLE
fix(parser): accept RFC 3261 §7.3.3 compact header forms on every lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   unaffected; there is no separate `answer_now()`.
 
 ### Fixed
-- **UAS-mode `call.answer()` now emits a To-tag** (RFC 3261 §12.1.1). A B2BUA
+- **Compact SIP header forms (RFC 3261 §7.3.3) are now recognized on every
+  lookup, not just a few.** Header names are matched by their canonical form, so
+  the single-letter compact forms (`v`→Via, `f`→From, `t`→To, `i`→Call-ID,
+  `m`→Contact, `c`→Content-Type, `e`→Content-Encoding, `l`→Content-Length,
+  `s`→Subject, `k`→Supported, plus the extension forms `o`/`r`/`u`/`x`/`y`/`b`/
+  `a`/`d`/`j`) resolve to the same header as their long name throughout the
+  stack. Previously only a handful of typed accessors expanded the compact form,
+  while the transaction and response-routing layers looked up `Via` literally —
+  so a response arriving with a compact `v:` (some registrars/PBXes send all
+  headers compact) was dropped with "response has no Via header", stranding the
+  transaction and leaving the peer to retransmit its request until it timed out
+  (seen against an upstream registrar answering REGISTER `401` with compact
+  headers). The on-the-wire header name is preserved verbatim on forwarding
+  (compact stays compact); canonicalization affects lookup only.
   script that answers an INVITE directly (`call.answer(200, ...)` — MRF /
   announcement / echo / IVR) previously sent a 2xx whose To header was copied
   verbatim from the tagless INVITE, so the caller's dialog had no remote tag. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   (seen against an upstream registrar answering REGISTER `401` with compact
   headers). The on-the-wire header name is preserved verbatim on forwarding
   (compact stays compact); canonicalization affects lookup only.
+- **Parser no longer panics on a `Content-Length` that points into the middle of
+  a multi-byte UTF-8 body character.** The body was sliced by byte index without
+  a char-boundary check, so a message whose `Content-Length` fell mid-character
+  aborted the parse thread (a DoS on the parse path, found by fuzzing). The
+  parser now degrades to taking the whole remaining input as the body instead of
+  panicking; char-boundary-aligned lengths split exactly as before.
   script that answers an INVITE directly (`call.answer(200, ...)` — MRF /
   announcement / echo / IVR) previously sent a 2xx whose To header was copied
   verbatim from the tagless INVITE, so the caller's dialog had no remote tag. The

--- a/src/sip/codec.rs
+++ b/src/sip/codec.rs
@@ -15,15 +15,10 @@ impl SipMessage {
     /// Multiple Via header lines and comma-separated values within a single
     /// header are both handled. Returns them in order (topmost first).
     pub fn typed_vias(&self) -> Result<Vec<Via>, String> {
+        // `get_all` canonicalizes the compact form (`v`) to `Via`
+        // (RFC 3261 §7.3.3), so one lookup covers both wire forms.
         let mut result = Vec::new();
         if let Some(values) = self.headers.get_all("Via") {
-            for raw in values {
-                let mut vias = Via::parse_multi(raw)?;
-                result.append(&mut vias);
-            }
-        }
-        // Also check compact form "v"
-        if let Some(values) = self.headers.get_all("v") {
             for raw in values {
                 let mut vias = Via::parse_multi(raw)?;
                 result.append(&mut vias);
@@ -34,11 +29,7 @@ impl SipMessage {
 
     /// Parse the From header into a typed [`NameAddr`].
     pub fn typed_from(&self) -> Result<Option<NameAddr>, String> {
-        let raw = self
-            .headers
-            .get("From")
-            .or_else(|| self.headers.get("f"));
-        match raw {
+        match self.headers.get("From") {
             Some(value) => Ok(Some(NameAddr::parse(value)?)),
             None => Ok(None),
         }
@@ -46,11 +37,7 @@ impl SipMessage {
 
     /// Parse the To header into a typed [`NameAddr`].
     pub fn typed_to(&self) -> Result<Option<NameAddr>, String> {
-        let raw = self
-            .headers
-            .get("To")
-            .or_else(|| self.headers.get("t"));
-        match raw {
+        match self.headers.get("To") {
             Some(value) => Ok(Some(NameAddr::parse(value)?)),
             None => Ok(None),
         }
@@ -58,11 +45,7 @@ impl SipMessage {
 
     /// Parse Contact headers into typed [`NameAddr`] values.
     pub fn typed_contacts(&self) -> Result<Vec<NameAddr>, String> {
-        let raw = self
-            .headers
-            .get("Contact")
-            .or_else(|| self.headers.get("m"));
-        match raw {
+        match self.headers.get("Contact") {
             Some(value) => NameAddr::parse_multi(value),
             None => Ok(Vec::new()),
         }
@@ -133,6 +116,47 @@ mod tests {
         assert_eq!(vias[1].host, "proxy.example.com");
         assert_eq!(vias[1].transport, "TCP");
         assert_eq!(vias[1].port, Some(5060));
+    }
+
+    /// Regression: a REGISTER `401` whose headers are all in RFC 3261 §7.3.3
+    /// compact form end-to-end (`v`/`f`/`t`/`i`/`k`/`l`), as some registrars and
+    /// PBXes emit. Before compact-form canonicalization the dispatcher's
+    /// `headers.get("Via")` returned `None` on this shape and the response was
+    /// dropped ("response has no Via header"), leaving the peer retransmitting
+    /// REGISTER forever. Two stacked Vias (comma-separated in one `v:` line)
+    /// exercise the top-branch extraction the client transaction keys on.
+    #[test]
+    fn compact_header_response_routes_by_via() {
+        let raw = "SIP/2.0 401 Unauthorized\r\n\
+                    v:SIP/2.0/UDP proxy.example.com:5060;branch=z9hG4bK-proxytop;received=192.0.2.1;rport=5060,SIP/2.0/UDP ua.example.com:5060;branch=z9hG4bK-uabottom;received=192.0.2.9;rport=21571\r\n\
+                    f:<sip:alice@example.com:5060>\r\n\
+                    t:\"Bob\"<sip:bob@example.com:5060>;tag=uastag123\r\n\
+                    i:call-abc@ua.example.com\r\n\
+                    CSeq:1 REGISTER\r\n\
+                    k:timer,path,replaces\r\n\
+                    WWW-Authenticate:Digest realm=\"example.com\",nonce=\"abc123\",algorithm=MD5,qop=\"auth\"\r\n\
+                    l:0\r\n\
+                    \r\n";
+
+        let (_, message) = parse_sip_message(raw).unwrap();
+
+        // The exact lookup the response-routing path does (dispatcher.rs).
+        assert!(
+            message.headers.get("Via").is_some(),
+            "compact `v:` must be visible as Via",
+        );
+
+        // Both stacked Vias parse; the top branch is what keys the client txn.
+        let vias = message.typed_vias().unwrap();
+        assert_eq!(vias.len(), 2);
+        assert_eq!(vias[0].branch.as_deref(), Some("z9hG4bK-proxytop"));
+
+        // The other compact forms resolve to their long names too.
+        assert_eq!(message.headers.call_id().map(String::as_str), Some("call-abc@ua.example.com"));
+        assert_eq!(message.typed_from().unwrap().unwrap().uri.user.as_deref(), Some("alice"));
+        assert_eq!(message.typed_to().unwrap().unwrap().tag.as_deref(), Some("uastag123"));
+        assert_eq!(message.headers.content_length(), Some(0));
+        assert_eq!(message.headers.get("Supported").map(String::as_str), Some("timer,path,replaces"));
     }
 
     #[test]

--- a/src/sip/headers/mod.rs
+++ b/src/sip/headers/mod.rs
@@ -46,6 +46,56 @@ impl HeadersInner {
     }
 }
 
+/// Canonical lookup key for a header name.
+///
+/// RFC 3261 §7.3.3 defines single-letter *compact forms* that are exactly
+/// equivalent to their long-form field names, and §7.3.1 makes field names
+/// case-insensitive. A message may use either form (or mix them), so the
+/// container must treat `v`/`Via`, `f`/`From`, `i`/`Call-ID`, etc. as the same
+/// header — otherwise a response arriving with `v:` is invisible to
+/// `get("Via")` and the transaction/response-routing layer drops it as
+/// "no Via header".
+///
+/// This maps any name to a single canonical key: ASCII-lowercased, with the
+/// registered compact single-letter forms expanded to their long name. The
+/// on-the-wire name is stored separately and preserved verbatim for
+/// serialization, so canonicalization only affects lookup, never output.
+///
+/// Compact-form set is the IANA "SIP Header Fields" registry (RFC 3261 §20 +
+/// the extension registrations RFC 3515/3841/3892/4028/6665/8224).
+fn canonical_key(name: &str) -> String {
+    // Only a single-character token can be a compact form (§7.3.3); expand it.
+    // Everything else is just lowercased.
+    if name.len() == 1 {
+        let full = match name.as_bytes()[0].to_ascii_lowercase() {
+            b'a' => Some("accept-contact"),   // RFC 3841
+            b'b' => Some("referred-by"),       // RFC 3892
+            b'c' => Some("content-type"),      // RFC 3261
+            b'd' => Some("request-disposition"), // RFC 3841
+            b'e' => Some("content-encoding"),  // RFC 3261
+            b'f' => Some("from"),              // RFC 3261
+            b'i' => Some("call-id"),           // RFC 3261
+            b'j' => Some("reject-contact"),    // RFC 3841
+            b'k' => Some("supported"),         // RFC 3261
+            b'l' => Some("content-length"),    // RFC 3261
+            b'm' => Some("contact"),           // RFC 3261
+            b'o' => Some("event"),             // RFC 6665 (orig RFC 3265)
+            b'r' => Some("refer-to"),          // RFC 3515
+            b's' => Some("subject"),           // RFC 3261
+            b't' => Some("to"),                // RFC 3261
+            b'u' => Some("allow-events"),      // RFC 6665
+            b'v' => Some("via"),               // RFC 3261
+            b'x' => Some("session-expires"),   // RFC 4028
+            b'y' => Some("identity"),          // RFC 8224
+            _ => None,
+        };
+        if let Some(full) = full {
+            return full.to_string();
+        }
+    }
+    name.to_ascii_lowercase()
+}
+
 impl SipHeaders {
     pub fn new() -> Self {
         Self { inner: Arc::new(HeadersInner::new()) }
@@ -55,13 +105,14 @@ impl SipHeaders {
         Arc::make_mut(&mut self.inner)
     }
 
-    // Keys are lowercased ASCII: RFC 3261 §7.3.1 makes field names
-    // case-insensitive tokens, and tokens are ASCII (§25.1), so
-    // `to_ascii_lowercase` is the correct canonical key.
+    // Keys are the canonical form (see `canonical_key`): ASCII-lowercased with
+    // RFC 3261 §7.3.3 compact single-letter forms expanded to their long name,
+    // so `v`/`Via`, `f`/`From`, `i`/`Call-ID`, … resolve to the same entry.
+    // The original on-the-wire name is kept alongside for serialization.
 
     /// Add a header value (appends if header already exists)
     pub fn add(&mut self, name: &str, value: String) {
-        let key = name.to_ascii_lowercase();
+        let key = canonical_key(name);
         let inner = self.make_mut();
         inner
             .headers
@@ -73,7 +124,7 @@ impl SipHeaders {
 
     /// Set a header value (replaces existing, preserves position in header order)
     pub fn set(&mut self, name: &str, value: String) {
-        let key = name.to_ascii_lowercase();
+        let key = canonical_key(name);
         let inner = self.make_mut();
         inner.headers.insert(key, (name.to_string(), vec![value]));
     }
@@ -83,7 +134,7 @@ impl SipHeaders {
     /// Use this when replacing a multi-value header like Via where you need to
     /// keep insertion ordering but supply more than one value.
     pub fn set_all(&mut self, name: &str, values: Vec<String>) {
-        let key = name.to_ascii_lowercase();
+        let key = canonical_key(name);
         let inner = self.make_mut();
         inner.headers.insert(key, (name.to_string(), values));
     }
@@ -92,7 +143,7 @@ impl SipHeaders {
     pub fn get(&self, name: &str) -> Option<&String> {
         self.inner
             .headers
-            .get(&name.to_ascii_lowercase())
+            .get(&canonical_key(name))
             .and_then(|(_, values)| values.first())
     }
 
@@ -100,20 +151,20 @@ impl SipHeaders {
     pub fn get_all(&self, name: &str) -> Option<&Vec<String>> {
         self.inner
             .headers
-            .get(&name.to_ascii_lowercase())
+            .get(&canonical_key(name))
             .map(|(_, values)| values)
     }
 
     /// Remove a header
     pub fn remove(&mut self, name: &str) {
-        let key = name.to_ascii_lowercase();
+        let key = canonical_key(name);
         let inner = self.make_mut();
         inner.headers.shift_remove(&key);
     }
 
     /// Check if header exists
     pub fn has(&self, name: &str) -> bool {
-        self.inner.headers.contains_key(&name.to_ascii_lowercase())
+        self.inner.headers.contains_key(&canonical_key(name))
     }
 
     /// Get all header names (in original case)
@@ -183,6 +234,121 @@ impl SipHeaders {
 impl Default for SipHeaders {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 3261 §7.3.3 — a header stored under its compact form must be
+    /// retrievable by its long name. This is the exact failure behind a
+    /// dropped 401: an upstream registrar answers with `v:` (compact Via)
+    /// and the response-routing layer's `get("Via")` came back `None`.
+    #[test]
+    fn compact_via_found_by_long_name() {
+        let mut headers = SipHeaders::new();
+        headers.add("v", "SIP/2.0/UDP siphon.example:5060;branch=z9hG4bK-abc".to_string());
+        assert_eq!(
+            headers.via().map(String::as_str),
+            Some("SIP/2.0/UDP siphon.example:5060;branch=z9hG4bK-abc"),
+        );
+        assert!(headers.has("Via"));
+        assert!(headers.has("v"));
+    }
+
+    /// All RFC 3261 §20 compact forms resolve to their long name, and the
+    /// reverse (store long, read compact) works too.
+    #[test]
+    fn all_compact_forms_alias_long_names() {
+        let cases = [
+            ("v", "Via"),
+            ("f", "From"),
+            ("t", "To"),
+            ("i", "Call-ID"),
+            ("m", "Contact"),
+            ("c", "Content-Type"),
+            ("e", "Content-Encoding"),
+            ("l", "Content-Length"),
+            ("s", "Subject"),
+            ("k", "Supported"),
+            // Extension compact forms (RFC 3515/3841/3892/4028/6665/8224)
+            ("o", "Event"),
+            ("r", "Refer-To"),
+            ("u", "Allow-Events"),
+            ("x", "Session-Expires"),
+            ("y", "Identity"),
+            ("b", "Referred-By"),
+            ("a", "Accept-Contact"),
+            ("d", "Request-Disposition"),
+            ("j", "Reject-Contact"),
+        ];
+        for (compact, long) in cases {
+            let mut headers = SipHeaders::new();
+            headers.add(compact, "value".to_string());
+            assert_eq!(
+                headers.get(long).map(String::as_str),
+                Some("value"),
+                "compact `{compact}` should be readable as `{long}`",
+            );
+
+            let mut headers = SipHeaders::new();
+            headers.add(long, "value".to_string());
+            assert_eq!(
+                headers.get(compact).map(String::as_str),
+                Some("value"),
+                "long `{long}` should be readable as compact `{compact}`",
+            );
+        }
+    }
+
+    /// The on-the-wire name is preserved: canonicalization is lookup-only.
+    /// A message received with `v:` is forwarded as `v:`, not rewritten.
+    #[test]
+    fn compact_form_preserved_in_names_for_serialization() {
+        let mut headers = SipHeaders::new();
+        headers.add("v", "SIP/2.0/UDP h:5060;branch=z9hG4bK1".to_string());
+        assert_eq!(headers.names(), vec![&"v".to_string()]);
+        let (name, values) = headers.iter_original().next().unwrap();
+        assert_eq!(name, "v");
+        assert_eq!(values, &vec!["SIP/2.0/UDP h:5060;branch=z9hG4bK1".to_string()]);
+    }
+
+    /// Compact and long form of the same header merge into one entry
+    /// (multi-value), not two separate headers.
+    #[test]
+    fn compact_and_long_merge_into_one_entry() {
+        let mut headers = SipHeaders::new();
+        headers.add("Via", "SIP/2.0/UDP first:5060;branch=z9hG4bK1".to_string());
+        headers.add("v", "SIP/2.0/UDP second:5060;branch=z9hG4bK2".to_string());
+        let all = headers.get_all("Via").unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0], "SIP/2.0/UDP first:5060;branch=z9hG4bK1");
+        assert_eq!(all[1], "SIP/2.0/UDP second:5060;branch=z9hG4bK2");
+    }
+
+    /// `set`/`remove` by long name affects a header stored compactly.
+    #[test]
+    fn set_and_remove_cross_form() {
+        let mut headers = SipHeaders::new();
+        headers.add("i", "call-abc@host".to_string());
+        headers.set("Call-ID", "call-xyz@host".to_string());
+        assert_eq!(headers.call_id().map(String::as_str), Some("call-xyz@host"));
+
+        headers.remove("i");
+        assert!(!headers.has("Call-ID"));
+        assert!(headers.call_id().is_none());
+    }
+
+    /// An unknown single-letter header (not a registered compact form) is
+    /// treated as an ordinary header, not silently aliased.
+    #[test]
+    fn unknown_single_letter_is_not_a_compact_form() {
+        let mut headers = SipHeaders::new();
+        headers.add("z", "opaque".to_string());
+        assert_eq!(headers.get("z").map(String::as_str), Some("opaque"));
+        // `z` has no long-form alias, so it stays distinct from any header.
+        assert!(!headers.has("Via"));
     }
 }
 

--- a/src/sip/parser.rs
+++ b/src/sip/parser.rs
@@ -383,7 +383,17 @@ fn parse_body<'a>(input: &'a str, headers: &SipHeaders) -> IResult<&'a str, &'a 
         if content_length == 0 {
             Ok((input, ""))
         } else if input.len() >= content_length {
-            Ok((&input[content_length..], &input[..content_length]))
+            // Content-Length is an octet count (RFC 3261 §20.14). Slice by byte
+            // index, but never split a UTF-8 character: `input.get(..n)` returns
+            // None when `n` is not a char boundary, so a Content-Length that
+            // points into the middle of a multi-byte body character degrades to
+            // "take the whole remaining input as the body" instead of panicking.
+            // (Truly binary bodies should use `parse_sip_message_bytes`, which
+            // slices `&[u8]`.)
+            match (input.get(..content_length), input.get(content_length..)) {
+                (Some(body), Some(rest)) => Ok((rest, body)),
+                _ => Ok(("", input)),
+            }
         } else {
             Ok((input, ""))
         }
@@ -554,6 +564,52 @@ mod tests {
         let input = "sip:0017;phone-context=ims.mnc001.mcc206.3gppnetwork.org@ims.mnc090.mcc208.3gppnetwork.org;user=phone";
         let uri = parse_uri_standalone(input).expect("should parse");
         assert_eq!(uri.to_string(), input);
+    }
+
+    /// Regression (fuzz): a Content-Length that points into the middle of a
+    /// multi-byte UTF-8 body character must not panic the parser. `parse_body`
+    /// slices the `&str` body by byte index; before the `.get()` guard,
+    /// `&input[..n]` panicked with "byte index is not a char boundary".
+    /// Reachable via any Content-Length form — surfaced through the compact
+    /// `l:` once compact forms started being honored.
+    #[test]
+    fn content_length_mid_utf8_char_does_not_panic() {
+        // Body "€" is 3 bytes (0xE2 0x82 0xAC); char boundaries at 0 and 3 only.
+        // Content-Length: 2 lands mid-character.
+        let raw = "SIP/2.0 200 OK\r\n\
+                    Via: SIP/2.0/UDP h:5060;branch=z9hG4bK1\r\n\
+                    l:2\r\n\
+                    \r\n€";
+        let (_, message) = parse_sip_message(raw).expect("must parse without panicking");
+        assert!(matches!(message.start_line, StartLine::Response(_)));
+        // Degrades to taking the whole remaining input as the body.
+        assert_eq!(message.body, "€".as_bytes());
+    }
+
+    /// The exact libFuzzer-minimized crash input for the above panic, replayed
+    /// through the same entry point the fuzz target uses (`parse_sip_message`
+    /// over the UTF-8 view of the bytes). Must not panic.
+    #[test]
+    fn fuzz_crash_content_length_mid_char() {
+        let data: &[u8] = &[
+            83, 73, 80, 47, 48, 46, 48, 32, 48, 32, 18, 0, 9, 9, 9, 13, 10, 108, 58, 55, 32, 13,
+            10, 10, 108, 58, 0, 0, 10, 9, 231, 185, 187, 231, 185, 187, 65, 67, 75, 67, 67, 231,
+            185, 187, 231, 185, 187, 65, 17, 0, 118, 78,
+        ];
+        let input = std::str::from_utf8(data).expect("crash input is valid UTF-8");
+        let _ = parse_sip_message(input); // just must not panic
+    }
+
+    /// A char-boundary-aligned Content-Length still splits exactly as before
+    /// (no behavior change for the common ASCII / aligned case).
+    #[test]
+    fn content_length_aligned_still_splits() {
+        let raw = "SIP/2.0 200 OK\r\n\
+                    Via: SIP/2.0/UDP h:5060;branch=z9hG4bK1\r\n\
+                    Content-Length: 3\r\n\
+                    \r\n€tail";
+        let (_, message) = parse_sip_message(raw).expect("must parse");
+        assert_eq!(message.body, "€".as_bytes());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

SIP peers may send any header in its RFC 3261 §7.3.3 compact single-letter form (`v` Via, `f` From, `t` To, `i` Call-ID, `m` Contact, `l` Content-Length, ...), and some registrars/PBXes send *every* header compact. An RFC-compliant element must accept both forms interchangeably.

Siphon only expanded the compact form in a handful of typed accessors in `sip/codec.rs`. The transaction layer and the dispatcher's response-routing path looked up `Via` literally:

```rust
let top_via = match message.headers.get("Via") {   // "via" — never matches "v"
    None => { warn!("response has no Via header"); return; }   // dropped here
```

So a response arriving with a compact `v:` was invisible to `headers.get("Via")`: the transaction went unmatched, the response was dropped, and the peer retransmitted its request until it timed out. Observed against an upstream registrar answering REGISTER with a `401` whose headers were all compact — the challenge never reached the UA, which retried REGISTER indefinitely.

## Fix

Canonicalize header names centrally in `SipHeaders`. A new `canonical_key()` maps any name to its canonical lookup key: ASCII-lowercased, with the registered compact single-letter forms expanded to their long name (RFC 3261 §20 core forms plus the extension forms from RFC 3515/3841/3892/4028/6665/8224). It is applied in `add`/`set`/`set_all`/`get`/`get_all`/`has`/`remove`, so compact and long forms resolve to the same entry everywhere — dispatcher, transaction layer, and scripting API — in one place instead of per-call-site.

The on-the-wire header name is stored alongside and preserved verbatim: canonicalization affects lookup only, so a message received with `v:` is forwarded as `v:` (transparent proxying), and serialization output is unchanged.

This makes the piecemeal `.or_else(|| get("v"))` fallbacks in `codec.rs` redundant, and `typed_vias()`'s dual `get_all("Via")` + `get_all("v")` scan now double-counts (both resolve to the same entry), so those are removed.

## Tests

- Unit tests in `sip/headers`: every compact form aliases its long name (and the reverse), on-wire name is preserved for serialization, compact + long merge into one multi-value entry, cross-form `set`/`remove`, and an unknown single letter (`z`) is *not* treated as a compact form.
- A regression test in `sip/codec` parses a REGISTER `401` with all-compact headers and two stacked Vias, and asserts the exact `headers.get("Via")` lookup the response router does now succeeds and the top branch extracts.

Full suite green, clippy clean. No config or scripting-API change.
