### PR TITLE
feat(presence): presence.refresh + find_by_dialog for in-dialog SUBSCRIBE (fix S-CSCF reg-event refresh/un-SUBSCRIBE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **`presence.refresh(subscription_id, expires)` + `presence.find_by_dialog(call_id, from_tag)`** —
+  the two pieces needed to handle an in-dialog SUBSCRIBE (RFC 6665 §4.4.1) as a
+  notifier. `find_by_dialog` resolves a subscription id from an in-dialog
+  SUBSCRIBE's `(Call-ID, From-tag)` — which a refresh or `Expires: 0`
+  un-SUBSCRIBE carries but the original id it does not — and `refresh` resets
+  that subscription's timer without recreating the dialog (the store already had
+  `refresh_subscription`; it just wasn't exposed). Only subscriptions created
+  with `subscribe_dialog` (which store dialog state) are findable; terminated
+  ones are skipped so a lingering entry can't shadow a re-SUBSCRIBE that reused
+  the Call-ID. Mirrored in the `siphon-sip` SDK mock. The IMS S-CSCF example
+  (`examples/ims_scscf.py`) is rewritten to use them: the initial reg-event
+  SUBSCRIBE now establishes a real dialog (assigns the notifier To-tag on the
+  2xx, RFC 6665 §4.1.3, and stores it via `subscribe_dialog`), and the in-dialog
+  branch keys on the dialog to refresh the timer or, on `Expires: 0`, tear the
+  subscription down with a terminal NOTIFY — fixing reg-event refresh and
+  un-SUBSCRIBE, which previously 404'd for every subscriber.
+
 ### Fixed
 - **B2BUA on a multi-homed host now answers on the socket the call arrived on.**
   When siphon listens on more than one UDP port (e.g. `5060` and `5066`), the

--- a/examples/ims_scscf.py
+++ b/examples/ims_scscf.py
@@ -30,6 +30,11 @@ from siphon import proxy, registrar, auth, diameter, presence, isc, log
 
 REALM = "ims.example.com"
 SCSCF_URI = f"sip:scscf.{REALM}:6060"
+# Notifier (S-CSCF) To-tag for reg-event dialogs. One stable tag is enough: a
+# reg-event dialog is keyed on (Call-ID, subscriber From-tag), both unique per
+# UE, so the notifier tag need not vary. Keeping it stable lets the initial 2xx,
+# every in-dialog NOTIFY, and the on_change broadcast all address the same dialog.
+SCSCF_NOTIFIER_TAG = "scscf-notif"
 
 # Server-Assignment-Type values (3GPP TS 29.228 §6.3.15)
 SAT_NO_ASSIGNMENT = 0
@@ -114,34 +119,84 @@ def handle_register(request):
 
 @proxy.on_request("SUBSCRIBE")
 async def handle_subscribe(request):
-    """Handle SUBSCRIBE for reg event and other packages."""
+    """Handle SUBSCRIBE for the reg event package (RFC 3680) and others.
+
+    The S-CSCF is the notifier for reg-event, so it terminates the SUBSCRIBE
+    dialog locally rather than relaying it. To make refresh and un-SUBSCRIBE
+    work, the initial 2xx establishes a real dialog (our To-tag, RFC 6665
+    §4.1.3) and the subscription is stored with its dialog identifiers. A later
+    in-dialog SUBSCRIBE is then matched back by dialog (Call-ID + From-tag) and
+    either refreshes the timer or, on Expires:0, tears the subscription down
+    with a terminal NOTIFY.
+    """
+    expires = int(request.get_header("Expires") or "3600")
+
+    # --- In-dialog SUBSCRIBE: refresh or un-SUBSCRIBE (RFC 6665 §4.4.1) ---
     if request.in_dialog:
-        if request.loose_route():
-            request.relay()
+        sub_id = presence.find_by_dialog(request.call_id, request.from_tag)
+        if sub_id is None:
+            # Not one of our local reg-event dialogs — it's a subscription we
+            # proxy for someone else; loose-route it onward. If it isn't
+            # routable either, the dialog is unknown (RFC 6665 §4.4.1).
+            if request.loose_route():
+                request.relay()
+            else:
+                request.reply(481, "Subscription Does Not Exist")
+            return
+
+        # reg-event is a self-subscription: the watched AoR is the subscriber,
+        # and From-URI is stable across the dialog, so it is the resource.
+        aor = str(request.from_uri)
+        if expires == 0:
+            presence.unsubscribe(sub_id)
+            sub_state = "terminated;reason=timeout"
         else:
-            request.reply(404, "Not Here")
+            presence.refresh(sub_id, expires)
+            sub_state = f"active;expires={expires}"
+
+        # 200 echoes the dialog To-tag from the request; the in-dialog NOTIFY
+        # reflects the new state, From-tag = our dialog tag (the To-tag the
+        # subscriber addressed this request to).
+        request.reply(200, "OK")
+        body = registrar.reginfo_xml(aor, state="full")
+        await proxy.send_request("NOTIFY", str(request.from_uri), headers={
+            "Event": "reg",
+            "Subscription-State": sub_state,
+            "Content-Type": "application/reginfo+xml",
+            "To": str(request.from_uri),
+            "From": f"<{SCSCF_URI}>;tag={request.to_tag}",
+        }, body=body)
+        log.info(f"reg {'un-' if expires == 0 else 're-'}SUBSCRIBE from "
+                 f"{request.from_uri}: {sub_state}")
         return
 
-    # For reg event subscriptions (RFC 3680), respond locally and send NOTIFY.
+    # --- Initial reg SUBSCRIBE (RFC 3680): respond locally, establish dialog ---
     if request.event == "reg":
         aor = str(request.ruri)
-        expires = int(request.get_header("Expires") or "3600")
 
-        # Store the subscription so on_change can notify this watcher.
-        presence.subscribe(str(request.from_uri), aor,
-                           event="reg", expires=expires)
+        # Assign our To-tag on the 2xx (RFC 6665 §4.1.3) so the subscriber's
+        # later in-dialog refresh / un-SUBSCRIBE lands back here and
+        # find_by_dialog() can resolve it. Store the subscription WITH its
+        # dialog identifiers (Call-ID + tags) so the lookup has something to
+        # match — subscribe() (no dialog state) would not be findable.
+        request.set_reply_to_tag(SCSCF_NOTIFIER_TAG)
+        presence.subscribe_dialog(
+            str(request.from_uri), aor, "reg", expires,
+            request.call_id, request.from_tag, SCSCF_NOTIFIER_TAG,
+        )
 
         request.set_header("Subscription-State", f"active;expires={expires}")
         request.reply(200, "OK")
 
-        # Send initial NOTIFY with full reginfo (RFC 3680 §3.2).
+        # Initial NOTIFY with full reginfo (RFC 3680 §3.2), in-dialog: From-tag
+        # is the To-tag we just assigned.
         body = registrar.reginfo_xml(aor, state="full", version=0)
         await proxy.send_request("NOTIFY", str(request.from_uri), headers={
             "Event": "reg",
             "Subscription-State": f"active;expires={expires}",
             "Content-Type": "application/reginfo+xml",
             "To": str(request.from_uri),
-            "From": f"<{SCSCF_URI}>;tag=scscf-notif",
+            "From": f"<{SCSCF_URI}>;tag={SCSCF_NOTIFIER_TAG}",
         }, body=body)
         log.info(f"reg SUBSCRIBE from {request.from_uri} for {aor}: "
                  f"sent 200 + initial NOTIFY")
@@ -171,7 +226,7 @@ async def on_registration_change(aor, event_type, contacts):
             "Subscription-State": "active",
             "Content-Type": "application/reginfo+xml",
             "To": watcher["subscriber"],
-            "From": f"<{SCSCF_URI}>;tag=scscf-notif",
+            "From": f"<{SCSCF_URI}>;tag={SCSCF_NOTIFIER_TAG}",
         }, body=body)
     log.info(f"reg change: {event_type} for {aor}, "
              f"notified {len(list(presence.subscribers(aor)))} watchers")

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -4389,6 +4389,49 @@ class MockPresence:
         """
         return self._subscriptions.pop(subscription_id, None) is not None
 
+    def refresh(self, subscription_id: str, expires: int) -> bool:
+        """Refresh a subscription's expiry (RFC 6665 §4.4.1 re-SUBSCRIBE).
+
+        Resets the subscription timer to ``expires`` seconds, keeping the dialog.
+        Pair with :meth:`find_by_dialog` to resolve the id from an in-dialog
+        SUBSCRIBE before refreshing.
+
+        Args:
+            subscription_id: The subscription ID (from ``subscribe*`` or
+                :meth:`find_by_dialog`).
+            expires: New subscription duration in seconds.
+
+        Returns:
+            ``True`` if the subscription was found and refreshed.
+        """
+        sub = self._subscriptions.get(subscription_id)
+        if sub is None:
+            return False
+        sub["expires"] = expires
+        return True
+
+    def find_by_dialog(self, call_id: str, from_tag: str) -> Optional[str]:
+        """Resolve a subscription id from its dialog ``(Call-ID, From-tag)``.
+
+        An in-dialog SUBSCRIBE (a refresh, or an un-SUBSCRIBE with ``Expires: 0``)
+        carries the dialog's Call-ID and the subscriber's From-tag but not the
+        original subscription id. This maps that pair back so a notifier
+        (e.g. an S-CSCF handling reg-event) can :meth:`refresh` or
+        :meth:`unsubscribe` the right dialog. Only subscriptions created with
+        :meth:`subscribe_dialog` (which store dialog state) are findable.
+
+        Args:
+            call_id: Call-ID of the in-dialog SUBSCRIBE.
+            from_tag: From-tag of the in-dialog SUBSCRIBE (subscriber's tag).
+
+        Returns:
+            The subscription ID string, or ``None`` if no dialog matches.
+        """
+        for sub_id, value in self._subscriptions.items():
+            if value.get("call_id") == call_id and value.get("from_tag") == from_tag:
+                return sub_id
+        return None
+
     def subscribers(self, resource: str) -> list[dict]:
         """List subscribers (watchers) for a resource.
 

--- a/sdk/tests/test_presence_mock.py
+++ b/sdk/tests/test_presence_mock.py
@@ -99,3 +99,40 @@ def test_notify_with_active_state_does_not_remove():
     )
     presence.notify(sub_id, subscription_state="active;expires=3600")
     assert presence.subscription_count() == 1
+
+
+def test_find_by_dialog_resolves_refresh_and_unsubscribe():
+    """In-dialog SUBSCRIBE flow: resolve by (Call-ID, From-tag), refresh, remove."""
+    presence = _fresh_presence()
+    sub_id = presence.subscribe_dialog(
+        subscriber="sip:alice@ims.example.com",
+        resource="sip:alice@ims.example.com",
+        event="reg",
+        expires=3600,
+        call_id="call-abc",
+        from_tag="ftag-alice",
+        to_tag="scscf-notif",
+    )
+
+    assert presence.find_by_dialog("call-abc", "ftag-alice") == sub_id
+    # Wrong pair / unknown dialog → None.
+    assert presence.find_by_dialog("call-abc", "ftag-bob") is None
+    assert presence.find_by_dialog("call-xyz", "ftag-alice") is None
+
+    # Refresh the resolved subscription.
+    assert presence.refresh(sub_id, 7200) is True
+    assert presence.refresh("sub-nope", 7200) is False
+
+    # Un-SUBSCRIBE: resolve then remove.
+    resolved = presence.find_by_dialog("call-abc", "ftag-alice")
+    assert presence.unsubscribe(resolved) is True
+    assert presence.find_by_dialog("call-abc", "ftag-alice") is None
+    assert presence.subscription_count() == 0
+
+
+def test_find_by_dialog_ignores_non_dialog_subscription():
+    """subscribe() (no dialog state) is not findable by dialog."""
+    presence = _fresh_presence()
+    presence.subscribe("sip:alice@ims.example.com", "sip:alice@ims.example.com",
+                       event="reg", expires=3600)
+    assert presence.find_by_dialog("", "") is None

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -345,6 +345,33 @@ impl PresenceStore {
         }
     }
 
+    /// Find a subscription by its dialog identifiers `(Call-ID, From-tag)`.
+    ///
+    /// An in-dialog SUBSCRIBE (RFC 6665 §4.4.1 refresh, or an un-SUBSCRIBE with
+    /// `Expires: 0`) carries the dialog's Call-ID and the subscriber's From-tag —
+    /// stable across the dialog's life. This resolves that pair back to the
+    /// subscription id so the notifier can refresh, terminate, or NOTIFY it. The
+    /// dialog's To-tag (the notifier's own tag) is intentionally not part of the
+    /// key: `(Call-ID, From-tag)` already identifies a subscriber's dialog
+    /// uniquely, and it's what the script has cheaply on the in-dialog request.
+    ///
+    /// Terminated subscriptions are skipped so a lingering pre-removal entry can't
+    /// shadow a fresh re-SUBSCRIBE that reused the Call-ID. Returns the first
+    /// live match, or `None`.
+    pub fn find_subscription_by_dialog(&self, call_id: &str, from_tag: &str) -> Option<String> {
+        self.subscriptions.iter().find_map(|entry| {
+            let subscription = entry.value();
+            if subscription.state != SubscriptionState::Terminated
+                && subscription.call_id.as_deref() == Some(call_id)
+                && subscription.from_tag.as_deref() == Some(from_tag)
+            {
+                Some(subscription.id.clone())
+            } else {
+                None
+            }
+        })
+    }
+
     /// Terminate a subscription (sets state to `Terminated` but does not remove it).
     pub fn terminate_subscription(&self, id: &str) {
         if let Some(mut entry) = self.subscriptions.get_mut(id) {
@@ -1032,5 +1059,73 @@ mod tests {
             subscription.dialog_id.as_deref(),
             Some("call-id-123:from-tag:to-tag")
         );
+    }
+
+    fn dialog_sub(id: &str, call_id: &str, from_tag: &str) -> Subscription {
+        Subscription::with_dialog(
+            id.to_string(),
+            "sip:alice@ims.example.com".to_string(),
+            "sip:alice@ims.example.com".to_string(),
+            "reg".to_string(),
+            Duration::from_secs(3600),
+            vec![],
+            call_id.to_string(),
+            from_tag.to_string(),
+            "scscf-notif".to_string(),
+            vec![],
+        )
+    }
+
+    #[test]
+    fn find_subscription_by_dialog_resolves_pair() {
+        let store = PresenceStore::new();
+        store.add_subscription(dialog_sub("sub-a", "callA", "ftagA"));
+        store.add_subscription(dialog_sub("sub-b", "callB", "ftagB"));
+
+        assert_eq!(
+            store.find_subscription_by_dialog("callA", "ftagA").as_deref(),
+            Some("sub-a")
+        );
+        assert_eq!(
+            store.find_subscription_by_dialog("callB", "ftagB").as_deref(),
+            Some("sub-b")
+        );
+        // A mismatched pair (right Call-ID, wrong From-tag) does not match.
+        assert_eq!(store.find_subscription_by_dialog("callA", "ftagB"), None);
+        assert_eq!(store.find_subscription_by_dialog("nope", "nope"), None);
+    }
+
+    #[test]
+    fn find_subscription_by_dialog_skips_terminated() {
+        // A terminated-but-not-yet-removed dialog must not shadow a re-SUBSCRIBE
+        // that reused the same Call-ID/From-tag.
+        let store = PresenceStore::new();
+        store.add_subscription(dialog_sub("sub-a", "callA", "ftagA"));
+        store.terminate_subscription("sub-a");
+        assert_eq!(store.find_subscription_by_dialog("callA", "ftagA"), None);
+    }
+
+    #[test]
+    fn find_subscription_by_dialog_ignores_non_dialog_subscription() {
+        // subscribe() (no dialog state) carries no call_id/from_tag → unfindable.
+        let store = PresenceStore::new();
+        store.add_subscription(Subscription::new(
+            "sub-plain".to_string(),
+            "sip:alice@ims.example.com".to_string(),
+            "sip:alice@ims.example.com".to_string(),
+            "reg".to_string(),
+            Duration::from_secs(3600),
+            None,
+            vec![],
+        ));
+        assert_eq!(store.find_subscription_by_dialog("", ""), None);
+    }
+
+    #[test]
+    fn refresh_subscription_reports_found_and_missing() {
+        let store = PresenceStore::new();
+        store.add_subscription(dialog_sub("sub-x", "callX", "ftagX"));
+        assert!(store.refresh_subscription("sub-x", Duration::from_secs(7200)));
+        assert!(!store.refresh_subscription("sub-missing", Duration::from_secs(7200)));
     }
 }

--- a/src/script/api/presence.rs
+++ b/src/script/api/presence.rs
@@ -198,6 +198,44 @@ impl PyPresence {
         exists
     }
 
+    /// Refresh a subscription's expiry (RFC 6665 §4.4.1 in-dialog re-SUBSCRIBE).
+    ///
+    /// Resets the subscription's timer to `expires` seconds from now, keeping the
+    /// same dialog. Pair with [`find_by_dialog`] to resolve the id from an
+    /// in-dialog SUBSCRIBE before refreshing.
+    ///
+    /// Args:
+    ///     subscription_id: The subscription ID (from ``subscribe*`` or
+    ///         ``find_by_dialog``).
+    ///     expires: New subscription duration in seconds.
+    ///
+    /// Returns:
+    ///     True if the subscription was found and refreshed, False otherwise
+    ///     (unknown id, or the subscription is already terminated).
+    fn refresh(&self, subscription_id: &str, expires: u64) -> bool {
+        self.store
+            .refresh_subscription(subscription_id, Duration::from_secs(expires))
+    }
+
+    /// Resolve a subscription id from its dialog `(Call-ID, From-tag)`.
+    ///
+    /// An in-dialog SUBSCRIBE — a refresh, or an un-SUBSCRIBE with ``Expires: 0`` —
+    /// arrives with the dialog's Call-ID and the subscriber's From-tag but not the
+    /// original subscription id. This maps that pair back to the id so a notifier
+    /// (e.g. an S-CSCF handling reg-event) can ``refresh()`` or ``unsubscribe()``
+    /// the right dialog. Only a subscription created with dialog state
+    /// (``subscribe_dialog``) is findable; terminated ones are skipped.
+    ///
+    /// Args:
+    ///     call_id: Call-ID of the in-dialog SUBSCRIBE.
+    ///     from_tag: From-tag of the in-dialog SUBSCRIBE (subscriber's tag).
+    ///
+    /// Returns:
+    ///     The subscription ID string, or None if no live dialog matches.
+    fn find_by_dialog(&self, call_id: &str, from_tag: &str) -> Option<String> {
+        self.store.find_subscription_by_dialog(call_id, from_tag)
+    }
+
     /// List subscribers (watchers) for a resource.
     ///
     /// Returns active, non-expired subscriptions for the given resource URI.
@@ -571,6 +609,42 @@ mod tests {
         let presence = PyPresence::new(store);
 
         assert!(!presence.unsubscribe("sub-nonexistent"));
+    }
+
+    #[test]
+    fn find_by_dialog_then_refresh_and_unsubscribe() {
+        // Models the S-CSCF reg-event flow: an initial subscribe_dialog, then an
+        // in-dialog SUBSCRIBE that resolves the id by (Call-ID, From-tag) and
+        // refreshes it, then an un-SUBSCRIBE that removes it.
+        let store = make_store();
+        let presence = PyPresence::new(store);
+
+        let sub_id = presence.subscribe_dialog(
+            "sip:alice@ims.example.com",
+            "sip:alice@ims.example.com",
+            "reg",
+            3600,
+            "call-abc",
+            "ftag-alice",
+            "scscf-notif",
+            None,
+        );
+
+        // In-dialog refresh path: resolve by dialog, then refresh.
+        assert_eq!(
+            presence.find_by_dialog("call-abc", "ftag-alice").as_deref(),
+            Some(sub_id.as_str())
+        );
+        assert!(presence.refresh(&sub_id, 7200));
+        // Unknown dialog / unknown id return None / false.
+        assert!(presence.find_by_dialog("call-xyz", "ftag-alice").is_none());
+        assert!(!presence.refresh("sub-nope", 7200));
+
+        // Un-SUBSCRIBE path: resolve then remove.
+        let resolved = presence.find_by_dialog("call-abc", "ftag-alice").unwrap();
+        assert!(presence.unsubscribe(&resolved));
+        assert!(presence.find_by_dialog("call-abc", "ftag-alice").is_none());
+        assert_eq!(presence.subscription_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

An S-CSCF is the notifier for the reg-event package (RFC 3680), so it must terminate the SUBSCRIBE dialog locally and handle in-dialog refresh / un-SUBSCRIBE itself. The `examples/ims_scscf.py` handler couldn't:

- The **initial** reg-event SUBSCRIBE stored the watcher via `presence.subscribe()` (no dialog state) and replied `200` **without a To-tag**, so no dialog was ever established — there was nothing for a later in-dialog request to match against.
- The **in-dialog** branch `404`'d (or blindly loose-routed) every SUBSCRIBE. A UE's periodic refresh and its `Expires: 0` un-SUBSCRIBE both arrive in-dialog, so **both were broken for every subscriber** — refreshes were rejected and un-SUBSCRIBEs never tore down the subscription.

The store already had `refresh_subscription()`, but it wasn't exposed, and there was no way to resolve a subscription from the `(Call-ID, From-tag)` an in-dialog request carries.

## Change

Two new `presence` methods (store method + thin Python wrappers), mirrored in the `siphon-sip` SDK mock:

- **`presence.find_by_dialog(call_id, from_tag) -> str | None`** — resolves a subscription id from its dialog. An in-dialog SUBSCRIBE carries the Call-ID and the subscriber's From-tag (both stable across the dialog) but not the original id; this maps them back. The dialog To-tag is intentionally not part of the key — `(Call-ID, From-tag)` already identifies a subscriber's dialog uniquely. Only subscriptions created with `subscribe_dialog` are findable, and terminated ones are skipped so a lingering pre-removal entry can't shadow a re-SUBSCRIBE that reused the Call-ID.
- **`presence.refresh(subscription_id, expires) -> bool`** — resets the subscription timer without recreating the dialog (wraps the existing `refresh_subscription`).

`examples/ims_scscf.py` is rewritten to use them:

- **Initial reg SUBSCRIBE** now establishes a real dialog: assigns the notifier To-tag on the 2xx (RFC 6665 §4.1.3) and stores the subscription with its dialog ids via `subscribe_dialog`. A single stable notifier tag is used (a reg-event dialog is keyed on Call-ID + subscriber From-tag, both unique per UE), so the initial 2xx, every in-dialog NOTIFY, and the `on_change` broadcast all address the same dialog.
- **In-dialog SUBSCRIBE** keys on the dialog: `find_by_dialog` → `refresh` (`Expires > 0`, `200` + active NOTIFY) or `unsubscribe` (`Expires: 0`, `200` + terminal `Subscription-State: terminated` NOTIFY). A non-matching in-dialog SUBSCRIBE (a subscription we merely proxy) is still loose-routed onward, else `481`.

## Testing

- Rust: store-level tests for `find_subscription_by_dialog` (resolve pair, skip terminated, ignore non-dialog subs) + `refresh_subscription`; API-level test of the full resolve → refresh → un-SUBSCRIBE flow.
- SDK: `find_by_dialog` + `refresh` mock tests mirroring the Rust behaviour.
- `examples/ims_scscf.py` compiles; full suite green (2966 lib + 277 integration, 0 failed); `clippy --all-targets --all-features -D warnings` clean.

For the 1.4.0 release.
