### PR TITLE
fix(b2bua): stop the b-leg INVITE To header emitting a double port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   unaffected; there is no separate `answer_now()`.
 
 ### Fixed
+- **B2BUA no longer emits a malformed double-port To header on the B-leg
+  INVITE.** When topology-hiding the To URI to the dial target, siphon replaced
+  only the host token and left the original To port in place — so an inbound To
+  carrying siphon's own inbound port (e.g. `callee@pcscf.example:5061`) dialed to
+  a next-hop that advertises a port (`gw.example:5060`) produced
+  `gw.example:5060:5061`, two ports on one URI (RFC 3261 §19.1.1), which strict
+  SBCs reject with `400 Wrong URI`. The default (dial-target) rewrite now
+  replaces the whole `host[:port]` authority; the `call.set_to_host()` override
+  still rewrites host-only and preserves the original port per its documented
+  contract. Only the B2BUA was affected — a proxy does not rewrite To/From.
 - **B2BUA no longer emits a spurious `502 Bad Gateway` in response to a caller's
   ACK.** When a B2BUA forwarded a non-2xx final response (e.g. a relayed `407`)
   to the caller and the caller ACKed it, siphon could route that ACK as a fresh

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -282,6 +282,34 @@ pub fn rewrite_uri_host(header_value: &str, new_host: &str) -> String {
     }
 }
 
+/// Rewrite the whole `host[:port]` authority of a SIP URI in a From/To header
+/// value.
+///
+/// Unlike [`rewrite_uri_host`] — which replaces only the host token and leaves
+/// any existing `:port` in place — this replaces the entire `host[:port]`
+/// authority with `new_authority`. Use it when substituting a dial-target
+/// authority that itself carries a port (e.g. topology-hiding the B-leg To to
+/// the next-hop): replacing host-only there would splice the new `host:port` in
+/// front of the retained old port and emit a malformed `host:newport:oldport`
+/// (double port), which some SBCs reject as `400 Wrong URI`.
+pub fn rewrite_uri_authority(header_value: &str, new_authority: &str) -> String {
+    if let Some(at_pos) = header_value.find('@') {
+        let after_at = &header_value[at_pos + 1..];
+        // Split only on the URI-param / bracket terminators, NOT on ':', so the
+        // original port is consumed along with the host.
+        let authority_end = after_at.find(['>', ';']).unwrap_or(after_at.len());
+        let end_pos = at_pos + 1 + authority_end;
+        format!(
+            "{}{}{}",
+            &header_value[..at_pos + 1],
+            new_authority,
+            &header_value[end_pos..],
+        )
+    } else {
+        header_value.to_string()
+    }
+}
+
 /// Generate a fresh SIP tag.
 pub fn generate_tag() -> String {
     format!("sb-{}", &uuid::Uuid::new_v4().as_simple().to_string()[..12])
@@ -2609,9 +2637,65 @@ mod tests {
 
     #[test]
     fn rewrite_uri_host_pai_with_display() {
-        let pai = "\"Outbound Call\" <sip:W5LeMb7O@172.31.47.238>";
-        let result = rewrite_uri_host(pai, "63.176.27.178");
-        assert_eq!(result, "\"Outbound Call\" <sip:W5LeMb7O@63.176.27.178>");
+        let pai = "\"Outbound Call\" <sip:alice@10.0.0.5>";
+        let result = rewrite_uri_host(pai, "203.0.113.5");
+        assert_eq!(result, "\"Outbound Call\" <sip:alice@203.0.113.5>");
+    }
+
+    // --- rewrite_uri_authority tests ---
+
+    #[test]
+    fn rewrite_uri_authority_replaces_host_and_port() {
+        // Regression: the original To carried siphon's inbound port (:5061)
+        // leaked from the A-leg.  Topology-hiding the To to a dial target that
+        // itself carries a port must replace host AND port — replacing host
+        // only left the old port and produced `host:5060:5061` (double port),
+        // which the SBC rejected as 400 Wrong URI.
+        let to = "<sip:bob@pcscf.example.com:5061;user=phone>";
+        let result = rewrite_uri_authority(to, "trunk.example.com:5060");
+        assert_eq!(
+            result,
+            "<sip:bob@trunk.example.com:5060;user=phone>"
+        );
+        // No double port anywhere in the result.
+        assert!(!result.contains(":5060:"));
+        assert!(!result.contains("5060:5061"));
+    }
+
+    #[test]
+    fn rewrite_uri_authority_drops_old_port_when_target_has_none() {
+        let to = "<sip:bob@10.0.0.1:5061;user=phone>";
+        let result = rewrite_uri_authority(to, "trunk.example.com");
+        assert_eq!(result, "<sip:bob@trunk.example.com;user=phone>");
+    }
+
+    #[test]
+    fn rewrite_uri_authority_no_original_port() {
+        let to = "<sip:bob@old.example.com;user=phone>";
+        let result = rewrite_uri_authority(to, "trunk.example.com:5060");
+        assert_eq!(result, "<sip:bob@trunk.example.com:5060;user=phone>");
+    }
+
+    #[test]
+    fn rewrite_uri_authority_no_params_no_port() {
+        let to = "<sip:bob@old.example.com>";
+        let result = rewrite_uri_authority(to, "trunk.example.com:5060");
+        assert_eq!(result, "<sip:bob@trunk.example.com:5060>");
+    }
+
+    #[test]
+    fn rewrite_uri_authority_display_name() {
+        let to = "\"Alice\" <sip:alice@old.example.net:5061;user=phone>";
+        let result = rewrite_uri_authority(to, "gw.example.net:5060");
+        assert_eq!(result, "\"Alice\" <sip:alice@gw.example.net:5060;user=phone>");
+    }
+
+    #[test]
+    fn rewrite_uri_authority_no_at_sign() {
+        let to = "<sip:host.a:5060>";
+        let result = rewrite_uri_authority(to, "gw.b:5060");
+        // No @ sign — returned unchanged.
+        assert_eq!(result, to);
     }
 
     // --- ensure_tag tests ---

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -9107,29 +9107,28 @@ fn b2bua_send_b_leg_invite(
         if let Some(tag_start) = new_to.find(";tag=") {
             new_to = new_to[..tag_start].to_string();
         }
-        // Rewrite the To URI host.  Default: the dial-target host (topology
-        // hiding).  When the script pinned a host via `call.set_to_host()`,
-        // use that instead (host only — the original To port is preserved).
-        if let Some(at_pos) = new_to.find('@') {
-            let after_at = &new_to[at_pos + 1..];
-            let host_end = after_at.find(['>', ';', ':'])
-                .unwrap_or(after_at.len());
-            let end_pos = at_pos + 1 + host_end;
-            let replacement = if let Some(ref pinned) = to_host_override {
-                pinned.clone()
-            } else if let Ok(target_parsed) = parse_uri_standalone(target_uri) {
-                // Include port if present in target
-                if let Some(port) = target_parsed.port {
-                    format!("{}:{}", target_parsed.host, port)
-                } else {
-                    target_parsed.host.clone()
-                }
-            } else {
-                // Unparseable target and no override — leave the host as-is.
-                new_to[at_pos + 1..end_pos].to_string()
+        // Rewrite the To URI host.
+        if let Some(ref pinned) = to_host_override {
+            // Script pinned a host via `call.set_to_host()`: host only — the
+            // original To port and URI params are preserved (documented
+            // `set_to_host` contract: `value` is a bare host, no port).
+            new_to = crate::b2bua::actor::rewrite_uri_host(&new_to, pinned);
+        } else if let Ok(target_parsed) = parse_uri_standalone(target_uri) {
+            // Default: topology-hide the To to the dial-target authority.  The
+            // original To host+port is siphon's own inbound address (leaked
+            // from the A-leg) and is meaningless on the B-leg, so replace host
+            // AND port with the target's `host[:port]`.  Replacing host-only
+            // here would leave the old `:port` in place and, when the target
+            // carries a port, emit a malformed `host:newport:oldport`
+            // (RFC 3261 §19.1.1 — a URI carries at most one port), which SBCs
+            // reject as `400 Wrong URI`.
+            let target_authority = match target_parsed.port {
+                Some(port) => format!("{}:{}", target_parsed.host, port),
+                None => target_parsed.host.clone(),
             };
-            new_to = format!("{}{}{}", &new_to[..at_pos + 1], replacement, &new_to[end_pos..]);
+            new_to = crate::b2bua::actor::rewrite_uri_authority(&new_to, &target_authority);
         }
+        // Unparseable target and no override — leave the To host untouched.
         b_leg_invite.headers.set("To", new_to);
     }
 

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -1401,21 +1401,48 @@ fn rewrite_uri_host_hides_private_ip_in_from() {
     use siphon::b2bua::actor::rewrite_uri_host;
 
     // Simulates BYE forwarding: A-leg From has private IP, must be rewritten
-    let from = "<sip:+alice@10.101.5.124>;tag=sb-17291b99bc2d";
-    let rewritten = rewrite_uri_host(from, "63.176.27.178");
-    assert_eq!(rewritten, "<sip:+alice@63.176.27.178>;tag=sb-17291b99bc2d");
-    assert!(!rewritten.contains("10.101.5.124"), "private IP must not leak");
+    let from = "<sip:alice@10.0.0.5>;tag=sb-17291b99bc2d";
+    let rewritten = rewrite_uri_host(from, "203.0.113.5");
+    assert_eq!(rewritten, "<sip:alice@203.0.113.5>;tag=sb-17291b99bc2d");
+    assert!(!rewritten.contains("10.0.0.5"), "private IP must not leak");
 }
 
 #[test]
 fn rewrite_uri_host_hides_private_ip_in_pai() {
     use siphon::b2bua::actor::rewrite_uri_host;
 
-    // Simulates PAI from A-leg: has RTT's private AWS IP
-    let pai = "<sip:+i52wkmRMaZ4u@172.31.47.238>";
-    let rewritten = rewrite_uri_host(pai, "63.176.27.178");
-    assert_eq!(rewritten, "<sip:+i52wkmRMaZ4u@63.176.27.178>");
-    assert!(!rewritten.contains("172.31.47.238"), "private IP must not leak");
+    // Simulates PAI from A-leg: has a private IP that must not leak downstream
+    let pai = "<sip:alice@10.0.0.6>";
+    let rewritten = rewrite_uri_host(pai, "203.0.113.5");
+    assert_eq!(rewritten, "<sip:alice@203.0.113.5>");
+    assert!(!rewritten.contains("10.0.0.6"), "private IP must not leak");
+}
+
+#[test]
+fn rewrite_uri_authority_no_double_port_when_topology_hiding_to() {
+    use siphon::b2bua::actor::rewrite_uri_authority;
+
+    // Regression: an inbound INVITE carried the callee's To against siphon's
+    // own inbound port (`pcscf.example.com:5061`).  When the B2BUA dials a
+    // trunk that itself advertises a port (`trunk.example.com:5060`), the
+    // To must be topology-hidden to the *whole* target authority.  Replacing
+    // host-only left the old port and emitted `trunk.example.com:5060:5061`
+    // (two ports on one URI, RFC 3261 §19.1.1 violation) which the trunk
+    // rejected with `400 Wrong URI`.
+    let to = "<sip:bob@pcscf.example.com:5061;user=phone>";
+    let rewritten = rewrite_uri_authority(to, "trunk.example.com:5060");
+    assert_eq!(
+        rewritten,
+        "<sip:bob@trunk.example.com:5060;user=phone>"
+    );
+    assert!(
+        !rewritten.contains("5060:5061"),
+        "double port must not appear: {rewritten}"
+    );
+    assert!(
+        !rewritten.contains("pcscf.example.com"),
+        "siphon's inbound host must not leak to the B-leg: {rewritten}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a B2BUA dials a target, it topology-hides the B-leg INVITE `To` URI to the dial-target host. The rewrite replaced only the **host token** (it stopped at the first `:`), leaving the original `To` port in the tail. That original port is siphon's own inbound port, bled through from the inbound A-leg `To`.

When the dial target itself advertises a port, the two collide:

```
inbound  To: <sip:callee@pcscf.example.com:5061;user=phone>
dial     sip:callee@gw.example.com:5060
B-leg    To: <sip:callee@gw.example.com:5060:5061;user=phone>   <-- two ports
```

Two ports on one URI violates RFC 3261 §19.1.1, and strict SBCs reject the INVITE with `400 Wrong URI`, failing the call.

## Fix

Split the two rewrite intents:

- **Default (dial-target) path** now replaces the whole `host[:port]` authority via a new `rewrite_uri_authority()` helper — the leaked inbound port is dropped along with the host.
- **`call.set_to_host()` override** still rewrites host-only and preserves the original port, per its documented contract (bare host, no port).

The `From` rewrite is unaffected (its replacement host is always a bare host, so it never doubles), and the **proxy path is not affected at all** — a proxy does not rewrite `To`/`From`.

## Tests

- `rewrite_uri_authority` unit tests in `b2bua/actor.rs` (host+port replace, no-port target, params, display name, no-@).
- Integration regression in `tests/integration/b2bua_tests.rs` asserting the exact scenario produces no double port.
- Full suite green (2907 lib + 277 integration), clippy clean.
- CHANGELOG updated under `[Unreleased] > Fixed`.