### PR TITLE
feat(metrics): optional CORS on the /metrics + admin HTTP endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 _Codename: bjorn._
 
 ### Added
+- **CORS for the `/metrics` and admin HTTP endpoints.** A browser dashboard
+  served from a different origin can now `fetch()` the Prometheus `/metrics`
+  listener and/or the admin API — previously the browser hid the response
+  because no `Access-Control-Allow-Origin` header was sent. Opt in per endpoint
+  with `metrics.prometheus.cors.allowed_origins: [ ... ]` and/or
+  `admin.cors.allowed_origins: [ ... ]` (full origins including scheme and
+  port; a single `"*"` allows any origin, but an explicit list is recommended
+  — the admin API can force-unregister AoRs and lift bans). Omitting the block
+  emits no CORS headers, so same-origin callers and Prometheus scrapers are
+  unaffected. The layer also answers CORS preflight (`OPTIONS`) requests, so a
+  dashboard that sends custom headers or hits the admin `DELETE` routes works.
 - **Scripts can `import` sibling `.py` helper modules.** A script's own directory
   is now added to the Python `sys.path`, so `import helpers` resolves a
   `helpers.py` sitting next to the main script — no `sys.path.insert` boilerplate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ tokio-postgres = { version = "0.7", optional = true }
 prometheus = { version = "0.14", features = ["process"] }
 axum = { version = "0.8.8", features = ["tokio"] }
 tower = { version = "0.5.3", features = ["util"] }
+tower-http = { version = "0.6.8", features = ["cors"] }
 
 # Lawful Intercept — ETSI ASN.1/BER + XML
 rasn = "0.28"

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -607,6 +607,15 @@ auth:
 #   prometheus:
 #     listen: "0.0.0.0:8888"
 #     path: "/metrics"
+#     # Optional CORS policy so a browser dashboard served from a different
+#     # origin can fetch() /metrics (a browser hides a cross-origin response
+#     # from page JS unless the server echoes Access-Control-Allow-Origin).
+#     # Omit the block entirely for no CORS headers (the default). List full
+#     # origins (scheme + host + port); a single "*" allows any origin
+#     # (handy for local dev, but prefer an explicit list).
+#     cors:
+#       allowed_origins:
+#         - "http://localhost:5173"
 
 # ---------------------------------------------------------------------------
 # HTTP admin API (health/readiness probes + registration inspection)
@@ -624,6 +633,12 @@ auth:
 #   GET    /metrics                   Prometheus scrape (same body as the metrics port)
 # admin:
 #   listen: "0.0.0.0:9091"
+#   # Optional CORS policy for the admin API (and the /metrics it also serves),
+#   # same shape as metrics.prometheus.cors. Prefer an explicit origin list
+#   # here — the admin API can force-unregister AoRs and lift auto-bans.
+#   cors:
+#     allowed_origins:
+#       - "http://localhost:5173"
 
 # ---------------------------------------------------------------------------
 # Gateway dispatcher (named groups with load balancing + health probing)

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -19,6 +19,7 @@ use axum::Router;
 use serde::Serialize;
 use tracing::{error, info};
 
+use crate::config::CorsConfig;
 use crate::dispatcher::DrainState;
 use crate::registrar::Registrar;
 
@@ -34,8 +35,12 @@ pub struct AdminState {
 }
 
 /// Start the HTTP admin API server.
-pub async fn serve(listen_addr: SocketAddr, state: AdminState) {
-    let app = router(state);
+///
+/// `cors` optionally attaches an `Access-Control-Allow-Origin` policy so a
+/// browser dashboard served from another origin can `fetch()` the admin API
+/// (and the `/metrics` it also serves). `None` = no CORS headers.
+pub async fn serve(listen_addr: SocketAddr, state: AdminState, cors: Option<CorsConfig>) {
+    let app = router(state, cors.as_ref());
 
     info!("Admin API listening on {}", listen_addr);
 
@@ -53,8 +58,8 @@ pub async fn serve(listen_addr: SocketAddr, state: AdminState) {
 }
 
 /// Build the router (also used by tests without binding a port).
-fn router(state: AdminState) -> Router {
-    Router::new()
+fn router(state: AdminState, cors: Option<&CorsConfig>) -> Router {
+    let mut app = Router::new()
         .route("/metrics", get(metrics_handler))
         .route("/admin/health", get(health_handler))
         .route("/admin/ready", get(ready_handler))
@@ -64,7 +69,11 @@ fn router(state: AdminState) -> Router {
         .route("/admin/registrations/{aor}", delete(registration_delete_handler))
         .route("/admin/bans", get(bans_handler))
         .route("/admin/bans/{ip}", delete(ban_delete_handler))
-        .with_state(state)
+        .with_state(state);
+    if let Some(layer) = cors.and_then(crate::cors::build_cors_layer) {
+        app = app.layer(layer);
+    }
+    app
 }
 
 // ---------------------------------------------------------------------------
@@ -290,7 +299,7 @@ mod tests {
     }
 
     fn test_app() -> Router {
-        router(test_state())
+        router(test_state(), None)
     }
 
     #[tokio::test]
@@ -337,7 +346,7 @@ mod tests {
             start_time: Instant::now(),
             draining: Some(drain),
         };
-        let app = router(state);
+        let app = router(state, None);
 
         let response = app
             .oneshot(Request::get("/admin/ready").body(Body::empty()).unwrap())
@@ -474,5 +483,89 @@ mod tests {
         let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["error"], "invalid IP address");
+    }
+
+    #[tokio::test]
+    async fn cors_echoes_configured_origin_on_metrics() {
+        crate::metrics::init().unwrap();
+        let cors = CorsConfig {
+            allowed_origins: vec!["http://localhost:5173".to_owned()],
+        };
+        let app = router(test_state(), Some(&cors));
+
+        // A simple cross-origin GET must come back with the allow-origin echo,
+        // or the browser hides the body from the dashboard.
+        let response = app
+            .oneshot(
+                Request::get("/metrics")
+                    .header("origin", "http://localhost:5173")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("http://localhost:5173"),
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_preflight_is_answered_for_admin_delete() {
+        let cors = CorsConfig {
+            allowed_origins: vec!["http://localhost:5173".to_owned()],
+        };
+        let app = router(test_state(), Some(&cors));
+
+        // The admin DELETE routes are non-simple requests, so the browser sends
+        // an OPTIONS preflight first; the layer must answer it 2xx with the echo.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("OPTIONS")
+                    .uri("/admin/registrations/sip:alice@example.com")
+                    .header("origin", "http://localhost:5173")
+                    .header("access-control-request-method", "DELETE")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(response.status().is_success());
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("http://localhost:5173"),
+        );
+    }
+
+    #[tokio::test]
+    async fn no_cors_config_emits_no_header() {
+        crate::metrics::init().unwrap();
+        // Default (no cors block) stays byte-for-byte as before — no CORS header.
+        let app = router(test_state(), None);
+
+        let response = app
+            .oneshot(
+                Request::get("/metrics")
+                    .header("origin", "http://localhost:5173")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(response
+            .headers()
+            .get("access-control-allow-origin")
+            .is_none());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1471,10 +1471,40 @@ pub struct PrometheusConfig {
     pub listen: String,
     #[serde(default = "default_metrics_path")]
     pub path: String,
+    /// Optional CORS policy so a browser dashboard served from another origin
+    /// can `fetch()` this endpoint. Unset = no CORS headers (default).
+    #[serde(default)]
+    pub cors: Option<CorsConfig>,
 }
 
 fn default_metrics_path() -> String {
     "/metrics".to_owned()
+}
+
+// ---------------------------------------------------------------------------
+// CORS (browser-facing HTTP endpoints)
+// ---------------------------------------------------------------------------
+
+/// Cross-Origin Resource Sharing policy for a browser-facing HTTP endpoint
+/// (the Prometheus `/metrics` listener and/or the admin API).
+///
+/// A browser blocks a cross-origin `fetch()` of these endpoints unless the
+/// server echoes an `Access-Control-Allow-Origin` header. Set this to let a
+/// monitoring dashboard served from a different origin (e.g. a local dev
+/// server on `http://localhost:5173`) read the endpoint. Leaving it unset
+/// emits no CORS headers at all — same-origin callers and Prometheus scrapers
+/// are unaffected either way, so this is opt-in and backwards compatible.
+#[derive(Debug, Deserialize, Clone)]
+pub struct CorsConfig {
+    /// Origins allowed to read this endpoint from a browser, echoed into
+    /// `Access-Control-Allow-Origin`. Each entry is a full origin including
+    /// scheme and port (`http://localhost:5173`, `https://dash.example.com`).
+    /// A single `"*"` entry allows any origin — convenient for local
+    /// development, but prefer an explicit list in production, especially for
+    /// the admin API (which can force-unregister AoRs and lift bans). An empty
+    /// list disables CORS.
+    #[serde(default)]
+    pub allowed_origins: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1496,6 +1526,12 @@ fn default_metrics_path() -> String {
 pub struct AdminConfig {
     /// Address to expose the admin API on (e.g. "0.0.0.0:9091").
     pub listen: String,
+    /// Optional CORS policy so a browser dashboard served from another origin
+    /// can `fetch()` the admin API (and the `/metrics` it also serves). Unset =
+    /// no CORS headers (default). Prefer an explicit origin list here — the
+    /// admin API can force-unregister AoRs and lift auto-bans.
+    #[serde(default)]
+    pub cors: Option<CorsConfig>,
 }
 
 // ---------------------------------------------------------------------------
@@ -3117,6 +3153,89 @@ auth:
             config.script.include_paths,
             vec!["/etc/siphon/lib".to_string(), "shared".to_string()]
         );
+    }
+
+    #[test]
+    fn parses_metrics_and_admin_cors() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/main.py"
+auth:
+  realm: "example.com"
+metrics:
+  prometheus:
+    listen: "0.0.0.0:8888"
+    cors:
+      allowed_origins:
+        - "http://localhost:5173"
+        - "https://dash.example.com"
+admin:
+  listen: "0.0.0.0:9091"
+  cors:
+    allowed_origins:
+      - "*"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+
+        let prom_cors = config
+            .metrics
+            .as_ref()
+            .and_then(|metrics| metrics.prometheus.as_ref())
+            .and_then(|prom| prom.cors.as_ref())
+            .expect("metrics.prometheus.cors must parse");
+        assert_eq!(
+            prom_cors.allowed_origins,
+            vec![
+                "http://localhost:5173".to_string(),
+                "https://dash.example.com".to_string()
+            ]
+        );
+
+        let admin_cors = config
+            .admin
+            .as_ref()
+            .and_then(|admin| admin.cors.as_ref())
+            .expect("admin.cors must parse");
+        assert_eq!(admin_cors.allowed_origins, vec!["*".to_string()]);
+    }
+
+    #[test]
+    fn metrics_without_cors_leaves_it_none() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/main.py"
+auth:
+  realm: "example.com"
+metrics:
+  prometheus:
+    listen: "0.0.0.0:8888"
+admin:
+  listen: "0.0.0.0:9091"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert!(config
+            .metrics
+            .as_ref()
+            .and_then(|metrics| metrics.prometheus.as_ref())
+            .and_then(|prom| prom.cors.as_ref())
+            .is_none());
+        assert!(config
+            .admin
+            .as_ref()
+            .and_then(|admin| admin.cors.as_ref())
+            .is_none());
     }
 
     #[test]

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -1,0 +1,96 @@
+//! CORS layer construction for SIPhon's browser-facing HTTP endpoints.
+//!
+//! Both the Prometheus `/metrics` listener and the admin API are plain axum
+//! routers. A browser refuses to expose a cross-origin `fetch()` response to
+//! page JavaScript unless the server sends an `Access-Control-Allow-Origin`
+//! header matching the caller's origin. This module turns a [`CorsConfig`] into
+//! a [`tower_http::cors::CorsLayer`] that both routers can `.layer(...)`.
+//!
+//! The layer also answers CORS preflight (`OPTIONS`) requests automatically, so
+//! a dashboard that sends custom headers or hits the admin API's `DELETE`
+//! routes works too — not just the simple `GET /metrics` case.
+
+use axum::http::HeaderValue;
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tracing::warn;
+
+use crate::config::CorsConfig;
+
+/// Build a [`CorsLayer`] from a [`CorsConfig`], or `None` when CORS should stay
+/// off (no origins configured, or every configured origin was unparseable).
+///
+/// - A single `"*"` origin (or any entry equal to `"*"`) allows any origin via
+///   `Access-Control-Allow-Origin: *`.
+/// - Otherwise each entry is parsed as an exact origin; invalid ones are
+///   logged and skipped rather than failing the whole endpoint.
+///
+/// Methods and request headers are allowed wildcard: these endpoints carry no
+/// cookies/credentials, so `Access-Control-Allow-Origin` never needs to be a
+/// single credentialed origin, and a dashboard is free to send whatever headers
+/// and methods (`GET`, the admin `DELETE`) it needs.
+pub fn build_cors_layer(config: &CorsConfig) -> Option<CorsLayer> {
+    if config.allowed_origins.is_empty() {
+        return None;
+    }
+
+    let base = CorsLayer::new().allow_methods(Any).allow_headers(Any);
+
+    if config.allowed_origins.iter().any(|origin| origin == "*") {
+        return Some(base.allow_origin(Any));
+    }
+
+    let mut values: Vec<HeaderValue> = Vec::with_capacity(config.allowed_origins.len());
+    for origin in &config.allowed_origins {
+        match origin.parse::<HeaderValue>() {
+            Ok(value) => values.push(value),
+            Err(error) => {
+                warn!(origin = %origin, "ignoring invalid CORS origin: {error}");
+            }
+        }
+    }
+
+    if values.is_empty() {
+        return None;
+    }
+    Some(base.allow_origin(AllowOrigin::list(values)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_origins_disables_cors() {
+        let config = CorsConfig {
+            allowed_origins: vec![],
+        };
+        assert!(build_cors_layer(&config).is_none());
+    }
+
+    #[test]
+    fn explicit_origins_build_a_layer() {
+        let config = CorsConfig {
+            allowed_origins: vec!["http://localhost:5173".to_owned()],
+        };
+        assert!(build_cors_layer(&config).is_some());
+    }
+
+    #[test]
+    fn wildcard_origin_builds_a_layer() {
+        let config = CorsConfig {
+            allowed_origins: vec!["*".to_owned()],
+        };
+        assert!(build_cors_layer(&config).is_some());
+    }
+
+    #[test]
+    fn all_invalid_origins_disable_cors() {
+        // `HeaderValue` accepts visible ASCII (spaces included) but rejects
+        // control characters, so an embedded newline is never parseable — the
+        // only configured origin drops out and the layer collapses to None.
+        let config = CorsConfig {
+            allowed_origins: vec!["http://bad\norigin".to_owned()],
+        };
+        assert!(build_cors_layer(&config).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod b2bua;
 pub mod cache;
 pub mod config;
+pub mod cors;
 pub mod diameter;
 pub mod dialog;
 pub mod dispatcher;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1476,11 +1476,15 @@ impl SiphonServer {
                     std::process::exit(1);
                 });
                 let path = prom_config.path.clone();
+                let cors = prom_config.cors.clone();
                 tokio::spawn(async move {
                     use axum::{routing::get, Router};
-                    let app = Router::new().route(&path, get(|| async {
+                    let mut app = Router::new().route(&path, get(|| async {
                         crate::metrics::encode_metrics()
                     }));
+                    if let Some(layer) = cors.as_ref().and_then(crate::cors::build_cors_layer) {
+                        app = app.layer(layer);
+                    }
                     info!(addr = %listen_addr, path = %path, "Prometheus metrics endpoint started");
                     match tokio::net::TcpListener::bind(listen_addr).await {
                         Ok(listener) => {
@@ -1905,7 +1909,11 @@ impl SiphonServer {
                             start_time: std::time::Instant::now(),
                             draining: Some(Arc::clone(&drain)),
                         };
-                        tokio::spawn(crate::admin::serve(listen_addr, admin_state));
+                        tokio::spawn(crate::admin::serve(
+                            listen_addr,
+                            admin_state,
+                            admin_config.cors.clone(),
+                        ));
                     } else {
                         error!("admin API enabled but registrar is not initialized; not starting");
                     }


### PR DESCRIPTION
## What

Optional CORS on SIPhon's two browser-facing HTTP endpoints — the Prometheus
`/metrics` listener and the admin API — so a monitoring dashboard served from a
different origin can `fetch()` them. Until now the browser fetched the response
but hid it from page JavaScript, because no `Access-Control-Allow-Origin` header
was sent ("no CORS, so you can't open it from localhost").

## Config

Opt in per endpoint. Omitting the block emits no CORS headers, so same-origin
callers and Prometheus scrapers are unaffected — fully backwards compatible.

```yaml
metrics:
  prometheus:
    listen: "0.0.0.0:8888"
    cors:
      allowed_origins:
        - "http://localhost:5173"
admin:
  listen: "0.0.0.0:9091"
  cors:
    allowed_origins:
      - "http://localhost:5173"
```

- `allowed_origins` entries are full origins (scheme + host + port).
- A single `"*"` entry allows any origin (handy for local dev). An explicit list
  is recommended, especially for the admin API — it can force-unregister AoRs
  and lift auto-bans.
- Invalid origins are logged and skipped rather than failing the endpoint; if
  every configured origin is unparseable the layer stays off.

## How

- New shared `CorsConfig { allowed_origins: Vec<String> }`, added to both
  `PrometheusConfig` and `AdminConfig`.
- New `src/cors.rs` builds a `tower-http` `CorsLayer` from it (methods/headers
  wildcard — these endpoints carry no credentials). The layer also answers CORS
  preflight (`OPTIONS`), so a dashboard that sends custom headers or hits the
  admin `DELETE` routes works, not just the simple `GET /metrics` case.
- Applied to the Prometheus router (`server.rs`) and the admin router
  (`admin/mod.rs`).
- `tower-http` promoted to a direct dependency with the `cors` feature; it was
  already 0.6.8 in the lockfile transitively, so no version churn and no new
  transitive crates.

## Tests

- `src/cors.rs`: layer built for explicit origins and `"*"`, `None` for empty /
  all-invalid origin lists.
- `admin/mod.rs`: allow-origin echo on a cross-origin `GET /metrics`, preflight
  `OPTIONS` answered on an admin `DELETE` route, and no header when unconfigured.
- `config.rs`: `metrics.prometheus.cors` + `admin.cors` deserialize; absent =
  `None`.

Full suite green (3362 passed), clippy clean.
