### PR TITLE
fix(rtpengine): stop warning on the redundant media-session delete after a media timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   live-swappable connector and a watcher on the client cert/key files rebuilds and
   swaps the identity on change, evicting stale pooled TLS connections so the next
   outbound call re-handshakes with the new cert. No config or scripting-API change.
+- **No more spurious `safety-net RTPEngine delete failed: unknown call` WARN on
+  every media-timeout teardown.** The media engine owns the call and reaps it on
+  media timeout (the reaper removes the call before emitting the timeout event),
+  so siphon-sip's own media-session bookkeeping is now dropped when it handles the
+  event. The teardown that an `@rtpengine.on_media_timeout` handler drives (e.g.
+  `b2bua.terminate`) then finds no record and issues no delete against a call the
+  engine already dropped, saving a wasted round-trip and a misleading warning on
+  every timeout. Separately, a safety-net delete that returns "call not found"
+  (rtpengine `Unknown call-id`, siphon-rtp `unknown call`, rtpproxy `E8`) is now
+  logged at `debug` rather than `warn` at all four safety-net delete sites: the
+  media was already cleaned, which is exactly what the safety net is for, so this
+  also quiets double-BYE / glare and caller-BYE-vs-IVR-terminate races.
 - **Compact SIP header forms (RFC 3261 §7.3.3) are now recognized on every
   lookup, not just a few.** Header names are matched by their canonical form, so
   the single-letter compact forms (`v`→Via, `f`→From, `t`→To, `i`→Call-ID,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -964,6 +964,17 @@ pub async fn run(
                         call_id,
                         from_tag,
                     } => {
+                        // The media engine owns the call and reaped it on timeout
+                        // (the reaper removes the call *before* emitting this
+                        // event), so drop our own per-call media bookkeeping now.
+                        // The teardown that any @rtpengine.on_media_timeout handler
+                        // drives (e.g. b2bua.terminate) then finds no record and
+                        // issues no safety-net delete against a call the engine
+                        // already dropped — no wasted round-trip, no "unknown call".
+                        clear_media_session_on_timeout(
+                            state_for_events.rtpengine_sessions.as_ref(),
+                            &call_id,
+                        );
                         // The media engine tore down a dead-path call. Log it for
                         // visibility regardless of whether a script handles it,
                         // then invoke any @rtpengine.on_media_timeout handlers so
@@ -1045,6 +1056,30 @@ pub async fn run(
     }
 
     info!("dispatcher shutting down (inbound channel closed)");
+}
+
+/// Drop siphon-sip's own media-session bookkeeping for a call the media engine
+/// already reaped (media-timeout). The engine owns the call and tore it down
+/// before emitting the `MediaTimeout` event, so a later safety-net `delete`
+/// would just return "unknown call". Every safety-net delete site is gated on
+/// `if let Some(session) = rtpengine_sessions.remove(&…)`, so removing the
+/// record here makes those sites no-ops — no delete is issued.
+///
+/// Returns true if a record was actually present (i.e. we cleared something).
+fn clear_media_session_on_timeout(
+    rtpengine_sessions: Option<&Arc<crate::rtpengine::session::MediaSessionStore>>,
+    call_id: &str,
+) -> bool {
+    match rtpengine_sessions {
+        Some(store) if store.remove(call_id).is_some() => {
+            debug!(
+                %call_id,
+                "media timeout: dropped media-session bookkeeping (engine already reaped call)"
+            );
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Fire all expired timers in the timer wheel.
@@ -8102,7 +8137,11 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
             let set = Arc::clone(rtpengine_set);
             tokio::spawn(async move {
                 if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
-                    warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed (timeout): {error}");
+                    if error.is_call_not_found() {
+                        debug!(call_id = %session.call_id, "safety-net RTPEngine delete (timeout): call already gone ({error})");
+                    } else {
+                        warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed (timeout): {error}");
+                    }
                 }
             });
         }
@@ -11282,7 +11321,11 @@ fn handle_b2bua_response(
                 let set = Arc::clone(rtpengine_set);
                 tokio::spawn(async move {
                     if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
-                        warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                        if error.is_call_not_found() {
+                            debug!(call_id = %session.call_id, "safety-net RTPEngine delete: call already gone ({error})");
+                        } else {
+                            warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                        }
                     }
                 });
             }
@@ -11620,7 +11663,11 @@ fn handle_b2bua_bye(
             let set = Arc::clone(rtpengine_set);
             tokio::spawn(async move {
                 if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
-                    warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                    if error.is_call_not_found() {
+                        debug!(call_id = %session.call_id, "safety-net RTPEngine delete: call already gone ({error})");
+                    } else {
+                        warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                    }
                 }
             });
         }
@@ -11939,7 +11986,11 @@ fn b2bua_terminate_call_inner(
             let set = Arc::clone(rtpengine_set);
             tokio::spawn(async move {
                 if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
-                    warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                    if error.is_call_not_found() {
+                        debug!(call_id = %session.call_id, "safety-net RTPEngine delete: call already gone ({error})");
+                    } else {
+                        warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                    }
                 }
             });
         }
@@ -15586,6 +15637,56 @@ a=rtpmap:8 PCMA/8000\r\n";
             parse_contact_expires("<sip:trunk@10.0.0.1:5060>;q=0.8;expires=900;+sip.instance=\"<urn:uuid:abc>\""),
             Some(900),
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // MediaTimeout bookkeeping — clear siphon-sip's own media session so the
+    // downstream safety-net delete (gated on a present record) is a no-op.
+    // -----------------------------------------------------------------------
+
+    fn media_session_fixture(call_id: &str) -> crate::rtpengine::session::MediaSession {
+        crate::rtpengine::session::MediaSession {
+            call_id: call_id.to_string(),
+            from_tag: "a-tag".to_string(),
+            to_tag: None,
+            profile: "srtp_to_rtp".to_string(),
+            created_at: std::time::Instant::now(),
+        }
+    }
+
+    #[test]
+    fn clear_media_session_on_timeout_removes_the_record() {
+        let store = Arc::new(crate::rtpengine::session::MediaSessionStore::new());
+        store.insert(media_session_fixture("1-1354742@host"));
+        assert_eq!(store.len(), 1);
+
+        // The event's call_id equals the store key (engine call-id == SIP Call-ID).
+        let cleared = clear_media_session_on_timeout(Some(&store), "1-1354742@host");
+
+        // Record removed → returns true and the store is empty. Because every
+        // safety-net delete site is gated on `if let Some(session) =
+        // media_sessions.remove(&…)`, an empty store means the later teardown
+        // (e.g. via b2bua.terminate) issues NO `set.delete` — no round-trip, no
+        // "unknown call" warn. (MediaBackend is a concrete enum with no trait to
+        // mock, so store-is-empty is the structurally-equivalent assertion to a
+        // spy that expects zero delete calls.)
+        assert!(cleared);
+        assert!(store.get("1-1354742@host").is_none());
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn clear_media_session_on_timeout_no_record_is_noop() {
+        let store = Arc::new(crate::rtpengine::session::MediaSessionStore::new());
+        // Unknown call_id → nothing to clear, returns false, does not panic.
+        assert!(!clear_media_session_on_timeout(Some(&store), "no-such-call@host"));
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn clear_media_session_on_timeout_no_store_is_noop() {
+        // Media backend not configured (rtpengine_sessions is None) → false.
+        assert!(!clear_media_session_on_timeout(None, "1-1354742@host"));
     }
 
 }

--- a/src/rtpengine/error.rs
+++ b/src/rtpengine/error.rs
@@ -20,6 +20,32 @@ pub enum RtpEngineError {
     EngineError(String),
 }
 
+impl RtpEngineError {
+    /// True when the error means "the engine has no such call" — the media
+    /// session was already torn down (media-timeout reaper, a prior delete,
+    /// glare). On a *safety-net* delete this is success, not failure: the net
+    /// exists precisely to catch the not-yet-deleted case, so a not-found
+    /// result confirms the media is already gone.
+    ///
+    /// No typed not-found variant crosses the wire; each backend surfaces it as
+    /// an [`RtpEngineError::EngineError`] carrying its own reason text:
+    ///   - rtpengine NG -> `"Unknown call-id"`
+    ///   - siphon-rtp   -> `"unknown call: <call-id>"`
+    ///   - rtpproxy     -> `"rtpproxy delete error E8"` (E8 = unknown call id)
+    ///
+    /// so match on the reason text. `"unknown call"` (lowercased) covers both
+    /// rtpengine NG and siphon-rtp; `"delete error e8"` covers rtpproxy.
+    pub fn is_call_not_found(&self) -> bool {
+        match self {
+            RtpEngineError::EngineError(reason) => {
+                let lower = reason.to_ascii_lowercase();
+                lower.contains("unknown call") || lower.contains("delete error e8")
+            }
+            _ => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,5 +98,38 @@ mod tests {
         let error = RtpEngineError::Decode("test".to_string());
         let debug = format!("{:?}", error);
         assert!(debug.contains("Decode"));
+    }
+
+    #[test]
+    fn is_call_not_found_matches_siphon_rtp_reason() {
+        // siphon-rtp surfaces not-found as "unknown call: <call-id>".
+        let error = RtpEngineError::EngineError("unknown call: 1-abc@host".to_string());
+        assert!(error.is_call_not_found());
+    }
+
+    #[test]
+    fn is_call_not_found_matches_rtpengine_ng_reason() {
+        // rtpengine NG surfaces not-found as "Unknown call-id" (note the case).
+        let error = RtpEngineError::EngineError("Unknown call-id".to_string());
+        assert!(error.is_call_not_found());
+    }
+
+    #[test]
+    fn is_call_not_found_matches_rtpproxy_reason() {
+        // rtpproxy surfaces not-found as error code E8.
+        let error = RtpEngineError::EngineError("rtpproxy delete error E8".to_string());
+        assert!(error.is_call_not_found());
+    }
+
+    #[test]
+    fn is_call_not_found_false_for_transport_and_unrelated_errors() {
+        // Real failures — a safety-net delete must still warn on these.
+        assert!(!RtpEngineError::Timeout { timeout_ms: 1000 }.is_call_not_found());
+        assert!(!RtpEngineError::Protocol("missing result field".to_string()).is_call_not_found());
+        assert!(!RtpEngineError::Decode("bad bytes".to_string()).is_call_not_found());
+        let io_error = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+        assert!(!RtpEngineError::from(io_error).is_call_not_found());
+        // An engine error that is NOT a not-found must still warn.
+        assert!(!RtpEngineError::EngineError("no-encodable-codec".to_string()).is_call_not_found());
     }
 }


### PR DESCRIPTION
## Problem

Every media-timeout teardown logs a spurious
`WARN … safety-net RTPEngine delete failed: … unknown call`. The media engine
owns the call and reaps it on timeout: siphon-rtp's reaper runs `teardown_call`
(removes the call) and *then* emits the `MediaTimeout` event. So by the time
siphon-sip reacts, the engine call is already gone.

siphon-sip keeps its own per-call bookkeeping in `state.rtpengine_sessions`
(a `MediaSessionStore`, keyed by SIP Call-ID) and never cleared it when handling
`MediaTimeout` — even though the event *is* the "engine already reaped this"
signal. The `@rtpengine.on_media_timeout` handler then drives `b2bua.terminate`,
whose teardown finds the stale record and issues `set.delete(...)`, which the
engine answers `unknown call` → a wasted round-trip plus a misleading `warn!` on
every timeout. Dispatcher-internal, so the fix lives here.

## Fix (two independent parts)

1. **Clear the record on the `MediaTimeout` event.** New
   `clear_media_session_on_timeout()` helper drops siphon-sip's media-session
   bookkeeping at the top of the `RtpEngineEvent::MediaTimeout` arm. Every
   safety-net delete site is gated on
   `if let Some(session) = media_sessions.remove(&…)`, so removing the record
   makes them no-ops — no delete is issued, no round-trip, no warning.

2. **"call not found" on a safety-net delete is success, not a warning.** New
   `RtpEngineError::is_call_not_found()` classifies the not-found reason across
   backends (rtpengine `Unknown call-id`, siphon-rtp `unknown call: <id>`,
   rtpproxy `E8`). All four safety-net delete sites now log that at `debug` and
   reserve `warn!` for real failures (engine unreachable, transport/protocol
   error). This also quiets double-BYE / glare and caller-BYE-vs-IVR-terminate
   races, not just timeouts.

## Tests

- `rtpengine::error` — unit tests for `is_call_not_found()`: `true` for each
  backend's not-found reason, `false` for `Timeout`/`Io`/`Protocol`/`Decode` and
  an unrelated `EngineError`.
- `dispatcher` — inserting a `MediaSession` then calling
  `clear_media_session_on_timeout` returns `true` and empties the store (proving
  the gated safety-net issues no subsequent delete); no-record and no-store cases
  return `false` without panicking.
- Full suite green (3250 passed, 0 failed); clippy clean.

## Not in scope

- No Python API surface change → no SDK mirror.
- apps/sbc unchanged — the app already BYEs correctly via `b2bua.terminate`; this
  only removes siphon-sip's redundant delete + the noise. The SBC pin gets bumped
  after merge.
