### PR TITLE
feat(cdr): media CDR from the siphon-rtp CallSummary event (proto 0.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   best-effort direction hint on UDP). Returns `False` / `None` where no single
   source applies — e.g. a fork-aggregated `@proxy.on_failure` reply. Mirrored in
   the SDK mock.
+- **Media CDR from the engine's end-of-call summary** — on the native
+  `siphon-rtp` backend (`siphon-rtp-proto` 0.1.4), the engine now pushes a
+  structured `CallSummary` event when it tears a call down. When `cdr.auto_emit`
+  is on, siphon writes a `method="MEDIA"` CDR keyed on the SIP Call-ID (so a
+  collector joins it to the SIP-side CDR) carrying the per-leg byte/packet
+  counters and, where a userspace media actor measured them, the RFC 3550
+  loss/jitter and ITU-T G.107 MOS shape — the structured twin of the engine's
+  media log, no log scraping. Per-leg figures are flattened under `near_`
+  (offerer) / `far_` (answerer) / `leg{n}_` prefixes (`_codec`, `_packets_in`,
+  `_bytes_out`, `_packets_dropped`, and when measured `_ssrc`, `_packets_lost`,
+  `_loss_percent`, `_jitter_ms`, `_rtt_ms`, `_mos_average`/`_min`/`_max`,
+  `_mos_basis`); top-level `media_reason` (`delete` / `media_timeout`) and
+  `media_duration_ms` accompany the standard `duration_secs`. Unmeasured fields
+  are omitted, not emitted empty. The rtpengine / rtpproxy backends do not
+  surface this event, so no media CDR is written there.
 - **`call.dial(..., auth_passthrough=True)` / `call.fork(..., auth_passthrough=True)`** —
   relay B-leg authentication to the caller end-to-end instead of siphon answering
   it (RFC 3261 §22.3), for device-driven proxy auth where the endpoint (not siphon)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,9 +3059,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6576cad04bc54affc3d7680517d4f75058fdaa2c55e388a99b91b05a907f5f94"
+checksum = "226aef8325e781c170039a9a580312c28aa52aa6dac5c5f797a0df9a513f1309"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.1.3"
+siphon-rtp-proto = "0.1.4"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -173,7 +173,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.1.3"
+siphon-rtp-proto = "0.1.4"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1057,6 +1057,24 @@ pub async fn run(
                         })
                         .await;
                     }
+                    crate::rtpengine::events::RtpEngineEvent::CallSummary(summary) => {
+                        // The media engine reports the end-of-call byte/packet
+                        // counters and (when a userspace actor measured them) the
+                        // RFC 3550 loss/jitter + ITU-T G.107 MOS shape. Write a
+                        // media CDR keyed on the SIP Call-ID so a collector joins
+                        // it to the SIP-side CDR — the structured twin of the
+                        // engine's `siphon_rtp::cdr` log, no log scraping. Gated
+                        // on auto-emit, same as the proxy/b2bua lifecycle CDRs.
+                        tracing::debug!(
+                            call_id = %summary.call_id,
+                            reason = %summary.reason,
+                            legs = summary.legs.len(),
+                            "media engine reported end-of-call summary"
+                        );
+                        if crate::cdr::auto_emit_enabled() {
+                            crate::cdr::write(media_summary_to_cdr(&summary));
+                        }
+                    }
                     crate::rtpengine::events::RtpEngineEvent::Unknown { event, call_id, .. } => {
                         tracing::debug!(
                             %event,
@@ -6684,6 +6702,85 @@ fn cdr_emit_register(aor: &str, event_type: &str) {
     .with_response_code(200)
     .with_extra("reg_event".to_string(), event_type.to_string());
     crate::cdr::write(cdr);
+}
+
+/// Build a media CDR from a media-engine end-of-call summary.
+///
+/// A `method="MEDIA"` record keyed on the SIP Call-ID so a collector joins it to
+/// the SIP-side CDR (which carries the URIs and disconnect side). The SIP URI /
+/// source / transport fields are empty — the media summary carries none; the
+/// join key is the Call-ID. `duration_secs` is the media call lifetime, with the
+/// exact value also in `media_duration_ms`, and `media_reason` records why the
+/// call ended (`"delete"` / `"media_timeout"`).
+///
+/// Each leg's figures are flattened into `extra`: index 0 → `near_`, index 1 →
+/// `far_`, any further leg → `leg{n}_`. Unmeasured optional fields (a plain
+/// in-kernel relay leg has no MOS/loss/jitter) are omitted, not emitted empty.
+fn media_summary_to_cdr(summary: &crate::rtpengine::events::CallSummary) -> crate::cdr::Cdr {
+    let mut cdr = crate::cdr::Cdr::new(
+        summary.call_id.clone(),
+        String::new(), // from_uri — not carried by the media summary
+        String::new(), // to_uri
+        String::new(), // ruri
+        "MEDIA".to_string(),
+        String::new(), // source_ip
+        String::new(), // transport
+    )
+    .with_duration(summary.duration_ms as f64 / 1000.0)
+    .with_extra("media_reason".to_string(), summary.reason.clone())
+    .with_extra(
+        "media_duration_ms".to_string(),
+        summary.duration_ms.to_string(),
+    );
+
+    for (index, leg) in summary.legs.iter().enumerate() {
+        let prefix = match index {
+            0 => "near".to_string(),
+            1 => "far".to_string(),
+            n => format!("leg{n}"),
+        };
+        let extra = &mut cdr.extra;
+        let mut put = |suffix: &str, value: String| {
+            extra.insert(format!("{prefix}_{suffix}"), value);
+        };
+        put("tag", leg.tag.clone());
+        if let Some(codec) = &leg.codec {
+            put("codec", codec.clone());
+        }
+        put("packets_in", leg.packets_in.to_string());
+        put("bytes_in", leg.bytes_in.to_string());
+        put("packets_out", leg.packets_out.to_string());
+        put("bytes_out", leg.bytes_out.to_string());
+        put("packets_dropped", leg.packets_dropped.to_string());
+        if let Some(ssrc) = leg.ssrc {
+            put("ssrc", ssrc.to_string());
+        }
+        if let Some(packets_lost) = leg.packets_lost {
+            put("packets_lost", packets_lost.to_string());
+        }
+        if let Some(loss_percent) = leg.loss_percent {
+            put("loss_percent", loss_percent.to_string());
+        }
+        if let Some(jitter_ms) = leg.jitter_ms {
+            put("jitter_ms", jitter_ms.to_string());
+        }
+        if let Some(rtt_ms) = leg.rtt_ms {
+            put("rtt_ms", rtt_ms.to_string());
+        }
+        if let Some(mos_average) = leg.mos_average {
+            put("mos_average", mos_average.to_string());
+        }
+        if let Some(mos_min) = leg.mos_min {
+            put("mos_min", mos_min.to_string());
+        }
+        if let Some(mos_max) = leg.mos_max {
+            put("mos_max", mos_max.to_string());
+        }
+        if let Some(mos_basis) = &leg.mos_basis {
+            put("mos_basis", mos_basis.clone());
+        }
+    }
+    cdr
 }
 
 /// Proxy CDR START — the proxy is relaying/forking an INVITE. Records the call
@@ -13716,6 +13813,132 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    // -----------------------------------------------------------------------
+    // Media CDR from an end-of-call summary (media.backend: siphon-rtp)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn media_summary_to_cdr_flattens_legs() {
+        use crate::rtpengine::events::{CallLegSummary, CallSummary};
+
+        fn measured_leg(tag: &str, codec: &str) -> CallLegSummary {
+            CallLegSummary {
+                tag: tag.to_string(),
+                codec: Some(codec.to_string()),
+                packets_in: 2100,
+                bytes_in: 336_000,
+                packets_out: 2098,
+                bytes_out: 335_680,
+                packets_dropped: 2,
+                ssrc: Some(0x0102_0304),
+                packets_lost: Some(6),
+                loss_percent: Some(0.3),
+                jitter_ms: Some(4.2),
+                rtt_ms: Some(21.0),
+                mos_average: Some(4.11),
+                mos_min: Some(3.9),
+                mos_max: Some(4.3),
+                mos_basis: Some("full".to_string()),
+            }
+        }
+
+        // A counters-only far leg (plain in-kernel relay, no actor) — every
+        // quality field is None and must be omitted from the CDR, not empty.
+        let far = CallLegSummary {
+            tag: "far-tag".to_string(),
+            codec: None,
+            packets_in: 2099,
+            bytes_in: 335_840,
+            packets_out: 2100,
+            bytes_out: 336_000,
+            packets_dropped: 0,
+            ssrc: None,
+            packets_lost: None,
+            loss_percent: None,
+            jitter_ms: None,
+            rtt_ms: None,
+            mos_average: None,
+            mos_min: None,
+            mos_max: None,
+            mos_basis: None,
+        };
+
+        let summary = CallSummary {
+            call_id: "call-9".to_string(),
+            reason: "delete".to_string(),
+            duration_ms: 42_500,
+            legs: vec![measured_leg("near-tag", "AMR-WB"), far],
+        };
+
+        let cdr = media_summary_to_cdr(&summary);
+
+        assert_eq!(cdr.call_id, "call-9");
+        assert_eq!(cdr.method, "MEDIA");
+        assert_eq!(cdr.response_code, 0);
+        // Media lifetime surfaces both as the standard duration and precisely.
+        assert!((cdr.duration_secs - 42.5).abs() < 1e-9);
+        assert_eq!(cdr.extra.get("media_duration_ms").map(String::as_str), Some("42500"));
+        assert_eq!(cdr.extra.get("media_reason").map(String::as_str), Some("delete"));
+
+        // Near (measured) leg — counters + quality present under `near_`.
+        assert_eq!(cdr.extra.get("near_tag").map(String::as_str), Some("near-tag"));
+        assert_eq!(cdr.extra.get("near_codec").map(String::as_str), Some("AMR-WB"));
+        assert_eq!(cdr.extra.get("near_packets_in").map(String::as_str), Some("2100"));
+        assert_eq!(cdr.extra.get("near_bytes_out").map(String::as_str), Some("335680"));
+        assert_eq!(cdr.extra.get("near_packets_dropped").map(String::as_str), Some("2"));
+        assert_eq!(cdr.extra.get("near_packets_lost").map(String::as_str), Some("6"));
+        assert_eq!(cdr.extra.get("near_loss_percent").map(String::as_str), Some("0.3"));
+        assert_eq!(cdr.extra.get("near_mos_average").map(String::as_str), Some("4.11"));
+        assert_eq!(cdr.extra.get("near_mos_basis").map(String::as_str), Some("full"));
+
+        // Far (counters-only) leg — quality fields omitted entirely.
+        assert_eq!(cdr.extra.get("far_tag").map(String::as_str), Some("far-tag"));
+        assert_eq!(cdr.extra.get("far_packets_in").map(String::as_str), Some("2099"));
+        assert!(!cdr.extra.contains_key("far_codec"));
+        assert!(!cdr.extra.contains_key("far_ssrc"));
+        assert!(!cdr.extra.contains_key("far_mos_average"));
+        assert!(!cdr.extra.contains_key("far_mos_basis"));
+    }
+
+    #[test]
+    fn media_summary_to_cdr_indexes_extra_legs() {
+        use crate::rtpengine::events::{CallLegSummary, CallSummary};
+
+        fn bare_leg(tag: &str) -> CallLegSummary {
+            CallLegSummary {
+                tag: tag.to_string(),
+                codec: None,
+                packets_in: 1,
+                bytes_in: 2,
+                packets_out: 3,
+                bytes_out: 4,
+                packets_dropped: 0,
+                ssrc: None,
+                packets_lost: None,
+                loss_percent: None,
+                jitter_ms: None,
+                rtt_ms: None,
+                mos_average: None,
+                mos_min: None,
+                mos_max: None,
+                mos_basis: None,
+            }
+        }
+
+        // A third leg (MPTY / conference) indexes as `leg2_`, not near/far.
+        let summary = CallSummary {
+            call_id: "conf-1".to_string(),
+            reason: "media_timeout".to_string(),
+            duration_ms: 1_000,
+            legs: vec![bare_leg("a"), bare_leg("b"), bare_leg("c")],
+        };
+        let cdr = media_summary_to_cdr(&summary);
+        assert_eq!(cdr.extra.get("near_tag").map(String::as_str), Some("a"));
+        assert_eq!(cdr.extra.get("far_tag").map(String::as_str), Some("b"));
+        assert_eq!(cdr.extra.get("leg2_tag").map(String::as_str), Some("c"));
+        assert_eq!(cdr.extra.get("media_reason").map(String::as_str), Some("media_timeout"));
+    }
 
     // -----------------------------------------------------------------------
     // Imperative B2BUA terminate helpers (b2bua.terminate / session timer)

--- a/src/rtpengine/events.rs
+++ b/src/rtpengine/events.rs
@@ -35,6 +35,14 @@ pub enum RtpEngineEvent {
         call_id: String,
         from_tag: String,
     },
+    /// End-of-call media summary (the structured twin of the `siphon_rtp::cdr`
+    /// log block), emitted once when the engine tears a call down.  Carries the
+    /// per-leg byte/packet counters and, when a userspace media actor measured
+    /// them, the RFC 3550 loss/jitter and ITU-T G.107 MOS shape — so siphon
+    /// writes a media CDR (correlated to the SIP CDR by Call-ID) instead of
+    /// scraping logs.  Emitted by the `siphon-rtp` native backend only; the
+    /// rtpengine NG backend does not surface it.
+    CallSummary(CallSummary),
     /// An event we didn't recognise — passed through for logging.
     Unknown {
         event: String,
@@ -59,6 +67,63 @@ pub struct DtmfEvent {
     pub volume: i32,
     /// rtpengine's view of the media source (IP:port) — informational.
     pub source: Option<String>,
+}
+
+/// End-of-call media summary for one call, carried by
+/// [`RtpEngineEvent::CallSummary`].  A siphon-sip-owned mirror of the native
+/// backend's `siphon_rtp_proto::Event::CallSummary` payload, so this generic
+/// event enum stays free of the proto type (same posture as `MediaTimeout`
+/// being native-only).
+#[derive(Debug, Clone)]
+pub struct CallSummary {
+    /// SIP Call-ID the media session was keyed on — correlates to the SIP CDR.
+    pub call_id: String,
+    /// Why the call ended: `"delete"` (controller teardown) or `"media_timeout"`
+    /// (dead-path reap).
+    pub reason: String,
+    /// Call lifetime in milliseconds (logical-clock resolution, ~1 s grain).
+    pub duration_ms: u64,
+    /// One entry per leg — index 0 is the near (offerer) leg, index 1 the far
+    /// (answerer) leg.
+    pub legs: Vec<CallLegSummary>,
+}
+
+/// One leg's end-of-call figures in a [`CallSummary`].  The quality fields are
+/// `None` on a leg with no userspace actor (a plain in-kernel relay) or one that
+/// never received media, so a consumer can tell "counters only" from "measured".
+#[derive(Debug, Clone)]
+pub struct CallLegSummary {
+    /// The leg's tag: the offerer's `from_tag` (near) or the answerer's `to_tag`
+    /// (far).
+    pub tag: String,
+    /// The leg's negotiated audio codec name, if known.
+    pub codec: Option<String>,
+    pub packets_in: u64,
+    pub bytes_in: u64,
+    pub packets_out: u64,
+    pub bytes_out: u64,
+    /// Packets dropped on the engine's side of this leg (source-gate / latch /
+    /// jitter overflow), not network loss.
+    pub packets_dropped: u64,
+    /// The inbound stream's SSRC (RFC 3550), when measured.
+    pub ssrc: Option<u32>,
+    /// Cumulative network packets lost on the inbound stream (RFC 3550 §6.4.1),
+    /// when measured.
+    pub packets_lost: Option<u32>,
+    /// Inbound network packet loss as a percentage, when measured.
+    pub loss_percent: Option<f64>,
+    /// Inbound interarrival jitter in milliseconds (RFC 3550 §6.4.1), when measured.
+    pub jitter_ms: Option<f64>,
+    /// Engine↔peer round-trip time in milliseconds, when a reception report
+    /// yielded one.
+    pub rtt_ms: Option<f64>,
+    /// Mean / lowest / highest ITU-T G.107 MOS across the call, when measured.
+    pub mos_average: Option<f64>,
+    pub mos_min: Option<f64>,
+    pub mos_max: Option<f64>,
+    /// `"full"` (MOS includes the G.107 delay term) or `"loss+jitter"` — how the
+    /// MOS was derived.
+    pub mos_basis: Option<String>,
 }
 
 /// Helpers for extracting values from a bencoded event dict.

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -28,8 +28,8 @@ use std::time::Duration;
 use dashmap::DashMap;
 use futures_util::future::join_all;
 use siphon_rtp_proto::{
-    frame, CmdResult, Command, Event, PlayEndReason, PlayMediaSource as ProtoPlayMediaSource,
-    ProfileFlags, Request, Response,
+    frame, CmdResult, Command, Event, LegSummary as ProtoLegSummary, PlayEndReason,
+    PlayMediaSource as ProtoPlayMediaSource, ProfileFlags, Request, Response,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -39,7 +39,7 @@ use tracing::{debug, info, trace, warn};
 
 use super::client::PlayMediaSource;
 use super::error::RtpEngineError;
-use super::events::{DtmfEvent, RtpEngineEvent};
+use super::events::{CallLegSummary, CallSummary, DtmfEvent, RtpEngineEvent};
 use super::profile::NgFlags;
 
 /// Reserved request id for the auth handshake (real requests start at 1).
@@ -1045,6 +1045,17 @@ fn convert_event(event: Event) -> RtpEngineEvent {
             call_id,
             from_tag,
         },
+        Event::CallSummary {
+            call_id,
+            reason,
+            duration_ms,
+            legs,
+        } => RtpEngineEvent::CallSummary(CallSummary {
+            call_id,
+            reason,
+            duration_ms,
+            legs: legs.into_iter().map(convert_leg_summary).collect(),
+        }),
         Event::ActiveSpeaker {
             conference_id,
             from_tag,
@@ -1078,6 +1089,29 @@ fn convert_event(event: Event) -> RtpEngineEvent {
             call_id: None,
             from_tag: None,
         },
+    }
+}
+
+/// Convert a proto [`ProtoLegSummary`] into siphon's [`CallLegSummary`] — a
+/// field-for-field copy that keeps the generic event enum free of the proto type.
+fn convert_leg_summary(leg: ProtoLegSummary) -> CallLegSummary {
+    CallLegSummary {
+        tag: leg.tag,
+        codec: leg.codec,
+        packets_in: leg.packets_in,
+        bytes_in: leg.bytes_in,
+        packets_out: leg.packets_out,
+        bytes_out: leg.bytes_out,
+        packets_dropped: leg.packets_dropped,
+        ssrc: leg.ssrc,
+        packets_lost: leg.packets_lost,
+        loss_percent: leg.loss_percent,
+        jitter_ms: leg.jitter_ms,
+        rtt_ms: leg.rtt_ms,
+        mos_average: leg.mos_average,
+        mos_min: leg.mos_min,
+        mos_max: leg.mos_max,
+        mos_basis: leg.mos_basis,
     }
 }
 
@@ -1520,6 +1554,84 @@ mod tests {
                 assert_eq!(from_tag, "f");
             }
             other => panic!("expected MediaTimeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_event_call_summary() {
+        // A measured near leg (actor quality present) + a counters-only far leg
+        // (no actor) — the two shapes the summary must carry through.
+        let near = ProtoLegSummary {
+            tag: "near-tag".into(),
+            codec: Some("AMR-WB".into()),
+            packets_in: 2100,
+            bytes_in: 336_000,
+            packets_out: 2098,
+            bytes_out: 335_680,
+            packets_dropped: 2,
+            ssrc: Some(0xDEAD_BEEF),
+            packets_lost: Some(6),
+            loss_percent: Some(0.3),
+            jitter_ms: Some(4.2),
+            rtt_ms: Some(21.0),
+            mos_average: Some(4.11),
+            mos_min: Some(3.9),
+            mos_max: Some(4.3),
+            mos_basis: Some("full".into()),
+        };
+        let far = ProtoLegSummary {
+            tag: "far-tag".into(),
+            codec: Some("PCMU".into()),
+            packets_in: 2099,
+            bytes_in: 335_840,
+            packets_out: 2100,
+            bytes_out: 336_000,
+            packets_dropped: 0,
+            ssrc: None,
+            packets_lost: None,
+            loss_percent: None,
+            jitter_ms: None,
+            rtt_ms: None,
+            mos_average: None,
+            mos_min: None,
+            mos_max: None,
+            mos_basis: None,
+        };
+        match convert_event(Event::CallSummary {
+            call_id: "call-9".into(),
+            reason: "delete".into(),
+            duration_ms: 42_000,
+            legs: vec![near, far],
+        }) {
+            RtpEngineEvent::CallSummary(summary) => {
+                assert_eq!(summary.call_id, "call-9");
+                assert_eq!(summary.reason, "delete");
+                assert_eq!(summary.duration_ms, 42_000);
+                assert_eq!(summary.legs.len(), 2);
+
+                let near = &summary.legs[0];
+                assert_eq!(near.tag, "near-tag");
+                assert_eq!(near.codec.as_deref(), Some("AMR-WB"));
+                assert_eq!(near.packets_in, 2100);
+                assert_eq!(near.bytes_out, 335_680);
+                assert_eq!(near.packets_dropped, 2);
+                assert_eq!(near.ssrc, Some(0xDEAD_BEEF));
+                assert_eq!(near.packets_lost, Some(6));
+                assert_eq!(near.loss_percent, Some(0.3));
+                assert_eq!(near.jitter_ms, Some(4.2));
+                assert_eq!(near.rtt_ms, Some(21.0));
+                assert_eq!(near.mos_average, Some(4.11));
+                assert_eq!(near.mos_basis.as_deref(), Some("full"));
+
+                let far = &summary.legs[1];
+                assert_eq!(far.tag, "far-tag");
+                assert_eq!(far.codec.as_deref(), Some("PCMU"));
+                assert_eq!(far.ssrc, None);
+                assert_eq!(far.packets_lost, None);
+                assert_eq!(far.mos_average, None);
+                assert_eq!(far.mos_basis, None);
+            }
+            other => panic!("expected CallSummary, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## What

Consume the media engine's end-of-call summary (`siphon-rtp-proto` 0.1.4) and turn it into a CDR, so operators get per-leg media stats (byte/packet counters, RFC 3550 loss/jitter, ITU-T G.107 MOS) as structured data instead of scraping the engine's `siphon_rtp::cdr` log.

On the native `siphon-rtp` backend the engine now pushes a `CallSummary` event when it tears a call down (controller `delete` or the media-timeout reaper). This decodes it and, when `cdr.auto_emit` is on, writes a **separate media CDR** keyed on the SIP Call-ID so a collector joins it to the SIP-side CDR (which owns the URIs / disconnect side).

## Why a separate media CDR (not a single merged record)

The SIP-side CDR is finalized synchronously at teardown, which in the normal flow (BYE → SIP CDR → media `delete` → engine emits `CallSummary`) happens **before** the async summary arrives. A single merged record would mean holding every media call's SIP CDR behind a pending buffer + timeout sweep and eating that latency even for calls that never produce a summary (rtpengine backend, no media anchoring). A distinct `method="MEDIA"` record correlated by Call-ID is race-free, always fires (including the media-timeout reap with no BYE), and keeps a deterministic CDR shape for the collector to join.

## CDR shape

- top-level: `call_id`, `method="MEDIA"`, `media_reason` (`delete` / `media_timeout`), `media_duration_ms`, plus the standard `duration_secs` (= duration_ms / 1000)
- per leg, flattened into `extra` under `near_` (offerer) / `far_` (answerer) / `leg{n}_`: `_tag`, `_codec`, `_packets_in`/`_out`, `_bytes_in`/`_out`, `_packets_dropped`, and when a userspace actor measured them `_ssrc`, `_packets_lost`, `_loss_percent`, `_jitter_ms`, `_rtt_ms`, `_mos_average`/`_min`/`_max`, `_mos_basis`
- unmeasured optional fields (a plain in-kernel relay leg has no MOS/loss/jitter) are omitted, not emitted empty

The rtpengine / rtpproxy backends don't surface this event, so no media CDR is written there.

## Changes

- `siphon-rtp-proto` pin `0.1.3` → `0.1.4` (dep + dev-dep)
- `src/rtpengine/events.rs` — new `RtpEngineEvent::CallSummary(CallSummary)` + siphon-owned `CallSummary` / `CallLegSummary` structs (keeps the generic event enum free of the proto type, same posture as `MediaTimeout` being native-only)
- `src/rtpengine/siphon_rtp.rs` — map `Event::CallSummary` in `convert_event` via a `convert_leg_summary` helper
- `src/dispatcher.rs` — `CallSummary` event-loop arm + testable `media_summary_to_cdr` builder
- CHANGELOG `[Unreleased]`

## Tests

- `convert_event_call_summary` — proto → event mapping (measured + counters-only legs)
- `media_summary_to_cdr_flattens_legs` — near/far prefixes, measured vs omitted fields, duration
- `media_summary_to_cdr_indexes_extra_legs` — a third (conference/MPTY) leg indexes `leg2_`
- full suite green (3269 passed), clippy clean

No SDK change — this adds CDR JSON fields, not Python API surface.
