### PR TITLE
feat(gateway): source_networks CIDR membership + call.source_ip_in (fix from_gateway for range-sourced peers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ _Codename: bjorn._
   absolute imports are supported (the script is not a package, so `from . import`
   does not work), and the "no cross-request module state" rule applies to helper
   modules too.
+- **`gateway.groups[].source_networks` + `call.source_ip_in(cidr_list)`** — source
+  membership for a peer that sends SIP from a whole published subnet, not only the
+  IPs its signalling FQDNs resolve to. `from_gateway` matches the source IP against
+  a group's *resolved destination addresses* (it tracks DNS) — correct for a
+  fixed-IP trunk, but it silently misses a peer whose inbound can arrive from any
+  address in a documented range: the FQDNs resolve to a moving subset, so
+  `from_gateway` flaps as DNS rotates and rejects a legitimate source it just
+  hasn't resolved. List those ranges under a group's `source_networks` (CIDR or
+  bare IP, IPv4 or IPv6) and they count as members regardless of DNS.
+  `call.source_ip_in(["203.0.113.0/24"])` is the B2BUA counterpart of
+  `request.source_ip_in` for gating on ranges inline without a gateway group.
+  Mirrored in the SDK mock.
 - **`presence.refresh(subscription_id, expires)` + `presence.find_by_dialog(call_id, from_tag)`** —
   the two pieces needed to handle an in-dialog SUBSCRIBE (RFC 6665 §4.4.1) as a
   notifier. `find_by_dialog` resolves a subscription id from an in-dialog
@@ -37,45 +49,6 @@ _Codename: bjorn._
   subscription down with a terminal NOTIFY — fixing reg-event refresh and
   un-SUBSCRIBE, which previously 404'd for every subscriber.
 
-### Fixed
-- **B2BUA on a multi-homed host now answers on the socket the call arrived on.**
-  When siphon listens on more than one UDP port (e.g. `5060` and `5066`), the
-  B2BUA sent every A-leg response (100 Trying, 18x, 2xx, 4xx–6xx, 487, 408, PRACK
-  200, and the reliable-1xx / 2xx retransmits) out the *first-configured* UDP
-  listener instead of the one the INVITE arrived on, so a peer doing symmetric
-  signalling (received on `:5066`) rejected replies sourced from `:5060`. Every
-  A-leg reply path now pins the egress socket to the arrival listener. This is
-  UDP-only — TCP/TLS/WS/WSS already answer on the accepted connection. Separately,
-  the `Contact` siphon advertises to the A-leg (and the stored A-leg dialog
-  Contact) carried the default listener's port on *all* transports; it now
-  carries the arrival port, so in-dialog requests (ACK/BYE/re-INVITE) reach the
-  port the dialog is anchored on (over a stream transport RFC 5923 connection
-  reuse had been masking this). siphon-*originated* in-dialog requests to the
-  A-leg (framework BYE on `b2bua.terminate` / session-timer teardown, the
-  forwarded B→A BYE / re-INVITE / UPDATE) now also carry the arrival port in their
-  Via and leave from the arrival socket, and the 200-to-BYE answers on the socket
-  the BYE arrived on — so the whole call (setup, hold/re-INVITE, teardown) stays
-  on one listener. Single-listener deployments are unaffected (the arrival port
-  equals the default), so the performance baseline is unchanged.
-
-### Changed
-- **`rtpengine.play_media()` now blocks until the prompt finishes by default**
-  (`wait=True`), on the native `siphon-rtp` backend. `await rtpengine.play_media(...)`
-  returns only once the prompt has fully played out, so an IVR handler can
-  sequence `answer → play → echo` with no overlap; the coroutine parks while it
-  waits (no worker is held). Pass `wait=False` for fire-and-forget playback
-  (music-on-hold / background), which returns as soon as the engine accepts the
-  prompt. Backed by the new `Event::PlayFinished` completion event
-  (`siphon-rtp-proto` 0.1.2): the play accepts immediately with a `play_id` and
-  the engine reports completion asynchronously, correlated by `play_id`. A
-  configurable fallback (`media.siphon_rtp.play_timeout_ms`, default 5 min) caps
-  the wait so a lost event / dead engine can't hang the call. The rtpengine and
-  rtpproxy backends have no completion signal, so they ignore `wait` and return
-  on accept as before. Return value is now the actual played duration (or `None`
-  when the prompt was stopped / superseded before finishing, or the fallback
-  elapsed).
-
-### Added
 - **`registrar.lookup_contact(uri)` / `registrar.is_registered_contact(uri)` —
   reverse-lookup a binding by its Contact URI.** `registrar.lookup(uri)` keys on
   the AoR (`user@domain`); these key on the stored **Contact** (user + host +
@@ -189,6 +162,22 @@ _Codename: bjorn._
   `reject()` for a final response.
 
 ### Changed
+- **`rtpengine.play_media()` now blocks until the prompt finishes by default**
+  (`wait=True`), on the native `siphon-rtp` backend. `await rtpengine.play_media(...)`
+  returns only once the prompt has fully played out, so an IVR handler can
+  sequence `answer → play → echo` with no overlap; the coroutine parks while it
+  waits (no worker is held). Pass `wait=False` for fire-and-forget playback
+  (music-on-hold / background), which returns as soon as the engine accepts the
+  prompt. Backed by the new `Event::PlayFinished` completion event
+  (`siphon-rtp-proto` 0.1.2): the play accepts immediately with a `play_id` and
+  the engine reports completion asynchronously, correlated by `play_id`. A
+  configurable fallback (`media.siphon_rtp.play_timeout_ms`, default 5 min) caps
+  the wait so a lost event / dead engine can't hang the call. The rtpengine and
+  rtpproxy backends have no completion signal, so they ignore `wait` and return
+  on accept as before. Return value is now the actual played duration (or `None`
+  when the prompt was stopped / superseded before finishing, or the fallback
+  elapsed).
+
 - **`call.answer()` now sends the final 2xx immediately** instead of deferring it
   to when the handler returns. This lets an `async` `@b2bua.on_invite` answer and
   then keep working — e.g. `await rtpengine.play_media(...)` a prompt to
@@ -200,6 +189,26 @@ _Codename: bjorn._
   unaffected; there is no separate `answer_now()`.
 
 ### Fixed
+- **B2BUA on a multi-homed host now answers on the socket the call arrived on.**
+  When siphon listens on more than one UDP port (e.g. `5060` and `5066`), the
+  B2BUA sent every A-leg response (100 Trying, 18x, 2xx, 4xx–6xx, 487, 408, PRACK
+  200, and the reliable-1xx / 2xx retransmits) out the *first-configured* UDP
+  listener instead of the one the INVITE arrived on, so a peer doing symmetric
+  signalling (received on `:5066`) rejected replies sourced from `:5060`. Every
+  A-leg reply path now pins the egress socket to the arrival listener. This is
+  UDP-only — TCP/TLS/WS/WSS already answer on the accepted connection. Separately,
+  the `Contact` siphon advertises to the A-leg (and the stored A-leg dialog
+  Contact) carried the default listener's port on *all* transports; it now
+  carries the arrival port, so in-dialog requests (ACK/BYE/re-INVITE) reach the
+  port the dialog is anchored on (over a stream transport RFC 5923 connection
+  reuse had been masking this). siphon-*originated* in-dialog requests to the
+  A-leg (framework BYE on `b2bua.terminate` / session-timer teardown, the
+  forwarded B→A BYE / re-INVITE / UPDATE) now also carry the arrival port in their
+  Via and leave from the arrival socket, and the 200-to-BYE answers on the socket
+  the BYE arrived on — so the whole call (setup, hold/re-INVITE, teardown) stays
+  on one listener. Single-listener deployments are unaffected (the arrival port
+  equals the default), so the performance baseline is unchanged.
+
 - **B2BUA no longer emits a malformed double-port To header on the B-leg
   INVITE.** When topology-hiding the To URI to the dial target, siphon replaced
   only the host token and left the original To port in place — so an inbound To
@@ -268,6 +277,7 @@ _Codename: bjorn._
   aborted the parse thread (a DoS on the parse path, found by fuzzing). The
   parser now degrades to taking the whole remaining input as the body instead of
   panicking; char-boundary-aligned lengths split exactly as before.
+- **B2BUA UAS-mode answer now tags the 2xx To header (RFC 3261 §12.1.1).** A
   script that answers an INVITE directly (`call.answer(200, ...)` — MRF /
   announcement / echo / IVR) previously sent a 2xx whose To header was copied
   verbatim from the tagless INVITE, so the caller's dialog had no remote tag. The

--- a/docs/migrating-from-kamailio-opensips.md
+++ b/docs/migrating-from-kamailio-opensips.md
@@ -72,6 +72,7 @@ them (see the framework-handles-automatically notes in the API reference).
 | `htable` (`$sht(...)`) | `cache` namespace (local LRU + optional Redis, shared live) |
 | `dispatcher` module + `ds_select_dst()` | `gateway` namespace (`gateway.select(group, key=…)`) + YAML `gateway.groups` |
 | `ds_is_from_list()` / `ds_is_in_list()` | `request.from_gateway(group)` / `call.from_gateway(group)` / `reply.from_gateway(group)` (source-IP membership of a `gateway` group; the `reply` form tests which trunk answered) |
+| `permissions` module (`allow_source_address()`, the address table with CIDR) | `gateway.groups[].source_networks` (static CIDR/IP ranges that count as group members for `from_gateway`, for a peer that sources from a whole published subnet, not only its FQDN-resolved IPs) + `request.source_ip_in([...])` / `call.source_ip_in([...])` for inline CIDR checks |
 | `dialog` module (`$dlg_val`, profiles) | the B2BUA call object (`@b2bua.*`, `call.*`) for true call control |
 | `rtpengine_*()` | `call.media.anchor()` / the `rtpengine` namespace |
 | `sqlops` / `avpops` against a DB | plain Python (use a DB client in an `async` handler, off the hot path) |

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -7,6 +7,7 @@ Passed to ``@b2bua.on_invite``, ``@b2bua.on_early_media``,
 
 from __future__ import annotations
 
+import ipaddress
 import uuid
 from typing import Optional, Union
 
@@ -135,6 +136,33 @@ class Call:
         from siphon_sdk.mock_module import get_gateway
 
         return get_gateway().contains_source(group_name, self._source_ip)
+
+    def source_ip_in(self, cidr_list: list[str]) -> bool:
+        """Check if the A-leg source IP is within any of the given CIDR ranges.
+
+        The B2BUA counterpart of :meth:`Request.source_ip_in`.  Use it to gate on
+        a peer's published source subnets directly, when that peer sources SIP
+        from a whole range rather than only the IPs its signalling FQDNs resolve
+        to — the case :meth:`from_gateway` (which tracks the destinations' DNS)
+        cannot cover.  Accepts IPv4 and IPv6 CIDRs.
+
+        Args:
+            cidr_list: List of CIDR strings (e.g. ``["203.0.113.0/24"]``).
+
+        Returns:
+            ``True`` if the A-leg source IP falls within any range; ``False`` if
+            the source IP does not parse.
+
+        Example::
+
+            if call.source_ip_in(["203.0.113.0/24", "2001:db8::/32"]):
+                ...
+        """
+        try:
+            addr = ipaddress.ip_address(self._source_ip)
+        except ValueError:
+            return False
+        return any(addr in ipaddress.ip_network(cidr) for cidr in cidr_list)
 
     @property
     def from_uri(self) -> Optional[SipUri]:

--- a/sdk/tests/test_from_gateway.py
+++ b/sdk/tests/test_from_gateway.py
@@ -127,3 +127,23 @@ def test_reply_from_gateway_false_for_bad_source_ip():
     _register_teams_group()
     reply = Reply(status_code=200, source_ip="not-an-ip")
     assert reply.from_gateway("teams") is False
+
+
+# --- Call.source_ip_in (CIDR membership, the from_gateway complement) -------
+
+
+def test_call_source_ip_in_matches_v4_and_v6():
+    # For a peer that sources from a whole published subnet rather than only its
+    # FQDN-resolved IPs, a script gates on the ranges directly.
+    call = Call(source_ip="203.0.113.9")
+    assert call.source_ip_in(["203.0.113.0/24"]) is True
+    assert call.source_ip_in(["198.51.100.0/24"]) is False
+    # IPv6 source inside a documented /32.
+    call6 = Call(source_ip="2001:db8::5")
+    assert call6.source_ip_in(["2001:db8::/32"]) is True
+    assert call6.source_ip_in(["2001:db9::/32"]) is False
+
+
+def test_call_source_ip_in_false_for_unparseable_source():
+    call = Call(source_ip="not-an-ip")
+    assert call.source_ip_in(["203.0.113.0/24"]) is False

--- a/src/config.rs
+++ b/src/config.rs
@@ -1974,6 +1974,20 @@ pub struct GatewayGroupConfig {
     pub probe: GatewayProbeConfig,
     /// Destinations in this group.
     pub destinations: Vec<GatewayDestConfig>,
+    /// Source IP CIDR ranges whose senders count as members of this group for
+    /// `request.from_gateway` / `call.from_gateway`, in addition to the
+    /// destinations' resolved addresses.
+    ///
+    /// Use this for a peer that sources SIP from a whole published subnet rather
+    /// than only the IPs its signalling FQDNs resolve to — a carrier trunk or
+    /// cloud voice service whose inbound signalling can arrive from any address
+    /// in a documented range, not just what its SIP FQDNs currently resolve to.
+    /// Listing the ranges here makes membership stable regardless of DNS. Each
+    /// entry is a CIDR or a bare IP, IPv4 or IPv6: `"203.0.113.0/24"`,
+    /// `"2001:db8::/32"`, or a bare address (`"203.0.113.7"` → `/32`,
+    /// `"2001:db8::1"` → `/128`).
+    #[serde(default)]
+    pub source_networks: Vec<String>,
 }
 
 /// Per-group health probe settings.

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -20,6 +20,7 @@ use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
+use ipnet::IpNet;
 use tracing::{debug, info, warn};
 
 use crate::sip::uri::SipUri;
@@ -263,6 +264,12 @@ pub struct DispatcherGroup {
     /// hot path by `refresh_member_ips` (startup + each probe cycle). The
     /// `ArcSwap` gives an atomic swap with no empty window during refresh.
     member_ips: ArcSwap<HashSet<IpAddr>>,
+    /// Static source CIDR ranges (from `gateway.groups[].source_networks`) whose
+    /// senders also count as members, checked by `contains_source` on top of
+    /// `member_ips`. For a peer that sources SIP from a whole published subnet
+    /// rather than only the IPs its FQDNs resolve to, so membership is stable
+    /// regardless of DNS. Configured once at startup — not refreshed.
+    source_networks: Vec<IpNet>,
 }
 
 impl DispatcherGroup {
@@ -276,6 +283,7 @@ impl DispatcherGroup {
             destinations,
             counters: DashMap::new(),
             member_ips: ArcSwap::from_pointee(HashSet::new()),
+            source_networks: Vec::new(),
         };
         // Startup resolution — sync context, `to_socket_addrs` is fine here.
         group.refresh_member_ips();
@@ -284,6 +292,13 @@ impl DispatcherGroup {
 
     pub fn with_probe_config(mut self, config: ProbeConfig) -> Self {
         self.probe_config = config;
+        self
+    }
+
+    /// Set the static source CIDR ranges that also count as group members for
+    /// `contains_source` (`request.from_gateway` / `call.from_gateway`).
+    pub fn with_source_networks(mut self, networks: Vec<IpNet>) -> Self {
+        self.source_networks = networks;
         self
     }
 
@@ -458,13 +473,32 @@ impl DispatcherGroup {
         self.member_ips.store(Arc::new(set));
     }
 
-    /// True when `ip` is a member of this group's cached resolved-address set.
+    /// True when `ip` is a member of this group — either in the cached
+    /// resolved-address set (the destinations' current DNS) or inside one of the
+    /// configured static `source_networks` CIDR ranges.
     ///
     /// Matches on IP only (source port is ignored — gateways answer from
-    /// varied ports). Reads the lock-free cache; never resolves DNS.
+    /// varied ports). Reads the lock-free cache and a small static CIDR list;
+    /// never resolves DNS.
     pub fn contains_source(&self, ip: IpAddr) -> bool {
         self.member_ips.load().contains(&ip)
+            || self.source_networks.iter().any(|network| network.contains(&ip))
     }
+}
+
+/// Parse a `source_networks` entry into an [`IpNet`].
+///
+/// Accepts either a CIDR (`"203.0.113.0/24"`) or a bare IP address
+/// (`"203.0.113.7"`), which is treated as a host route (`/32` for IPv4, `/128`
+/// for IPv6). Returns `None` for anything that is neither, so the caller can
+/// warn and skip a malformed entry rather than fail startup.
+pub fn parse_source_network(spec: &str) -> Option<IpNet> {
+    if let Ok(network) = spec.parse::<IpNet>() {
+        return Some(network);
+    }
+    let ip = spec.parse::<IpAddr>().ok()?;
+    let host_prefix = if ip.is_ipv4() { 32 } else { 128 };
+    IpNet::new(ip, host_prefix).ok()
 }
 
 
@@ -1829,6 +1863,60 @@ mod tests {
         group.all_destinations()[0].set_address("203.0.113.7:5060".parse().unwrap());
         group.refresh_member_ips();
         assert!(group.contains_source("203.0.113.7".parse().unwrap()));
+    }
+
+    #[test]
+    fn parse_source_network_accepts_cidr_and_bare_ip() {
+        // CIDR, IPv4 and IPv6.
+        assert!(parse_source_network("203.0.113.0/24").is_some());
+        assert!(parse_source_network("2001:db8::/32").is_some());
+        // Bare IP → host route (/32 for v4, /128 for v6).
+        assert_eq!(parse_source_network("203.0.113.7").unwrap().prefix_len(), 32);
+        assert_eq!(parse_source_network("2001:db8::1").unwrap().prefix_len(), 128);
+        // Neither a CIDR nor an IP → None (caller warns and skips).
+        assert!(parse_source_network("not-an-ip").is_none());
+        assert!(parse_source_network("203.0.113.0/99").is_none());
+        assert!(parse_source_network("").is_none());
+    }
+
+    #[test]
+    fn contains_source_matches_static_source_networks_v4_and_v6() {
+        // The whole point: a peer that sources SIP from a published range, not
+        // only the IPs its destination FQDNs resolve to. The floor destination
+        // resolves to 10.0.0.1; the ranges add membership independent of DNS.
+        let group = DispatcherGroup::new(
+            "range-peer".to_string(),
+            Algorithm::Weighted,
+            vec![make_dest("sip:gw1.example.com", 5060, 1, 1)],
+        )
+        .with_source_networks(vec![
+            parse_source_network("203.0.113.0/24").unwrap(),
+            parse_source_network("2001:db8::/32").unwrap(),
+        ]);
+
+        // Inside a configured range, though it never resolved from any FQDN.
+        assert!(group.contains_source("203.0.113.199".parse().unwrap()));
+        assert!(group.contains_source("2001:db8::dead:beef".parse().unwrap()));
+        // The resolved-destination floor still counts.
+        assert!(group.contains_source("10.0.0.1".parse().unwrap()));
+        // Outside both the resolved set and the ranges → not a member.
+        assert!(!group.contains_source("198.51.100.5".parse().unwrap()));
+        assert!(!group.contains_source("2001:db9::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn source_in_group_honours_source_networks() {
+        let manager = DispatcherManager::new();
+        manager.add_group(
+            DispatcherGroup::new(
+                "range-peer".to_string(),
+                Algorithm::Weighted,
+                vec![make_dest("sip:gw1.example.com", 5060, 1, 1)],
+            )
+            .with_source_networks(vec![parse_source_network("203.0.113.0/24").unwrap()]),
+        );
+        assert!(manager.source_in_group("range-peer", "203.0.113.42".parse().unwrap()));
+        assert!(!manager.source_in_group("range-peer", "198.51.100.1".parse().unwrap()));
     }
 
     // --- Probe health verdict (apply_probe_response) ---

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -702,6 +702,33 @@ impl PyCall {
         self.from_gateway_impl(group_name, super::gateway_manager())
     }
 
+    /// Check if the A-leg source IP is within any of the given CIDR ranges.
+    ///
+    /// The B2BUA counterpart of `request.source_ip_in`. Use it to gate on a
+    /// peer's published source subnets directly, when that peer sources SIP from
+    /// a whole range rather than only the IPs its signalling FQDNs resolve to —
+    /// the case `from_gateway` (which tracks the destinations' DNS) cannot cover.
+    /// Same trust semantics as `from_gateway`: handshake-verified on
+    /// TCP/TLS/WS/WSS, a best-effort direction hint on UDP.
+    ///
+    /// Raises `ValueError` only if the A-leg source IP itself is unparseable;
+    /// malformed CIDR entries in the list are skipped.
+    ///
+    /// Example: `if call.source_ip_in(["203.0.113.0/24"]): ...`
+    fn source_ip_in(&self, cidr_list: Vec<String>) -> PyResult<bool> {
+        let source_ip: std::net::IpAddr = self.source_ip.parse().map_err(|error| {
+            pyo3::exceptions::PyValueError::new_err(format!("bad source IP: {error}"))
+        })?;
+        for cidr in &cidr_list {
+            if let Ok(network) = cidr.parse::<ipnet::IpNet>() {
+                if network.contains(&source_ip) {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
     /// Media anchoring handle.
     ///
     /// Usage:
@@ -2135,6 +2162,40 @@ mod tests {
         let call = PyCall::new("test-id".to_string(), message, "not-an-ip".to_string(), "udp".to_string());
         let manager = gateway_manager_with_group();
         assert!(!call.from_gateway_impl("trunks", Some(&manager)));
+    }
+
+    #[test]
+    fn call_source_ip_in_matches_v4_and_v6_cidrs() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        // IPv4 source inside a /24; outside another; malformed entries skipped.
+        let call = PyCall::new(
+            "t".to_string(),
+            Arc::clone(&message),
+            "203.0.113.9".to_string(),
+            "tls".to_string(),
+        );
+        assert!(call.source_ip_in(vec!["203.0.113.0/24".to_string()]).unwrap());
+        assert!(!call.source_ip_in(vec!["198.51.100.0/24".to_string()]).unwrap());
+        assert!(call
+            .source_ip_in(vec!["garbage".to_string(), "203.0.113.0/24".to_string()])
+            .unwrap());
+
+        // IPv6 source inside a /32; outside another.
+        let call6 = PyCall::new(
+            "t".to_string(),
+            Arc::clone(&message),
+            "2001:db8::5".to_string(),
+            "tls".to_string(),
+        );
+        assert!(call6.source_ip_in(vec!["2001:db8::/32".to_string()]).unwrap());
+        assert!(!call6.source_ip_in(vec!["2001:db9::/32".to_string()]).unwrap());
+    }
+
+    #[test]
+    fn call_source_ip_in_raises_on_bad_source_ip() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let call = PyCall::new("t".to_string(), message, "not-an-ip".to_string(), "udp".to_string());
+        assert!(call.source_ip_in(vec!["203.0.113.0/24".to_string()]).is_err());
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -2315,9 +2315,28 @@ fn init_gateway(config: &Config) -> Option<Arc<DispatcherManager>> {
             from_domain: group_config.probe.from_domain.clone(),
         };
 
+        // Static source CIDR membership (for from_gateway) — peers that source
+        // SIP from a whole published subnet, not only their FQDN-resolved IPs.
+        let source_networks: Vec<ipnet::IpNet> = group_config
+            .source_networks
+            .iter()
+            .filter_map(|spec| {
+                let parsed = crate::gateway::parse_source_network(spec);
+                if parsed.is_none() {
+                    warn!(
+                        group = %group_config.name,
+                        entry = %spec,
+                        "ignoring invalid gateway source_networks entry (not a CIDR or IP)"
+                    );
+                }
+                parsed
+            })
+            .collect();
+
         manager.add_group(
             DispatcherGroup::new(group_config.name.clone(), algorithm, destinations)
-                .with_probe_config(probe),
+                .with_probe_config(probe)
+                .with_source_networks(source_networks),
         );
     }
 


### PR DESCRIPTION
## Problem

`request.from_gateway(group)` / `call.from_gateway(group)` decide membership by matching the source IP against a gateway group's **resolved destination addresses** — the current DNS of the group's signalling FQDNs. That's correct for a fixed-IP trunk, but it silently breaks for a peer that **sources SIP from a whole published subnet, not only the IPs its FQDNs resolve to**: the FQDNs resolve to a moving subset, so `from_gateway` returns `False` for a legitimate source it simply hasn't resolved, and it flaps as DNS rotates (a restart "fixes" one IP by re-resolving a different subset). There was no way to tell a group "membership = this CIDR range."

## Change

- **`gateway.groups[].source_networks`** (config) — a list of static source CIDR ranges (or bare IPs) whose senders count as group members for `from_gateway`, in addition to the resolved destinations. Membership is then stable regardless of DNS. IPv4 and IPv6; a bare IP is treated as a host route (`/32`, `/128`). Parsed once at startup; a malformed entry is warned and skipped, never fatal.
- **`call.source_ip_in(cidr_list)`** — the B2BUA counterpart of the existing `request.source_ip_in`, for gating on ranges inline without configuring a group. IPv4 + IPv6.

`contains_source` now checks the resolved-address set **or** the static CIDR set. Single-listener/hot-path cost is a short CIDR-list scan only when the resolved-set miss falls through (typically 1–2 ranges).

```yaml
gateway:
  groups:
    - name: "upstream-trunk"
      source_networks: ["203.0.113.0/24", "2001:db8::/32"]   # inbound membership
      destinations: [ ... FQDNs for outbound routing ... ]
```

## Testing

- Rust: `parse_source_network` (CIDR + bare IP → host route, IPv4/IPv6, garbage → skip), `contains_source` and `source_in_group` with static ranges (v4 + v6, inside/outside), `call.source_ip_in` (v4 + v6, malformed-entry skip, bad-source-IP raises).
- SDK: `call.source_ip_in` mock tests (v4 + v6) mirroring the Rust behaviour.
- Full suite green (2977 lib+integration; one unrelated `async_pool` flake that passes in isolation); `clippy --all-targets --all-features -D warnings` clean.
- Kamailio/OpenSIPS migration doc gets a `permissions`-module → `source_networks` / `source_ip_in` row.

For the 1.4.0 release.
