### PR TITLE
fix(hep): report advertised address in captures, not the raw 0.0.0.0 wildcard bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,17 @@ _Codename: bjorn._
   unaffected; there is no separate `answer_now()`.
 
 ### Fixed
+- **HEP/Homer captures no longer report siphon's own side as `0.0.0.0`.** When
+  siphon binds to the wildcard address (`listen.udp: 0.0.0.0:5060`, the usual
+  production config), every captured leg carried siphon's endpoint as the raw
+  bind/recv address — unspecified — so Homer showed `0.0.0.0` as the source of
+  outbound messages and the destination of inbound ones (the remote peer rendered
+  correctly). The capture path now resolves the local endpoint to the advertised
+  address per transport, the same substitution Via/Contact already apply, so a
+  leg shows which node/interface it belongs to and IP-based correlation works. The
+  SIP on the wire was always correct — this was capture metadata only. Set
+  `advertised_address` (or a per-transport `advertise`) for the real IP; without
+  it the substitute is loopback, exactly as Via behaves today.
 - **B2BUA on a multi-homed host now answers on the socket the call arrived on.**
   When siphon listens on more than one UDP port (e.g. `5060` and `5066`), the
   B2BUA sent every A-leg response (100 Trying, 18x, 2xx, 4xx–6xx, 487, 408, PRACK

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -335,6 +335,22 @@ impl DispatcherState {
             .unwrap_or(self.local_addr.port())
     }
 
+    /// Resolve siphon's own endpoint to report in a HEP capture for `transport`.
+    ///
+    /// When siphon binds to the wildcard address (`0.0.0.0` / `[::]`, the usual
+    /// production `listen` config), the raw bind/recv address is unspecified and
+    /// renders as `0.0.0.0` in Homer — hiding which node/interface the leg
+    /// belongs to and breaking IP-based correlation. Substitute the advertised
+    /// address (the same resolution Via/Contact use, per transport) so the
+    /// capture carries siphon's real address. The candidate's port is preserved,
+    /// and a non-unspecified candidate passes through unchanged.
+    fn hep_local_addr(&self, candidate: SocketAddr, transport: Transport) -> SocketAddr {
+        // `advertised_addrs` is the merged map — the global `advertised_address`
+        // is already folded into every listener transport at startup — so the
+        // trailing `None` never drops the global fallback.
+        crate::uac::resolve_via_addr(candidate, &transport, &self.advertised_addrs, None)
+    }
+
     /// Resolve a script `send_socket=` spec against the configured listeners.
     ///
     /// Returns `Some(SendSocket)` only when the spec is well-formed AND names a
@@ -2189,7 +2205,7 @@ fn handle_inbound(inbound: InboundMessage, state: &Arc<DispatcherState>) {
     if let Some(ref hep) = state.hep_sender {
         hep.capture_inbound(
             inbound.remote_addr,
-            inbound.local_addr,
+            state.hep_local_addr(inbound.local_addr, inbound.transport),
             inbound.transport,
             &inbound.data,
         );
@@ -4895,7 +4911,7 @@ fn send_to_target(
     // HEP capture — outbound (sent to network)
     if let Some(ref hep) = state.hep_sender {
         let local = state.listen_addrs.get(&transport).copied().unwrap_or(state.local_addr);
-        hep.capture_outbound(local, destination, transport, &data);
+        hep.capture_outbound(state.hep_local_addr(local, transport), destination, transport, &data);
     }
 
     match transport {
@@ -6241,7 +6257,7 @@ fn send_outbound_from(
         let local = source_local_addr
             .or_else(|| state.listen_addrs.get(&transport).copied())
             .unwrap_or(state.local_addr);
-        hep.capture_outbound(local, destination, transport, &data);
+        hep.capture_outbound(state.hep_local_addr(local, transport), destination, transport, &data);
     }
 
     let outbound_message = OutboundMessage {

--- a/src/hep/encoder.rs
+++ b/src/hep/encoder.rs
@@ -302,6 +302,37 @@ mod tests {
     }
 
     #[test]
+    fn encode_hep3_wildcard_local_resolves_to_advertised() {
+        use crate::uac::resolve_via_addr;
+        use std::collections::HashMap;
+
+        let payload = sample_sip_payload();
+
+        // siphon bound to the wildcard address — the usual production `listen`
+        // config. The raw bind/recv address is unspecified.
+        let wildcard = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5060);
+
+        // The encoder is a faithful writer: hand it the raw wildcard and it emits
+        // `0.0.0.0`, which is exactly the leak the pre-fix HEP path produced.
+        let raw = CaptureInfo { source: wildcard, ..make_capture_info(payload) };
+        let raw_chunks = parse_chunks(&encode_hep3(&raw)[6..]);
+        assert_eq!(raw_chunks.get(&CHUNK_IPV4_SRC).unwrap(), &[0, 0, 0, 0]);
+
+        // The dispatcher/uac resolve the local addr through `resolve_via_addr`
+        // before encoding, substituting the advertised address for the wildcard
+        // and preserving the port.
+        let mut advertised = HashMap::new();
+        advertised.insert(Transport::Udp, "203.0.113.7".to_string());
+        let resolved = resolve_via_addr(wildcard, &Transport::Udp, &advertised, None);
+        assert_eq!(resolved.ip(), IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)));
+        assert_eq!(resolved.port(), 5060);
+
+        let fixed = CaptureInfo { source: resolved, ..make_capture_info(payload) };
+        let fixed_chunks = parse_chunks(&encode_hep3(&fixed)[6..]);
+        assert_eq!(fixed_chunks.get(&CHUNK_IPV4_SRC).unwrap(), &[203, 0, 113, 7]);
+    }
+
+    #[test]
     fn encode_hep3_ipv6_chunks() {
         let payload = sample_sip_payload();
         let source = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5060);

--- a/src/uac/mod.rs
+++ b/src/uac/mod.rs
@@ -360,9 +360,15 @@ impl UacSender {
 
         let data = Bytes::from(message.to_bytes());
 
-        // HEP capture — outbound OPTIONS
+        // HEP capture — outbound OPTIONS.  For a captured-flow probe `addr` is
+        // the inbound flow's local socket, which is `0.0.0.0`/`[::]` when the
+        // listener is wildcard-bound; resolve it to the advertised address so the
+        // capture doesn't report an unspecified source (the `addr_for` fallback is
+        // already resolved, so this is a no-op there).
         if let Some(ref hep) = self.hep_sender {
-            hep.capture_outbound(addr, destination, transport, &data);
+            let hep_local =
+                resolve_via_addr(addr, &transport, &self.advertised_addrs, self.advertised_address.as_deref());
+            hep.capture_outbound(hep_local, destination, transport, &data);
         }
 
         let outbound_message = OutboundMessage {


### PR DESCRIPTION
## Problem

With siphon bound to the wildcard address (`listen.udp: 0.0.0.0:5060`, the usual production config), HEP/Homer captures showed siphon's own side of every leg as `0.0.0.0` — the source of outbound messages and the destination of inbound ones. The remote peer always rendered correctly; only siphon's endpoint was wrong.

This is capture metadata only — the SIP on the wire was always correct. But it breaks Homer: you can't tell which node/interface a leg belongs to, and IP-based correlation/aggregation falls over.

## Root cause

The HEP encoder faithfully writes whatever `SocketAddr` it's handed. The capture call sites handed it siphon's **raw socket bind/recv address**, which is unspecified (`0.0.0.0` / `[::]`) for a wildcard bind:

- inbound — `inbound.local_addr` is the wildcard listener address (no `IP_PKTINFO` on recv to recover the real destination IP)
- outbound — `state.listen_addrs[transport]` / `source_local_addr` is the wildcard bind

The Via/Contact/Record-Route path already solves the identical problem: it resolves the wildcard to the advertised address. The HEP path never got that treatment.

## Fix

Run the local endpoint through the existing, tested `resolve_via_addr` helper (per transport, wildcard → advertised address, port preserved, non-wildcard passes through unchanged) before encoding — the same substitution Via/Contact use. Applied at:

- the three dispatcher capture sites (inbound + both outbound paths; all B2BUA/proxy sends funnel through these)
- the uac captured-flow OPTIONS probe (where `addr` can be a wildcard `flow.local_addr`)

The registrant and the other uac capture sites already went through `resolve_via_addr` / `addr_for`, so they were already correct.

Operators should set `advertised_address` (or a per-transport `advertise`) for the real IP; without it the substitute is loopback, exactly as Via behaves today.

## Test

`encode_hep3_wildcard_local_resolves_to_advertised` documents both halves of the contract: the encoder emits `0.0.0.0` for a raw wildcard (the pre-fix leak), and the resolved address encodes the advertised IP with the port preserved.

`cargo clippy --all-targets --all-features -- -D warnings` clean; HEP + uac + dispatcher tests green. (Two unrelated free-threaded-Python async-pool tests flake under parallel execution and pass in isolation — untouched by this change.)
