### PR TITLE
feat(script): reply.from_gateway() — response-path source-membership (proxy + b2bua)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   elapsed).
 
 ### Added
+- **`reply.from_gateway(group)` / `reply.source_ip` / `reply.source_port`** —
+  source-membership predicate on the response path, the reply-side counterpart of
+  `request.from_gateway` / `call.from_gateway` (Kamailio `ds_is_from_list()` /
+  OpenSIPS `ds_is_in_list()`). `reply.from_gateway("carriers")` is `True` when the
+  entity that sent the response has a source IP resolving into the named gateway
+  group — so a script can tell which trunk actually answered, e.g. in
+  `@proxy.on_reply` or `@b2bua.on_answer` / `@b2bua.on_early_media`. The B2BUA
+  reply now carries the B-leg peer's observed wire source (previously unset), and
+  `reply.source_ip` / `reply.source_port` expose it directly. Same trust
+  semantics as the request/call form (handshake-verified on TCP/TLS/WS/WSS, a
+  best-effort direction hint on UDP). Returns `False` / `None` where no single
+  source applies — e.g. a fork-aggregated `@proxy.on_failure` reply. Mirrored in
+  the SDK mock.
 - **`call.dial(..., auth_passthrough=True)` / `call.fork(..., auth_passthrough=True)`** —
   relay B-leg authentication to the caller end-to-end instead of siphon answering
   it (RFC 3261 §22.3), for device-driven proxy auth where the endpoint (not siphon)

--- a/docs/migrating-from-kamailio-opensips.md
+++ b/docs/migrating-from-kamailio-opensips.md
@@ -71,7 +71,7 @@ them (see the framework-handles-automatically notes in the API reference).
 |---|---|
 | `htable` (`$sht(...)`) | `cache` namespace (local LRU + optional Redis, shared live) |
 | `dispatcher` module + `ds_select_dst()` | `gateway` namespace (`gateway.select(group, key=…)`) + YAML `gateway.groups` |
-| `ds_is_from_list()` / `ds_is_in_list()` | `request.from_gateway(group)` / `call.from_gateway(group)` (source-IP membership of a `gateway` group) |
+| `ds_is_from_list()` / `ds_is_in_list()` | `request.from_gateway(group)` / `call.from_gateway(group)` / `reply.from_gateway(group)` (source-IP membership of a `gateway` group; the `reply` form tests which trunk answered) |
 | `dialog` module (`$dlg_val`, profiles) | the B2BUA call object (`@b2bua.*`, `call.*`) for true call control |
 | `rtpengine_*()` | `call.media.anchor()` / the `rtpengine` namespace |
 | `sqlops` / `avpops` against a DB | plain Python (use a DB client in an `async` handler, off the hot path) |

--- a/sdk/siphon_sdk/reply.py
+++ b/sdk/siphon_sdk/reply.py
@@ -42,6 +42,8 @@ class Reply:
         body: Optional[bytes] = None,
         content_type: Optional[str] = None,
         headers: Optional[dict[str, str]] = None,
+        source_ip: Optional[str] = None,
+        source_port: Optional[int] = None,
     ) -> None:
         self._status_code = status_code
         self._reason = reason
@@ -51,6 +53,8 @@ class Reply:
         self._body = body
         self._content_type = content_type
         self._headers: dict[str, str] = dict(headers) if headers else {}
+        self._source_ip = source_ip
+        self._source_port = source_port
         self._actions: list[Action] = []
 
     @property
@@ -87,6 +91,70 @@ class Reply:
     def content_type(self) -> Optional[str]:
         """Content-Type header value."""
         return self._content_type
+
+    @property
+    def source_ip(self) -> Optional[str]:
+        """Source IP of the entity that sent this response, or ``None``.
+
+        Populated on ``@proxy.on_reply``, ``@proxy.on_failure`` per-relay
+        callbacks, and the B2BUA ``@b2bua.on_answer`` / ``@b2bua.on_early_media``
+        replies (the B-leg peer that answered).  ``None`` on a fork-aggregated
+        ``@proxy.on_failure`` reply, where the "best" error is selected across
+        branches and no single source applies.  Reply-side counterpart of
+        ``request.source_ip``.
+        """
+        return self._source_ip
+
+    @property
+    def source_port(self) -> Optional[int]:
+        """Source port of the entity that sent this response, or ``None``
+        (see :attr:`source_ip` for when it is populated)."""
+        return self._source_port
+
+    def from_gateway(self, group_name: str) -> bool:
+        """Check if this response's source IP is a member of a gateway group.
+
+        The reply-side counterpart of ``request.from_gateway`` /
+        ``call.from_gateway`` — returns ``True`` when the source IP of the entity
+        that sent this response is one of the resolved addresses of the gateway
+        group ``group_name`` (configured under ``gateway.groups`` in
+        ``siphon.yaml``, or via ``gateway.add_group``).  Use it on a response to
+        decide which trunk actually answered — siphon's answer to Kamailio
+        ``ds_is_from_list()`` / OpenSIPS ``ds_is_in_list()`` on the reply path.
+
+        The match is on IP only (source port ignored) against **every** resolved
+        address in the group, so a hostname that round-robins across many IPs
+        matches on any of them.
+
+        Infallible: returns ``False`` (never raises) when the group does not
+        exist, no gateway is configured, the response source is unknown (see
+        :attr:`source_ip`), or the source IP does not parse.
+
+        Security: on connection-oriented transports (TCP/TLS/WS/WSS) the source
+        IP is handshake-verified and trustworthy as an authorization signal; on
+        UDP it is spoofable, so ``from_gateway`` there is a best-effort
+        direction hint, not an auth gate.
+
+        Args:
+            group_name: Name of the gateway group to test membership against.
+
+        Returns:
+            ``True`` if the response source IP belongs to the group.
+
+        Example::
+
+            @b2bua.on_answer
+            async def on_answer(call, reply):
+                if reply.from_gateway("carriers"):
+                    log.info("answered by the carrier trunk")
+        """
+        # Lazy import avoids a circular import (mock_module imports from the
+        # request module, which the reply module also imports at load time).
+        from siphon_sdk.mock_module import get_gateway
+
+        if self._source_ip is None:
+            return False
+        return get_gateway().contains_source(group_name, self._source_ip)
 
     # -- Header access ---------------------------------------------------------
 

--- a/sdk/tests/test_from_gateway.py
+++ b/sdk/tests/test_from_gateway.py
@@ -1,10 +1,10 @@
-"""Tests for the ``from_gateway`` source-membership predicate on both the
-proxy ``Request`` and the B2BUA ``Call`` mocks.
+"""Tests for the ``from_gateway`` source-membership predicate on the proxy
+``Request``, the B2BUA ``Call``, and the ``Reply`` mocks.
 
-``request.from_gateway("group")`` / ``call.from_gateway("group")`` return
-``True`` when the message's source IP is one of the resolved addresses of the
-named gateway group — siphon's equivalent of Kamailio ``ds_is_from_list()`` /
-OpenSIPS ``ds_is_in_list()``.
+``request.from_gateway("group")`` / ``call.from_gateway("group")`` /
+``reply.from_gateway("group")`` return ``True`` when the message's source IP is
+one of the resolved addresses of the named gateway group — siphon's equivalent
+of Kamailio ``ds_is_from_list()`` / OpenSIPS ``ds_is_in_list()``.
 """
 from siphon_sdk import mock_module
 
@@ -12,6 +12,7 @@ mock_module.install()
 
 from siphon import gateway  # noqa: E402  (must come after install)
 from siphon_sdk.call import Call  # noqa: E402
+from siphon_sdk.reply import Reply  # noqa: E402
 from siphon_sdk.request import Request  # noqa: E402
 
 
@@ -89,3 +90,40 @@ def test_call_from_gateway_matches_ip_ignoring_port():
     gateway.add_group("trunk", [{"uri": "sip:gw", "address": "192.0.2.50:5060"}])
     call = Call(source_ip="192.0.2.50")
     assert call.from_gateway("trunk") is True
+
+
+# --- Reply.from_gateway ----------------------------------------------------
+
+
+def test_reply_from_gateway_true_for_member():
+    _register_teams_group()
+    reply = Reply(status_code=200, source_ip="203.0.113.11")
+    assert reply.from_gateway("teams") is True
+    assert reply.source_ip == "203.0.113.11"
+
+
+def test_reply_from_gateway_false_for_non_member():
+    _register_teams_group()
+    reply = Reply(status_code=200, source_ip="198.51.100.5")
+    assert reply.from_gateway("teams") is False
+
+
+def test_reply_from_gateway_false_for_unknown_group():
+    _register_teams_group()
+    reply = Reply(status_code=200, source_ip="203.0.113.10")
+    assert reply.from_gateway("nonexistent") is False
+
+
+def test_reply_from_gateway_false_when_source_unknown():
+    # A fork-aggregated @proxy.on_failure reply carries no single source.
+    _register_teams_group()
+    reply = Reply(status_code=503)
+    assert reply.source_ip is None
+    assert reply.source_port is None
+    assert reply.from_gateway("teams") is False
+
+
+def test_reply_from_gateway_false_for_bad_source_ip():
+    _register_teams_group()
+    reply = Reply(status_code=200, source_ip="not-an-ip")
+    assert reply.from_gateway("teams") is False

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -3861,7 +3861,7 @@ fn handle_response(
 
     // Check if this response belongs to a B2BUA call
     if let Some(call_id) = state.call_actors.call_id_for_branch(&branch) {
-        handle_b2bua_response(&call_id, &branch, &mut message, status_code, state);
+        handle_b2bua_response(&call_id, &branch, &mut message, status_code, inbound.remote_addr, state);
         return;
     }
 
@@ -4158,7 +4158,11 @@ fn handle_response(
                 let msg_arc = Arc::new(std::sync::Mutex::new(message));
                 let req_arc = Arc::new(std::sync::Mutex::new(original_request.clone()));
                 let (updated_msg, cb_forward, cb_reject): (Option<SipMessage>, bool, Option<(u16, String)>) = Python::attach(|python| {
-                    let py_reply_obj = PyReply::new(Arc::clone(&msg_arc));
+                    let py_reply_obj = PyReply::new(Arc::clone(&msg_arc))
+                        .with_response_source(
+                            inbound.remote_addr.ip().to_string(),
+                            inbound.remote_addr.port(),
+                        );
                     let py_reply = match Py::new(python, py_reply_obj) {
                         Ok(obj) => obj,
                         Err(error) => {
@@ -9730,6 +9734,7 @@ fn handle_b2bua_response(
     branch: &str,
     message: &mut SipMessage,
     status_code: u16,
+    response_source: SocketAddr,
     state: &DispatcherState,
 ) {
     debug!(
@@ -10556,7 +10561,11 @@ fn handle_b2bua_response(
                     format!("{}", a_leg.transport.transport).to_lowercase(),
                 );
                 let py_reply = PyReply::new(Arc::clone(&response_arc))
-                    .with_a_leg(Arc::clone(invite_arc));
+                    .with_a_leg(Arc::clone(invite_arc))
+                    .with_response_source(
+                        response_source.ip().to_string(),
+                        response_source.port(),
+                    );
 
                 Python::attach(|python| {
                     let call_obj = match Py::new(python, py_call) {
@@ -10981,7 +10990,11 @@ fn handle_b2bua_response(
                         format!("{}", a_leg.transport.transport).to_lowercase(),
                     );
                     let py_reply = PyReply::new(Arc::clone(&response_arc))
-                        .with_a_leg(Arc::clone(invite_arc));
+                        .with_a_leg(Arc::clone(invite_arc))
+                        .with_response_source(
+                            response_source.ip().to_string(),
+                            response_source.port(),
+                        );
 
                     Python::attach(|python| {
                         let call_obj = match Py::new(python, py_call) {

--- a/src/script/api/reply.rs
+++ b/src/script/api/reply.rs
@@ -100,6 +100,29 @@ impl PyReply {
     pub fn a_leg_message(&self) -> Option<Arc<Mutex<SipMessage>>> {
         self.a_leg_message.as_ref().map(Arc::clone)
     }
+
+    /// Source-membership predicate shared by the `from_gateway` pymethod and its
+    /// unit tests. Kept infallible: an absent/unparseable response source, a
+    /// missing manager, or an unknown group all resolve to `false`. The
+    /// `manager` seam lets tests inject a `DispatcherManager` without touching
+    /// the process singleton (a first-writer-wins `OnceLock`).
+    #[allow(clippy::wrong_self_convention)]
+    fn from_gateway_impl(
+        &self,
+        group_name: &str,
+        manager: Option<&Arc<crate::gateway::DispatcherManager>>,
+    ) -> bool {
+        let Some(source) = self.response_source_ip.as_deref() else {
+            return false;
+        };
+        let Ok(source_ip) = source.parse::<std::net::IpAddr>() else {
+            return false;
+        };
+        match manager {
+            Some(manager) => manager.source_in_group(group_name, source_ip),
+            None => false,
+        }
+    }
 }
 
 #[pymethods]
@@ -183,6 +206,52 @@ impl PyReply {
             pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
         })?;
         Ok(message.headers.content_type().cloned())
+    }
+
+    /// Source IP of the entity that sent this response, or `None` when siphon
+    /// did not observe a single wire source for it.
+    ///
+    /// Populated on `@proxy.on_reply`, `@proxy.on_failure` per-relay callbacks,
+    /// and the B2BUA `@b2bua.on_answer` / `@b2bua.on_early_media` replies (the
+    /// B-leg peer that answered). `None` on a fork-aggregated
+    /// `@proxy.on_failure` reply, where the "best" error is selected across
+    /// branches and no single source applies. Reply-side counterpart of
+    /// `request.source_ip`.
+    #[getter]
+    fn source_ip(&self) -> Option<String> {
+        self.response_source_ip.clone()
+    }
+
+    /// Source port of the entity that sent this response, or `None` (see
+    /// `source_ip` for when it is populated).
+    #[getter]
+    fn source_port(&self) -> Option<u16> {
+        self.response_source_port
+    }
+
+    /// True when the source IP of this response is a member of the resolved
+    /// addresses of the gateway group named `group_name`.
+    ///
+    /// The reply-side counterpart of `request.from_gateway` / `call.from_gateway`
+    /// — a routing-direction / trust predicate (siphon's answer to Kamailio
+    /// `ds_is_from_list()` / OpenSIPS `ds_is_in_list()`). Use it on a response to
+    /// decide which trunk actually answered, e.g. in `@proxy.on_reply` or
+    /// `@b2bua.on_answer`. Matches on IP only (source port ignored) against every
+    /// resolved A/AAAA candidate of every destination in the group.
+    ///
+    /// Infallible — returns `false` (never raises) when the group does not
+    /// exist, no gateway is configured, the response source is unknown (see
+    /// `source_ip`), or the source IP does not parse.
+    ///
+    /// Security: on connection-oriented transports (TCP/TLS/WS/WSS) the source
+    /// IP is handshake-verified and trustworthy as an authorization signal; on
+    /// UDP it is spoofable, so `from_gateway` there is a best-effort direction
+    /// hint, not an auth gate.
+    ///
+    /// Example: `if reply.from_gateway("carriers"): ...`
+    #[allow(clippy::wrong_self_convention)]
+    fn from_gateway(&self, group_name: &str) -> bool {
+        self.from_gateway_impl(group_name, super::gateway_manager())
     }
 
     /// Check if a header exists.
@@ -785,6 +854,99 @@ mod tests {
 
         // Should not error even without Contact header
         reply.fix_nated_contact().unwrap();
+    }
+
+    // -----------------------------------------------------------------------
+    // source_ip / source_port / from_gateway (source-membership predicate)
+    // -----------------------------------------------------------------------
+
+    fn gateway_manager_with_group() -> Arc<crate::gateway::DispatcherManager> {
+        use crate::gateway::{Algorithm, Destination, DispatcherGroup};
+        use crate::transport::Transport;
+
+        let manager = Arc::new(crate::gateway::DispatcherManager::new());
+        manager.add_group(DispatcherGroup::new(
+            "carriers".to_string(),
+            Algorithm::Weighted,
+            vec![Destination::new(
+                "sip:gw1.example.com".to_string(),
+                "10.0.0.1:5060".parse().unwrap(),
+                Transport::Udp,
+                1,
+                1,
+            )],
+        ));
+        manager
+    }
+
+    #[test]
+    fn source_ip_and_port_exposed_when_set() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        let reply = PyReply::new(message)
+            .with_response_source("10.0.0.1".to_string(), 5060);
+        assert_eq!(reply.source_ip(), Some("10.0.0.1".to_string()));
+        assert_eq!(reply.source_port(), Some(5060));
+    }
+
+    #[test]
+    fn source_ip_and_port_none_when_unset() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        let reply = PyReply::new(message);
+        assert_eq!(reply.source_ip(), None);
+        assert_eq!(reply.source_port(), None);
+    }
+
+    #[test]
+    fn from_gateway_true_for_member_source() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        let reply = PyReply::new(message)
+            .with_response_source("10.0.0.1".to_string(), 5060);
+        let manager = gateway_manager_with_group();
+        assert!(reply.from_gateway_impl("carriers", Some(&manager)));
+    }
+
+    #[test]
+    fn from_gateway_false_for_non_member_source() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        // RFC 5737 TEST-NET-1 — not a member of the group.
+        let reply = PyReply::new(message)
+            .with_response_source("192.0.2.7".to_string(), 5060);
+        let manager = gateway_manager_with_group();
+        assert!(!reply.from_gateway_impl("carriers", Some(&manager)));
+    }
+
+    #[test]
+    fn from_gateway_false_for_unknown_group() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        let reply = PyReply::new(message)
+            .with_response_source("10.0.0.1".to_string(), 5060);
+        let manager = gateway_manager_with_group();
+        assert!(!reply.from_gateway_impl("nonexistent", Some(&manager)));
+    }
+
+    #[test]
+    fn from_gateway_false_when_source_unset() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        let reply = PyReply::new(message);
+        let manager = gateway_manager_with_group();
+        assert!(!reply.from_gateway_impl("carriers", Some(&manager)));
+    }
+
+    #[test]
+    fn from_gateway_false_when_no_manager() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        let reply = PyReply::new(message)
+            .with_response_source("10.0.0.1".to_string(), 5060);
+        assert!(!reply.from_gateway_impl("carriers", None));
+    }
+
+    #[test]
+    fn from_gateway_false_for_unparseable_source_ip() {
+        let message = Arc::new(Mutex::new(make_response(200, "OK")));
+        let reply = PyReply::new(message)
+            .with_response_source("not-an-ip".to_string(), 5060);
+        let manager = gateway_manager_with_group();
+        assert!(!reply.from_gateway_impl("carriers", Some(&manager)));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Adds the reply-side counterpart of `request.from_gateway` / `call.from_gateway` (Kamailio `ds_is_from_list()` / OpenSIPS `ds_is_in_list()`), so a script can tell **which trunk answered** from a response handler.

## API
- `reply.from_gateway("group") -> bool` — true when the entity that sent the response has a source IP resolving into the named `gateway` group. IP-only match against every resolved A/AAAA of every destination; infallible (false on unknown group / no source / unparseable IP).
- `reply.source_ip -> str | None` / `reply.source_port -> int | None` — the observed wire source of the response, mirroring `request.source_ip`.

Same trust semantics as the request/call form: handshake-verified on TCP/TLS/WS/WSS, a best-effort direction hint on UDP.

## Where the source comes from
- `@proxy.on_reply` and single-target `relay(on_reply=/on_failure=)` callbacks — already carried the response source (`inbound.remote_addr`); the method just reads it.
- `@b2bua.on_answer` / `@b2bua.on_early_media` — the B-leg reply previously carried **no** source. Threaded `inbound.remote_addr` through `handle_b2bua_response` so it now reflects the B-leg peer that answered.
- Fork-aggregated `@proxy.on_failure` — the best error is selected across branches, so no single source applies: `from_gateway` returns `false`, `source_ip` is `None`. Documented. (`@b2bua.on_failure` gets `(call, code, reason)` with no reply object — `call.from_gateway` covers the A-leg there.)

## Tests
- Rust: 8 unit tests on `PyReply` (member / non-member / unknown group / source-unset / no-manager / unparseable / getters).
- SDK mock: `reply.from_gateway` + `source_ip`/`source_port` mirrored, 5 new cases in `test_from_gateway.py`.
- clippy `--all-targets --all-features -D warnings` clean; reply unit (37) + b2bua integration (53) + full SDK suite (419) green.

CHANGELOG + kamailio/opensips migration table updated.