### PR TITLE
fix(gateway): reuse the prober's resolved address for FQDN next hops instead of a per-call DNS resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,20 @@ _Codename: bjorn._
   unaffected; there is no separate `answer_now()`.
 
 ### Fixed
+- **Routing a call to a gateway FQDN no longer pays a per-call DNS resolve.** When
+  a next hop is a configured `gateway` destination with a hostname URI (an FQDN SIP
+  trunk, a Teams Direct Routing SBC `sip*.pstnhub.microsoft.com`), the datapath now
+  reuses the address the health prober already resolved for that destination
+  instead of doing a blocking `resolve()` on every relay/dial. On a low-traffic
+  node the resolver's own cache goes cold between calls, so each call was blocking
+  the worker on a fresh A/AAAA lookup — visible as a ~1 second gap between "call
+  received" and the outbound request going on the wire (and a matching gap in the
+  SIP trace). The cached address is the prober's, refreshed every probe cycle and
+  health-checked, and the hostname is still carried through for the R-URI and TLS
+  SNI, so nothing on the wire changes. Static-IP destinations and non-gateway next
+  hops are unaffected (a bare `IP:port` already skips DNS; an unknown host still
+  resolves normally). Enable probing on the group (the default) so the cache stays
+  fresh.
 - **HEP/Homer captures no longer report siphon's own side as `0.0.0.0`.** When
   siphon binds to the wildcard address (`listen.udp: 0.0.0.0:5060`, the usual
   production config), every captured leg carried siphon's endpoint as the raw

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -4835,6 +4835,46 @@ struct RelayTarget {
 /// ([`resolve_in_dialog_flow_uri`]) needs the *whole* set to test whether the
 /// dialog's established peer is still among the next hop's members.
 fn resolve_candidates(uri_string: &str, resolver: &SipResolver) -> Vec<RelayTarget> {
+    // Inject the process-wide gateway manager (the same one `from_gateway`
+    // reads) so a next hop that is a configured gateway FQDN can reuse the
+    // prober's already-resolved address instead of a per-call DNS lookup.
+    resolve_candidates_inner(
+        uri_string,
+        resolver,
+        crate::script::api::gateway_manager().map(|manager| &**manager),
+    )
+}
+
+/// Map a SIP `transport=` token (or SRV proto hint) to the internal
+/// [`Transport`]. Case-insensitive; `None` for an unrecognised token.
+fn transport_from_token(token: &str) -> Option<Transport> {
+    match token.to_lowercase().as_str() {
+        "tcp" => Some(Transport::Tcp),
+        "tls" => Some(Transport::Tls),
+        "udp" => Some(Transport::Udp),
+        "ws" => Some(Transport::WebSocket),
+        "wss" => Some(Transport::WebSocketSecure),
+        _ => None,
+    }
+}
+
+/// Core of [`resolve_candidates`] with the gateway address cache injected, so it
+/// is unit-testable without the process-wide gateway singleton.
+///
+/// Before falling back to a blocking DNS resolve, this checks whether the next
+/// hop is a configured gateway hostname destination whose address the health
+/// prober has already resolved (and `set_address`'d every probe cycle). A hit
+/// returns that cached, health-checked address with **zero** DNS on the hot
+/// path — the fix for a per-call ~1s stall routing to an FQDN trunk / Teams
+/// Direct Routing SBC on a low-traffic node where the resolver's own cache has
+/// gone cold between calls. The hostname is preserved as `server_name` so TLS
+/// SNI is unchanged, and the R-URI (built elsewhere from the same URI) is
+/// untouched.
+fn resolve_candidates_inner(
+    uri_string: &str,
+    resolver: &SipResolver,
+    gateway: Option<&crate::gateway::DispatcherManager>,
+) -> Vec<RelayTarget> {
     // Try as bare IP:port first (cheapest check)
     if let Ok(addr) = uri_string.parse::<SocketAddr>() {
         return vec![RelayTarget { address: addr, transport: None, server_name: None }];
@@ -4844,6 +4884,27 @@ fn resolve_candidates(uri_string: &str, resolver: &SipResolver) -> Vec<RelayTarg
     if let Ok(uri) = parse_uri_standalone(uri_string) {
         // Extract transport hint from URI params (e.g. ;transport=tcp)
         let transport_hint = uri.get_param("transport").map(|s| s.to_string());
+
+        // Gateway hot-path shortcut: if this next hop is a gateway hostname
+        // destination, reuse the address the prober already resolved instead of
+        // a blocking resolver.resolve on every call. Keyed on the same
+        // normalized `host:port` the gateway stored (extract_address_from_uri).
+        if let Some(gateway) = gateway {
+            let host_port = crate::gateway::extract_address_from_uri(uri_string);
+            if let Some((address, gateway_transport)) = gateway.cached_address_for(&host_port) {
+                // A script-supplied ;transport= wins; else the destination's
+                // configured transport.
+                let transport = transport_hint
+                    .as_deref()
+                    .and_then(transport_from_token)
+                    .or(Some(gateway_transport));
+                return vec![RelayTarget {
+                    address,
+                    transport,
+                    server_name: Some(uri.host.clone()),
+                }];
+            }
+        }
 
         let results = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(resolver.resolve(
@@ -4861,14 +4922,7 @@ fn resolve_candidates(uri_string: &str, resolver: &SipResolver) -> Vec<RelayTarg
                     .transport
                     .as_deref()
                     .or(transport_hint.as_deref())
-                    .and_then(|t| match t.to_lowercase().as_str() {
-                        "tcp" => Some(Transport::Tcp),
-                        "tls" => Some(Transport::Tls),
-                        "udp" => Some(Transport::Udp),
-                        "ws" => Some(Transport::WebSocket),
-                        "wss" => Some(Transport::WebSocketSecure),
-                        _ => None,
-                    });
+                    .and_then(transport_from_token);
                 // All candidates from one URI share the target hostname — carry
                 // it for TLS SNI so a hostname-vhost peer routes the handshake.
                 RelayTarget { address: r.address, transport, server_name: Some(uri.host.clone()) }
@@ -15575,6 +15629,80 @@ a=rtpmap:8 PCMA/8000\r\n";
     async fn resolve_target_unresolvable_domain() {
         let resolver = test_resolver();
         assert!(resolve_target("sip:alice@this-domain-should-not-exist-xyzzy.invalid", &resolver).is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resolve_candidates_inner_uses_gateway_cache_without_dns() {
+        use crate::gateway::{Algorithm, Destination, DispatcherGroup, DispatcherManager};
+        let resolver = test_resolver();
+        // `.invalid` never resolves in DNS (RFC 6761), so a fallthrough to
+        // resolver.resolve returns an empty set — a non-empty result here proves
+        // the gateway cache served the address with zero DNS.
+        let destination = Destination::new(
+            "sip:gw.test.invalid:5061;transport=tls".to_string(),
+            "127.0.0.9:5061".parse().unwrap(),
+            Transport::Tls,
+            1,
+            1,
+        )
+        .with_address_str("gw.test.invalid:5061".to_string());
+        let group =
+            DispatcherGroup::new("teams".to_string(), Algorithm::Weighted, vec![destination]);
+        // Simulate the health prober having resolved the FQDN.
+        let resolved: SocketAddr = "203.0.113.77:5061".parse().unwrap();
+        group.all_destinations()[0].set_address(resolved);
+        let manager = DispatcherManager::new();
+        manager.add_group(group);
+
+        let candidates = resolve_candidates_inner(
+            "sip:gw.test.invalid:5061;transport=tls",
+            &resolver,
+            Some(&manager),
+        );
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].address, resolved);
+        // Hostname preserved for TLS SNI to the FQDN peer.
+        assert_eq!(candidates[0].server_name.as_deref(), Some("gw.test.invalid"));
+        assert_eq!(candidates[0].transport, Some(Transport::Tls));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resolve_candidates_inner_falls_through_when_host_not_a_gateway() {
+        use crate::gateway::{Algorithm, Destination, DispatcherGroup, DispatcherManager};
+        let resolver = test_resolver();
+        let destination = Destination::new(
+            "sip:gw.test.invalid:5061;transport=tls".to_string(),
+            "127.0.0.9:5061".parse().unwrap(),
+            Transport::Tls,
+            1,
+            1,
+        )
+        .with_address_str("gw.test.invalid:5061".to_string());
+        let group =
+            DispatcherGroup::new("teams".to_string(), Algorithm::Weighted, vec![destination]);
+        let manager = DispatcherManager::new();
+        manager.add_group(group);
+
+        // A different unresolvable host is not a gateway member → no cache hit →
+        // DNS fallthrough → empty (does NOT borrow the gateway's cached address).
+        let candidates = resolve_candidates_inner(
+            "sip:other.host.invalid:5061;transport=tls",
+            &resolver,
+            Some(&manager),
+        );
+        assert!(candidates.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resolve_candidates_inner_bare_ip_short_circuits_before_gateway() {
+        let resolver = test_resolver();
+        let candidates = resolve_candidates_inner("203.0.113.5:5060", &resolver, None);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].address,
+            "203.0.113.5:5060".parse::<SocketAddr>().unwrap()
+        );
+        assert!(candidates[0].server_name.is_none());
     }
 
     // --- In-dialog connection reuse (RFC 5923) ---

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -537,6 +537,35 @@ impl DispatcherManager {
         self.groups.iter().map(|e| e.key().clone()).collect()
     }
 
+    /// The probe-maintained resolved address for a next-hop `host:port`, if it
+    /// belongs to a configured gateway **hostname** destination.
+    ///
+    /// The request datapath calls this before a blocking DNS resolve (see
+    /// `crate::dispatcher::resolve_candidates`): a gateway FQDN — an SBC trunk,
+    /// Teams Direct Routing `*.pstnhub.microsoft.com` — is re-resolved and
+    /// `set_address`'d by the health prober every cycle, so routing a call to it
+    /// can reuse that address with zero DNS on the hot path. That closes a
+    /// per-call ~1s stall on a low-traffic node where the resolver's own cache
+    /// has gone cold between calls.
+    ///
+    /// Static-IP destinations carry no `address_str` and are skipped — a bare
+    /// `IP:port` next hop already short-circuits DNS. `host_port` must be the
+    /// normalized form produced by [`extract_address_from_uri`]; the match is
+    /// case-insensitive. Returns the destination's current address and its
+    /// configured transport, or `None` when no gateway hostname matches.
+    pub fn cached_address_for(&self, host_port: &str) -> Option<(SocketAddr, Transport)> {
+        for group in self.groups.iter() {
+            for destination in group.value().all_destinations() {
+                if let Some(ref address_str) = destination.address_str {
+                    if address_str.eq_ignore_ascii_case(host_port) {
+                        return Some((destination.address(), destination.transport));
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Select a destination from a named group.
     pub fn select(
         &self,
@@ -1768,6 +1797,73 @@ mod tests {
     #[test]
     fn resolve_address_rejects_garbage() {
         assert!(resolve_address("not_valid").is_err());
+    }
+
+    // --- cached_address_for (datapath DNS-skip for gateway FQDNs) ---
+
+    #[test]
+    fn cached_address_for_returns_probe_address_for_hostname_dest() {
+        let dest = Destination::new(
+            "sip:gw.test.invalid:5060".to_string(),
+            "127.0.0.9:5060".parse().unwrap(),
+            Transport::Udp,
+            1,
+            1,
+        )
+        .with_address_str("gw.test.invalid:5060".to_string());
+        let group = DispatcherGroup::new("t".to_string(), Algorithm::Weighted, vec![dest]);
+        // Simulate the prober having re-resolved the FQDN to a concrete IP.
+        let resolved: SocketAddr = "203.0.113.77:5060".parse().unwrap();
+        group.all_destinations()[0].set_address(resolved);
+        let manager = DispatcherManager::new();
+        manager.add_group(group);
+
+        assert_eq!(
+            manager.cached_address_for("gw.test.invalid:5060"),
+            Some((resolved, Transport::Udp))
+        );
+        // Host match is case-insensitive (DNS names are).
+        assert_eq!(
+            manager.cached_address_for("GW.TEST.INVALID:5060"),
+            Some((resolved, Transport::Udp))
+        );
+    }
+
+    #[test]
+    fn cached_address_for_none_for_unknown_host_or_wrong_port() {
+        let dest = Destination::new(
+            "sip:gw.test.invalid:5061;transport=tls".to_string(),
+            "127.0.0.9:5061".parse().unwrap(),
+            Transport::Tls,
+            1,
+            1,
+        )
+        .with_address_str("gw.test.invalid:5061".to_string());
+        let group = DispatcherGroup::new("t".to_string(), Algorithm::Weighted, vec![dest]);
+        let manager = DispatcherManager::new();
+        manager.add_group(group);
+
+        assert!(manager.cached_address_for("other.host.invalid:5061").is_none());
+        // Same host, different port → not the same destination.
+        assert!(manager.cached_address_for("gw.test.invalid:5060").is_none());
+    }
+
+    #[test]
+    fn cached_address_for_ignores_static_ip_destinations() {
+        // A static IP:port destination carries no address_str, so it never
+        // shadows a resolve — a bare IP next hop short-circuits DNS anyway.
+        let dest = Destination::new(
+            "sip:198.51.100.5:5060".to_string(),
+            "198.51.100.5:5060".parse().unwrap(),
+            Transport::Udp,
+            1,
+            1,
+        );
+        let group = DispatcherGroup::new("t".to_string(), Algorithm::Weighted, vec![dest]);
+        let manager = DispatcherManager::new();
+        manager.add_group(group);
+
+        assert!(manager.cached_address_for("198.51.100.5:5060").is_none());
     }
 
     // --- Member-IP set / source membership (from_gateway backing store) ---


### PR DESCRIPTION
## Problem

Routing a call to a `gateway` destination configured with a hostname URI (an FQDN SIP trunk, a Teams Direct Routing SBC `sip*.pstnhub.microsoft.com`) did a blocking `resolver.resolve()` on every relay/dial. On a low-traffic node the resolver's own cache goes cold between calls, so each call blocked the executor worker on a fresh A/AAAA lookup — a ~1 second gap between "call received" and the outbound request leaving, with a matching gap in the SIP trace. `from_gateway` was never involved (it's a cached membership check); the cost was the re-resolution on the outbound leg.

## Fix

The gateway health prober already re-resolves and `set_address`'s each destination every probe cycle. The datapath now reuses that address:

- `DispatcherManager::cached_address_for(host_port)` returns the destination's current probe-refreshed address + transport for a matching gateway hostname (keyed on the normalized `host:port` `extract_address_from_uri` produces).
- `resolve_candidates` consults it before falling back to DNS. On a hit it returns the cached, health-checked address with `server_name` = the hostname, so the R-URI and TLS SNI are unchanged and nothing on the wire differs.

## Scope

- Static-IP destinations (no `address_str`) and non-gateway next hops are unaffected: a bare `IP:port` short-circuits before the check, and an unknown host still resolves normally.
- The SIPp perf rows target bare `IP:port`, which short-circuits before the new lookup, so the benchmarked hot path is unchanged. The extra scan (a handful of destinations) only runs for hostname next hops.
- Transparent: keep routing via `call.dial(gw.uri)` / `request.relay(gw.uri)` unchanged.

## Tests

- `cached_address_for`: hit (case-insensitive), miss on wrong host/port, static-IP ignored.
- `resolve_candidates_inner`: serves an unresolvable `.invalid` FQDN from the cache (proving zero DNS), falls through to a real resolve for a non-gateway host, bare-IP short-circuit.
- Full lib suite green (2993), clippy clean.