### PR TITLE
fix(script): purge sys.modules via snapshot (free-threaded hot-reload race) + stabilize async-pool drain test

### DIFF
--- a/src/script/async_pool.rs
+++ b/src/script/async_pool.rs
@@ -911,12 +911,28 @@ mod tests {
             force_python_gc();
             flush_drivers().await;
 
-            // Probe each driver: expected count is 0.
-            let counts = count_pending_tasks_per_driver().await;
+            // Poll until every driver's asyncio task table drains. A completed
+            // task lingers in `asyncio.all_tasks()` until the driver loop runs its
+            // done-callback + finalizer, which can lag the single flush above — so
+            // give the drivers a bounded window (flush + GC + a short settle) to
+            // reach 0 rather than probing a beat too early. This does NOT weaken
+            // the leak assertion: a genuine leak never drains, so the loop exhausts
+            // its window and still fails; it only removes the finalization race.
+            let mut counts = count_pending_tasks_per_driver().await;
+            for _ in 0..50 {
+                if counts.iter().all(|count| *count == 0) {
+                    break;
+                }
+                flush_drivers().await;
+                force_python_gc();
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                counts = count_pending_tasks_per_driver().await;
+            }
             for (driver, count) in counts.iter().enumerate() {
                 assert_eq!(
                     *count, 0,
-                    "driver {} has {} pending tasks after handler batch — leak",
+                    "driver {} has {} pending tasks after handler batch — leak \
+                     (did not drain within the poll window)",
                     driver, count
                 );
             }

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -825,9 +825,19 @@ fn purge_user_modules(python: Python<'_>, dirs: &[PathBuf]) -> Result<()> {
         .cast_into::<PyDict>()
         .map_err(|error| SiphonError::Script(format!("sys.modules not a dict: {error}")))?;
 
-    // Collect first, delete after — never mutate the dict mid-iteration.
+    // Iterate a *snapshot*, not the live dict. `sys.modules` is process-global,
+    // so another thread — a handler lazily importing a module under free-threaded
+    // Python (3.14t), or a parallel test compiling a script — can change its size
+    // mid-iteration, which CPython rejects with "dictionary changed size during
+    // iteration" (a panic here, e.g. on hot-reload). `dict.copy()` is atomic under
+    // the free-threaded build's per-object lock and the copy is thread-local, so
+    // iterating it is race-free. Deletions below still target the live `modules`;
+    // a key already removed by a concurrent purge just makes `del_item` warn.
+    let snapshot = modules
+        .copy()
+        .map_err(|error| SiphonError::Script(format!("snapshot sys.modules: {error}")))?;
     let mut to_remove: Vec<String> = Vec::new();
-    for (name, module) in modules.iter() {
+    for (name, module) in snapshot.iter() {
         let Ok(file_attr) = module.getattr("__file__") else {
             continue; // builtins / namespace packages have no __file__
         };


### PR DESCRIPTION
Two release-gate fixes surfaced while cutting 1.4.0.

**1. Real bug — hot-reload crash under free-threaded Python.** `purge_user_modules` (added in #94) iterated the live process-global `sys.modules` while collecting stale helper modules to drop. It collects-first/deletes-after, so it is safe against its *own* mutation — but not against another thread: under free-threaded Python 3.14t (the production interpreter) a dispatcher thread lazily importing a module, or a parallel test compiling a script, changes `sys.modules` size mid-iteration, which CPython rejects with `dictionary changed size during iteration` -> panic on reload. Fix: iterate `dict.copy()` (atomic under the nogil per-object lock, thread-local) and `del_item` from the live dict as before. Surfaced by the release 's `cargo test` gate (the parallel suite hit the race).

**2. Flaky test — async-pool task drain.** `pool_drains_asyncio_tasks_after_batch` probed `asyncio.all_tasks()` a single beat after a flush and asserted 0, but a completed task lingers in the task table until the loop finalizes it, so it flaked ~40% of full-suite runs (`29 pending`). Now polls-until-drained within a bounded window (flush + GC + settle). Does NOT weaken the leak assertion: a genuine leak never drains, so it still fails after the window.

No CHANGELOG entry: both are fixes to *unreleased* code (#94's purge is in the unshipped 1.4.0; the other is test-only).

Verified: full lib suite 10/10 green (both flakes were reproducing before — purge ~1/run, async-pool ~40%); clippy --all-targets --all-features clean.