### PR TITLE
chore(release): promote CHANGELOG to 1.4.0 + bump yanked spin 0.9.8→0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-07-14
+
 _Codename: bjorn._
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
Release prep for 1.4.0 (codename bjorn):

- Promote CHANGELOG `[Unreleased]` -> `## [1.4.0] — 2026-07-14` (codename + sections ride under it; fresh empty `[Unreleased]` on top). Satisfies the cut-release.sh CHANGELOG gate.
- Bump transitive `spin` 0.9.8 -> 0.9.9 (via `flume`): 0.9.8 was yanked, which the cut-release cargo-deny advisory gate denies (`cargo deny --all-features check advisories`). Now `advisories ok`. Spinlock-crate patch, no behaviour/perf impact.

10k-CPS validation on `ac0afea` (this release main): proxy/b2bua x udp/tcp all PASS (0 failed / 0 retransmits, ~10k peak), mem-leak both modes PASS (allocated flat, stores drain).