### PR TITLE
fix(b2bua): device-driven proxy auth — drop the spurious 502, retransmit the a-leg 2xx, add auth_passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   elapsed).
 
 ### Added
+- **`call.dial(..., auth_passthrough=True)` / `call.fork(..., auth_passthrough=True)`** —
+  relay B-leg authentication to the caller end-to-end instead of siphon answering
+  it (RFC 3261 §22.3), for device-driven proxy auth where the endpoint (not siphon)
+  holds the credentials — e.g. an extension authenticating to its own PBX through
+  the B2BUA. One knob: it copies `Proxy-Authenticate` (B→A) and `Proxy-Authorization`
+  (A→B) across the B2BUA, and treats a B-leg `401`/`407` (when the call has no
+  `set_credentials()`) as a *non-terminal* challenge — the challenge is forwarded
+  to the caller without firing `@b2bua.on_failure`, writing a failure CDR, or
+  tearing down the anchored media, so the caller can authenticate and re-INVITE.
+  Mutually exclusive with `set_credentials()`; if both are set the stored
+  credentials win (siphon answers the challenge itself). Mirrored in the SDK mock.
 - **`rtpengine.answer_local(call, profile=None, auto_reject=True)`** — single-leg
   UAS answer for the caller's own offer, with the media engine as the far side
   (IVR / echo / announcement server). Unlike `answer()` it takes the INVITE offer,
@@ -76,6 +87,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   unaffected; there is no separate `answer_now()`.
 
 ### Fixed
+- **B2BUA no longer emits a spurious `502 Bad Gateway` in response to a caller's
+  ACK.** When a B2BUA forwarded a non-2xx final response (e.g. a relayed `407`)
+  to the caller and the caller ACKed it, siphon could route that ACK as a fresh
+  request and — when its Request-URI failed to resolve — fabricate a `502` back
+  to the caller (a response to an ACK, which RFC 3261 §17 forbids). An ACK that
+  matches no server transaction, dialog session, or B2BUA call is now dropped
+  silently, as required. Surfaced with device-driven proxy auth
+  (`auth_passthrough`), where the caller ACKs the forwarded challenge.
+- **B2BUA now retransmits the A-leg `2xx` until the caller ACKs** (RFC 3261
+  §13.3.1.4), so a single lost `200 OK` on the caller leg no longer leaves the
+  call ringing until it CANCELs. The B2BUA has no INVITE server transaction for
+  the A-leg (it owns the dialog end-to-end), so the 2xx was previously sent once
+  with no UAS-core retransmission; it is now resent on the T1→T2 schedule
+  (giving up after 64·T1), cancelled the moment the caller's ACK arrives.
 - **Compact SIP header forms (RFC 3261 §7.3.3) are now recognized on every
   lookup, not just a few.** Header names are matched by their canonical form, so
   the single-letter compact forms (`v`→Via, `f`→From, `t`→To, `i`→Call-ID,

--- a/scripts/b2bua_auth_passthrough.py
+++ b/scripts/b2bua_auth_passthrough.py
@@ -1,0 +1,48 @@
+"""
+SIPhon B2BUA auth-passthrough test script.
+
+Models an outbound call that siphon B2BUAs toward a downstream PBX / SIP trunk,
+which challenges the *caller* with 407 Proxy Authentication Required. The caller
+(not siphon) holds the credentials, so siphon relays the challenge end-to-end
+instead of answering it — call.dial(auth_passthrough=True).
+
+Used by the b2bua_auth SIPp scenario to prove siphon:
+  1. forwards the B-leg 407 (with its Proxy-Authenticate challenge) to the caller,
+  2. does NOT emit a spurious 502 in response to the caller's ACK for that 407.
+"""
+from siphon import b2bua, proxy, log
+
+# The downstream PBX / SIP trunk the outbound call is routed to. In the test
+# this is the SIPp UAS; in production it is the PBX/trunk that challenges the
+# caller. The 407 comes from HERE, not from a registered endpoint.
+PBX_NEXT_HOP = "sip:172.20.0.52:5060"
+
+
+@proxy.on_request
+def route(request):
+    # OPTIONS keepalive (health probe)
+    if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+
+
+@b2bua.on_invite
+def new_call(call):
+    # Route the outbound call to the downstream PBX/trunk. The PBX challenges
+    # (407); auth_passthrough relays that challenge to the caller instead of
+    # siphon answering it, so the endpoint authenticates end-to-end and re-INVITEs.
+    # (A production script would authorise the caller first, e.g. by checking
+    # registrar.is_registered(call.from_uri) — omitted here to keep the gate
+    # focused on the 407-relay behaviour.)
+    log.info(f"auth-passthrough dial {call.from_uri} -> {PBX_NEXT_HOP}")
+    call.dial(str(call.ruri), timeout=30, next_hop=PBX_NEXT_HOP, auth_passthrough=True)
+
+
+@b2bua.on_failure
+def call_failed(call, code, reason):
+    log.warn(f"B leg failed {code} {reason} for call {call.id}")
+    call.reject(code, reason)
+
+
+@b2bua.on_bye
+def call_ended(call, initiator):
+    call.terminate()

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -30,6 +30,7 @@ RUN_RTPENGINE=false
 RUN_RTPPROXY=false
 RUN_REINVITE=false
 RUN_B2BUA=false
+RUN_B2BUA_AUTH=false
 RUN_GATEWAY=false
 RUN_AUTO100=false
 RUN_HTTP_AUTH=false
@@ -48,6 +49,7 @@ for arg in "$@"; do
     --rtpproxy)   RUN_RTPPROXY=true ;;
     --reinvite)   RUN_REINVITE=true ;;
     --b2bua)      RUN_B2BUA=true ;;
+    --b2bua-auth) RUN_B2BUA_AUTH=true ;;
     --gateway)    RUN_GATEWAY=true ;;
     --auto100)    RUN_AUTO100=true ;;
     --http-auth)  RUN_HTTP_AUTH=true ;;
@@ -57,7 +59,7 @@ for arg in "$@"; do
     --webrtc)     RUN_WEBRTC=true ;;
     --skip-rust)  SKIP_RUST=true ;;
     --help|-h)
-      echo "Usage: $0 [--ipsec] [--call] [--presence] [--rtpengine] [--rtpproxy] [--reinvite] [--b2bua] [--gateway] [--auto100] [--http-auth] [--wedge] [--banscan] [--security] [--webrtc] [--skip-rust]"
+      echo "Usage: $0 [--ipsec] [--call] [--presence] [--rtpengine] [--rtpproxy] [--reinvite] [--b2bua] [--b2bua-auth] [--gateway] [--auto100] [--http-auth] [--wedge] [--banscan] [--security] [--webrtc] [--skip-rust]"
       exit 0
       ;;
     *)
@@ -195,6 +197,22 @@ if [[ "$RUN_B2BUA" == true ]]; then
   echo "=== B2BUA topology hiding test (CSeq/Max-Forwards/From host/SDP/PAI) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-topology up --abort-on-container-exit --exit-code-from sipp-b2bua-topology-uac sipp-b2bua-topology-uac sipp-b2bua-topology-uas
   docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-topology rm -sf sipp-b2bua-topology-uac sipp-b2bua-topology-uas 2>/dev/null || true
+fi
+
+# ── Step 9b: B2BUA device-driven proxy-auth test (optional) ─────────────────
+# A B-leg 407 relayed to the caller (auth_passthrough) must NOT draw a spurious
+# 502 in response to the caller's ACK for that 407. The UAC scenario aborts on
+# an unexpected 502, so --exit-code-from makes it a hard FAIL on the buggy build.
+if [[ "$RUN_B2BUA_AUTH" == true ]]; then
+  echo "=== Building siphon-b2bua-auth image ==="
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-auth build siphon-b2bua-auth
+
+  echo "=== Starting siphon-b2bua-auth ==="
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-auth up -d --wait siphon-b2bua-auth
+
+  echo "=== B2BUA auth-passthrough test (outbound call to a PBX that 407s; challenge relayed, no spurious 502) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua-auth up --abort-on-container-exit --exit-code-from sipp-b2bua-auth-uac sipp-b2bua-auth-uac sipp-b2bua-auth-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-auth rm -sf sipp-b2bua-auth-uac sipp-b2bua-auth-uas 2>/dev/null || true
 fi
 
 # ── Step 10: Gateway routing tests (optional) ──────────────────────────────────

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -308,6 +308,7 @@ class Call:
         translate: Optional[list[tuple[str, str]]] = None,
         route: Optional[list[str]] = None,
         send_socket: Optional[str] = None,
+        auth_passthrough: bool = False,
     ) -> None:
         """Dial a single B-leg target.
 
@@ -360,11 +361,28 @@ class Call:
                 ephemeral port.  Ignored when ``flow`` is set (the flow already
                 pins egress), and when its transport doesn't match the B-leg
                 transport.  A malformed spec raises ``ValueError``.
+            auth_passthrough: Relay B-leg authentication to the caller
+                end-to-end instead of siphon answering it (RFC 3261 §22.3).
+                When ``True``, siphon copies ``Proxy-Authenticate`` (B→A) and
+                ``Proxy-Authorization`` (A→B) across the B2BUA, and treats a
+                B-leg ``401``/``407`` (with no ``set_credentials()`` on this
+                call) as a *non-terminal* challenge: it forwards the challenge
+                to the caller without firing ``@b2bua.on_failure``, writing a
+                failure CDR, or tearing down the anchored media — so the caller
+                (which holds the credentials) can authenticate and re-INVITE.
+                Use this when the endpoint, not siphon, owns the credentials
+                (e.g. an extension authenticating to its own PBX through the
+                B2BUA).  Mutually exclusive with ``set_credentials()``; if both
+                are set, the stored credentials win.
 
         Example::
 
             # Basic dial (uses configured default policy)
             call.dial("sip:bob@10.0.0.2:5060", timeout=30)
+
+            # Device-driven proxy auth: let the extension authenticate to the
+            # PBX itself; siphon just relays the challenge and credentials.
+            call.dial("sip:bob@pbx.example.com:5060", auth_passthrough=True)
 
             # IMS edge: stamp canonical IMPU on R-URI, route via I-CSCF,
             # apply the trust-domain-boundary preset for outbound hygiene.
@@ -399,6 +417,7 @@ class Call:
                 "translate": translate or [],
                 "route": route or [],
                 "send_socket": send_socket,
+                "auth_passthrough": auth_passthrough,
             },
         ))
 
@@ -412,6 +431,7 @@ class Call:
         strip: Optional[list[str]] = None,
         translate: Optional[list[tuple[str, str]]] = None,
         send_socket: Optional[str] = None,
+        auth_passthrough: bool = False,
     ) -> None:
         """Fork to multiple B-leg targets.
 
@@ -435,6 +455,9 @@ class Call:
             send_socket: Optional egress socket pin applied to every branch
                 (same ``"<transport>:<ip>:<port>"`` form as :meth:`dial`).  A
                 per-branch captured flow still takes precedence for that branch.
+            auth_passthrough: Relay B-leg authentication to the caller
+                end-to-end — same semantics as :meth:`dial`.  Applies to every
+                branch of the fork.
 
         Example::
 
@@ -455,6 +478,7 @@ class Call:
                 "strip": strip or [],
                 "translate": translate or [],
                 "send_socket": send_socket,
+                "auth_passthrough": auth_passthrough,
             },
         ))
 

--- a/sipp/b2bua_auth_uac.xml
+++ b/sipp/b2bua_auth_uac.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA device-driven proxy-auth UAC scenario (A-leg / caller side).
+
+  Regression gate for the "B-leg 407 -> spurious 502" bug:
+    1. INVITE (CSeq 1) -> siphon B2BUAs to the UAS, which returns 407.
+       siphon (auth_passthrough) forwards the 407 to us  -> recv 407 (asserts
+       the challenge crosses the B2BUA; a 502 here would fail the call).
+    2. We ACK the 407.  On the BUGGY build siphon fabricates a 502 in response
+       to this ACK (CSeq 1 ACK) and sends it to us.
+    3. We send the authenticated re-INVITE (CSeq 2) and wait for its 407.  On
+       the buggy build the stray 502 arrives first and, being unexpected at
+       this recv, ABORTS the call (non-zero UAC exit -> test fails).  On the
+       fixed build no 502 is sent, the second 407 arrives, we ACK, and the
+       scenario ends cleanly (exit 0 -> test passes).
+
+  Run: sipp <siphon>:5060 -sf b2bua_auth_uac.xml -s bob -ap secret -m 1
+  Requires b2bua_auth_uas.xml on the B-leg and bob registered -> the UAS.
+-->
+<scenario name="B2BUA auth UAC">
+
+  <!-- Step 1: initial INVITE (no credentials) -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-auth-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <!-- The B-leg 407 relayed to us (auth_passthrough). A 502 here fails. -->
+  <recv response="407" auth="true" />
+
+  <!-- ACK the 407 (CSeq 1). The buggy build answers THIS ACK with a 502. -->
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Step 2: authenticated re-INVITE (CSeq 2). -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 2 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+[authentication]
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-auth-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <!-- Second challenge relayed to us. On the buggy build the stray 502 from
+       the CSeq-1 ACK arrives here instead and aborts the call. -->
+  <recv response="407" auth="true" />
+
+  <!-- ACK the second 407 (CSeq 2) and finish. -->
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/b2bua_auth_uas.xml
+++ b/sipp/b2bua_auth_uas.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA auth UAS scenario (B-leg side):
+  Receive INVITE -> 407 Proxy Authentication Required (with a Proxy-Authenticate
+  challenge) -> receive ACK.
+
+  Models a downstream PBX that challenges the caller.  siphon (auth_passthrough)
+  must relay the 407 to the A-leg caller and must NOT respond to the caller's
+  ACK with a 502.  Every B-leg INVITE is challenged (the caller's authenticated
+  re-INVITE arrives on a fresh B2BUA call / Call-ID, so it lands as a new UAS
+  instance and is challenged again — the UAC scenario only asserts the challenge
+  is forwarded and no 502 appears).
+-->
+<scenario name="B2BUA auth UAS">
+
+  <!-- Receive an INVITE from the B2BUA (B-leg) -->
+  <recv request="INVITE" crlf="true" />
+
+  <!-- Challenge it: 407 with a Proxy-Authenticate digest challenge -->
+  <send>
+    <![CDATA[
+SIP/2.0 407 Proxy Authentication Required
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Proxy-Authenticate: Digest realm="pbx.siphon.test", nonce="47f0b3a1c2d4e5f60718293a4b5c6d7e", algorithm=MD5, qop="auth"
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Absorb the ACK for the 407 (RFC 3261 §17.1.1.3) -->
+  <recv request="ACK" optional="true" timeout="5000" />
+
+</scenario>

--- a/sipp/configs/siphon.b2bua-auth-test.yaml
+++ b/sipp/configs/siphon.b2bua-auth-test.yaml
@@ -1,0 +1,38 @@
+# siphon.b2bua-auth-test.yaml — B2BUA device-driven proxy-auth test config
+#
+# Used with: sipp/docker-compose.yaml (b2bua-auth profile)
+# Script:    scripts/b2bua_auth_passthrough.py
+# Tests:     a B-leg 407 is relayed to the caller (auth_passthrough) and siphon
+#            does NOT emit a spurious 502 in response to the caller's ACK.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.50"
+    - "127.0.0.1"
+
+script:
+  path: "scripts/b2bua_auth_passthrough.py"
+  reload: auto
+
+advertised_address: "172.20.0.50"
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -960,6 +960,86 @@ services:
     profiles:
       - b2bua
 
+  # --- B2BUA device-driven proxy-auth test (auth_passthrough) ---
+  # A B-leg 407 must be relayed to the caller (auth_passthrough) and the
+  # caller's ACK for that 407 must NOT draw a spurious 502 — regression gate
+  # for the auth_passthrough fix. Uses the b2bua_auth_passthrough.py script.
+
+  siphon-b2bua-auth:
+    build:
+      context: ..
+    container_name: siphon-b2bua-auth-test
+    volumes:
+      - ./configs/siphon.b2bua-auth-test.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.50
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - b2bua-auth
+
+  sipp-b2bua-auth-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-auth:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_auth_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "2"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-auth
+
+  sipp-b2bua-auth-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-auth:
+        condition: service_healthy
+      sipp-b2bua-auth-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.50:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_auth_uac.xml
+      - -au
+      - alice
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-auth
+
   # --- B2BUA early media test (183 with SDP) ---
 
   sipp-b2bua-early-media-uas:

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -653,6 +653,12 @@ pub struct CallActor {
     /// the call is still un-answered. `None` = no application timeout (the 24h
     /// orphan backstop still applies).
     pub answer_deadline: Option<std::time::Instant>,
+    /// When true (`call.dial(auth_passthrough=True)`), a B-leg 401/407 with no
+    /// siphon-side credentials is relayed to the caller as a non-terminal
+    /// challenge: the dispatcher forwards it and keeps the call alive instead of
+    /// firing `@b2bua.on_failure`, deleting media, and removing the call — so the
+    /// caller can authenticate end-to-end and re-INVITE (RFC 3261 §22.3).
+    pub auth_passthrough: bool,
 }
 
 impl CallActor {
@@ -686,6 +692,7 @@ impl CallActor {
             a_leg_supports_100rel: false,
             auth_retry_count: 0,
             answer_deadline: None,
+            auth_passthrough: false,
         }
     }
 

--- a/src/b2bua/header_policy/mod.rs
+++ b/src/b2bua/header_policy/mod.rs
@@ -842,6 +842,22 @@ mod tests {
         assert!(msg.headers.has("Proxy-Authenticate"), "delta copy should override preset strip");
     }
 
+    #[test]
+    fn transparent_proxy_can_opt_in_to_proxy_authorization_passthrough() {
+        // The A→B (request) half of device-driven auth (auth_passthrough): the
+        // caller's re-INVITE carries Proxy-Authorization, which must survive to
+        // the challenging B-leg.  The preset strips it by default; a per-call
+        // copy delta (what call.dial(auth_passthrough=True) injects) overrides that.
+        let mut policy = ResolvedPolicy::from_preset(transparent());
+        policy.deltas_copy.push("Proxy-Authorization".to_string());
+        let mut msg = invite_with(&[("Proxy-Authorization", "Digest username=\"a\"")]);
+        apply_to_request(&mut msg, &policy, &ctx());
+        assert!(
+            msg.headers.has("Proxy-Authorization"),
+            "delta copy should override preset strip on the request"
+        );
+    }
+
     // ----- transparent-b2bua@2026: behaviour equivalence with pre-migration -----
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -175,6 +175,15 @@ struct DispatcherState {
     /// task watches for cancellation, plus the original CSeq number for RAck
     /// validation. Removed when PRACK arrives or the retransmit deadline hits.
     reliable_provisionals: Arc<DashMap<(String, u32), Arc<ReliableProvisional>>>,
+    /// Outstanding B2BUA A-leg 2xx responses awaiting the caller's ACK.
+    /// Keyed by internal call ID. RFC 3261 §13.3.1.4: the UAS *core* (not the
+    /// transaction) retransmits a 2xx until ACK or 64×T1. The B2BUA intercepts
+    /// the A-leg INVITE before an IST exists (see `handle_b2bua_invite`), and
+    /// the IST steps aside on 2xx anyway ("TU owns retransmissions"), so nothing
+    /// else recovers a lost A-leg 200 — without this the caller rings until it
+    /// CANCELs. The entry's `Notify` is fired by the late-ACK handler when the
+    /// caller's ACK arrives; the retransmit task otherwise gives up at 64×T1.
+    uas_2xx_retransmits: Arc<DashMap<String, Arc<tokio::sync::Notify>>>,
     /// Shared drain state — the server flips `drain.is_draining` on
     /// SIGTERM/SIGINT. While set, new INVITEs are rejected with 503 Service
     /// Unavailable; in-dialog requests (ACK, BYE, PRACK, re-INVITE) and
@@ -567,6 +576,7 @@ pub async fn run(
             .unwrap_or_else(|| product_name.to_string()),
         call_event_receivers: Arc::new(DashMap::new()),
         reliable_provisionals: Arc::new(DashMap::new()),
+        uas_2xx_retransmits: Arc::new(DashMap::new()),
         is_draining: drain.clone(),
         rf_charger,
         rf_sessions: Arc::new(DashMap::new()),
@@ -2071,6 +2081,12 @@ fn handle_request(
                     // ACK to the winning B-leg. This completes both legs of the
                     // INVITE transaction simultaneously (RFC 3261 §14.1).
                     if let Some(internal_id) = state.call_actors.find_by_sip_call_id(cid) {
+                        // The caller's ACK stops A-leg 2xx retransmission
+                        // (RFC 3261 §13.3.1.4). Fire the Notify so the retransmit
+                        // task exits; no-op if none is armed (non-2xx ACK).
+                        if let Some((_, notify)) = state.uas_2xx_retransmits.remove(&internal_id) {
+                            notify.notify_one();
+                        }
                         // Take the pending ACK and mark both legs as ACKed
                         let pending_ack = if let Some(mut call) = state.call_actors.get_call_mut(&internal_id) {
                             call.a_leg.initial_acked = true;
@@ -2098,12 +2114,21 @@ fn handle_request(
                         return;
                     }
                 }
-                debug!("ACK has no matching IST or session — passing through");
+                debug!("ACK matched no IST/session/dialog — dropping (RFC 3261: never respond to or route an ACK)");
             }
             Err(error) => {
-                debug!("failed to match ACK to transaction: {error}");
+                debug!("failed to match ACK to transaction: {error} — dropping ACK");
             }
         }
+        // An ACK that matched no server transaction, dialog session, or B2BUA
+        // call is a stray/orphan — e.g. the caller's ACK for a B2BUA-forwarded
+        // non-2xx (407/486/…) whose call was already torn down, or an ACK that
+        // arrives after teardown. RFC 3261 §17: a stateful element MUST NOT
+        // respond to an ACK, and an ACK is never a routable standalone request.
+        // Drop it silently — never fall through to request routing, which would
+        // otherwise fabricate a 502 back to the ACK when its R-URI does not
+        // resolve (a response to an ACK — itself a protocol violation).
+        return;
     }
 
     // --- Server transaction retransmission detection ---
@@ -8340,12 +8365,13 @@ fn handle_b2bua_invite(
         to_host_override,
         contact_user_override,
         contact_override,
+        auth_passthrough,
     ) = Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {
             Ok(obj) => obj,
             Err(error) => {
                 error!("failed to create PyCall: {error}");
-                return (CallAction::None, None, None, false, false, None, None, None, None, None);
+                return (CallAction::None, None, None, false, false, None, None, None, None, None, false);
             }
         };
 
@@ -8359,7 +8385,7 @@ fn handle_b2bua_invite(
                             return (CallAction::Reject {
                                 code: 500,
                                 reason: "Script Error".to_string(),
-                            }, None, None, false, false, None, None, None, None, None);
+                            }, None, None, false, false, None, None, None, None, None, false);
                         }
                     }
                 }
@@ -8368,7 +8394,7 @@ fn handle_b2bua_invite(
                     return (CallAction::Reject {
                         code: 500,
                         reason: "Script Error".to_string(),
-                    }, None, None, false, false, None, None, None, None, None);
+                    }, None, None, false, false, None, None, None, None, None, false);
                 }
             }
         }
@@ -8384,7 +8410,8 @@ fn handle_b2bua_invite(
         let to_host_ovr = borrowed.to_host_override().map(String::from);
         let contact_user_ovr = borrowed.contact_user_override().map(String::from);
         let contact_ovr = borrowed.contact_override().map(String::from);
-        (action, timer_override, credentials, li_record, preserve_cid, policy_input, from_host_ovr, to_host_ovr, contact_user_ovr, contact_ovr)
+        let auth_passthrough = borrowed.auth_passthrough();
+        (action, timer_override, credentials, li_record, preserve_cid, policy_input, from_host_ovr, to_host_ovr, contact_user_ovr, contact_ovr, auth_passthrough)
     });
 
     // Store the A-leg INVITE for later use by on_answer/on_failure/on_bye handlers
@@ -8430,6 +8457,18 @@ fn handle_b2bua_invite(
         Arc::new(resolved)
     });
 
+    // auth_passthrough (relay the challenge for the endpoint to answer) and
+    // set_credentials (siphon answers the challenge itself) are mutually
+    // exclusive uses of the same 401/407 handling. If both are set, credentials
+    // win (the auth_passthrough branch is only reachable when there are none) —
+    // warn so the misconfiguration is visible.
+    if credentials.is_some() && auth_passthrough {
+        warn!(
+            call_id = %call_id,
+            "call has both set_credentials() and auth_passthrough=True — credentials win; ignoring auth_passthrough"
+        );
+    }
+
     // Store per-call overrides from script
     if timer_override.is_some()
         || credentials.is_some()
@@ -8440,6 +8479,7 @@ fn handle_b2bua_invite(
         || to_host_override.is_some()
         || contact_user_override.is_some()
         || contact_override.is_some()
+        || auth_passthrough
     {
         if let Some(mut call) = state.call_actors.get_call_mut(&call_id) {
             if let Some(override_config) = timer_override {
@@ -8467,6 +8507,7 @@ fn handle_b2bua_invite(
             if contact_override.is_some() {
                 call.contact_override = contact_override;
             }
+            call.auth_passthrough = auth_passthrough;
         }
     }
 
@@ -10538,8 +10579,25 @@ fn handle_b2bua_response(
         // Extract SDP body before forwarding (needed for SIPREC)
         let sdp_body = response.body.clone();
 
+        // Clone the sanitized 2xx before it is moved into send_message so the
+        // A-leg retransmit is byte-identical (RFC 3261 §13.3.1.4).
+        let retransmit_2xx = response.clone();
+
         send_message(
             response,
+            a_leg.transport.transport,
+            a_leg.transport.remote_addr,
+            a_leg.transport.connection_id,
+            state,
+        );
+
+        // Arm A-leg 2xx retransmission — the B2BUA has no IST for the A-leg, so
+        // nothing else recovers a lost 200. Cancelled by the caller's ACK in the
+        // late-ACK handler (search `uas_2xx_retransmits`). Done before the SIPREC
+        // block below so its early returns can't skip it.
+        arm_b2bua_2xx_retransmit(
+            call_id,
+            retransmit_2xx,
             a_leg.transport.transport,
             a_leg.transport.remote_addr,
             a_leg.transport.connection_id,
@@ -11168,15 +11226,44 @@ fn handle_b2bua_response(
             }
         }
 
+        // auth_passthrough: a B-leg 401/407 with no siphon-side credentials is a
+        // NON-terminal challenge that we relay to the caller for end-to-end
+        // authentication (RFC 3261 §22.3). We still ACK the B-leg and forward the
+        // challenge to the A-leg below (unconditionally), but must NOT treat the
+        // call as failed: skip the CDR, @b2bua.on_failure, and the media teardown.
+        // The call actor is still removed (the caller re-INVITEs as a fresh call);
+        // the media session — keyed by SIP Call-ID, which the re-INVITE reuses —
+        // is deliberately left in place. The caller's ACK for the forwarded
+        // challenge matches no live call and is dropped by the unmatched-ACK guard
+        // (never answered with a 502).
+        let relay_challenge = (status_code == 401 || status_code == 407)
+            && outbound_credentials.is_none()
+            && state
+                .call_actors
+                .get_call(call_id)
+                .map(|call| call.auth_passthrough)
+                .unwrap_or(false);
+        if relay_challenge {
+            debug!(
+                call_id = %call_id,
+                status = status_code,
+                "B2BUA: relaying auth challenge to A-leg (auth_passthrough) — not a failure"
+            );
+        }
+
         // CDR: the call failed before answer (cdr.auto_emit). Fire regardless of
         // whether a @b2bua.on_failure handler is registered — the record must be
-        // written for the failed call either way.
-        cdr_finalize_b2bua_fail(state, call_id, status_code);
+        // written for the failed call either way. Skipped for a relayed challenge
+        // (the call has not failed).
+        if !relay_challenge {
+            cdr_finalize_b2bua_fail(state, call_id, status_code);
+        }
 
-        // Error response — invoke @b2bua.on_failure with (PyCall, code, reason)
+        // Error response — invoke @b2bua.on_failure with (PyCall, code, reason).
+        // Skipped for a relayed challenge (not a failure — the caller authenticates).
         let engine_state = state.engine.state();
         let handlers = engine_state.handlers_for(&HandlerKind::B2buaFailure);
-        if !handlers.is_empty() {
+        if !relay_challenge && !handlers.is_empty() {
             let reason = match &message.start_line {
                 StartLine::Response(status_line) => status_line.reason_phrase.clone(),
                 _ => "Unknown".to_string(),
@@ -11274,17 +11361,22 @@ fn handle_b2bua_response(
 
         // Safety-net: if RTPEngine was offered but call failed, clean up the session.
         // Only runs when the call is truly ending (script called reject, not retry).
-        let a_sip_call_id = a_leg.dialog.call_id.clone();
-        if let (Some(rtpengine_set), Some(media_sessions)) =
-            (&state.rtpengine_set, &state.rtpengine_sessions)
-        {
-            if let Some(session) = media_sessions.remove(&a_sip_call_id) {
-                let set = Arc::clone(rtpengine_set);
-                tokio::spawn(async move {
-                    if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
-                        warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
-                    }
-                });
+        // Skipped for a relayed auth challenge: the imminent authenticated
+        // re-INVITE reuses the media session (keyed by SIP Call-ID), so deleting
+        // it here would just force a needless re-offer (and could race that offer).
+        if !relay_challenge {
+            let a_sip_call_id = a_leg.dialog.call_id.clone();
+            if let (Some(rtpengine_set), Some(media_sessions)) =
+                (&state.rtpengine_set, &state.rtpengine_sessions)
+            {
+                if let Some(session) = media_sessions.remove(&a_sip_call_id) {
+                    let set = Arc::clone(rtpengine_set);
+                    tokio::spawn(async move {
+                        if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
+                            warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                        }
+                    });
+                }
             }
         }
 
@@ -12180,6 +12272,80 @@ fn arm_reliable_provisional_retransmit(
                     debug!(
                         call_id = %key.0, rseq = key.1, interval_ms = interval.as_millis() as u64,
                         "retransmitting reliable 1xx (RFC 3262)"
+                    );
+                    let _ = outbound.send(OutboundMessage {
+                        connection_id,
+                        transport,
+                        destination,
+                        data: bytes.clone(),
+                        source_local_addr: None,
+                        server_name: None,
+                    });
+                    interval = (interval * 2).min(cap);
+                }
+            }
+        }
+    });
+}
+
+/// Arm B2BUA A-leg 2xx retransmission (RFC 3261 §13.3.1.4).
+///
+/// The B2BUA intercepts the A-leg INVITE before a server transaction is
+/// created (see `handle_b2bua_invite`), so the transaction layer never
+/// retransmits the A-leg 2xx — and the IST would step aside on 2xx anyway
+/// ("TU owns retransmissions"). Without this, a single lost 200 leaves the
+/// caller ringing until it CANCELs. Stores a `Notify` under the internal call
+/// ID and spawns a task that resends `response` on the RFC 3261 §17.2.1 UAS
+/// schedule (T1 = 500 ms doubling to T2 = 4 s, give up after 64×T1 = 32 s).
+/// The late-ACK handler fires the `Notify` when the caller's ACK arrives.
+///
+/// Mirrors [`arm_reliable_provisional_retransmit`]. On give-up it removes its
+/// own entry and warns (a genuinely abandoned answered call is reclaimed by the
+/// session timer / orphan sweep) rather than tearing down from the task, which
+/// would need a `&DispatcherState` the spawned future cannot hold.
+fn arm_b2bua_2xx_retransmit(
+    internal_call_id: &str,
+    response: SipMessage,
+    transport: Transport,
+    destination: SocketAddr,
+    connection_id: ConnectionId,
+    state: &DispatcherState,
+) {
+    let entry = Arc::new(tokio::sync::Notify::new());
+    state
+        .uas_2xx_retransmits
+        .insert(internal_call_id.to_string(), Arc::clone(&entry));
+
+    let store = Arc::clone(&state.uas_2xx_retransmits);
+    let outbound = Arc::clone(&state.outbound);
+    let key = internal_call_id.to_string();
+
+    tokio::spawn(async move {
+        // RFC 3261 §17.2.1 UAS timing: start at T1 = 500 ms, double on each
+        // retransmit up to T2 = 4 s, give up after 64 × T1 = 32 s if no ACK.
+        let mut interval = std::time::Duration::from_millis(500);
+        let cap = std::time::Duration::from_secs(4);
+        let started = tokio::time::Instant::now();
+        let deadline = started + std::time::Duration::from_secs(32);
+        let bytes = bytes::Bytes::from(response.to_bytes());
+
+        loop {
+            let sleep = tokio::time::sleep(interval);
+            tokio::pin!(sleep);
+            tokio::select! {
+                _ = entry.notified() => break,
+                _ = &mut sleep => {
+                    if tokio::time::Instant::now() >= deadline {
+                        warn!(
+                            call_id = %key,
+                            "RFC 3261 §13.3.1.4: no ACK after 32s — giving up A-leg 2xx retransmits"
+                        );
+                        store.remove(&key);
+                        break;
+                    }
+                    debug!(
+                        call_id = %key, interval_ms = interval.as_millis() as u64,
+                        "retransmitting A-leg 2xx (RFC 3261 §13.3.1.4)"
                     );
                     let _ = outbound.send(OutboundMessage {
                         connection_id,

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -198,6 +198,14 @@ pub struct PyCall {
     /// the preset registry and applies deltas to produce a
     /// [`crate::b2bua::header_policy::ResolvedPolicy`] on the call actor.
     header_policy_input: Option<HeaderPolicyInput>,
+    /// When true (set via `call.dial(auth_passthrough=True)` / `call.fork(...)`),
+    /// this call relays B-leg auth challenges to the caller end-to-end instead
+    /// of siphon answering them. It copies `Proxy-Authenticate`/`Proxy-Authorization`
+    /// across the B2BUA (injected into `header_policy_input.deltas_copy`) AND, on
+    /// a B-leg 401/407 with no siphon-side credentials, tells the dispatcher to
+    /// forward the challenge without firing `@b2bua.on_failure`, deleting media,
+    /// or tearing the call down — so the caller can authenticate and re-INVITE.
+    auth_passthrough_flag: bool,
 }
 
 /// Per-call header policy input from `call.dial(header_policy=…, copy=…, strip=…, translate=…)`.
@@ -278,6 +286,7 @@ impl PyCall {
             contact_user_override: None,
             contact_override: None,
             header_policy_input: None,
+            auth_passthrough_flag: false,
         }
     }
 
@@ -286,6 +295,25 @@ impl PyCall {
     /// can be attached to the [`crate::b2bua::actor::CallActor`].
     pub fn header_policy_input(&self) -> Option<&HeaderPolicyInput> {
         self.header_policy_input.as_ref()
+    }
+
+    /// Whether this call relays B-leg auth challenges to the caller
+    /// (`call.dial(auth_passthrough=True)`). Read by the dispatcher's 401/407
+    /// handling so a relayed challenge does not tear the call down.
+    pub fn auth_passthrough(&self) -> bool {
+        self.auth_passthrough_flag
+    }
+
+    /// Append the two auth headers to `copy` for `auth_passthrough`, unless the
+    /// script already listed them (case-insensitive) — so the challenge
+    /// (`Proxy-Authenticate`, B→A) and the credentials (`Proxy-Authorization`,
+    /// A→B) both cross the B2BUA verbatim (RFC 3261 §22.3).
+    fn add_auth_passthrough_copies(copy: &mut Vec<String>) {
+        for header in ["Proxy-Authenticate", "Proxy-Authorization"] {
+            if !copy.iter().any(|h| h.eq_ignore_ascii_case(header)) {
+                copy.push(header.to_string());
+            }
+        }
     }
 
     /// Internal helper — called from `dial()` and `fork()` to record the
@@ -1008,7 +1036,7 @@ impl PyCall {
     ///         copy=["X-Operator-Tag"],
     ///         strip=["History-Info"],
     ///     )
-    #[pyo3(signature = (uri, timeout=30, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new(), send_socket=None))]
+    #[pyo3(signature = (uri, timeout=30, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new(), send_socket=None, auth_passthrough=false))]
     #[allow(clippy::too_many_arguments)]
     fn dial(
         &mut self,
@@ -1017,11 +1045,12 @@ impl PyCall {
         next_hop: Option<&str>,
         flow: Option<super::registrar::PyFlow>,
         header_policy: Option<&str>,
-        copy: Vec<String>,
+        mut copy: Vec<String>,
         strip: Vec<String>,
         translate: Vec<(String, String)>,
         route: Vec<String>,
         send_socket: Option<String>,
+        auth_passthrough: bool,
     ) -> PyResult<()> {
         super::request::validate_send_socket(send_socket.as_deref())?;
         self.action = CallAction::Dial {
@@ -1032,6 +1061,10 @@ impl PyCall {
             send_socket,
             timeout,
         };
+        if auth_passthrough {
+            self.auth_passthrough_flag = true;
+            Self::add_auth_passthrough_copies(&mut copy);
+        }
         self.update_header_policy_input(header_policy, copy, strip, translate);
         Ok(())
     }
@@ -1044,7 +1077,7 @@ impl PyCall {
     /// connection reuse, mandatory for WebSocket callees (RFC 7118 §5 / RFC
     /// 5626 §5.3).  `header_policy` / `copy` / `strip` / `translate` apply to
     /// every branch — per-branch policy is a follow-up enhancement.
-    #[pyo3(signature = (targets, strategy="parallel", timeout=30, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), send_socket=None))]
+    #[pyo3(signature = (targets, strategy="parallel", timeout=30, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), send_socket=None, auth_passthrough=false))]
     #[allow(clippy::too_many_arguments)]
     fn fork(
         &mut self,
@@ -1052,10 +1085,11 @@ impl PyCall {
         strategy: &str,
         timeout: u32,
         header_policy: Option<&str>,
-        copy: Vec<String>,
+        mut copy: Vec<String>,
         strip: Vec<String>,
         translate: Vec<(String, String)>,
         send_socket: Option<String>,
+        auth_passthrough: bool,
     ) -> PyResult<()> {
         super::request::validate_send_socket(send_socket.as_deref())?;
         let mut target_uris: Vec<String> = Vec::with_capacity(targets.len());
@@ -1077,6 +1111,10 @@ impl PyCall {
             send_socket,
             timeout,
         };
+        if auth_passthrough {
+            self.auth_passthrough_flag = true;
+            Self::add_auth_passthrough_copies(&mut copy);
+        }
         self.update_header_policy_input(header_policy, copy, strip, translate);
         Ok(())
     }
@@ -1484,7 +1522,7 @@ mod tests {
     fn call_dial() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        call.dial("sip:bob@10.0.0.2:5060", 30, None, None, None, vec![], vec![], vec![], vec![], None).unwrap();
+        call.dial("sip:bob@10.0.0.2:5060", 30, None, None, None, vec![], vec![], vec![], vec![], None, false).unwrap();
         assert_eq!(
             call.action(),
             &CallAction::Dial {
@@ -1515,6 +1553,7 @@ mod tests {
             vec![],
             vec!["<sip:scscf.ims.mnc01.mcc001.3gppnetwork.org:6060;lr>".to_string()],
             None,
+            false,
         ).unwrap();
         match call.action() {
             CallAction::Dial { route, .. } => {
@@ -1539,6 +1578,7 @@ mod tests {
             vec![],
             vec![],
             None,
+            false,
         ).unwrap();
         assert_eq!(
             call.action(),
@@ -1568,6 +1608,7 @@ mod tests {
             vec![("Diversion".to_string(), "rfc7044".to_string())],
             vec![],
             None,
+            false,
         ).unwrap();
         let input = call.header_policy_input().expect("policy input must be captured");
         assert_eq!(input.policy_name.as_deref(), Some("ims-trust-domain-boundary@2026"));
@@ -1587,6 +1628,7 @@ mod tests {
             "sip:bob@10.0.0.2:5060", 30, None, None, None,
             vec![], vec![], vec![], vec![],
             Some("udp:10.0.0.1:5060".to_string()),
+            false,
         ).unwrap();
         match call.action() {
             CallAction::Dial { send_socket, .. } => {
@@ -1604,6 +1646,7 @@ mod tests {
             "sip:bob@10.0.0.2:5060", 30, None, None, None,
             vec![], vec![], vec![], vec![],
             Some("not-a-socket".to_string()),
+            false,
         );
         assert!(result.is_err());
     }
@@ -1618,7 +1661,7 @@ mod tests {
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.2").into_any(),
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.3").into_any(),
             ];
-            call.fork(targets, "parallel", 30, None, vec![], vec![], vec![], None).unwrap();
+            call.fork(targets, "parallel", 30, None, vec![], vec![], vec![], None, false).unwrap();
             assert_eq!(
                 call.action(),
                 &CallAction::Fork {
@@ -1642,11 +1685,59 @@ mod tests {
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.2").into_any(),
                 pyo3::types::PyString::new(py, "sip:bob@10.0.0.3").into_any(),
             ];
-            call.fork(targets, "parallel", 30, Some("sip-trunk-edge@2026"), vec![], vec!["X-Internal-Tag".to_string()], vec![], None).unwrap();
+            call.fork(targets, "parallel", 30, Some("sip-trunk-edge@2026"), vec![], vec!["X-Internal-Tag".to_string()], vec![], None, false).unwrap();
             let input = call.header_policy_input().expect("policy input must be captured");
             assert_eq!(input.policy_name.as_deref(), Some("sip-trunk-edge@2026"));
             assert_eq!(input.deltas_strip, vec!["X-Internal-Tag".to_string()]);
         });
+    }
+
+    #[test]
+    fn call_dial_auth_passthrough_sets_flag_and_copies_both_auth_headers() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.dial("sip:bob@pbx.example.com:5060", 30, None, None, None, vec![], vec![], vec![], vec![], None, true).unwrap();
+        assert!(call.auth_passthrough(), "auth_passthrough flag must be set");
+        let input = call
+            .header_policy_input()
+            .expect("auth_passthrough must capture policy input via the injected copies");
+        // The challenge (Proxy-Authenticate, B→A) and credentials (Proxy-Authorization,
+        // A→B) must both be copied so device-driven auth crosses the B2BUA (RFC 3261 §22.3).
+        assert!(input.deltas_copy.iter().any(|h| h.eq_ignore_ascii_case("Proxy-Authenticate")));
+        assert!(input.deltas_copy.iter().any(|h| h.eq_ignore_ascii_case("Proxy-Authorization")));
+    }
+
+    #[test]
+    fn call_dial_auth_passthrough_does_not_duplicate_or_clobber_script_copies() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        // Script already listed Proxy-Authenticate (case-insensitive) plus an unrelated
+        // header; auth_passthrough must add only the missing Proxy-Authorization and
+        // preserve the script's own copies.
+        call.dial(
+            "sip:bob@pbx.example.com:5060", 30, None, None, None,
+            vec!["proxy-authenticate".to_string(), "X-Keep".to_string()],
+            vec![], vec![], vec![], None, true,
+        ).unwrap();
+        let input = call.header_policy_input().expect("policy input captured");
+        let authenticate_count = input
+            .deltas_copy
+            .iter()
+            .filter(|h| h.eq_ignore_ascii_case("Proxy-Authenticate"))
+            .count();
+        assert_eq!(authenticate_count, 1, "must not duplicate a script-supplied Proxy-Authenticate");
+        assert!(input.deltas_copy.iter().any(|h| h == "X-Keep"), "script copies preserved");
+        assert!(input.deltas_copy.iter().any(|h| h.eq_ignore_ascii_case("Proxy-Authorization")));
+    }
+
+    #[test]
+    fn call_dial_auth_passthrough_defaults_false_zero_cost() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.dial("sip:bob@10.0.0.2:5060", 30, None, None, None, vec![], vec![], vec![], vec![], None, false).unwrap();
+        assert!(!call.auth_passthrough());
+        // No auth_passthrough and no policy kwargs → nothing captured (existing scripts pay zero cost).
+        assert!(call.header_policy_input().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Device-driven proxy authentication across the B2BUA (the endpoint holds the
credentials and authenticates to a downstream node itself; siphon relays the
challenge) was broken in two ways, both reproduced from a packet capture:

1. **Spurious `502 Bad Gateway`.** siphon correctly forwarded the B-leg `407`
   to the caller, but when the caller ACKed that `407`, siphon routed the ACK
   as a fresh request; its Request-URI didn't resolve, so it fabricated a `502`
   back to the caller — a response *to an ACK* (its `CSeq` was `1 ACK`), which
   RFC 3261 §17 forbids.
2. **The answered call then hung.** The authenticated retry connected on the
   wire, but siphon sent the A-leg `200 OK` exactly once and never retransmitted
   it. A lost `200` left the caller ringing until it CANCELed ~30 s later.

## Root cause

- The B2BUA intercepts the A-leg INVITE before a server transaction (IST) is
  created, so it owns the A-leg dialog with no IST there. A forwarded non-2xx
  therefore left no transaction to absorb the caller's ACK, and the removed call
  meant the ACK matched nothing and fell through to request routing → `502`.
- With no IST and the IST stepping aside on 2xx anyway ("TU owns
  retransmissions"), nothing retransmitted the A-leg `200` (RFC 3261 §13.3.1.4).

## Fix (three layers)

- **Never route/answer an unmatched ACK.** An ACK that matches no server
  transaction, dialog session, or B2BUA call is dropped silently (RFC 3261 §17).
  Kills the `502` for the `407` case *and* any other forwarded non-2xx.
- **Retransmit the A-leg 2xx until the caller ACKs** — a dedicated UAS-core
  timer (T1→T2, give up at 64·T1), cancelled on the caller's ACK. Mirrors the
  existing reliable-provisional retransmit. Fixes the lost-`200` hang.
- **`call.dial(..., auth_passthrough=True)` / `call.fork(..., auth_passthrough=True)`.**
  One knob for device-driven auth: copies `Proxy-Authenticate` (B→A) and
  `Proxy-Authorization` (A→B) across the B2BUA, and treats a B-leg `401`/`407`
  with no `set_credentials()` on the call as a non-terminal challenge — forwarded
  to the caller without firing `@b2bua.on_failure`, writing a failure CDR, or
  tearing down the anchored media. Mutually exclusive with `set_credentials()`
  (stored credentials win). Mirrored in the SDK mock.

## Testing

- `cargo test`: full suite green (3247 passed), including new unit tests for the
  `auth_passthrough` header-copy injection and the request-direction
  `Proxy-Authorization` opt-in.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- SDK mock suite green (414 passed).
- New SIPp acceptance scenario (`sipp/b2bua_auth_uac.xml` / `_uas.xml`, profile
  `b2bua-auth`, `run-tests.sh --b2bua-auth`): the caller receives the relayed
  `407` and the run fails if a `502` arrives in its place. CHANGELOG updated.
