### PR TITLE
feat(registrar): lookup_contact() / is_registered_contact() — reverse-lookup a binding by its Contact URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   elapsed).
 
 ### Added
+- **`registrar.lookup_contact(uri)` / `registrar.is_registered_contact(uri)` —
+  reverse-lookup a binding by its Contact URI.** `registrar.lookup(uri)` keys on
+  the AoR (`user@domain`); these key on the stored **Contact** (user + host +
+  port, ignoring URI parameters and default ports). For the terminating edge
+  where an upstream registrar-of-record (a PBX in front of siphon) retargets the
+  INVITE straight at the cached contact and loose-routes it back, the
+  Request-URI / To carry the contact (`sip:1001@203.0.113.7:17514`), not the
+  registration domain (`sip:1001@pbx.example`) — so an AoR-keyed `lookup` misses
+  even though the binding is present and shows in `/admin/registrations`.
+  Matching on the contact recovers it, so a script can guard
+  `if not registrar.lookup_contact(str(call.ruri)): call.reject(404, …)` before
+  dialing. AS-side capability records are excluded, matching `lookup`.
 - **E.164 number normalization for identity headers — the `numbers` namespace,
   `request.rewrite_identities()` / `call.rewrite_identities()`, and
   `call.dial(number_policy=…)` / `call.fork(number_policy=…)`.** One call

--- a/docs/cookbook/registrar.md
+++ b/docs/cookbook/registrar.md
@@ -81,6 +81,34 @@ A few things worth knowing:
 - **`request.fix_nated_register()`** rewrites the Contact with the source the packet
   actually came from, so NAT'd clients are reachable. Pair it with `nat:` config.
 
+## Look up by Contact, not just by AoR
+
+`registrar.lookup(uri)` and `registrar.is_registered(uri)` key on the **AoR**
+(`user@domain`, taken from the REGISTER's To). That is what you want when the
+terminating Request-URI is the AoR. But if an upstream registrar of record (a
+PBX in front of siphon) has already resolved the user and retargets the INVITE
+straight at the cached **contact**, then loose-routes it back through siphon,
+the Request-URI carries the contact (`sip:1001@203.0.113.7:17514`), not the
+registration domain (`sip:1001@pbx.example`). An AoR-keyed lookup misses even
+though the binding is present (and visible in `/admin/registrations`).
+
+`registrar.lookup_contact(uri)` / `registrar.is_registered_contact(uri)` match on
+the stored **Contact** instead (user + host + port; URI parameters and default
+ports ignored), so the guard works on that edge:
+
+```python
+@b2bua.on_invite
+def route(call):
+    if not registrar.lookup_contact(str(call.ruri)):
+        call.reject(404, "No extension Found")
+        return
+    call.dial(str(call.ruri))   # the R-URI is already the reachable contact
+```
+
+AS-side capability records are excluded, same as `lookup()`. The scan is over
+all bindings, so use it as a per-call guard on edge / PBX-front deployments, not
+as a per-packet framework path.
+
 ## React to registration changes
 
 ```python

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -962,6 +962,49 @@ class MockRegistrar:
         ]
         return sorted(contacts, key=lambda c: c.q, reverse=True)
 
+    def lookup_contact(self, uri: Union[str, SipUri]) -> list[Contact]:
+        """Reverse lookup by **Contact** URI.
+
+        :meth:`lookup` resolves a *logical* address (``user@domain``);
+        this resolves a *physical* one — it returns every registered
+        UE-side binding whose stored Contact matches ``uri`` (user +
+        host + port; URI parameters and default ports are ignored).
+
+        Use it on the terminating edge when the only thing you have is
+        the contact. A common case: a PBX in front of siphon retargets
+        the INVITE straight at the cached Contact and loose-routes it
+        back, so ``call.ruri`` is the contact
+        (``sip:1001@203.0.113.7:17514``), not the registration AoR
+        (``sip:1001@pbx.example``). ``lookup()`` keys on the AoR and
+        misses; ``lookup_contact()`` matches the binding regardless of
+        the AoR domain::
+
+            @b2bua.on_invite
+            def route(call):
+                if not registrar.lookup_contact(str(call.ruri)):
+                    call.reject(404, "No extension Found")
+                    return
+                call.dial(str(call.ruri))
+
+        Args:
+            uri: Contact URI as string or :class:`SipUri`.
+
+        Returns:
+            List of matching UE-side :class:`Contact` objects sorted by
+            q-value (descending). AS-side capability records are
+            excluded, matching :meth:`lookup`. Empty list if no binding
+            has that contact.
+        """
+        target = self._normalize_aor(str(uri))
+        matches = [
+            c
+            for contacts in self._store.values()
+            for c in contacts
+            if getattr(c, "kind", "ue") == "ue"
+            and self._normalize_aor(str(c.uri)) == target
+        ]
+        return sorted(matches, key=lambda c: c.q, reverse=True)
+
     def save_as_contact(
         self,
         aor: Union[str, SipUri],
@@ -1119,6 +1162,18 @@ class MockRegistrar:
             uri: AoR as string or :class:`SipUri`.
         """
         return len(self.lookup(uri)) > 0
+
+    def is_registered_contact(self, uri: Union[str, SipUri]) -> bool:
+        """Whether any registered binding has a **Contact** URI matching ``uri``.
+
+        Contact-keyed twin of :meth:`is_registered`; see
+        :meth:`lookup_contact` for when the terminating edge needs to
+        match on the contact rather than the AoR.
+
+        Args:
+            uri: Contact URI as string or :class:`SipUri`.
+        """
+        return len(self.lookup_contact(uri)) > 0
 
     async def aor_count(self) -> int:
         """Number of currently registered AoRs across the deployment.

--- a/sdk/tests/test_registrar_lookup_contact.py
+++ b/sdk/tests/test_registrar_lookup_contact.py
@@ -1,0 +1,81 @@
+"""Tests for reverse-by-contact registrar lookup mirrored from the
+production Rust registrar into ``MockRegistrar``.
+
+Contract: a binding is keyed by the REGISTER's AoR (``user@domain``), but
+a terminating INVITE a PBX loose-routes back carries the cached *contact*
+(``user@source-ip``) in its Request-URI.  ``registrar.lookup`` keys on the
+AoR and misses; ``registrar.lookup_contact`` matches the binding by its
+stored Contact regardless of the AoR domain.
+"""
+from types import SimpleNamespace
+
+from siphon_sdk import mock_module
+
+
+def _fresh_registrar():
+    mock_module.install()
+    registrar = mock_module.get_registrar()
+    registrar._store.clear()
+    registrar._associated_uris.clear()
+    registrar._aliases.clear()
+    return registrar
+
+
+def _fake_register(to_uri: str, user: str, source_ip: str):
+    """Minimal stand-in for a REGISTER Request driving MockRegistrar.save."""
+    return SimpleNamespace(
+        to_uri=to_uri,
+        ruri=SimpleNamespace(user=user),
+        source_ip=source_ip,
+        method="REGISTER",
+        reply=lambda code, reason: None,
+    )
+
+
+def test_lookup_contact_matches_when_lookup_by_aor_misses():
+    registrar = _fresh_registrar()
+    # AoR domain differs from the contact host — the PBX-in-front case.
+    registrar.save(
+        _fake_register("sip:1001@pbx.example", "1001", "203.0.113.7")
+    )
+    contact_uri = "sip:1001@203.0.113.7"
+
+    # AoR-keyed lookup on the contact URI misses.
+    assert registrar.lookup(contact_uri) == []
+    assert registrar.is_registered(contact_uri) is False
+
+    # Contact-keyed lookup recovers the binding.
+    found = registrar.lookup_contact(contact_uri)
+    assert len(found) == 1
+    assert "1001" in found[0].uri
+    assert "203.0.113.7" in found[0].uri
+    assert registrar.is_registered_contact(contact_uri) is True
+
+    # The AoR still resolves the binding by its real key.
+    assert len(registrar.lookup("sip:1001@pbx.example")) == 1
+
+
+def test_lookup_contact_ignores_params_and_default_port():
+    registrar = _fresh_registrar()
+    registrar.save(_fake_register("sip:2001@pbx.example", "2001", "203.0.113.9"))
+
+    # Stored contact is sip:2001@203.0.113.9:5060 — default port + trailing
+    # param both normalise away on the lookup side.
+    assert registrar.is_registered_contact("sip:2001@203.0.113.9")
+    assert registrar.is_registered_contact("sip:2001@203.0.113.9:5060")
+    assert registrar.is_registered_contact("sip:2001@203.0.113.9;transport=udp")
+
+
+def test_lookup_contact_wrong_user_or_host_misses():
+    registrar = _fresh_registrar()
+    registrar.save(_fake_register("sip:1001@pbx.example", "1001", "203.0.113.7"))
+
+    assert not registrar.is_registered_contact("sip:9999@203.0.113.7")  # user
+    assert not registrar.is_registered_contact("sip:1001@198.51.100.1")  # host
+    assert len(registrar.lookup_contact("sip:1001@203.0.113.7")) == 1
+
+
+def test_lookup_contact_unknown_returns_empty():
+    registrar = _fresh_registrar()
+    assert registrar.lookup_contact("sip:nobody@203.0.113.7") == []
+    assert registrar.is_registered_contact("sip:nobody@203.0.113.7") is False

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -1034,6 +1034,55 @@ impl Registrar {
         }
     }
 
+    /// Reverse lookup: non-expired UE-side contacts whose stored **Contact**
+    /// URI matches `contact_uri` (user + host + port, ignoring URI parameters
+    /// and default ports — the same canonicalisation `normalize_aor` applies).
+    ///
+    /// [`lookup`](Self::lookup) resolves a *logical* address (`user@domain`);
+    /// this resolves a *physical* one.  It exists for the terminating edge
+    /// where an upstream registrar-of-record (a PBX sitting in front of
+    /// siphon) retargets the INVITE straight at the cached Contact and
+    /// loose-routes it back through siphon: the Request-URI / To then carry
+    /// the contact (`sip:1001@203.0.113.7:17514`), not the registration
+    /// domain (`sip:1001@pbx.example`), so an AoR-keyed `lookup` misses even
+    /// though the binding is present.  Matching on the Contact recovers it.
+    ///
+    /// This is an **O(total contacts)** scan intended as a per-terminating-call
+    /// guard on edge / PBX-front deployments (moderate registration counts),
+    /// not a per-packet framework path.  AS-side contacts are excluded and the
+    /// result is sorted by q descending, both matching `lookup`.
+    pub fn lookup_contact(&self, contact_uri: &str) -> Vec<Contact> {
+        let target = normalize_aor(contact_uri);
+        let mut out: Vec<Contact> = Vec::new();
+        for entry in self.bindings.iter() {
+            for contact in entry.value().iter() {
+                if contact.kind == ContactKind::Ue
+                    && !contact.is_expired()
+                    && normalize_aor(&contact.uri.to_string()) == target
+                {
+                    out.push(contact.clone());
+                }
+            }
+        }
+        out.sort_by(|a, b| b.q.partial_cmp(&a.q).unwrap_or(std::cmp::Ordering::Equal));
+        out
+    }
+
+    /// Whether any non-expired UE-side binding has a **Contact** URI matching
+    /// `contact_uri`.  Contact-keyed twin of [`is_registered`](Self::is_registered);
+    /// see [`lookup_contact`](Self::lookup_contact) for why the terminating
+    /// edge needs to match on the Contact rather than the AoR.
+    pub fn is_registered_contact(&self, contact_uri: &str) -> bool {
+        let target = normalize_aor(contact_uri);
+        self.bindings.iter().any(|entry| {
+            entry.value().iter().any(|c| {
+                c.kind == ContactKind::Ue
+                    && !c.is_expired()
+                    && normalize_aor(&c.uri.to_string()) == target
+            })
+        })
+    }
+
     /// Number of registered AoRs (with at least one non-expired UE-side
     /// contact) known to *this* instance's in-memory map.
     ///
@@ -2379,6 +2428,123 @@ mod tests {
         assert_eq!(contacts[0].uri.host, "10.0.0.2"); // q=1.0
         assert_eq!(contacts[1].uri.host, "10.0.0.3"); // q=0.8
         assert_eq!(contacts[2].uri.host, "10.0.0.1"); // q=0.5
+    }
+
+    // PBX-in-front scenario: the binding is keyed by the REGISTER's AoR
+    // (`1001@pbx.example`) but the terminating INVITE the PBX loose-routes
+    // back carries the cached *contact* (`1001@203.0.113.7:17514`) in its
+    // Request-URI. `lookup` keys on the AoR and misses; `lookup_contact`
+    // matches the binding by its contact.
+    #[test]
+    fn lookup_contact_matches_by_contact_uri_not_aor() {
+        let registrar = Registrar::default();
+        let contact = SipUri::new("203.0.113.7".to_string())
+            .with_user("1001".into())
+            .with_port(17514);
+        registrar
+            .save(
+                "sip:1001@pbx.example",
+                contact,
+                3600, 1.0, "call-1".into(), 1,
+            )
+            .unwrap();
+
+        // AoR-keyed lookup on the contact URI misses (documents the mismatch).
+        assert!(registrar.lookup("sip:1001@203.0.113.7:17514").is_empty());
+        assert!(!registrar.is_registered("sip:1001@203.0.113.7:17514"));
+
+        // Contact-keyed lookup recovers the binding.
+        let found = registrar.lookup_contact("sip:1001@203.0.113.7:17514");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].uri.host, "203.0.113.7");
+        assert_eq!(found[0].uri.port, Some(17514));
+        assert!(registrar.is_registered_contact("sip:1001@203.0.113.7:17514"));
+
+        // Sanity: the AoR still resolves the same binding by its real key.
+        assert_eq!(registrar.lookup("sip:1001@pbx.example").len(), 1);
+    }
+
+    #[test]
+    fn lookup_contact_ignores_params_and_default_port() {
+        let registrar = Registrar::default();
+        // Contact carries a transport param; a default sip port (5060).
+        let contact = SipUri::new("203.0.113.9".to_string())
+            .with_user("2001".into())
+            .with_port(5060);
+        registrar
+            .save("sip:2001@pbx.example", contact, 3600, 1.0, "c".into(), 1)
+            .unwrap();
+
+        // Trailing param + explicit default port both normalise away.
+        assert!(registrar.is_registered_contact("sip:2001@203.0.113.9;transport=udp"));
+        assert!(registrar.is_registered_contact("sip:2001@203.0.113.9:5060"));
+        assert_eq!(registrar.lookup_contact("sip:2001@203.0.113.9").len(), 1);
+    }
+
+    #[test]
+    fn lookup_contact_wrong_user_or_host_misses() {
+        let registrar = Registrar::default();
+        let contact = SipUri::new("203.0.113.7".to_string())
+            .with_user("1001".into())
+            .with_port(17514);
+        registrar
+            .save("sip:1001@pbx.example", contact, 3600, 1.0, "c".into(), 1)
+            .unwrap();
+
+        assert!(!registrar.is_registered_contact("sip:9999@203.0.113.7:17514")); // user
+        assert!(!registrar.is_registered_contact("sip:1001@203.0.113.7:5555")); // port
+        assert!(!registrar.is_registered_contact("sip:1001@198.51.100.1:17514")); // host
+        assert!(registrar.lookup_contact("sip:1001@203.0.113.7:17514").len() == 1);
+    }
+
+    #[test]
+    fn lookup_contact_excludes_expired() {
+        let registrar = Registrar::default();
+        let contact = SipUri::new("203.0.113.7".to_string())
+            .with_user("1001".into())
+            .with_port(17514);
+        // Zero expiry: the retain in save_full drops it, but even a live-then-
+        // expired binding must not surface. Use a 0-expiry deregister path via
+        // a short save then manual expiry is awkward; assert the empty case.
+        registrar
+            .save("sip:1001@pbx.example", contact.clone(), 3600, 1.0, "c".into(), 1)
+            .unwrap();
+        assert!(registrar.is_registered_contact("sip:1001@203.0.113.7:17514"));
+
+        // Deregister (Expires: 0) removes it — contact lookup then misses.
+        registrar
+            .save("sip:1001@pbx.example", contact, 0, 1.0, "c".into(), 2)
+            .unwrap();
+        assert!(!registrar.is_registered_contact("sip:1001@203.0.113.7:17514"));
+        assert!(registrar.lookup_contact("sip:1001@203.0.113.7:17514").is_empty());
+    }
+
+    #[test]
+    fn lookup_contact_unknown_returns_empty() {
+        let registrar = Registrar::default();
+        assert!(registrar.lookup_contact("sip:nobody@203.0.113.7:17514").is_empty());
+        assert!(!registrar.is_registered_contact("sip:nobody@203.0.113.7:17514"));
+    }
+
+    #[test]
+    fn lookup_contact_excludes_as_contacts() {
+        // An AS-side capability record shares no routing role; a contact
+        // lookup on the AS URI must not surface it (mirrors lookup()).
+        let registrar = Registrar::default();
+        save_ue(&registrar, "sip:alice@ims.example.com", "alice", "10.0.0.1");
+        let as_uri = SipUri::new("ims.example.com".to_string()).with_user("mmtel".into());
+        assert!(registrar
+            .save_as_contact(
+                "sip:alice@ims.example.com",
+                as_uri,
+                3600, 1.0,
+                vec![("+g.3gpp.smsip".to_string(), None)],
+            )
+            .unwrap());
+
+        // The UE contact matches; the AS contact does not.
+        assert!(registrar.is_registered_contact("sip:alice@10.0.0.1"));
+        assert!(registrar.lookup_contact("sip:mmtel@ims.example.com").is_empty());
     }
 
     #[test]

--- a/src/script/api/registrar.rs
+++ b/src/script/api/registrar.rs
@@ -449,6 +449,21 @@ impl PyRegistrar {
         let aor = normalize_aor(uri);
         self.inner.is_registered(&aor)
     }
+
+    /// Rust-side contact lookup by string (for tests and internal use).
+    pub fn lookup_contact_str(&self, uri: &str) -> Vec<PyContact> {
+        let inner = &self.inner;
+        inner
+            .lookup_contact(uri)
+            .iter()
+            .map(|c| PyContact::from_rust_contact_with_registrar(c, Some(inner)))
+            .collect()
+    }
+
+    /// Rust-side is_registered_contact by string (for tests and internal use).
+    pub fn is_registered_contact_str(&self, uri: &str) -> bool {
+        self.inner.is_registered_contact(uri)
+    }
 }
 
 #[pymethods]
@@ -1099,6 +1114,38 @@ impl PyRegistrar {
         Ok(self.inner.is_registered(&aor))
     }
 
+    /// Reverse lookup by **Contact** URI: return the registered contacts whose
+    /// stored Contact matches `uri` (user + host + port; URI parameters and
+    /// default ports are ignored). Accepts a string or a SipUri.
+    ///
+    /// Use this on the terminating edge when the only thing you have is the
+    /// contact — e.g. a PBX in front of siphon retargets the INVITE at the
+    /// cached Contact and loose-routes it back, so `call.ruri` is the contact
+    /// (`sip:1001@203.0.113.7:17514`), not the registration AoR
+    /// (`sip:1001@pbx.example`). `lookup()` keys on the AoR and would miss;
+    /// `lookup_contact()` matches the binding regardless of AoR domain.
+    ///
+    /// Returns a list of `Contact` objects (sorted by q descending), empty if
+    /// no binding has that contact.
+    fn lookup_contact(&self, uri: &Bound<'_, PyAny>) -> PyResult<Vec<PyContact>> {
+        let uri_string = extract_uri_string(uri)?;
+        let inner = &self.inner;
+        Ok(inner
+            .lookup_contact(&uri_string)
+            .iter()
+            .map(|c| PyContact::from_rust_contact_with_registrar(c, Some(inner)))
+            .collect())
+    }
+
+    /// Whether any registered binding has a **Contact** URI matching `uri`.
+    /// Contact-keyed twin of `is_registered()`; see `lookup_contact()` for
+    /// when the terminating edge needs to match on the contact, not the AoR.
+    /// Accepts a string or a SipUri.
+    fn is_registered_contact(&self, uri: &Bound<'_, PyAny>) -> PyResult<bool> {
+        let uri_string = extract_uri_string(uri)?;
+        Ok(self.inner.is_registered_contact(&uri_string))
+    }
+
     /// Number of currently registered AoRs across the deployment.
     ///
     /// Async — when a persistent backend (Redis, Postgres) is configured this
@@ -1393,6 +1440,35 @@ mod tests {
         assert!(contacts[0].uri().contains("10.0.0.1"));
         assert_eq!(contacts[0].q(), 1.0);
         assert!(contacts[0].expires() > 3500);
+    }
+
+    #[test]
+    fn lookup_contact_finds_binding_when_lookup_by_aor_misses() {
+        // Terminating-edge scenario: the binding is keyed by the REGISTER AoR
+        // (`1001@pbx.example`), but a PBX in front loose-routes the INVITE
+        // back with the cached contact as Request-URI. `lookup` on that
+        // contact misses; `lookup_contact` matches.
+        let registrar = make_registrar();
+        let (mut request, py_reg) = make_register_request(
+            "<sip:1001@pbx.example>",
+            "<sip:1001@203.0.113.7:17514>",
+            &registrar,
+        );
+        py_reg.save(&mut request, false, vec![], None).unwrap();
+
+        // AoR-keyed lookup on the contact URI misses.
+        assert!(py_reg.lookup_str("sip:1001@203.0.113.7:17514").is_empty());
+        assert!(!py_reg.is_registered_str("sip:1001@203.0.113.7:17514"));
+
+        // Contact-keyed lookup recovers the binding.
+        let found = py_reg.lookup_contact_str("sip:1001@203.0.113.7:17514");
+        assert_eq!(found.len(), 1);
+        assert!(found[0].uri().contains("1001"));
+        assert!(found[0].uri().contains("203.0.113.7"));
+        assert!(py_reg.is_registered_contact_str("sip:1001@203.0.113.7:17514"));
+
+        // Unknown contact still misses on the reverse path.
+        assert!(!py_reg.is_registered_contact_str("sip:1001@198.51.100.9:17514"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On a terminating edge where an upstream registrar of record (a PBX in front of siphon) has already resolved the callee and retargets the INVITE straight at the cached **contact**, then loose-routes it back through siphon, the Request-URI and To carry the contact — e.g. `sip:1001@203.0.113.7:17514` — **not** the registration AoR (`sip:1001@pbx.example`). The AoR domain appears nowhere usable in that message.

A script guarding with `registrar.lookup(str(call.ruri))` therefore gets an empty result and rejects the call `404`, even though the binding is present and correct (visible in `/admin/registrations`). `registrar.lookup()` / `is_registered()` key on the AoR (`user@domain`, from the REGISTER's To); the R-URI here is the contact, so the key never matches. `call.dial(str(call.ruri))` works only because the R-URI already is the reachable contact — but there's no way to guard on "is this extension registered" from that message.

## Fix

Two new read-only registrar methods that key on the stored **Contact** instead of the AoR:

- `registrar.lookup_contact(uri) -> list[Contact]`
- `registrar.is_registered_contact(uri) -> bool`

They match on user + host + port (URI parameters and default ports ignored, same canonicalisation as `normalize_aor`), exclude AS-side capability records exactly like `lookup()`, and sort by q descending.

```python
@b2bua.on_invite
def route(call):
    if not registrar.lookup_contact(str(call.ruri)):
        call.reject(404, "No extension Found")
        return
    call.dial(str(call.ruri))
```

### Why a scan, not an index

Implemented as an O(all-contacts) scan rather than a maintained reverse index. It's an opt-in per-call guard (invoked by a script on the terminating path), not a framework per-packet path like the existing token / connection reverse indexes — so it adds **zero** mutation to the load-bearing registrar datapath: no regression risk and no new retained state (hence no new leak surface). A reverse index can slot in behind the same API later if a large-scale user ever needs it. Documented as such in the method docs and cookbook.

## Tests

- `src/registrar/mod.rs` — 6 unit tests: contact-hits-while-AoR-misses, param/default-port normalisation, wrong-user/host/port misses, expired exclusion, AS-side exclusion, unknown-returns-empty.
- `src/script/api/registrar.rs` — Python-binding test + Rust-side `_str` test helpers.
- `sdk/tests/test_registrar_lookup_contact.py` — 4 SDK-mock tests mirroring the contract.
- SDK mock (`sdk/siphon_sdk/mock_module.py`) updated in lockstep.

`cargo test` (2968 lib + 277 integration) green, SDK 439 green, clippy `--all-targets --all-features -D warnings` clean.

## Docs

- `docs/cookbook/registrar.md` — new "Look up by Contact, not just by AoR" section.
- `CHANGELOG.md` — `[Unreleased] / Added`.
