### PR TITLE
feat(admin): embedded web dashboard + /admin/metrics.json + bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **Embedded web dashboard on the admin listener** (opt-in `ui` cargo feature +
+  `admin.ui.enabled`). Serves a single-page operator dashboard same-origin with
+  the admin API — Overview (live tiles + charts for dialogs, SIP request rate,
+  and memory), Registrations (searchable, with force-unregister), Security
+  (threat counters + active bans, with lift-ban), System (jemalloc/glibc memory,
+  Python executor pool, runtime facts), and Integrations (Diameter / rtpengine /
+  SBI). Assets are baked into the binary (no external files, no runtime fetch);
+  the feature is off by default so the default build and any library consumer
+  pull none of it. A binary built without `--features ui` logs a warning and
+  serves no UI when `admin.ui.enabled` is set.
+- **`GET /admin/metrics.json`** — a curated JSON snapshot of the live gauges and
+  counters (SIP, memory, Python executor, Diameter, rtpengine, SBI, security),
+  intended for the dashboard and any custom tooling that would rather not parse
+  the Prometheus text format. Cumulative counters are exposed raw so a client
+  diffs them over time to derive rates.
+- **Bearer-token auth for the admin API** (`admin.auth.token`). When set, the
+  mutating `DELETE` routes (force-unregister, lift-ban) require
+  `Authorization: Bearer <token>`, compared in constant time; set
+  `admin.auth.protect_reads: true` to require it on the read routes and
+  `/metrics` too. Unset leaves the admin API open exactly as before.
+
 ## [1.4.0] — 2026-07-14
 
 _Codename: bjorn._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   priority, address, transport, and attributes, read from the shared dispatcher
   (no new state or probing). Surfaced as a Gateways panel on the dashboard's
   Integrations page.
-- **Bearer-token auth for the admin API** (`admin.auth.token`). When set, the
-  mutating `DELETE` routes (force-unregister, lift-ban) require
-  `Authorization: Bearer <token>`, compared in constant time; set
-  `admin.auth.protect_reads: true` to require it on the read routes and
-  `/metrics` too. Unset leaves the admin API open exactly as before.
+- **`POST /admin/gateways/{group}/{destination}/{up|down}`** — manually mark a
+  gateway destination up or down (drain a bad carrier from the dashboard, then
+  restore it), with a per-destination button on the Gateways panel. Mutating, so
+  it requires the admin bearer token.
+- **Bearer-token auth for the admin API** (`admin.auth.token`). When set, every
+  mutating route (`POST`/`PUT`/`PATCH`/`DELETE` — force-unregister, lift-ban,
+  gateway up/down) requires `Authorization: Bearer <token>`, compared in
+  constant time; set `admin.auth.protect_reads: true` to require it on the read
+  routes and `/metrics` too. Unset leaves the admin API open exactly as before.
 
 ## [1.4.0] — 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   gateway destination up or down (drain a bad carrier from the dashboard, then
   restore it), with a per-destination button on the Gateways panel. Mutating, so
   it requires the admin bearer token.
+- **`GET /admin/calls`** — active B2BUA calls (internal id, SIP Call-ID, state,
+  A-leg From, B-leg target, and B-leg count), read from the dispatcher's call
+  store. Surfaced as a dedicated Calls view on the dashboard (which now groups
+  the nav into Monitor / Routing / System, with Gateways in its own Routing
+  section). Empty on a proxy-only node.
 - **Bearer-token auth for the admin API** (`admin.auth.token`). When set, every
   mutating route (`POST`/`PUT`/`PATCH`/`DELETE` — force-unregister, lift-ban,
   gateway up/down) requires `Authorization: Bearer <token>`, compared in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   intended for the dashboard and any custom tooling that would rather not parse
   the Prometheus text format. Cumulative counters are exposed raw so a client
   diffs them over time to derive rates.
+- **`GET /admin/gateways`** — per-group gateway dispatcher status: every
+  configured group with its algorithm and each destination's health, weight,
+  priority, address, transport, and attributes, read from the shared dispatcher
+  (no new state or probing). Surfaced as a Gateways panel on the dashboard's
+  Integrations page.
 - **Bearer-token auth for the admin API** (`admin.auth.token`). When set, the
   mutating `DELETE` routes (force-unregister, lift-ban) require
   `Authorization: Bearer <token>`, compared in constant time; set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
-- **Embedded web dashboard on the admin listener** (opt-in `ui` cargo feature +
-  `admin.ui.enabled`). Serves a single-page operator dashboard same-origin with
-  the admin API — Overview (live tiles + charts for dialogs, SIP request rate,
-  and memory), Registrations (searchable, with force-unregister), Security
-  (threat counters + active bans, with lift-ban), System (jemalloc/glibc memory,
-  Python executor pool, runtime facts), and Integrations (Diameter / rtpengine /
-  SBI). Assets are baked into the binary (no external files, no runtime fetch);
-  the feature is off by default so the default build and any library consumer
-  pull none of it. A binary built without `--features ui` logs a warning and
-  serves no UI when `admin.ui.enabled` is set.
+- **Embedded web dashboard on the admin listener — EXPERIMENTAL** (`ui` cargo
+  feature + `admin.ui.enabled`). Serves a single-page operator dashboard
+  same-origin with the admin API — Overview (live tiles + charts for dialogs, SIP
+  request rate, and memory), Calls (active B2BUA calls), Registrations
+  (searchable, with force-unregister), Security (threat counters + active bans,
+  with lift-ban), Gateways (per-group destination health, with drain/enable),
+  System (jemalloc/glibc memory, Python executor pool, runtime facts), and
+  Integrations (Diameter / rtpengine / SBI). Assets are baked into the binary (no
+  external files, no runtime fetch). The **release Docker image compiles it in by
+  default**; the plain `cargo build` leaves it off, so any library consumer pulls
+  none of it. Serving the dashboard logs an EXPERIMENTAL warning; a binary built
+  without `--features ui` warns and serves nothing when `admin.ui.enabled` is set.
 - **`GET /admin/metrics.json`** — a curated JSON snapshot of the live gauges and
   counters (SIP, memory, Python executor, Diameter, rtpengine, SBI, security),
   intended for the dashboard and any custom tooling that would rather not parse

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3126,7 @@ dependencies = [
  "ipnet",
  "libc",
  "md5",
+ "mime_guess",
  "netlink-sys",
  "nom 8.0.0",
  "notify",
@@ -3107,6 +3143,7 @@ dependencies = [
  "redis",
  "regex",
  "reqwest",
+ "rust-embed",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,11 +227,12 @@ postgres-backend = ["dep:tokio-postgres"]
 # loud warning; a Diameter peer with `transport: sctp` errors at connect time.
 sctp = ["dep:tokio-sctp"]
 
-# Embedded operator web dashboard, served by the admin HTTP listener behind
-# `admin.ui.enabled`. Off by default so the default binary and any library
-# consumer stay free of the asset-embedding deps. When disabled, an
-# `admin.ui.enabled: true` block still parses and is skipped with a loud warning
-# (mirrors the `sctp` contract).
+# Embedded operator web dashboard (EXPERIMENTAL), served by the admin HTTP
+# listener behind `admin.ui.enabled`. Off by default for the plain `cargo build`
+# so the default binary and any library consumer stay free of the asset-embedding
+# deps; the release Docker image compiles it in (`--features ui`). When the
+# feature is disabled, an `admin.ui.enabled: true` block still parses and is
+# skipped with a loud warning (mirrors the `sctp` contract).
 ui = ["dep:rust-embed", "dep:mime_guess"]
 
 # --- Lint policy ---

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,12 @@ prometheus = { version = "0.14", features = ["process"] }
 axum = { version = "0.8.8", features = ["tokio"] }
 tower = { version = "0.5.3", features = ["util"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
+# Embedded operator web UI (opt-in via the `ui` feature). rust-embed bakes the
+# dashboard assets into the binary; mime_guess types them on the way out. Both
+# are compiled only under `--features ui`, so the default library build (and any
+# consumer embedding siphon as a lib) pulls neither.
+rust-embed = { version = "8", optional = true }
+mime_guess = { version = "2", optional = true }
 
 # Lawful Intercept — ETSI ASN.1/BER + XML
 rasn = "0.28"
@@ -220,6 +226,13 @@ postgres-backend = ["dep:tokio-postgres"]
 # listener is started and a configured `listen.sctp` block is ignored with a
 # loud warning; a Diameter peer with `transport: sctp` errors at connect time.
 sctp = ["dep:tokio-sctp"]
+
+# Embedded operator web dashboard, served by the admin HTTP listener behind
+# `admin.ui.enabled`. Off by default so the default binary and any library
+# consumer stay free of the asset-embedding deps. When disabled, an
+# `admin.ui.enabled: true` block still parses and is skipped with a loud warning
+# (mirrors the `sctp` contract).
+ui = ["dep:rust-embed", "dep:mime_guess"]
 
 # --- Lint policy ---
 # The codebase is clippy-clean (see `clippy.toml` for the one tuned threshold).

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,13 +74,18 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ── Build dependencies (cached until Cargo.toml/lock change) ─────────────────
 FROM chef AS builder
 COPY --from=planner /build/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --features ui --recipe-path recipe.json
 
-# Build the real binary
+# Build the real binary. The embedded operator web UI (`ui` feature) is compiled
+# in by default in the image — it's an EXPERIMENTAL dashboard, served only when
+# `admin.ui.enabled` is set in siphon.yaml. `ui/` is a single self-contained HTML
+# file baked in by rust-embed (no Node/build step). Drop `--features ui` on both
+# the cook and build lines to produce a leaner image without it.
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 COPY benches/ benches/
-RUN cargo build --release
+COPY ui/ ui/
+RUN cargo build --release --features ui
 
 # ── Runtime stage ────────────────────────────────────────────────────────────
 FROM debian:trixie-slim

--- a/docs/cookbook/monitoring.md
+++ b/docs/cookbook/monitoring.md
@@ -62,6 +62,7 @@ admin:
 | `GET /admin/registrations[/{aor}]` | inspect bindings |
 | `DELETE /admin/registrations/{aor}` | force-unregister |
 | `GET /admin/bans` / `DELETE /admin/bans/{ip}` | list / lift auto-bans |
+| `GET /admin/gateways` | per-group dispatcher status (destinations, health, weight, priority) |
 | `GET /admin/metrics.json` | curated JSON snapshot of the live gauges + counters |
 
 Point Kubernetes liveness at `/admin/health` and readiness at `/admin/ready` so a

--- a/docs/cookbook/monitoring.md
+++ b/docs/cookbook/monitoring.md
@@ -87,11 +87,11 @@ With a token set, the `DELETE` routes require `Authorization: Bearer <token>`
 (constant-time compared). Reads stay open unless `protect_reads` is true. Unset
 leaves the API open, exactly as before.
 
-### Web dashboard
+### Web dashboard (experimental)
 
 A single-page operator dashboard is baked into the binary and served
-same-origin on the admin listener. It is opt-in twice — build with the `ui`
-cargo feature, then enable it in config:
+same-origin on the admin listener. **It's experimental** — expect changes. The
+release Docker image compiles it in; you just enable it in config:
 
 ```yaml
 admin:
@@ -100,9 +100,10 @@ admin:
     enabled: true
 ```
 
-The default binary and any project embedding siphon as a library carry none of
-it; a binary built without `--features ui` logs a warning and serves nothing
-when `enabled` is set. The dashboard reads `/admin/metrics.json` (Overview,
+A plain `cargo build` leaves the `ui` feature off, so any project embedding
+siphon as a library carries none of it; a binary built without `--features ui`
+logs a warning and serves nothing when `enabled` is set. Serving the dashboard
+logs an EXPERIMENTAL warning. The dashboard reads `/admin/metrics.json` (Overview,
 System), `/admin/registrations`, and `/admin/bans`, and performs
 force-unregister / lift-ban through the same token — click **Unlock** and paste
 the `admin.auth.token`. Bind the listener internally and put it behind your own

--- a/docs/cookbook/monitoring.md
+++ b/docs/cookbook/monitoring.md
@@ -61,9 +61,49 @@ admin:
 | `GET /admin/stats` | uptime + active registration count |
 | `GET /admin/registrations[/{aor}]` | inspect bindings |
 | `DELETE /admin/registrations/{aor}` | force-unregister |
+| `GET /admin/bans` / `DELETE /admin/bans/{ip}` | list / lift auto-bans |
+| `GET /admin/metrics.json` | curated JSON snapshot of the live gauges + counters |
 
 Point Kubernetes liveness at `/admin/health` and readiness at `/admin/ready` so a
 draining pod leaves rotation cleanly — see [Deployment & operations](../deployment.md).
+
+### Bearer-token auth
+
+The admin API can force-unregister bindings and lift bans, so gate it once it is
+reachable by anything but localhost:
+
+```yaml
+admin:
+  listen: "127.0.0.1:9091"
+  auth:
+    token: "${ADMIN_TOKEN}"     # keep the literal out of YAML
+    protect_reads: false         # true = also require it on GET + /metrics
+```
+
+With a token set, the `DELETE` routes require `Authorization: Bearer <token>`
+(constant-time compared). Reads stay open unless `protect_reads` is true. Unset
+leaves the API open, exactly as before.
+
+### Web dashboard
+
+A single-page operator dashboard is baked into the binary and served
+same-origin on the admin listener. It is opt-in twice — build with the `ui`
+cargo feature, then enable it in config:
+
+```yaml
+admin:
+  listen: "127.0.0.1:9091"
+  ui:
+    enabled: true
+```
+
+The default binary and any project embedding siphon as a library carry none of
+it; a binary built without `--features ui` logs a warning and serves nothing
+when `enabled` is set. The dashboard reads `/admin/metrics.json` (Overview,
+System), `/admin/registrations`, and `/admin/bans`, and performs
+force-unregister / lift-ban through the same token — click **Unlock** and paste
+the `admin.auth.token`. Bind the listener internally and put it behind your own
+ingress auth for anything beyond a trusted network.
 
 ## Call Detail Records
 

--- a/docs/cookbook/monitoring.md
+++ b/docs/cookbook/monitoring.md
@@ -63,6 +63,7 @@ admin:
 | `DELETE /admin/registrations/{aor}` | force-unregister |
 | `GET /admin/bans` / `DELETE /admin/bans/{ip}` | list / lift auto-bans |
 | `GET /admin/gateways` | per-group dispatcher status (destinations, health, weight, priority) |
+| `POST /admin/gateways/{group}/{destination}/{up\|down}` | mark a gateway destination up/down (drain / restore a carrier) |
 | `GET /admin/metrics.json` | curated JSON snapshot of the live gauges + counters |
 
 Point Kubernetes liveness at `/admin/health` and readiness at `/admin/ready` so a

--- a/docs/cookbook/monitoring.md
+++ b/docs/cookbook/monitoring.md
@@ -64,6 +64,7 @@ admin:
 | `GET /admin/bans` / `DELETE /admin/bans/{ip}` | list / lift auto-bans |
 | `GET /admin/gateways` | per-group dispatcher status (destinations, health, weight, priority) |
 | `POST /admin/gateways/{group}/{destination}/{up\|down}` | mark a gateway destination up/down (drain / restore a carrier) |
+| `GET /admin/calls` | active B2BUA calls (Call-ID, state, From, target, B-legs) |
 | `GET /admin/metrics.json` | curated JSON snapshot of the live gauges + counters |
 
 Point Kubernetes liveness at `/admin/health` and readiness at `/admin/ready` so a

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -206,6 +206,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Admin API — metrics snapshot | Implemented | `GET /admin/metrics.json` | Curated JSON of live gauges/counters (SIP, memory, pyexec, Diameter, rtpengine, SBI, security) for the dashboard + custom tooling; browser diffs cumulative counters for rates |
 | Admin API — bearer auth | Implemented | `admin.auth.token` / `admin.auth.protect_reads` | Constant-time bearer check; gates `DELETE` (and, with `protect_reads`, reads + `/metrics`). Unset = open (unchanged) |
 | Admin API — gateways | Implemented | `GET /admin/gateways` | Per-group dispatcher status: each destination's health/weight/priority/address/transport/attrs, read from the shared dispatcher (no new state or probing) |
+| Admin API — gateway control | Implemented | `POST /admin/gateways/{group}/{dest}/{up\|down}` | Manual mark-up/down of a destination (drain a bad carrier, then restore it); mutating, so it sits behind the bearer gate |
 | Web dashboard (embedded) | Implemented (opt-in) | `ui` cargo feature + `admin.ui.enabled` | Single-page operator UI baked into the binary, served same-origin on the admin listener: Overview / Registrations / Security / System / Integrations. Off by default; library consumers unaffected. Feature-off + `enabled: true` warns and serves nothing |
 
 ## Logging

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -207,6 +207,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Admin API — bearer auth | Implemented | `admin.auth.token` / `admin.auth.protect_reads` | Constant-time bearer check; gates `DELETE` (and, with `protect_reads`, reads + `/metrics`). Unset = open (unchanged) |
 | Admin API — gateways | Implemented | `GET /admin/gateways` | Per-group dispatcher status: each destination's health/weight/priority/address/transport/attrs, read from the shared dispatcher (no new state or probing) |
 | Admin API — gateway control | Implemented | `POST /admin/gateways/{group}/{dest}/{up\|down}` | Manual mark-up/down of a destination (drain a bad carrier, then restore it); mutating, so it sits behind the bearer gate |
+| Admin API — calls | Implemented | `GET /admin/calls` | Active B2BUA calls (SIP Call-ID, state, A-leg From, B-leg target, B-leg count), read from the dispatcher-owned call store. Empty on a proxy-only node |
 | Web dashboard (embedded) | Implemented (opt-in) | `ui` cargo feature + `admin.ui.enabled` | Single-page operator UI baked into the binary, served same-origin on the admin listener: Overview / Registrations / Security / System / Integrations. Off by default; library consumers unaffected. Feature-off + `enabled: true` warns and serves nothing |
 
 ## Logging

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -208,7 +208,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Admin API — gateways | Implemented | `GET /admin/gateways` | Per-group dispatcher status: each destination's health/weight/priority/address/transport/attrs, read from the shared dispatcher (no new state or probing) |
 | Admin API — gateway control | Implemented | `POST /admin/gateways/{group}/{dest}/{up\|down}` | Manual mark-up/down of a destination (drain a bad carrier, then restore it); mutating, so it sits behind the bearer gate |
 | Admin API — calls | Implemented | `GET /admin/calls` | Active B2BUA calls (SIP Call-ID, state, A-leg From, B-leg target, B-leg count), read from the dispatcher-owned call store. Empty on a proxy-only node |
-| Web dashboard (embedded) | Implemented (opt-in) | `ui` cargo feature + `admin.ui.enabled` | Single-page operator UI baked into the binary, served same-origin on the admin listener: Overview / Registrations / Security / System / Integrations. Off by default; library consumers unaffected. Feature-off + `enabled: true` warns and serves nothing |
+| Web dashboard (embedded) | **Experimental** | `ui` cargo feature + `admin.ui.enabled` | Single-page operator UI baked into the binary, served same-origin on the admin listener: Overview / Calls / Registrations / Security / Gateways / System / Integrations. Compiled into the release Docker image by default; off for the plain `cargo build`, library consumers unaffected. Serving it logs an EXPERIMENTAL warning; feature-off + `enabled: true` warns and serves nothing |
 
 ## Logging
 

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -203,6 +203,9 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Admin API — health | Implemented | `GET /admin/health` | Liveness/readiness probe |
 | Admin API — stats | Implemented | `GET /admin/stats` | Aggregate counters |
 | Admin API — registrations | Implemented | `GET/DELETE /admin/registrations` | List, detail, force-unregister |
+| Admin API — metrics snapshot | Implemented | `GET /admin/metrics.json` | Curated JSON of live gauges/counters (SIP, memory, pyexec, Diameter, rtpengine, SBI, security) for the dashboard + custom tooling; browser diffs cumulative counters for rates |
+| Admin API — bearer auth | Implemented | `admin.auth.token` / `admin.auth.protect_reads` | Constant-time bearer check; gates `DELETE` (and, with `protect_reads`, reads + `/metrics`). Unset = open (unchanged) |
+| Web dashboard (embedded) | Implemented (opt-in) | `ui` cargo feature + `admin.ui.enabled` | Single-page operator UI baked into the binary, served same-origin on the admin listener: Overview / Registrations / Security / System / Integrations. Off by default; library consumers unaffected. Feature-off + `enabled: true` warns and serves nothing |
 
 ## Logging
 

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -205,6 +205,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Admin API — registrations | Implemented | `GET/DELETE /admin/registrations` | List, detail, force-unregister |
 | Admin API — metrics snapshot | Implemented | `GET /admin/metrics.json` | Curated JSON of live gauges/counters (SIP, memory, pyexec, Diameter, rtpengine, SBI, security) for the dashboard + custom tooling; browser diffs cumulative counters for rates |
 | Admin API — bearer auth | Implemented | `admin.auth.token` / `admin.auth.protect_reads` | Constant-time bearer check; gates `DELETE` (and, with `protect_reads`, reads + `/metrics`). Unset = open (unchanged) |
+| Admin API — gateways | Implemented | `GET /admin/gateways` | Per-group dispatcher status: each destination's health/weight/priority/address/transport/attrs, read from the shared dispatcher (no new state or probing) |
 | Web dashboard (embedded) | Implemented (opt-in) | `ui` cargo feature + `admin.ui.enabled` | Single-page operator UI baked into the binary, served same-origin on the admin listener: Overview / Registrations / Security / System / Integrations. Off by default; library consumers unaffected. Feature-off + `enabled: true` warns and serves nothing |
 
 ## Logging

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -647,10 +647,11 @@ auth:
 #   auth:
 #     token: "${ADMIN_TOKEN}"     # keep the literal out of YAML; expand from env
 #     protect_reads: false        # true = also gate GET routes + /metrics
-#   # Optional embedded web dashboard, served at the admin listener root (/).
-#   # Requires a binary built with `--features ui`; on a binary without it, this
-#   # warns and serves nothing. Same-origin with the API, so no CORS is needed
-#   # for it. Bind `listen` to an internal/loopback address and set auth.token.
+#   # Optional embedded web dashboard (EXPERIMENTAL), served at the admin listener
+#   # root (/). Compiled into the release Docker image by default; a plain
+#   # `cargo build` needs `--features ui`, and a binary without it warns and serves
+#   # nothing here. Same-origin with the API, so no CORS is needed for it. Bind
+#   # `listen` to an internal/loopback address and set auth.token.
 #   ui:
 #     enabled: true
 

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -639,6 +639,20 @@ auth:
 #   cors:
 #     allowed_origins:
 #       - "http://localhost:5173"
+#   # Optional bearer-token auth (RFC 6750). When `token` is set, the mutating
+#   # DELETE routes (force-unregister, lift-ban) require
+#   # `Authorization: Bearer <token>`. Set protect_reads to require it on the GET
+#   # routes and /metrics too. Unset leaves the admin API open (network-placement
+#   # trust only, as before). Strongly recommended once the web UI is exposed.
+#   auth:
+#     token: "${ADMIN_TOKEN}"     # keep the literal out of YAML; expand from env
+#     protect_reads: false        # true = also gate GET routes + /metrics
+#   # Optional embedded web dashboard, served at the admin listener root (/).
+#   # Requires a binary built with `--features ui`; on a binary without it, this
+#   # warns and serves nothing. Same-origin with the API, so no CORS is needed
+#   # for it. Bind `listen` to an internal/loopback address and set auth.token.
+#   ui:
+#     enabled: true
 
 # ---------------------------------------------------------------------------
 # Gateway dispatcher (named groups with load balancing + health probing)

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -11,9 +11,10 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Instant;
 
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Json};
+use axum::extract::{Path, Request, State};
+use axum::http::{header, Method, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Json, Response};
 use axum::routing::{delete, get};
 use axum::Router;
 use serde::Serialize;
@@ -32,6 +33,16 @@ pub struct AdminState {
     /// draining so a load balancer / orchestrator stops sending new work. `None`
     /// (e.g. in tests) means "never draining".
     pub draining: Option<Arc<DrainState>>,
+    /// Bearer token gating the admin API. `None` = no auth (network-placement
+    /// trust only). Stored as `Arc<str>` for a cheap per-request clone in the
+    /// auth layer.
+    pub auth_token: Option<Arc<str>>,
+    /// When true, the token is required on the read routes too, not only the
+    /// mutating `DELETE` routes.
+    pub protect_reads: bool,
+    /// This node's instance id, surfaced in `/admin/metrics.json`. `None` when
+    /// `server.instance_id` is unset and `$HOSTNAME` is absent.
+    pub instance_id: Option<String>,
 }
 
 /// Start the HTTP admin API server.
@@ -39,8 +50,26 @@ pub struct AdminState {
 /// `cors` optionally attaches an `Access-Control-Allow-Origin` policy so a
 /// browser dashboard served from another origin can `fetch()` the admin API
 /// (and the `/metrics` it also serves). `None` = no CORS headers.
-pub async fn serve(listen_addr: SocketAddr, state: AdminState, cors: Option<CorsConfig>) {
-    let app = router(state, cors.as_ref());
+///
+/// `ui_enabled` serves the embedded web dashboard at `/` (and its assets),
+/// same-origin with the API. It only has an effect on a binary built with the
+/// `ui` cargo feature; without that feature a `true` here is a loud warning and
+/// nothing is served.
+pub async fn serve(
+    listen_addr: SocketAddr,
+    state: AdminState,
+    cors: Option<CorsConfig>,
+    ui_enabled: bool,
+) {
+    #[cfg(not(feature = "ui"))]
+    if ui_enabled {
+        tracing::warn!(
+            "admin.ui.enabled is set but this binary was built without the `ui` \
+             feature; no dashboard will be served (rebuild with --features ui)"
+        );
+    }
+
+    let app = router(state, cors.as_ref(), ui_enabled);
 
     info!("Admin API listening on {}", listen_addr);
 
@@ -58,9 +87,16 @@ pub async fn serve(listen_addr: SocketAddr, state: AdminState, cors: Option<Cors
 }
 
 /// Build the router (also used by tests without binding a port).
-fn router(state: AdminState, cors: Option<&CorsConfig>) -> Router {
-    let mut app = Router::new()
+///
+/// Layer order (outermost first): CORS → bearer auth → routes. CORS is
+/// outermost so an unauthenticated `401` still carries the
+/// `Access-Control-Allow-Origin` echo (else the browser hides the body from the
+/// dashboard). The auth layer gates mutating routes (and reads when
+/// `protect_reads`) on the configured bearer token.
+fn router(state: AdminState, cors: Option<&CorsConfig>, ui_enabled: bool) -> Router {
+    let base = Router::new()
         .route("/metrics", get(metrics_handler))
+        .route("/admin/metrics.json", get(metrics_json_handler))
         .route("/admin/health", get(health_handler))
         .route("/admin/ready", get(ready_handler))
         .route("/admin/stats", get(stats_handler))
@@ -68,12 +104,80 @@ fn router(state: AdminState, cors: Option<&CorsConfig>) -> Router {
         .route("/admin/registrations/{aor}", get(registration_detail_handler))
         .route("/admin/registrations/{aor}", delete(registration_delete_handler))
         .route("/admin/bans", get(bans_handler))
-        .route("/admin/bans/{ip}", delete(ban_delete_handler))
+        .route("/admin/bans/{ip}", delete(ban_delete_handler));
+
+    // Everything not matched by an API route falls through to the embedded
+    // dashboard (single-page app), so `/` and any client route serve it.
+    #[cfg(feature = "ui")]
+    let base = if ui_enabled {
+        base.fallback(get(ui_handler))
+    } else {
+        base
+    };
+    #[cfg(not(feature = "ui"))]
+    let _ = ui_enabled;
+
+    let app = base
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_admin_auth,
+        ))
         .with_state(state);
-    if let Some(layer) = cors.and_then(crate::cors::build_cors_layer) {
-        app = app.layer(layer);
+
+    match cors.and_then(crate::cors::build_cors_layer) {
+        Some(layer) => app.layer(layer),
+        None => app,
     }
-    app
+}
+
+/// Bearer-token gate for the admin API (RFC 6750). No-op when no token is
+/// configured. Always lets CORS preflight (`OPTIONS`) through so the browser
+/// can complete a preflight before it holds the token. Otherwise requires
+/// `Authorization: Bearer <token>` on `DELETE` (and, when `protect_reads`, on
+/// every method), comparing in constant time.
+async fn require_admin_auth(State(state): State<AdminState>, request: Request, next: Next) -> Response {
+    let method = request.method();
+    let needs_auth = state.auth_token.is_some()
+        && method != Method::OPTIONS
+        && (state.protect_reads || method == Method::DELETE);
+
+    if needs_auth {
+        let presented = request
+            .headers()
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "));
+        let authorized = match (presented, state.auth_token.as_deref()) {
+            (Some(presented), Some(expected)) => {
+                constant_time_eq(presented.as_bytes(), expected.as_bytes())
+            }
+            _ => false,
+        };
+        if !authorized {
+            return (
+                StatusCode::UNAUTHORIZED,
+                [(header::WWW_AUTHENTICATE, "Bearer")],
+                Json(serde_json::json!({ "error": "unauthorized" })),
+            )
+                .into_response();
+        }
+    }
+
+    next.run(request).await
+}
+
+/// Length-checked constant-time byte comparison, so a wrong token can't be
+/// recovered by timing the response. (Length is allowed to leak — a bearer
+/// token's length is not the secret.)
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut difference = 0u8;
+    for (left, right) in a.iter().zip(b.iter()) {
+        difference |= left ^ right;
+    }
+    difference == 0
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +242,85 @@ async fn stats_handler(State(state): State<AdminState>) -> impl IntoResponse {
         uptime_seconds: uptime,
         registrations_active: registrations,
     })
+}
+
+/// `GET /admin/metrics.json` — a curated JSON snapshot of the live gauges and
+/// counters for the embedded dashboard. Deliberately not the Prometheus text
+/// format: the browser polls this and diffs the cumulative counters over time
+/// to derive rates, so no server-side time series is needed. Returns a minimal
+/// shape (version/uptime/registrations) when metrics are not initialised.
+async fn metrics_json_handler(State(state): State<AdminState>) -> impl IntoResponse {
+    // Refresh jemalloc gauges so `memory.*` isn't stale between dispatcher ticks.
+    crate::metrics::update_memory_stats();
+
+    let uptime = state.start_time.elapsed().as_secs();
+    let registrations = state.registrar.aor_count();
+    let version = env!("CARGO_PKG_VERSION");
+
+    let Some(metrics) = crate::metrics::try_metrics() else {
+        return Json(serde_json::json!({
+            "version": version,
+            "instance_id": state.instance_id,
+            "uptime_seconds": uptime,
+            "registrations_active": registrations,
+            "metrics": "uninitialized",
+        }));
+    };
+
+    let connections = crate::metrics::gauge_vec_by_label(&metrics.connections_active, "transport");
+
+    Json(serde_json::json!({
+        "version": version,
+        "instance_id": state.instance_id,
+        "uptime_seconds": uptime,
+        "jemalloc_active": crate::metrics::jemalloc_is_active(),
+        "registrations_active": registrations,
+        "sip": {
+            "dialogs_active": metrics.dialogs_active.get(),
+            "transactions_active": metrics.transactions_active.get(),
+            "uac_pending": metrics.uac_pending_requests.get(),
+            "subscribe_dialogs": metrics.subscribe_dialogs.get(),
+            "cdr_sessions": metrics.cdr_sessions.get(),
+            "connections": connections,
+        },
+        "counters": {
+            "requests_total": crate::metrics::sum_int_counter_vec(&metrics.requests_total),
+            "responses_total": crate::metrics::sum_int_counter_vec(&metrics.responses_total),
+            "auth_failures_total": metrics.auth_failures_total.get(),
+            "credential_failures_total": metrics.credential_failures_total.get(),
+            "scanner_blocked_total": metrics.scanner_blocked_total.get(),
+            "rate_limited_total": metrics.rate_limited_total.get(),
+            "malformed_messages_total": metrics.malformed_messages_total.get(),
+            "script_errors_total": metrics.script_errors_total.get(),
+        },
+        "memory": {
+            "allocated": metrics.memory_allocated_bytes.get(),
+            "resident": metrics.memory_resident_bytes.get(),
+            "active": metrics.memory_active_bytes.get(),
+            "retained": metrics.memory_retained_bytes.get(),
+            "mapped": metrics.memory_mapped_bytes.get(),
+            "glibc_system": metrics.glibc_system_bytes.get(),
+            "glibc_in_use": metrics.glibc_in_use_bytes.get(),
+            "glibc_arenas": metrics.glibc_arena_count.get(),
+            "python_allocated_blocks": metrics.python_allocated_blocks.get(),
+        },
+        "pyexec": {
+            "pool_size": metrics.pyexec_pool_size.get(),
+            "pool_max": metrics.pyexec_pool_max.get(),
+            "inflight": metrics.pyexec_inflight.get(),
+            "queue_depth": metrics.pyexec_queue_depth.get(),
+            "jobs_completed": metrics.pyexec_jobs_completed_total.get(),
+            "jobs_shed": metrics.pyexec_jobs_shed_total.get(),
+        },
+        "diameter": { "peers_connected": metrics.diameter_peers_connected.get() },
+        "rtpengine": {
+            "up": metrics.rtpengine_instances_up.get(),
+            "total": metrics.rtpengine_instances_total.get(),
+        },
+        "sbi": { "npcf_sessions_active": metrics.sbi_npcf_app_sessions_active.get() },
+        "ipsec": { "sa_pairs": metrics.ipsec_sa_pairs.get() },
+        "security": { "banned_ips": metrics.banned_ips.get() },
+    }))
 }
 
 /// `GET /admin/registrations` — list all active AoRs with their contacts.
@@ -264,6 +447,49 @@ async fn ban_delete_handler(Path(ip): Path<String>) -> impl IntoResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Embedded web dashboard (feature = "ui")
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "ui")]
+mod embedded {
+    use rust_embed::RustEmbed;
+
+    /// Dashboard assets baked into the binary at compile time from the `ui/`
+    /// directory (a single self-contained `index.html` today — no build step).
+    #[derive(RustEmbed)]
+    #[folder = "ui"]
+    pub struct Assets;
+}
+
+/// Serve an embedded dashboard asset by path, falling back to `index.html` for
+/// any unmatched path (single-page-app routing). Content-type is guessed from
+/// the served file's name.
+#[cfg(feature = "ui")]
+async fn ui_handler(uri: axum::http::Uri) -> Response {
+    let requested = uri.path().trim_start_matches('/');
+    let requested = if requested.is_empty() {
+        "index.html"
+    } else {
+        requested
+    };
+
+    let (name, asset) = match embedded::Assets::get(requested) {
+        Some(asset) => (requested, asset),
+        None => match embedded::Assets::get("index.html") {
+            Some(asset) => ("index.html", asset),
+            None => return (StatusCode::NOT_FOUND, "not found").into_response(),
+        },
+    };
+
+    let mime = mime_guess::from_path(name).first_or_octet_stream();
+    (
+        [(header::CONTENT_TYPE, mime.as_ref())],
+        asset.data.into_owned(),
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
 // Response types
 // ---------------------------------------------------------------------------
 
@@ -295,11 +521,22 @@ mod tests {
             registrar: Arc::new(Registrar::new(crate::registrar::RegistrarConfig::default())),
             start_time: Instant::now(),
             draining: None,
+            auth_token: None,
+            protect_reads: false,
+            instance_id: None,
+        }
+    }
+
+    fn authed_state(token: &str, protect_reads: bool) -> AdminState {
+        AdminState {
+            auth_token: Some(Arc::from(token)),
+            protect_reads,
+            ..test_state()
         }
     }
 
     fn test_app() -> Router {
-        router(test_state(), None)
+        router(test_state(), None, false)
     }
 
     #[tokio::test]
@@ -345,8 +582,11 @@ mod tests {
             registrar: Arc::new(Registrar::new(crate::registrar::RegistrarConfig::default())),
             start_time: Instant::now(),
             draining: Some(drain),
+            auth_token: None,
+            protect_reads: false,
+            instance_id: None,
         };
-        let app = router(state, None);
+        let app = router(state, None, false);
 
         let response = app
             .oneshot(Request::get("/admin/ready").body(Body::empty()).unwrap())
@@ -491,7 +731,7 @@ mod tests {
         let cors = CorsConfig {
             allowed_origins: vec!["http://localhost:5173".to_owned()],
         };
-        let app = router(test_state(), Some(&cors));
+        let app = router(test_state(), Some(&cors), false);
 
         // A simple cross-origin GET must come back with the allow-origin echo,
         // or the browser hides the body from the dashboard.
@@ -520,7 +760,7 @@ mod tests {
         let cors = CorsConfig {
             allowed_origins: vec!["http://localhost:5173".to_owned()],
         };
-        let app = router(test_state(), Some(&cors));
+        let app = router(test_state(), Some(&cors), false);
 
         // The admin DELETE routes are non-simple requests, so the browser sends
         // an OPTIONS preflight first; the layer must answer it 2xx with the echo.
@@ -551,7 +791,7 @@ mod tests {
     async fn no_cors_config_emits_no_header() {
         crate::metrics::init().unwrap();
         // Default (no cors block) stays byte-for-byte as before — no CORS header.
-        let app = router(test_state(), None);
+        let app = router(test_state(), None, false);
 
         let response = app
             .oneshot(
@@ -567,5 +807,176 @@ mod tests {
             .headers()
             .get("access-control-allow-origin")
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn metrics_json_endpoint_shape() {
+        crate::metrics::init().unwrap();
+        let app = test_app();
+
+        let response = app
+            .oneshot(
+                Request::get("/admin/metrics.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
+        assert!(json["uptime_seconds"].as_u64().is_some());
+        // Metrics are initialised in this test, so the rich shape is present.
+        assert!(json["sip"]["dialogs_active"].as_i64().is_some());
+        assert!(json["counters"]["requests_total"].as_u64().is_some());
+        assert!(json["memory"]["allocated"].as_i64().is_some());
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_delete_without_bearer() {
+        crate::metrics::init().unwrap();
+        // A token is configured, so the mutating DELETE route must present it.
+        let app = router(authed_state("s3cret", false), None, false);
+
+        let response = app
+            .oneshot(
+                Request::delete("/admin/registrations/sip:alice@example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_allows_delete_with_bearer() {
+        crate::metrics::init().unwrap();
+        let app = router(authed_state("s3cret", false), None, false);
+
+        let response = app
+            .oneshot(
+                Request::delete("/admin/registrations/sip:nobody@example.com")
+                    .header("authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Passed the auth layer; the AoR isn't registered, so it's a 404, not 401.
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn auth_wrong_bearer_is_rejected() {
+        crate::metrics::init().unwrap();
+        let app = router(authed_state("s3cret", false), None, false);
+
+        let response = app
+            .oneshot(
+                Request::delete("/admin/registrations/sip:alice@example.com")
+                    .header("authorization", "Bearer wrong")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn reads_open_by_default_even_with_token() {
+        crate::metrics::init().unwrap();
+        // Token set but protect_reads = false: GET routes stay open.
+        let app = router(authed_state("s3cret", false), None, false);
+
+        let response = app
+            .oneshot(
+                Request::get("/admin/stats")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn protect_reads_requires_bearer_on_get() {
+        crate::metrics::init().unwrap();
+        let app = router(authed_state("s3cret", true), None, false);
+
+        let unauth = app
+            .clone()
+            .oneshot(Request::get("/admin/stats").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(unauth.status(), StatusCode::UNAUTHORIZED);
+
+        let authed = app
+            .oneshot(
+                Request::get("/admin/stats")
+                    .header("authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(authed.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn constant_time_eq_matches_and_rejects() {
+        assert!(constant_time_eq(b"token", b"token"));
+        assert!(!constant_time_eq(b"token", b"tokeX"));
+        assert!(!constant_time_eq(b"token", b"tok"));
+        assert!(!constant_time_eq(b"", b"x"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[cfg(feature = "ui")]
+    #[tokio::test]
+    async fn ui_served_at_root_when_enabled() {
+        let app = router(test_state(), None, true);
+
+        let response = app
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_owned();
+        assert!(content_type.starts_with("text/html"));
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.windows(6).any(|window| window == b"SIPhon"));
+    }
+
+    #[cfg(feature = "ui")]
+    #[tokio::test]
+    async fn ui_absent_when_disabled() {
+        // Feature is on but the operator left admin.ui.enabled off.
+        let app = router(test_state(), None, false);
+
+        let response = app
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -15,7 +15,7 @@ use axum::extract::{Path, Request, State};
 use axum::http::{header, Method, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Json, Response};
-use axum::routing::{delete, get};
+use axum::routing::{delete, get, post};
 use axum::Router;
 use serde::Serialize;
 use tracing::{error, info};
@@ -105,7 +105,11 @@ fn router(state: AdminState, cors: Option<&CorsConfig>, ui_enabled: bool) -> Rou
         .route("/admin/registrations/{aor}", delete(registration_delete_handler))
         .route("/admin/bans", get(bans_handler))
         .route("/admin/bans/{ip}", delete(ban_delete_handler))
-        .route("/admin/gateways", get(gateways_handler));
+        .route("/admin/gateways", get(gateways_handler))
+        .route(
+            "/admin/gateways/{group}/{destination}/{action}",
+            post(gateway_action_handler),
+        );
 
     // Everything not matched by an API route falls through to the embedded
     // dashboard (single-page app), so `/` and any client route serve it.
@@ -134,13 +138,15 @@ fn router(state: AdminState, cors: Option<&CorsConfig>, ui_enabled: bool) -> Rou
 /// Bearer-token gate for the admin API (RFC 6750). No-op when no token is
 /// configured. Always lets CORS preflight (`OPTIONS`) through so the browser
 /// can complete a preflight before it holds the token. Otherwise requires
-/// `Authorization: Bearer <token>` on `DELETE` (and, when `protect_reads`, on
-/// every method), comparing in constant time.
+/// `Authorization: Bearer <token>` on every mutating method (`POST`, `PUT`,
+/// `PATCH`, `DELETE`) — and, when `protect_reads`, on the read methods too —
+/// comparing in constant time.
 async fn require_admin_auth(State(state): State<AdminState>, request: Request, next: Next) -> Response {
     let method = request.method();
+    let is_read = method == Method::GET || method == Method::HEAD || method == Method::OPTIONS;
     let needs_auth = state.auth_token.is_some()
         && method != Method::OPTIONS
-        && (state.protect_reads || method == Method::DELETE);
+        && (state.protect_reads || !is_read);
 
     if needs_auth {
         let presented = request
@@ -500,6 +506,48 @@ fn gateways_json(manager: &crate::gateway::DispatcherManager) -> serde_json::Val
     // Stable order for the dashboard (DashMap iteration order is arbitrary).
     groups.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
     serde_json::Value::Array(groups)
+}
+
+/// `POST /admin/gateways/{group}/{destination}/{action}` — mark a gateway
+/// destination `up` or `down` by hand (drain a bad carrier, then restore it).
+/// `destination` is the destination URI exactly as returned by
+/// `GET /admin/gateways`. Mutating, so it sits behind the bearer gate.
+async fn gateway_action_handler(
+    Path((group, destination, action)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    let Some(manager) = crate::script::api::gateway_manager() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "no gateway groups configured" })),
+        );
+    };
+    let Some(dispatcher_group) = manager.get_group(&group) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "unknown group", "group": group })),
+        );
+    };
+    let changed = match action.as_str() {
+        "down" => dispatcher_group.mark_down(&destination),
+        "up" => dispatcher_group.mark_up(&destination),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "action must be 'up' or 'down'", "action": action })),
+            );
+        }
+    };
+    if changed {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": action, "group": group, "destination": destination })),
+        )
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "unknown destination", "group": group, "destination": destination })),
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1044,6 +1092,40 @@ mod tests {
         assert_eq!(destinations[0]["weight"], 3);
         assert_eq!(destinations[0]["healthy"], true);
         assert_eq!(destinations[0]["address"], "10.0.0.1:5060");
+    }
+
+    #[tokio::test]
+    async fn gateway_action_post_requires_bearer() {
+        crate::metrics::init().unwrap();
+        // The write action is a POST — the generalized gate must cover it, not
+        // just DELETE.
+        let app = router(authed_state("s3cret", false), None, false);
+        let response = app
+            .oneshot(
+                Request::post("/admin/gateways/carriers/sip:gw1.example.com:5060/down")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn gateway_action_unknown_group_is_404_with_token() {
+        crate::metrics::init().unwrap();
+        let app = router(authed_state("s3cret", false), None, false);
+        let response = app
+            .oneshot(
+                Request::post("/admin/gateways/nope/sip:gw1.example.com:5060/down")
+                    .header("authorization", "Bearer s3cret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // No gateway manager is wired in unit tests -> no groups configured.
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[cfg(feature = "ui")]

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -104,7 +104,8 @@ fn router(state: AdminState, cors: Option<&CorsConfig>, ui_enabled: bool) -> Rou
         .route("/admin/registrations/{aor}", get(registration_detail_handler))
         .route("/admin/registrations/{aor}", delete(registration_delete_handler))
         .route("/admin/bans", get(bans_handler))
-        .route("/admin/bans/{ip}", delete(ban_delete_handler));
+        .route("/admin/bans/{ip}", delete(ban_delete_handler))
+        .route("/admin/gateways", get(gateways_handler));
 
     // Everything not matched by an API route falls through to the embedded
     // dashboard (single-page app), so `/` and any client route serve it.
@@ -444,6 +445,61 @@ async fn ban_delete_handler(Path(ip): Path<String>) -> impl IntoResponse {
             Json(serde_json::json!({ "error": "auto-ban not enabled", "ip": address.to_string() })),
         ),
     }
+}
+
+/// `GET /admin/gateways` — per-group gateway dispatcher status: every configured
+/// group with its algorithm and each destination's health, weight, priority,
+/// address, transport, and attributes. Reads the shared dispatcher the routing
+/// datapath and `from_gateway` predicates already use (no new state, no probe).
+/// Empty array when no `gateway` block is configured.
+async fn gateways_handler() -> impl IntoResponse {
+    match crate::script::api::gateway_manager() {
+        Some(manager) => Json(gateways_json(manager)),
+        None => Json(serde_json::Value::Array(Vec::new())),
+    }
+}
+
+/// Serialize the gateway dispatcher state. Split from the handler so it can be
+/// unit-tested against a locally-built manager without the process-global.
+fn gateways_json(manager: &crate::gateway::DispatcherManager) -> serde_json::Value {
+    let mut groups: Vec<serde_json::Value> = Vec::new();
+    for name in manager.group_names() {
+        let Some(group) = manager.get_group(&name) else {
+            continue;
+        };
+        let destinations: Vec<serde_json::Value> = group
+            .list_destinations()
+            .iter()
+            .map(|destination| {
+                serde_json::json!({
+                    "uri": destination.uri,
+                    "address": destination
+                        .address_str
+                        .clone()
+                        .unwrap_or_else(|| destination.address().to_string()),
+                    "transport": destination.transport.to_string(),
+                    "healthy": destination.is_healthy(),
+                    "weight": destination.weight,
+                    "priority": destination.priority,
+                    "attrs": destination.attrs,
+                })
+            })
+            .collect();
+        let up = destinations
+            .iter()
+            .filter(|value| value.get("healthy").and_then(|h| h.as_bool()).unwrap_or(false))
+            .count();
+        groups.push(serde_json::json!({
+            "name": group.name,
+            "algorithm": group.algorithm.as_str(),
+            "up": up,
+            "total": destinations.len(),
+            "destinations": destinations,
+        }));
+    }
+    // Stable order for the dashboard (DashMap iteration order is arbitrary).
+    groups.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+    serde_json::Value::Array(groups)
 }
 
 // ---------------------------------------------------------------------------
@@ -940,6 +996,54 @@ mod tests {
         assert!(!constant_time_eq(b"token", b"tok"));
         assert!(!constant_time_eq(b"", b"x"));
         assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn gateways_json_empty_manager_is_empty_array() {
+        let manager = crate::gateway::DispatcherManager::new();
+        assert_eq!(gateways_json(&manager), serde_json::json!([]));
+    }
+
+    #[test]
+    fn gateways_json_serializes_groups_and_destinations() {
+        use crate::gateway::{Algorithm, Destination, DispatcherGroup, DispatcherManager};
+        use crate::transport::Transport;
+
+        let manager = DispatcherManager::new();
+        let dest_one = Destination::new(
+            "sip:gw1.carrier.com:5060".to_string(),
+            "10.0.0.1:5060".parse().unwrap(),
+            Transport::Udp,
+            3,
+            1,
+        );
+        let dest_two = Destination::new(
+            "sip:gw2.carrier.com:5061".to_string(),
+            "10.0.0.2:5061".parse().unwrap(),
+            Transport::Udp,
+            1,
+            2,
+        );
+        manager.add_group(DispatcherGroup::new(
+            "carriers".to_string(),
+            Algorithm::Weighted,
+            vec![dest_one, dest_two],
+        ));
+
+        let json = gateways_json(&manager);
+        let groups = json.as_array().unwrap();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0]["name"], "carriers");
+        assert_eq!(groups[0]["algorithm"], "weighted");
+        assert_eq!(groups[0]["total"], 2);
+        // Fresh destinations start healthy.
+        assert_eq!(groups[0]["up"], 2);
+        let destinations = groups[0]["destinations"].as_array().unwrap();
+        assert_eq!(destinations.len(), 2);
+        assert_eq!(destinations[0]["uri"], "sip:gw1.carrier.com:5060");
+        assert_eq!(destinations[0]["weight"], 3);
+        assert_eq!(destinations[0]["healthy"], true);
+        assert_eq!(destinations[0]["address"], "10.0.0.1:5060");
     }
 
     #[cfg(feature = "ui")]

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -109,7 +109,8 @@ fn router(state: AdminState, cors: Option<&CorsConfig>, ui_enabled: bool) -> Rou
         .route(
             "/admin/gateways/{group}/{destination}/{action}",
             post(gateway_action_handler),
-        );
+        )
+        .route("/admin/calls", get(calls_handler));
 
     // Everything not matched by an API route falls through to the embedded
     // dashboard (single-page app), so `/` and any client route serve it.
@@ -548,6 +549,49 @@ async fn gateway_action_handler(
             Json(serde_json::json!({ "error": "unknown destination", "group": group, "destination": destination })),
         )
     }
+}
+
+/// `GET /admin/calls` — active B2BUA calls: internal id, SIP Call-ID, state,
+/// A-leg From, B-leg target, and B-leg count. Reads the dispatcher-owned call
+/// store (published at construction). Empty array on a proxy-only node (no
+/// B2BUA calls) or before a dispatcher exists.
+async fn calls_handler() -> impl IntoResponse {
+    match crate::b2bua::actor::global_call_store() {
+        Some(store) => Json(calls_json(store)),
+        None => Json(serde_json::Value::Array(Vec::new())),
+    }
+}
+
+/// Serialize the active B2BUA calls. Split from the handler so it can be
+/// unit-tested against a locally-built store without the process-global.
+fn calls_json(store: &crate::b2bua::actor::CallActorStore) -> serde_json::Value {
+    use crate::b2bua::actor::CallState;
+
+    let mut calls: Vec<serde_json::Value> = Vec::new();
+    for entry in store.iter_calls() {
+        let call = entry.value();
+        let state = match call.state {
+            CallState::Calling => "calling",
+            CallState::Ringing => "ringing",
+            CallState::Answered => "answered",
+            CallState::Terminated => "terminated",
+        };
+        let target = call
+            .b_legs
+            .first()
+            .and_then(|leg| leg.dialog.target_uri.clone());
+        calls.push(serde_json::json!({
+            "id": call.id,
+            "call_id": call.a_leg.dialog.call_id,
+            "state": state,
+            "from": call.a_leg.dialog.local_from_uri,
+            "to": target,
+            "b_legs": call.b_legs.len(),
+        }));
+    }
+    // Stable order for the dashboard (DashMap iteration order is arbitrary).
+    calls.sort_by(|a, b| a["call_id"].as_str().cmp(&b["call_id"].as_str()));
+    serde_json::Value::Array(calls)
 }
 
 // ---------------------------------------------------------------------------
@@ -1126,6 +1170,40 @@ mod tests {
             .unwrap();
         // No gateway manager is wired in unit tests -> no groups configured.
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn calls_json_empty_store_is_empty_array() {
+        let store = crate::b2bua::actor::CallActorStore::new();
+        assert_eq!(calls_json(&store), serde_json::json!([]));
+    }
+
+    #[test]
+    fn calls_json_serializes_active_calls() {
+        use crate::b2bua::actor::{CallActorStore, Leg, TransportInfo};
+        use crate::transport::{ConnectionId, Transport};
+
+        let store = CallActorStore::new();
+        let a_leg = Leg::new_a_leg(
+            "call-abc@example.com".to_string(),
+            "fromtag".to_string(),
+            "z9hG4bKbranch".to_string(),
+            TransportInfo {
+                remote_addr: "10.0.0.1:5060".parse().unwrap(),
+                connection_id: ConnectionId(1),
+                transport: Transport::Udp,
+                local_addr: None,
+            },
+        );
+        store.create_call(a_leg);
+
+        let json = calls_json(&store);
+        let calls = json.as_array().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["call_id"], "call-abc@example.com");
+        // A freshly created call is in the Calling state with no B-legs yet.
+        assert_eq!(calls[0]["state"], "calling");
+        assert_eq!(calls[0]["b_legs"], 0);
     }
 
     #[cfg(feature = "ui")]

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -69,6 +69,14 @@ pub async fn serve(
         );
     }
 
+    #[cfg(feature = "ui")]
+    if ui_enabled {
+        tracing::warn!(
+            "admin web UI enabled — this is an EXPERIMENTAL feature and may change \
+             or be removed in a future release"
+        );
+    }
+
     let app = router(state, cors.as_ref(), ui_enabled);
 
     info!("Admin API listening on {}", listen_addr);

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -1493,6 +1493,28 @@ impl Default for CallActorStore {
 }
 
 // ---------------------------------------------------------------------------
+// Process-wide call store handle (read-only observability)
+// ---------------------------------------------------------------------------
+
+/// The dispatcher-owned B2BUA call store, published for read-only consumers
+/// (the admin API `/admin/calls`) that need to enumerate active calls without
+/// owning the dispatcher.
+static GLOBAL_CALL_STORE: std::sync::OnceLock<std::sync::Arc<CallActorStore>> =
+    std::sync::OnceLock::new();
+
+/// Register the process-wide B2BUA call store. Called once at dispatcher
+/// construction; a no-op if a store was already registered.
+pub fn set_global_call_store(store: std::sync::Arc<CallActorStore>) {
+    let _ = GLOBAL_CALL_STORE.set(store);
+}
+
+/// The process-wide B2BUA call store, or `None` in headless / unit-test
+/// contexts that never constructed a dispatcher.
+pub fn global_call_store() -> Option<&'static std::sync::Arc<CallActorStore>> {
+    GLOBAL_CALL_STORE.get()
+}
+
+// ---------------------------------------------------------------------------
 // LegActor — async actor for B-leg message classification
 // ---------------------------------------------------------------------------
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1532,6 +1532,47 @@ pub struct AdminConfig {
     /// admin API can force-unregister AoRs and lift auto-bans.
     #[serde(default)]
     pub cors: Option<CorsConfig>,
+    /// Optional bearer-token auth for the admin API. The admin API can
+    /// force-unregister AoRs and lift auto-bans, so when the embedded UI is
+    /// exposed a token should protect at least the mutating routes. Unset =
+    /// no auth (network-placement trust only, unchanged from before).
+    #[serde(default)]
+    pub auth: Option<AdminAuthConfig>,
+    /// Optional embedded web dashboard served from this listener. Requires a
+    /// binary built with the `ui` cargo feature; on a binary without it,
+    /// `enabled: true` warns and no UI is served.
+    #[serde(default)]
+    pub ui: Option<AdminUiConfig>,
+}
+
+/// Bearer-token auth for the admin API (RFC 6750). When `token` is set, the
+/// `DELETE` routes (force-unregister, lift-ban) require
+/// `Authorization: Bearer <token>`; set `protect_reads` to require it on the
+/// `GET` routes and `/metrics` too. Same-origin dashboard callers send the
+/// token themselves; Prometheus scrapers of a `protect_reads` endpoint must be
+/// configured with the bearer token.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct AdminAuthConfig {
+    /// Shared bearer token. Empty/unset disables auth. Supports `${VAR}`
+    /// expansion, so keep the literal out of the YAML: `token: "${ADMIN_TOKEN}"`.
+    #[serde(default)]
+    pub token: Option<String>,
+    /// Also require the token on the read routes (`GET`, `/metrics`,
+    /// `/admin/metrics.json`), not only the mutating `DELETE` routes. Default
+    /// false — reads stay open (back-compat), writes are gated as soon as a
+    /// token is set.
+    #[serde(default)]
+    pub protect_reads: bool,
+}
+
+/// Embedded web-dashboard settings for the admin listener.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct AdminUiConfig {
+    /// Serve the embedded dashboard at the admin listener root (`/`). Default
+    /// false. Requires a binary built with `--features ui`; otherwise a loud
+    /// warning is logged and no UI is served.
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -563,6 +563,11 @@ pub async fn run(
                 .expect("builtin transparent-b2bua@2026 must exist")
         });
 
+    // Publish the call store for read-only observability (admin `/admin/calls`)
+    // before it's moved into the dispatcher state.
+    let call_actors = Arc::new(CallActorStore::new());
+    crate::b2bua::actor::set_global_call_store(Arc::clone(&call_actors));
+
     let state = Arc::new(DispatcherState {
         engine,
         outbound,
@@ -574,7 +579,7 @@ pub async fn run(
         server_header,
         user_agent_header,
         transaction_timeout,
-        call_actors: Arc::new(CallActorStore::new()),
+        call_actors,
         transaction_manager,
         timer_wheel: Arc::new(DashMap::new()),
         session_store: Arc::new(ProxySessionStore::new()),

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -638,6 +638,43 @@ pub fn encode_metrics() -> String {
     String::from_utf8(buffer).unwrap_or_default()
 }
 
+/// Sum every series of a labelled counter vector across all label
+/// combinations. Used to expose a single scalar total (e.g. all SIP requests
+/// regardless of method) in the JSON metrics snapshot the web dashboard polls,
+/// where the browser diffs the total over time to derive a rate.
+pub fn sum_int_counter_vec(vector: &IntCounterVec) -> u64 {
+    use prometheus::core::Collector;
+    vector
+        .collect()
+        .iter()
+        .flat_map(|family| family.get_metric())
+        .map(|metric| metric.get_counter().value() as u64)
+        .sum()
+}
+
+/// Collapse a labelled gauge vector into a `label-value -> summed gauge` map,
+/// keyed on one label name (e.g. `"transport"` for `siphon_connections_active`).
+/// Series missing the label are grouped under the empty string.
+pub fn gauge_vec_by_label(
+    vector: &GaugeVec,
+    label: &str,
+) -> std::collections::BTreeMap<String, f64> {
+    use prometheus::core::Collector;
+    let mut out = std::collections::BTreeMap::new();
+    for family in vector.collect() {
+        for metric in family.get_metric() {
+            let key = metric
+                .get_label()
+                .iter()
+                .find(|pair| pair.name() == label)
+                .map(|pair| pair.value().to_owned())
+                .unwrap_or_default();
+            *out.entry(key).or_insert(0.0) += metric.get_gauge().value();
+        }
+    }
+    out
+}
+
 /// Refresh the jemalloc memory-stat gauges from the allocator's internal
 /// counters.  Call periodically (the dispatcher does so on its cleanup tick).
 /// No-op when metrics aren't initialised or jemalloc isn't the allocator.
@@ -871,6 +908,29 @@ mod tests {
             metrics.connections_active.with_label_values(&["TCP"]).get(),
             10.0
         );
+    }
+
+    #[test]
+    fn sum_int_counter_vec_totals_all_series() {
+        // Built on a local, isolated vector so the shared global registry can't
+        // perturb the total.
+        let vector =
+            IntCounterVec::new(Opts::new("test_reqs_total", "test"), &["method"]).unwrap();
+        vector.with_label_values(&["INVITE"]).inc_by(3);
+        vector.with_label_values(&["REGISTER"]).inc_by(5);
+        assert_eq!(sum_int_counter_vec(&vector), 8);
+    }
+
+    #[test]
+    fn gauge_vec_by_label_groups_by_key() {
+        let vector =
+            GaugeVec::new(Opts::new("test_conns_active", "test"), &["transport"]).unwrap();
+        vector.with_label_values(&["udp"]).set(6.0);
+        vector.with_label_values(&["tcp"]).set(2.0);
+        let map = gauge_vec_by_label(&vector, "transport");
+        assert_eq!(map.get("udp"), Some(&6.0));
+        assert_eq!(map.get("tcp"), Some(&2.0));
+        assert_eq!(map.len(), 2);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1904,15 +1904,30 @@ impl SiphonServer {
             match admin_config.listen.parse::<std::net::SocketAddr>() {
                 Ok(listen_addr) => {
                     if let Some(registrar) = crate::script::api::registrar_arc() {
+                        let auth = admin_config.auth.clone().unwrap_or_default();
+                        let ui_enabled =
+                            admin_config.ui.as_ref().map(|ui| ui.enabled).unwrap_or(false);
+                        let instance_id = config
+                            .server
+                            .as_ref()
+                            .and_then(|server| server.instance_id.clone())
+                            .or_else(|| std::env::var("HOSTNAME").ok());
                         let admin_state = crate::admin::AdminState {
                             registrar: Arc::clone(registrar),
                             start_time: std::time::Instant::now(),
                             draining: Some(Arc::clone(&drain)),
+                            auth_token: auth
+                                .token
+                                .filter(|token| !token.is_empty())
+                                .map(|token| std::sync::Arc::from(token.as_str())),
+                            protect_reads: auth.protect_reads,
+                            instance_id,
                         };
                         tokio::spawn(crate::admin::serve(
                             listen_addr,
                             admin_state,
                             admin_config.cors.clone(),
+                            ui_enabled,
                         ));
                     } else {
                         error!("admin API enabled but registrar is not initialized; not starting");

--- a/tests/integration/admin_tests.rs
+++ b/tests/integration/admin_tests.rs
@@ -20,6 +20,9 @@ fn test_state() -> AdminState {
         registrar: Arc::new(Registrar::new(RegistrarConfig::default())),
         start_time: Instant::now(),
         draining: None,
+        auth_token: None,
+        protect_reads: false,
+        instance_id: None,
     }
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -177,8 +177,12 @@
     <nav id="nav">
       <div class="lbl">Monitor</div>
       <a class="navitem active" data-view="overview"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><rect x="3" y="3" width="7" height="9" rx="1.5"/><rect x="14" y="3" width="7" height="5" rx="1.5"/><rect x="14" y="12" width="7" height="9" rx="1.5"/><rect x="3" y="16" width="7" height="5" rx="1.5"/></svg>Overview</a>
+      <a class="navitem" data-view="calls"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M4 5c0 9 6 15 15 15a1.5 1.5 0 001.5-1.5v-2.6a1 1 0 00-.8-1L16 13.5a1 1 0 00-1 .4l-.9 1.2a12 12 0 01-4.7-4.7l1.2-.9a1 1 0 00.4-1L9.6 4.3a1 1 0 00-1-.8H6A1.5 1.5 0 004 5z"/></svg>Calls <span class="count" id="nav-calls"></span></a>
       <a class="navitem" data-view="registrations"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M4 7h16M4 12h16M4 17h10"/></svg>Registrations <span class="count" id="nav-regs"></span></a>
       <a class="navitem" data-view="security"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/></svg>Security <span class="count" id="nav-bans"></span></a>
+      <div class="lbl">Routing</div>
+      <a class="navitem" data-view="gateways"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><rect x="4" y="4" width="16" height="6" rx="1.5"/><rect x="4" y="14" width="16" height="6" rx="1.5"/><path d="M7.5 7h.01M7.5 17h.01"/></svg>Gateways <span class="count" id="nav-gw"></span></a>
+      <div class="lbl">System</div>
       <a class="navitem" data-view="system"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 9h6v6H9z"/></svg>System</a>
       <a class="navitem" data-view="integrations"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><circle cx="6" cy="6" r="2.5"/><circle cx="18" cy="18" r="2.5"/><circle cx="18" cy="6" r="2.5"/><path d="M8.5 6H18M6 8.5V15a3 3 0 003 3h6"/></svg>Integrations</a>
     </nav>
@@ -280,10 +284,27 @@
         </div>
       </div>
 
-      <!-- INTEGRATIONS -->
-      <div class="view" id="view-integrations">
+      <!-- CALLS -->
+      <div class="view" id="view-calls">
+        <div class="toolbar">
+          <span class="count-pill"><b id="call-count">0</b> active B2BUA calls</span>
+          <span class="grow"></span>
+          <button class="iconbtn" id="call-refresh" title="Refresh"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M20 11a8 8 0 10-2 5.3M20 5v6h-6"/></svg></button>
+        </div>
+        <div class="card"><div class="tblscroll"><table class="tbl">
+          <thead><tr><th>Call-ID</th><th>State</th><th>From</th><th>Target</th><th>B-legs</th></tr></thead>
+          <tbody id="call-rows"><tr><td colspan="5" class="empty">loading…</td></tr></tbody>
+        </table></div></div>
+      </div>
+
+      <!-- GATEWAYS -->
+      <div class="view" id="view-gateways">
         <div class="sectlabel">Gateway groups</div>
         <div id="gw-groups"><div class="card"><div class="panelbody empty">loading…</div></div></div>
+      </div>
+
+      <!-- INTEGRATIONS -->
+      <div class="view" id="view-integrations">
         <div class="sectlabel">Connected subsystems</div>
         <div class="charts">
           <div class="card"><div class="panelhead"><span class="t">Diameter</span><span class="count-pill"><b id="dia-n">—</b> peers up</span></div><div class="panelbody"><div class="metaline"><span>Peers connected</span><b id="dia-peers">—</b></div></div></div>
@@ -341,7 +362,7 @@
   applyUnlock();
 
   // ---- router ----
-  var CRUMBS = { overview:'Overview', registrations:'Registrations', security:'Security', system:'System', integrations:'Integrations' };
+  var CRUMBS = { overview:'Overview', calls:'Calls', registrations:'Registrations', security:'Security', gateways:'Gateways', system:'System', integrations:'Integrations' };
   function go(view){
     document.querySelectorAll('.navitem').forEach(function(n){ n.classList.toggle('active', n.getAttribute('data-view') === view); });
     document.querySelectorAll('.view').forEach(function(v){ v.classList.toggle('show', v.id === 'view-' + view); });
@@ -349,7 +370,8 @@
     if (view === 'overview') charts.forEach(function(c){ c.resize(); });
     if (view === 'registrations') loadRegistrations();
     if (view === 'security') loadBans();
-    if (view === 'integrations') loadGateways();
+    if (view === 'calls') loadCalls();
+    if (view === 'gateways') loadGateways();
   }
   $('nav').addEventListener('click', function(e){ var it = e.target.closest('.navitem'); if (!it) return; e.preventDefault(); go(it.getAttribute('data-view')); });
   document.querySelectorAll('[data-goto]').forEach(function(a){ a.addEventListener('click', function(){ go(a.getAttribute('data-goto')); }); });
@@ -558,6 +580,7 @@
       if (r.status === 401){ $('gw-groups').innerHTML = '<div class="card"><div class="panelbody empty">read access is protected — Unlock with an admin token</div></div>'; return; }
       groups = await r.json();
     } catch(e){ $('gw-groups').innerHTML = '<div class="card"><div class="panelbody empty">failed to load</div></div>'; return; }
+    $('nav-gw').textContent = groups.length || '';
     if (!groups.length){ $('gw-groups').innerHTML = '<div class="card"><div class="panelbody empty">no gateway groups configured</div></div>'; return; }
     $('gw-groups').innerHTML = groups.map(function(g){
       var rows = (g.destinations||[]).map(function(d){
@@ -585,6 +608,25 @@
     }).catch(function(){ say('Request failed', true); });
   });
 
+  // ---- calls (B2BUA) ----
+  function callStateColor(s){ return s==='answered'?'var(--up)':s==='ringing'?'var(--warn)':s==='terminated'?'var(--faint)':'var(--cyan)'; }
+  async function loadCalls(){
+    var calls;
+    try {
+      var r = await api('/admin/calls');
+      if (r.status === 401){ $('call-rows').innerHTML = '<tr><td colspan="5" class="empty">read access is protected — Unlock with an admin token</td></tr>'; return; }
+      calls = await r.json();
+    } catch(e){ $('call-rows').innerHTML = '<tr><td colspan="5" class="empty">failed to load</td></tr>'; return; }
+    $('call-count').textContent = calls.length; $('nav-calls').textContent = calls.length || '';
+    $('call-rows').innerHTML = calls.length ? calls.map(function(c){
+      var col = callStateColor(c.state);
+      return '<tr><td class="aor">'+esc(c.call_id)+'</td>'
+        + '<td><span class="spill" style="color:'+col+';border-color:'+col+'">'+esc(c.state)+'</span></td>'
+        + '<td class="contact">'+esc(c.from||'—')+'</td><td class="contact">'+esc(c.to||'—')+'</td><td class="q">'+c.b_legs+'</td></tr>';
+    }).join('') : '<tr><td colspan="5" class="empty">no active B2BUA calls</td></tr>';
+  }
+  document.getElementById('call-refresh').addEventListener('click', loadCalls);
+
   // ---- overview recent-registrations preview ----
   async function loadOverviewRegs(){
     try { var r = await api('/admin/registrations'); if (!r.ok) return; var list = await r.json();
@@ -596,6 +638,8 @@
   poll(); loadOverviewRegs();
   setInterval(poll, 2000);
   setInterval(function(){ if (document.getElementById('view-overview').classList.contains('show')) loadOverviewRegs(); }, 10000);
+  // Calls churn quickly — auto-refresh while the Calls view is open.
+  setInterval(function(){ if (document.getElementById('view-calls').classList.contains('show')) loadCalls(); }, 3000);
 })();
 </script>
 </body>

--- a/ui/index.html
+++ b/ui/index.html
@@ -562,17 +562,28 @@
     $('gw-groups').innerHTML = groups.map(function(g){
       var rows = (g.destinations||[]).map(function(d){
         var attrs = Object.keys(d.attrs||{}).map(function(k){ return k+'='+d.attrs[k]; }).join(' ');
+        var act = d.healthy ? 'down' : 'up', actLabel = d.healthy ? 'drain' : 'enable';
         return '<tr><td class="aor">'+esc(d.uri)+'</td><td class="contact">'+esc(d.address)+' '+esc(d.transport)+'</td>'
           + '<td>'+(d.healthy?'<span class="spill up">● up</span>':'<span class="spill down">● down</span>')+'</td>'
-          + '<td class="q">'+d.weight+'</td><td class="q">'+d.priority+'</td><td class="contact">'+esc(attrs)+'</td></tr>';
+          + '<td class="q">'+d.weight+'</td><td class="q">'+d.priority+'</td><td class="contact">'+esc(attrs)+'</td>'
+          + '<td><button class="rowbtn'+(unlocked?' armed':'')+'" data-gw="'+esc(g.name)+'|'+esc(d.uri)+'|'+act+'">'+actLabel+'</button></td></tr>';
       }).join('');
       var col = g.up === g.total ? 'var(--up)' : (g.up > 0 ? 'var(--warn)' : 'var(--crit)');
       return '<div class="card" style="margin-bottom:14px"><div class="panelhead">'
         + '<span class="t">'+esc(g.name)+' <span class="count-pill" style="margin-left:8px">'+esc(g.algorithm)+'</span></span>'
         + '<span class="count-pill"><b style="color:'+col+'">'+g.up+' / '+g.total+'</b> up</span></div>'
-        + '<div class="tblscroll"><table class="tbl"><thead><tr><th>Destination</th><th>Address</th><th>Health</th><th>Weight</th><th>Priority</th><th>Attrs</th></tr></thead><tbody>'+rows+'</tbody></table></div></div>';
+        + '<div class="tblscroll"><table class="tbl"><thead><tr><th>Destination</th><th>Address</th><th>Health</th><th>Weight</th><th>Priority</th><th>Attrs</th><th></th></tr></thead><tbody>'+rows+'</tbody></table></div></div>';
     }).join('');
   }
+  document.getElementById('gw-groups').addEventListener('click', function(e){
+    var b = e.target.closest('[data-gw]'); if (!b) return;
+    if (!unlocked){ say('Locked — press Unlock and enter an admin token', true); return; }
+    var parts = b.getAttribute('data-gw').split('|');
+    api('/admin/gateways/'+encodeURIComponent(parts[0])+'/'+encodeURIComponent(parts[1])+'/'+parts[2], { method:'POST' }).then(function(r){
+      if (r.status === 401){ say('Unauthorized — check the admin token', true); return; }
+      if (r.ok){ say('Gateway '+parts[1]+' marked '+parts[2]); loadGateways(); } else { say('Failed ('+r.status+')', true); }
+    }).catch(function(){ say('Request failed', true); });
+  });
 
   // ---- overview recent-registrations preview ----
   async function loadOverviewRegs(){

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,563 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SIPhon — Control</title>
+<style>
+  :root {
+    --bg:#0a0f1e;--panel:#111a2e;--panel-2:#16203a;--border:#24304d;--border-soft:#1a2440;
+    --text:#e6ecf5;--muted:#8b9ab4;--faint:#5f6f8c;--grid:rgba(148,163,184,.10);
+    --sky:#0ea5e9;--indigo:#6366f1;--cyan:#22d3ee;--violet:#818cf8;
+    --up:#10b981;--warn:#f59e0b;--crit:#f43f5e;
+    --tube:linear-gradient(120deg,var(--sky),var(--indigo));
+    --font-mono:'JetBrains Mono',ui-monospace,'SFMono-Regular','SF Mono',Menlo,Consolas,monospace;
+    --font-sans:'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+    --radius:10px;--shadow:0 1px 0 rgba(255,255,255,.02) inset,0 8px 24px -12px rgba(0,0,0,.6);
+    color-scheme:dark;
+  }
+  @media (prefers-color-scheme:light){:root{
+    --bg:#eef1f8;--panel:#fff;--panel-2:#f6f8fc;--border:#dfe5f0;--border-soft:#e9edf5;
+    --text:#101828;--muted:#5a6a86;--faint:#94a3b8;--grid:rgba(15,23,42,.07);
+    --shadow:0 1px 2px rgba(16,24,40,.05),0 12px 28px -18px rgba(16,24,40,.25);color-scheme:light;}}
+  :root[data-theme=light]{--bg:#eef1f8;--panel:#fff;--panel-2:#f6f8fc;--border:#dfe5f0;--border-soft:#e9edf5;
+    --text:#101828;--muted:#5a6a86;--faint:#94a3b8;--grid:rgba(15,23,42,.07);
+    --shadow:0 1px 2px rgba(16,24,40,.05),0 12px 28px -18px rgba(16,24,40,.25);color-scheme:light;}
+  :root[data-theme=dark]{--bg:#0a0f1e;--panel:#111a2e;--panel-2:#16203a;--border:#24304d;--border-soft:#1a2440;
+    --text:#e6ecf5;--muted:#8b9ab4;--faint:#5f6f8c;--grid:rgba(148,163,184,.10);
+    --shadow:0 1px 0 rgba(255,255,255,.02) inset,0 8px 24px -12px rgba(0,0,0,.6);color-scheme:dark;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-sans);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+  .num,.mono{font-family:var(--font-mono);font-variant-numeric:tabular-nums}
+  .app{display:grid;grid-template-columns:232px 1fr;min-height:100vh}
+  .sidebar{background:var(--panel);border-right:1px solid var(--border);display:flex;flex-direction:column;position:sticky;top:0;height:100vh}
+  .brand{display:flex;align-items:center;gap:11px;padding:18px 18px 16px;border-bottom:1px solid var(--border-soft)}
+  .brand svg{width:34px;height:34px;flex:none}
+  .brand .word{font-weight:700;font-size:17px;letter-spacing:-.02em}
+  .brand .word b{background:var(--tube);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .brand .tag{display:block;font-size:10.5px;color:var(--faint);font-family:var(--font-mono);margin-top:1px}
+  nav{padding:12px;display:flex;flex-direction:column;gap:2px}
+  nav .lbl{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.12em;color:var(--faint);padding:10px 10px 6px}
+  .navitem{display:flex;align-items:center;gap:10px;padding:8px 10px;border-radius:8px;color:var(--muted);text-decoration:none;font-size:13.5px;border:1px solid transparent;cursor:pointer}
+  .navitem svg{width:17px;height:17px;flex:none;stroke:currentColor}
+  .navitem:hover{background:var(--panel-2);color:var(--text)}
+  .navitem.active{color:var(--text);background:linear-gradient(120deg,rgba(14,165,233,.16),rgba(99,102,241,.16));border-color:rgba(99,102,241,.35)}
+  .navitem.active svg{stroke:var(--cyan)}
+  .navitem .count{margin-left:auto;font-family:var(--font-mono);font-size:11px;color:var(--faint)}
+  .sidefoot{margin-top:auto;padding:14px 18px;border-top:1px solid var(--border-soft);font-family:var(--font-mono);font-size:11px;color:var(--faint);display:flex;flex-direction:column;gap:4px}
+  .main{min-width:0;display:flex;flex-direction:column}
+  .topbar{display:flex;align-items:center;gap:12px;padding:12px 22px;border-bottom:1px solid var(--border);background:color-mix(in srgb,var(--panel) 82%,transparent);backdrop-filter:blur(8px);position:sticky;top:0;z-index:5}
+  .crumb{font-size:15px;font-weight:650;letter-spacing:-.01em}
+  .crumb .sub{color:var(--muted);font-weight:400;margin-left:8px;font-size:13px}
+  .spacer{flex:1}
+  .badges{display:flex;align-items:center;gap:8px}
+  .badge{display:inline-flex;align-items:center;gap:6px;font-family:var(--font-mono);font-size:11.5px;padding:4px 9px;border-radius:999px;border:1px solid var(--border);color:var(--muted);background:var(--panel-2)}
+  .badge .led{width:7px;height:7px;border-radius:50%;background:var(--muted)}
+  .badge.ok{color:var(--up);border-color:color-mix(in srgb,var(--up) 40%,var(--border))}
+  .badge.ok .led{background:var(--up);animation:pulse 2.4s infinite}
+  .badge.info{color:var(--cyan);border-color:color-mix(in srgb,var(--cyan) 40%,var(--border))}
+  .badge.info .led{background:var(--cyan)}
+  .badge.bad{color:var(--crit);border-color:color-mix(in srgb,var(--crit) 40%,var(--border))}
+  .badge.bad .led{background:var(--crit)}
+  @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(16,185,129,.45)}70%{box-shadow:0 0 0 6px rgba(16,185,129,0)}100%{box-shadow:0 0 0 0 rgba(16,185,129,0)}}
+  .iconbtn{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:8px;border:1px solid var(--border);background:var(--panel-2);color:var(--muted);cursor:pointer}
+  .iconbtn:hover{color:var(--text);border-color:var(--indigo)}
+  .iconbtn svg{width:17px;height:17px;stroke:currentColor}
+  .unlock{display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:12px;padding:7px 12px;border-radius:8px;cursor:pointer;border:1px solid color-mix(in srgb,var(--warn) 45%,var(--border));background:color-mix(in srgb,var(--warn) 12%,transparent);color:var(--warn)}
+  .unlock svg{width:14px;height:14px;stroke:currentColor}
+  .unlock.on{border-color:color-mix(in srgb,var(--up) 50%,var(--border));background:color-mix(in srgb,var(--up) 12%,transparent);color:var(--up)}
+  :focus-visible{outline:2px solid var(--cyan);outline-offset:2px;border-radius:6px}
+  .content{padding:22px;display:flex;flex-direction:column;gap:18px;max-width:1600px}
+  .sectlabel{font-family:var(--font-mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.14em;color:var(--faint);margin:2px 0 -6px}
+  .view{display:none;flex-direction:column;gap:18px}
+  .view.show{display:flex}
+  .kpis{display:grid;grid-template-columns:repeat(6,1fr);gap:14px}
+  .tile{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius);padding:14px 15px 13px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:7px;min-width:0}
+  .tile .lab{font-family:var(--font-mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.09em;color:var(--muted)}
+  .tile .v{font-family:var(--font-mono);font-size:27px;font-weight:600;letter-spacing:-.02em;line-height:1}
+  .tile .v small{font-size:13px;color:var(--muted);font-weight:500;margin-left:3px}
+  .tile.hero .v{background:var(--tube);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .tile .foot{font-family:var(--font-mono);font-size:11px;color:var(--faint)}
+  .charts{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden}
+  .card .head{display:flex;align-items:center;justify-content:space-between;padding:13px 15px 4px}
+  .card .head .t{font-size:13px;font-weight:600}
+  .card .head .now{font-family:var(--font-mono);font-size:13px}
+  .card .head .now .u{color:var(--muted);font-weight:400;font-size:11px;margin-left:2px}
+  .chartwrap{position:relative;height:128px;padding:4px 6px 8px}
+  canvas{width:100%;height:100%;display:block}
+  .lower{display:grid;grid-template-columns:1fr 1.35fr;gap:14px}
+  .grid2{display:grid;grid-template-columns:1.4fr 1fr;gap:14px}
+  .panelhead{display:flex;align-items:center;justify-content:space-between;padding:13px 16px;border-bottom:1px solid var(--border-soft)}
+  .panelhead .t{font-size:13px;font-weight:600}
+  .panelbody{padding:15px 16px}
+  .stack{display:flex;height:12px;border-radius:6px;overflow:hidden;border:1px solid var(--border-soft)}
+  .stack i{display:block;height:100%}
+  .legend{display:grid;grid-template-columns:repeat(2,1fr);gap:8px 18px;margin-top:14px}
+  .legrow{display:flex;align-items:center;gap:8px;font-family:var(--font-mono);font-size:12px}
+  .legrow .sw{width:9px;height:9px;border-radius:3px;flex:none}
+  .legrow .n{color:var(--muted)}
+  .legrow .val{margin-left:auto;color:var(--text)}
+  .metaline{display:flex;justify-content:space-between;font-family:var(--font-mono);font-size:12px;color:var(--muted);padding:9px 0;border-top:1px dashed var(--border-soft)}
+  .metaline:first-child{border-top:0}
+  .metaline b{color:var(--text);font-weight:600}
+  .toolbar{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .search{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:8px 11px;min-width:280px;flex:1;max-width:420px}
+  .search svg{width:15px;height:15px;stroke:var(--faint);flex:none}
+  .search input{background:transparent;border:0;color:var(--text);font-family:var(--font-mono);font-size:13px;width:100%;outline:none}
+  .grow{flex:1}
+  .count-pill{font-family:var(--font-mono);font-size:12px;color:var(--muted)}
+  .count-pill b{color:var(--text)}
+  table.tbl{width:100%;border-collapse:collapse;font-size:12.5px}
+  .tbl th{text-align:left;font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:var(--faint);font-weight:500;padding:11px 12px}
+  .tbl td{padding:9px 12px;border-top:1px solid var(--border-soft);font-family:var(--font-mono)}
+  .tbl tbody tr:hover td{background:var(--panel-2)}
+  .tbl .aor{color:var(--text)}
+  .tbl .contact{color:var(--muted)}
+  .tbl .q{color:var(--faint)}
+  .exp{display:inline-flex;align-items:center;gap:7px}
+  .exp .bar{width:46px;height:5px;border-radius:3px;background:var(--border);overflow:hidden}
+  .exp .bar i{display:block;height:100%}
+  .rowbtn{font-family:var(--font-mono);font-size:11px;color:var(--faint);border:1px solid var(--border);background:transparent;border-radius:6px;padding:3px 9px;cursor:not-allowed;opacity:.5}
+  .rowbtn.armed{color:var(--crit);border-color:color-mix(in srgb,var(--crit) 50%,var(--border));opacity:1;cursor:pointer}
+  .rowbtn.armed:hover{background:color-mix(in srgb,var(--crit) 14%,transparent)}
+  .tblscroll{overflow-x:auto}
+  .empty{color:var(--faint);font-family:var(--font-mono);font-size:12.5px;padding:24px 12px;text-align:center}
+  .membar{display:grid;grid-template-columns:120px 1fr 92px;align-items:center;gap:12px;padding:7px 0}
+  .membar .ml{font-family:var(--font-mono);font-size:12px;color:var(--muted)}
+  .membar .track{height:9px;border-radius:5px;background:var(--border);overflow:hidden}
+  .membar .track i{display:block;height:100%;border-radius:5px}
+  .membar .mv{font-family:var(--font-mono);font-size:12px;color:var(--text);text-align:right}
+  .subhead{font-family:var(--font-mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.1em;color:var(--faint);margin:4px 0 6px}
+  .statrow{display:grid;grid-template-columns:repeat(2,1fr);gap:10px 16px;margin-top:6px}
+  .stat{font-family:var(--font-mono);font-size:12px;display:flex;justify-content:space-between;padding:7px 0;border-top:1px dashed var(--border-soft)}
+  .stat .k{color:var(--muted)}.stat .v{color:var(--text)}
+  .facts{display:grid;grid-template-columns:1fr 1fr;gap:0 24px}
+  .fact{display:flex;justify-content:space-between;gap:10px;font-family:var(--font-mono);font-size:12px;padding:8px 0;border-top:1px solid var(--border-soft)}
+  .fact .k{color:var(--muted)}.fact .v{color:var(--text)}
+  .irow{display:flex;align-items:center;gap:10px;padding:11px 0;border-top:1px solid var(--border-soft)}
+  .irow:first-child{border-top:0}
+  .irow .nm{font-family:var(--font-mono);font-size:13px;color:var(--text);font-weight:600}
+  .irow .meta{font-family:var(--font-mono);font-size:11px;color:var(--muted);margin-top:2px}
+  .irow .rt{margin-left:auto;text-align:right}
+  .spill{font-family:var(--font-mono);font-size:10.5px;padding:2px 9px;border-radius:999px;border:1px solid var(--border);color:var(--muted)}
+  .spill.up{color:var(--up);border-color:color-mix(in srgb,var(--up) 40%,var(--border));background:color-mix(in srgb,var(--up) 8%,transparent)}
+  .toast{position:fixed;bottom:22px;left:50%;transform:translateX(-50%) translateY(20px);background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:11px 16px;box-shadow:var(--shadow);font-family:var(--font-mono);font-size:12.5px;color:var(--text);opacity:0;pointer-events:none;transition:all .25s;z-index:40;display:flex;align-items:center;gap:9px}
+  .toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
+  .toast .di{width:8px;height:8px;border-radius:50%;background:var(--up)}
+  .toast.err .di{background:var(--crit)}
+  @media (max-width:1200px){.kpis{grid-template-columns:repeat(3,1fr)}.charts{grid-template-columns:1fr}.lower,.grid2{grid-template-columns:1fr}}
+  @media (max-width:780px){.app{grid-template-columns:1fr}.sidebar{display:none}.kpis{grid-template-columns:repeat(2,1fr)}}
+  @media (prefers-reduced-motion:reduce){.badge.ok .led{animation:none}}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="sidebar">
+    <div class="brand">
+      <svg viewBox="0 0 512 512" fill="none" aria-hidden="true">
+        <defs>
+          <linearGradient id="tube" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0ea5e9"/><stop offset="100%" stop-color="#6366f1"/></linearGradient>
+          <linearGradient id="liquid" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.6"/><stop offset="100%" stop-color="#818cf8" stop-opacity="0.3"/></linearGradient>
+          <linearGradient id="packet" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#818cf8"/></linearGradient>
+        </defs>
+        <rect x="60" y="200" width="120" height="220" rx="10" stroke="url(#tube)" stroke-width="14" fill="none"/>
+        <rect x="70" y="266" width="100" height="145" rx="8" fill="url(#liquid)"/>
+        <rect x="332" y="280" width="120" height="140" rx="10" stroke="url(#tube)" stroke-width="14" fill="none"/>
+        <rect x="342" y="342" width="100" height="70" rx="8" fill="url(#liquid)"/>
+        <path d="M 120 260 L 120 120 C 120 70, 170 50, 256 50 C 342 50, 392 70, 392 120 L 392 340" stroke="url(#tube)" stroke-width="18" stroke-linecap="round" fill="none"/>
+        <g>
+          <rect x="-8" y="-6" width="18" height="12" rx="3" fill="url(#packet)"><animateMotion dur="3s" repeatCount="indefinite" rotate="auto" path="M 120 260 L 120 120 C 120 70, 170 50, 256 50 C 342 50, 392 70, 392 120 L 392 340"/></rect>
+          <rect x="-8" y="-6" width="18" height="12" rx="3" fill="url(#packet)" opacity="0.6"><animateMotion dur="3s" begin="1.5s" repeatCount="indefinite" rotate="auto" path="M 120 260 L 120 120 C 120 70, 170 50, 256 50 C 342 50, 392 70, 392 120 L 392 340"/></rect>
+        </g>
+      </svg>
+      <div><span class="word">SIP<b>hon</b></span><span class="tag">control</span></div>
+    </div>
+    <nav id="nav">
+      <div class="lbl">Monitor</div>
+      <a class="navitem active" data-view="overview"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><rect x="3" y="3" width="7" height="9" rx="1.5"/><rect x="14" y="3" width="7" height="5" rx="1.5"/><rect x="14" y="12" width="7" height="9" rx="1.5"/><rect x="3" y="16" width="7" height="5" rx="1.5"/></svg>Overview</a>
+      <a class="navitem" data-view="registrations"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M4 7h16M4 12h16M4 17h10"/></svg>Registrations <span class="count" id="nav-regs"></span></a>
+      <a class="navitem" data-view="security"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/></svg>Security <span class="count" id="nav-bans"></span></a>
+      <a class="navitem" data-view="system"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 9h6v6H9z"/></svg>System</a>
+      <a class="navitem" data-view="integrations"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><circle cx="6" cy="6" r="2.5"/><circle cx="18" cy="18" r="2.5"/><circle cx="18" cy="6" r="2.5"/><path d="M8.5 6H18M6 8.5V15a3 3 0 003 3h6"/></svg>Integrations</a>
+    </nav>
+    <div class="sidefoot"><span id="foot-node">● connecting…</span><span id="foot-ver">siphon</span></div>
+  </aside>
+
+  <div class="main">
+    <header class="topbar">
+      <div class="crumb" id="crumb">Overview</div>
+      <div class="spacer"></div>
+      <div class="badges" id="badges">
+        <span class="badge" id="b-live"><span class="led"></span>LIVE</span>
+        <span class="badge" id="b-ready"><span class="led"></span>READY</span>
+        <span class="badge" id="b-jem"><span class="led"></span>jemalloc</span>
+        <span class="badge mono" id="b-up" style="color:var(--muted)">up —</span>
+      </div>
+      <button class="unlock" id="unlock" title="Enter admin token to enable write actions"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 018 0"/></svg><span id="unlock-t">Unlock</span></button>
+      <button class="iconbtn" id="theme" title="Toggle theme" aria-label="Toggle theme"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M21 12.8A8.5 8.5 0 1111.2 3a6.6 6.6 0 009.8 9.8z"/></svg></button>
+    </header>
+
+    <div class="content">
+      <!-- OVERVIEW -->
+      <div class="view show" id="view-overview">
+        <div class="sectlabel">Live · polled every 2s from /admin/metrics.json</div>
+        <section class="kpis">
+          <div class="tile hero"><span class="lab">Active dialogs</span><div class="v" id="k-dialogs">—</div><div class="foot">SIP dialogs in progress</div></div>
+          <div class="tile hero"><span class="lab">SIP req / sec</span><div class="v" id="k-rps">—</div><div class="foot"><span id="k-resp">—</span> resp/s</div></div>
+          <div class="tile"><span class="lab">Registrations</span><div class="v" id="k-regs">—</div><div class="foot">active bindings</div></div>
+          <div class="tile"><span class="lab">Transactions</span><div class="v" id="k-txn">—</div><div class="foot">active SIP txns</div></div>
+          <div class="tile"><span class="lab">Memory</span><div class="v" id="k-mem">—</div><div class="foot" id="k-mem-foot">allocated</div></div>
+          <div class="tile"><span class="lab">Py executor</span><div class="v" id="k-py">—</div><div class="foot" id="k-py-foot">pool</div></div>
+        </section>
+        <div class="sectlabel">Throughput &amp; resources</div>
+        <section class="charts">
+          <div class="card"><div class="head"><span class="t">SIP requests / sec</span><span class="now"><b id="n-rps" style="color:var(--cyan)">—</b><span class="u">req/s</span></span></div><div class="chartwrap"><canvas id="c-rps"></canvas></div></div>
+          <div class="card"><div class="head"><span class="t">Active dialogs</span><span class="now"><b id="n-dlg" style="color:var(--violet)">—</b></span></div><div class="chartwrap"><canvas id="c-dlg"></canvas></div></div>
+          <div class="card"><div class="head"><span class="t">Memory allocated</span><span class="now"><b id="n-mem" style="color:var(--sky)">—</b><span class="u">MB</span></span></div><div class="chartwrap"><canvas id="c-mem"></canvas></div></div>
+        </section>
+        <section class="lower">
+          <div class="card"><div class="panelhead"><span class="t">Connections &amp; health</span></div>
+            <div class="panelbody">
+              <div class="stack" id="conn-stack" role="img" aria-label="Connection mix by transport"></div>
+              <div class="legend" id="conn-legend"></div>
+              <div style="margin-top:16px" id="health-meta"></div>
+            </div></div>
+          <div class="card"><div class="panelhead"><span class="t">Recent registrations</span><a class="count-pill" style="color:var(--cyan);cursor:pointer;text-decoration:none" data-goto="registrations">View all →</a></div>
+            <div class="tblscroll"><table class="tbl"><thead><tr><th>AoR</th><th>Contact</th><th>Q</th><th>Expires</th></tr></thead><tbody id="ov-regs"><tr><td colspan="4" class="empty">loading…</td></tr></tbody></table></div>
+          </div>
+        </section>
+      </div>
+
+      <!-- REGISTRATIONS -->
+      <div class="view" id="view-registrations">
+        <div class="toolbar">
+          <label class="search"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg><input id="q" placeholder="Filter AoR or contact…" autocomplete="off"></label>
+          <span class="grow"></span>
+          <span class="count-pill"><b id="reg-count">0</b> shown</span>
+          <button class="iconbtn" id="reg-refresh" title="Refresh"><svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M20 11a8 8 0 10-2 5.3M20 5v6h-6"/></svg></button>
+        </div>
+        <div class="card"><div class="tblscroll"><table class="tbl">
+          <thead><tr><th>AoR</th><th>Contact</th><th>Q</th><th>Expires</th><th></th></tr></thead>
+          <tbody id="reg-rows"><tr><td colspan="5" class="empty">loading…</td></tr></tbody>
+        </table></div></div>
+      </div>
+
+      <!-- SECURITY -->
+      <div class="view" id="view-security">
+        <div class="sectlabel">Threats blocked · since restart</div>
+        <section class="kpis">
+          <div class="tile"><span class="lab">Auth failures</span><div class="v" id="s-auth">—</div><div class="foot">digest challenge failed</div></div>
+          <div class="tile"><span class="lab">Scanner blocked</span><div class="v" id="s-scan">—</div><div class="foot">bad UA / probe</div></div>
+          <div class="tile"><span class="lab">Rate limited</span><div class="v" id="s-rate">—</div><div class="foot">per-source window</div></div>
+          <div class="tile"><span class="lab">Malformed</span><div class="v" id="s-mal">—</div><div class="foot">sanity-check fail</div></div>
+          <div class="tile"><span class="lab">Credential fails</span><div class="v" id="s-cred">—</div><div class="foot">bad digest response</div></div>
+          <div class="tile"><span class="lab">Banned now</span><div class="v" id="s-ban" style="color:var(--warn)">—</div><div class="foot">auto-ban active</div></div>
+        </section>
+        <div class="card"><div class="panelhead"><span class="t">Active bans</span><span class="count-pill"><b id="ban-count">0</b> sources</span></div>
+          <div class="tblscroll"><table class="tbl"><thead><tr><th>Source IP</th><th>Expires</th><th></th></tr></thead><tbody id="ban-rows"><tr><td colspan="3" class="empty">loading…</td></tr></tbody></table></div>
+        </div>
+      </div>
+
+      <!-- SYSTEM -->
+      <div class="view" id="view-system">
+        <div class="grid2">
+          <div class="card"><div class="panelhead"><span class="t">Memory</span><span class="count-pill" id="alloc-tag">—</span></div>
+            <div class="panelbody">
+              <div class="subhead">jemalloc arenas</div>
+              <div id="mem-bars"></div>
+              <div class="subhead" style="margin-top:14px">glibc (C-side)</div>
+              <div id="glibc-bars"></div>
+            </div></div>
+          <div class="card"><div class="panelhead"><span class="t">Python executor pool</span></div>
+            <div class="panelbody">
+              <div class="statrow" id="py-stats"></div>
+            </div></div>
+        </div>
+        <div class="card"><div class="panelhead"><span class="t">Runtime</span></div>
+          <div class="panelbody"><div class="facts" id="facts"></div></div>
+        </div>
+      </div>
+
+      <!-- INTEGRATIONS -->
+      <div class="view" id="view-integrations">
+        <div class="sectlabel">Connected subsystems</div>
+        <div class="charts">
+          <div class="card"><div class="panelhead"><span class="t">Diameter</span><span class="count-pill"><b id="dia-n">—</b> peers up</span></div><div class="panelbody"><div class="metaline"><span>Peers connected</span><b id="dia-peers">—</b></div></div></div>
+          <div class="card"><div class="panelhead"><span class="t">rtpengine</span><span class="count-pill"><b id="rtp-n">—</b> up</span></div><div class="panelbody"><div class="metaline"><span>Instances up</span><b id="rtp-up">—</b></div><div class="metaline"><span>Instances total</span><b id="rtp-total">—</b></div></div></div>
+          <div class="card"><div class="panelhead"><span class="t">5GC · SBI</span><span class="count-pill">N5</span></div><div class="panelbody"><div class="metaline"><span>Npcf app sessions</span><b id="sbi-sess">—</b></div><div class="metaline"><span>IPsec SA pairs</span><b id="ipsec-sa">—</b></div></div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast"><span class="di"></span><span id="toast-t">Done</span></div>
+
+<script>
+(function(){
+  "use strict";
+  var reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var root = document.documentElement;
+  var $ = function(id){ return document.getElementById(id); };
+
+  // ---- token (write auth) ----
+  var token = sessionStorage.getItem('siphon_admin_token') || '';
+  function authHeaders(){ return token ? { 'Authorization': 'Bearer ' + token } : {}; }
+  async function api(path, opts){
+    opts = opts || {};
+    opts.headers = Object.assign({}, opts.headers || {}, authHeaders());
+    return fetch(path, opts);
+  }
+
+  // ---- toast ----
+  var toast = $('toast'), toastT = $('toast-t'), toastTimer;
+  function say(msg, err){ toastT.textContent = msg; toast.classList.toggle('err', !!err); toast.classList.add('show'); clearTimeout(toastTimer); toastTimer = setTimeout(function(){ toast.classList.remove('show'); }, 2800); }
+
+  // ---- theme ----
+  $('theme').addEventListener('click', function(){
+    var cur = root.getAttribute('data-theme') || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    root.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark');
+    charts.forEach(function(c){ c.draw(); });
+  });
+
+  // ---- unlock ----
+  var unlocked = !!token;
+  function applyUnlock(){
+    $('unlock').classList.toggle('on', unlocked);
+    $('unlock-t').textContent = unlocked ? 'Unlocked' : 'Unlock';
+    document.querySelectorAll('.rowbtn').forEach(function(b){ b.classList.toggle('armed', unlocked); });
+  }
+  $('unlock').addEventListener('click', function(){
+    if (unlocked){ token = ''; sessionStorage.removeItem('siphon_admin_token'); unlocked = false; say('Locked — write actions disabled'); applyUnlock(); return; }
+    var t = window.prompt('Admin bearer token (leave blank if auth is disabled):', '');
+    if (t === null) return;
+    token = t.trim(); if (token) sessionStorage.setItem('siphon_admin_token', token);
+    unlocked = true; say(token ? 'Token stored — write actions enabled' : 'Write actions enabled (no auth configured)'); applyUnlock();
+  });
+  applyUnlock();
+
+  // ---- router ----
+  var CRUMBS = { overview:'Overview', registrations:'Registrations', security:'Security', system:'System', integrations:'Integrations' };
+  function go(view){
+    document.querySelectorAll('.navitem').forEach(function(n){ n.classList.toggle('active', n.getAttribute('data-view') === view); });
+    document.querySelectorAll('.view').forEach(function(v){ v.classList.toggle('show', v.id === 'view-' + view); });
+    $('crumb').textContent = CRUMBS[view] || view;
+    if (view === 'overview') charts.forEach(function(c){ c.resize(); });
+    if (view === 'registrations') loadRegistrations();
+    if (view === 'security') loadBans();
+  }
+  $('nav').addEventListener('click', function(e){ var it = e.target.closest('.navitem'); if (!it) return; e.preventDefault(); go(it.getAttribute('data-view')); });
+  document.querySelectorAll('[data-goto]').forEach(function(a){ a.addEventListener('click', function(){ go(a.getAttribute('data-goto')); }); });
+
+  // ---- charts ----
+  function Chart(id, color){ this.cv = $(id); this.ctx = this.cv.getContext('2d'); this.data = []; this.color = color; this.resize(); var s = this; addEventListener('resize', function(){ s.resize(); }); }
+  Chart.prototype.resize = function(){ var dpr = devicePixelRatio || 1, r = this.cv.getBoundingClientRect(); this.w = r.width; this.h = r.height; this.cv.width = r.width * dpr; this.cv.height = r.height * dpr; this.ctx.setTransform(dpr,0,0,dpr,0,0); this.draw(); };
+  Chart.prototype.push = function(v){ this.data.push(v); if (this.data.length > 64) this.data.shift(); this.draw(); };
+  Chart.prototype.cssvar = function(n){ return getComputedStyle(root).getPropertyValue(n).trim(); };
+  Chart.prototype.draw = function(){
+    var ctx = this.ctx, w = this.w, h = this.h, d = this.data, n = d.length; if (!w || !h) return;
+    var pad = 6, gh = h - pad*2; ctx.clearRect(0,0,w,h);
+    ctx.strokeStyle = this.cssvar('--grid'); ctx.lineWidth = 1;
+    for (var g=0; g<=3; g++){ var yy = pad + gh*g/3; ctx.beginPath(); ctx.moveTo(pad,yy); ctx.lineTo(w-pad,yy); ctx.stroke(); }
+    if (n < 2) return;
+    var min = Math.min.apply(null,d), max = Math.max.apply(null,d), range = (max-min)||1; min -= range*0.35; max += range*0.25; var span = max-min;
+    var X = function(i){ return pad + (w-pad*2)*(i/(n-1)); }, Y = function(v){ return pad + gh - ((v-min)/span)*gh; };
+    var grad = ctx.createLinearGradient(0,pad,0,h); grad.addColorStop(0,this.color+'55'); grad.addColorStop(1,this.color+'00');
+    ctx.beginPath(); ctx.moveTo(X(0),Y(d[0])); for (var i=1;i<n;i++) ctx.lineTo(X(i),Y(d[i])); ctx.lineTo(X(n-1),h-pad); ctx.lineTo(X(0),h-pad); ctx.closePath(); ctx.fillStyle = grad; ctx.fill();
+    ctx.beginPath(); ctx.moveTo(X(0),Y(d[0])); for (var j=1;j<n;j++) ctx.lineTo(X(j),Y(d[j])); ctx.strokeStyle = this.color; ctx.lineWidth = 2; ctx.lineJoin = 'round'; ctx.stroke();
+    var ex = X(n-1), ey = Y(d[n-1]); ctx.beginPath(); ctx.arc(ex,ey,3.2,0,7); ctx.fillStyle = this.color; ctx.fill();
+  };
+  var rps = new Chart('c-rps', '#22d3ee'), dlg = new Chart('c-dlg', '#818cf8'), mem = new Chart('c-mem', '#0ea5e9');
+  var charts = [rps, dlg, mem];
+
+  // ---- helpers ----
+  function comma(v){ return Math.round(v).toLocaleString('en-US'); }
+  function mb(bytes){ return bytes / 1048576; }
+  function bar(name, valMB, maxMB, color){
+    var pct = maxMB > 0 ? Math.max(2, Math.min(100, Math.round(valMB/maxMB*100))) : 0;
+    return '<div class="membar"><span class="ml">'+name+'</span><span class="track"><i style="width:'+pct+'%;background:'+color+'"></i></span><span class="mv">'+comma(valMB)+' MB</span></div>';
+  }
+  var TCOLOR = { udp:'var(--sky)', tcp:'var(--indigo)', tls:'var(--cyan)', ws:'var(--violet)', wss:'var(--violet)' };
+
+  // ---- live poll ----
+  var prev = null, prevAt = 0, connected = false;
+  function setBadge(id, cls, on){ var el = $(id); el.classList.remove('ok','bad','info'); if (on) el.classList.add(cls); }
+  function fmtUptime(s){ var d=Math.floor(s/86400), h=Math.floor(s%86400/3600), m=Math.floor(s%3600/60); return (d?d+'d ':'')+String(h).padStart(2,'0')+':'+String(m).padStart(2,'0'); }
+
+  async function poll(){
+    var m;
+    try { var r = await api('/admin/metrics.json'); if (!r.ok) throw new Error(r.status); m = await r.json(); }
+    catch(e){ connected = false; $('foot-node').textContent = '● disconnected'; $('foot-node').style.color = 'var(--crit)'; setBadge('b-live','bad',true); $('b-live').lastChild.textContent = 'OFFLINE'; return; }
+    connected = true;
+    $('foot-node').textContent = '● node healthy'; $('foot-node').style.color = 'var(--up)';
+    $('foot-ver').textContent = 'siphon ' + (m.version || '');
+    setBadge('b-live','ok',true); $('b-live').lastChild.textContent = 'LIVE';
+    setBadge('b-jem', 'info', !!m.jemalloc_active);
+    $('b-up').textContent = 'up ' + fmtUptime(m.uptime_seconds || 0);
+
+    var sip = m.sip || {}, counters = m.counters || {}, memory = m.memory || {}, py = m.pyexec || {};
+    // derive req/s from cumulative counter delta
+    var now = Date.now(), reqTotal = counters.requests_total || 0, respTotal = counters.responses_total || 0, rpsVal = 0, respVal = 0;
+    if (prev && now > prevAt){ var dt = (now - prevAt)/1000; rpsVal = Math.max(0, (reqTotal - prev.req)/dt); respVal = Math.max(0, (respTotal - prev.resp)/dt); }
+    prev = { req: reqTotal, resp: respTotal }; prevAt = now;
+
+    var dialogs = sip.dialogs_active || 0, regs = m.registrations_active || 0, txn = sip.transactions_active || 0;
+    var memMB = mb(memory.allocated || 0);
+    $('k-dialogs').textContent = comma(dialogs);
+    $('k-rps').textContent = comma(rpsVal); $('k-resp').textContent = comma(respVal);
+    $('k-regs').textContent = comma(regs);
+    $('k-txn').textContent = comma(txn);
+    $('k-mem').innerHTML = comma(memMB) + '<small>MB</small>';
+    $('nav-regs').textContent = comma(regs);
+    var pool = (py.pool_size!=null?py.pool_size:'—'), pmax = (py.pool_max!=null?py.pool_max:'—');
+    $('k-py').innerHTML = pool + '<small>/' + pmax + '</small>';
+    $('k-py-foot').textContent = (py.inflight||0) + ' inflight · ' + (py.jobs_shed||0) + ' shed';
+
+    rps.push(rpsVal); dlg.push(dialogs); mem.push(memMB);
+    $('n-rps').textContent = comma(rpsVal); $('n-dlg').textContent = comma(dialogs); $('n-mem').textContent = comma(memMB);
+
+    // connection mix
+    var conns = sip.connections || {}, total = 0, keys = Object.keys(conns);
+    keys.forEach(function(k){ total += conns[k]; });
+    var stack = '', legend = '';
+    keys.sort().forEach(function(k){
+      var v = conns[k], pct = total>0 ? (v/total*100) : 0, col = TCOLOR[k.toLowerCase()] || 'var(--muted)';
+      if (pct > 0) stack += '<i style="width:'+pct+'%;background:'+col+'"></i>';
+      legend += '<div class="legrow"><span class="sw" style="background:'+col+'"></span><span class="n">'+k.toUpperCase()+'</span><span class="val">'+comma(v)+'</span></div>';
+    });
+    $('conn-stack').innerHTML = stack || '<i style="width:100%;background:var(--border)"></i>';
+    $('conn-legend').innerHTML = legend || '<div class="legrow"><span class="n">no active connections</span></div>';
+
+    var dia = m.diameter || {}, rtp = m.rtpengine || {}, sbi = m.sbi || {}, sec = m.security || {};
+    $('health-meta').innerHTML =
+      '<div class="metaline"><span>Draining</span><b id="hm-drain">—</b></div>' +
+      '<div class="metaline"><span>rtpengine</span><b>'+(rtp.up||0)+' / '+(rtp.total||0)+' up</b></div>' +
+      '<div class="metaline"><span>Diameter peers</span><b>'+(dia.peers_connected||0)+' connected</b></div>' +
+      '<div class="metaline"><span>Banned sources</span><b style="color:'+((sec.banned_ips||0)>0?'var(--warn)':'var(--text)')+'">'+(sec.banned_ips||0)+' active</b></div>';
+    refreshReady();
+
+    // security tiles
+    $('s-auth').textContent = comma(counters.auth_failures_total||0);
+    $('s-scan').textContent = comma(counters.scanner_blocked_total||0);
+    $('s-rate').textContent = comma(counters.rate_limited_total||0);
+    $('s-mal').textContent = comma(counters.malformed_messages_total||0);
+    $('s-cred').textContent = comma(counters.credential_failures_total||0);
+    $('s-ban').textContent = comma(sec.banned_ips||0);
+
+    // system
+    var maxMB = Math.max(mb(memory.mapped||0), mb(memory.resident||0), mb(memory.allocated||0), 1);
+    $('mem-bars').innerHTML =
+      bar('allocated', mb(memory.allocated||0), maxMB, 'var(--sky)') +
+      bar('active', mb(memory.active||0), maxMB, 'var(--indigo)') +
+      bar('resident', mb(memory.resident||0), maxMB, 'var(--violet)') +
+      bar('mapped', mb(memory.mapped||0), maxMB, 'var(--cyan)') +
+      bar('retained', mb(memory.retained||0), maxMB, 'var(--faint)');
+    var gMax = Math.max(mb(memory.glibc_system||0), 1);
+    $('glibc-bars').innerHTML =
+      bar('system', mb(memory.glibc_system||0), gMax, 'var(--faint)') +
+      bar('in-use', mb(memory.glibc_in_use||0), gMax, 'var(--faint)') +
+      '<div class="membar"><span class="ml">arenas</span><span class="track"></span><span class="mv">'+(memory.glibc_arenas||0)+'</span></div>';
+    $('alloc-tag').textContent = m.jemalloc_active ? 'jemalloc live' : 'system allocator';
+    $('py-stats').innerHTML =
+      stat('pool size', (py.pool_size||0) + ' / ' + (py.pool_max||0)) +
+      stat('inflight', py.inflight||0) + stat('queue depth', py.queue_depth||0) +
+      stat('jobs completed', comma(py.jobs_completed||0)) +
+      stat('jobs shed', py.jobs_shed||0, (py.jobs_shed||0)>0?'var(--warn)':'var(--up)') +
+      stat('py alloc blocks', comma(memory.python_allocated_blocks||0));
+    $('facts').innerHTML =
+      fact('version', m.version||'—') + fact('instance id', m.instance_id||'—') +
+      fact('uptime', fmtUptime(m.uptime_seconds||0)) + fact('allocator', m.jemalloc_active?'jemalloc':'system') +
+      fact('dialogs', comma(dialogs)) + fact('registrations', comma(regs));
+
+    // integrations
+    $('dia-n').textContent = dia.peers_connected||0; $('dia-peers').textContent = dia.peers_connected||0;
+    $('rtp-n').textContent = (rtp.up||0)+' / '+(rtp.total||0); $('rtp-up').textContent = rtp.up||0; $('rtp-total').textContent = rtp.total||0;
+    $('sbi-sess').textContent = sbi.npcf_sessions_active||0;
+    $('ipsec-sa').textContent = (m.ipsec && m.ipsec.sa_pairs)||0;
+  }
+  function stat(k,v,color){ return '<div class="stat"><span class="k">'+k+'</span><span class="v"'+(color?' style="color:'+color+'"':'')+'>'+v+'</span></div>'; }
+  function fact(k,v){ return '<div class="fact"><span class="k">'+k+'</span><span class="v">'+v+'</span></div>'; }
+
+  async function refreshReady(){
+    try { var r = await api('/admin/ready'); var j = await r.json(); var draining = j.status === 'draining';
+      setBadge('b-ready', draining ? 'bad' : 'ok', true); $('b-ready').lastChild.textContent = draining ? 'DRAINING' : 'READY';
+      var d = $('hm-drain'); if (d){ d.textContent = draining ? 'yes' : 'no'; d.style.color = draining ? 'var(--warn)' : 'var(--text)'; }
+    } catch(e){}
+  }
+
+  // ---- registrations ----
+  var regsCache = [], regQuery = '';
+  function expColor(s){ return s > 300 ? 'var(--up)' : s > 120 ? 'var(--warn)' : 'var(--crit)'; }
+  function expPct(s){ return Math.max(4, Math.min(100, Math.round(s/600*100))); }
+  function regRow(r, withBtn){
+    var exp = r.expires_remaining||0;
+    var h = '<td class="aor">'+esc(r.aor)+'</td><td class="contact">'+esc(r.uri)+'</td><td class="q">'+(r.q!=null?r.q:'')+'</td>'
+      + '<td><span class="exp"><span class="bar"><i style="width:'+expPct(exp)+'%;background:'+expColor(exp)+'"></i></span>'+exp+'s</span></td>';
+    if (withBtn) h += '<td><button class="rowbtn'+(unlocked?' armed':'')+'" data-unreg="'+esc(r.aor)+'">unreg</button></td>';
+    return '<tr>'+h+'</tr>';
+  }
+  function esc(s){ return String(s==null?'':s).replace(/[&<>"]/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]; }); }
+  async function loadRegistrations(){
+    try {
+      var r = await api('/admin/registrations'); if (r.status === 401){ $('reg-rows').innerHTML = lockedRow(5); return; }
+      regsCache = await r.json();
+    } catch(e){ $('reg-rows').innerHTML = '<tr><td colspan="5" class="empty">failed to load</td></tr>'; return; }
+    renderRegs();
+  }
+  function renderRegs(){
+    var rows = regsCache.filter(function(r){ return !regQuery || (String(r.aor)+' '+String(r.uri)).toLowerCase().indexOf(regQuery) >= 0; });
+    $('reg-count').textContent = rows.length;
+    $('reg-rows').innerHTML = rows.length ? rows.map(function(r){ return regRow(r, true); }).join('') : '<tr><td colspan="5" class="empty">no registrations</td></tr>';
+  }
+  function lockedRow(cols){ return '<tr><td colspan="'+cols+'" class="empty">read access is protected — Unlock with an admin token</td></tr>'; }
+  $('q').addEventListener('input', function(e){ regQuery = e.target.value.toLowerCase().trim(); renderRegs(); });
+  $('reg-refresh').addEventListener('click', loadRegistrations);
+  $('reg-rows').addEventListener('click', function(e){
+    var b = e.target.closest('[data-unreg]'); if (!b) return;
+    if (!unlocked){ say('Locked — press Unlock and enter an admin token', true); return; }
+    var aor = b.getAttribute('data-unreg');
+    if (!confirm('Force-unregister '+aor+'? This removes all its contacts.')) return;
+    api('/admin/registrations/'+encodeURIComponent(aor), { method:'DELETE' }).then(function(r){
+      if (r.status === 401){ say('Unauthorized — check the admin token', true); return; }
+      if (r.ok){ say('Unregistered '+aor); loadRegistrations(); } else { say('Failed ('+r.status+')', true); }
+    }).catch(function(){ say('Request failed', true); });
+  });
+
+  // ---- bans ----
+  async function loadBans(){
+    var bans;
+    try { var r = await api('/admin/bans'); if (r.status === 401){ $('ban-rows').innerHTML = lockedRow(3); return; } bans = await r.json(); }
+    catch(e){ $('ban-rows').innerHTML = '<tr><td colspan="3" class="empty">failed to load</td></tr>'; return; }
+    $('ban-count').textContent = bans.length; $('nav-bans').textContent = bans.length || '';
+    $('ban-rows').innerHTML = bans.length ? bans.map(function(b){
+      var exp = b.expires_remaining||0;
+      return '<tr><td class="aor">'+esc(b.ip)+'</td><td><span class="exp"><span class="bar"><i style="width:'+Math.min(100,Math.round(exp/900*100))+'%;background:var(--warn)"></i></span>'+Math.floor(exp/60)+'m '+(exp%60)+'s</span></td>'
+        + '<td><button class="rowbtn'+(unlocked?' armed':'')+'" data-lift="'+esc(b.ip)+'">lift</button></td></tr>';
+    }).join('') : '<tr><td colspan="3" class="empty">no active bans</td></tr>';
+  }
+  $('ban-rows').addEventListener('click', function(e){
+    var b = e.target.closest('[data-lift]'); if (!b) return;
+    if (!unlocked){ say('Locked — press Unlock and enter an admin token', true); return; }
+    var ip = b.getAttribute('data-lift');
+    api('/admin/bans/'+encodeURIComponent(ip), { method:'DELETE' }).then(function(r){
+      if (r.status === 401){ say('Unauthorized — check the admin token', true); return; }
+      if (r.ok){ say('Ban lifted for '+ip); loadBans(); } else { say('Failed ('+r.status+')', true); }
+    }).catch(function(){ say('Request failed', true); });
+  });
+
+  // ---- overview recent-registrations preview ----
+  async function loadOverviewRegs(){
+    try { var r = await api('/admin/registrations'); if (!r.ok) return; var list = await r.json();
+      $('ov-regs').innerHTML = list.length ? list.slice(0,5).map(function(x){ return regRow(x, false); }).join('') : '<tr><td colspan="4" class="empty">no registrations</td></tr>';
+    } catch(e){}
+  }
+
+  // ---- boot ----
+  poll(); loadOverviewRegs();
+  setInterval(poll, 2000);
+  setInterval(function(){ if (document.getElementById('view-overview').classList.contains('show')) loadOverviewRegs(); }, 10000);
+})();
+</script>
+</body>
+</html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -142,6 +142,7 @@
   .irow .rt{margin-left:auto;text-align:right}
   .spill{font-family:var(--font-mono);font-size:10.5px;padding:2px 9px;border-radius:999px;border:1px solid var(--border);color:var(--muted)}
   .spill.up{color:var(--up);border-color:color-mix(in srgb,var(--up) 40%,var(--border));background:color-mix(in srgb,var(--up) 8%,transparent)}
+  .spill.down{color:var(--crit);border-color:color-mix(in srgb,var(--crit) 40%,var(--border))}
   .toast{position:fixed;bottom:22px;left:50%;transform:translateX(-50%) translateY(20px);background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:11px 16px;box-shadow:var(--shadow);font-family:var(--font-mono);font-size:12.5px;color:var(--text);opacity:0;pointer-events:none;transition:all .25s;z-index:40;display:flex;align-items:center;gap:9px}
   .toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
   .toast .di{width:8px;height:8px;border-radius:50%;background:var(--up)}
@@ -281,6 +282,8 @@
 
       <!-- INTEGRATIONS -->
       <div class="view" id="view-integrations">
+        <div class="sectlabel">Gateway groups</div>
+        <div id="gw-groups"><div class="card"><div class="panelbody empty">loading…</div></div></div>
         <div class="sectlabel">Connected subsystems</div>
         <div class="charts">
           <div class="card"><div class="panelhead"><span class="t">Diameter</span><span class="count-pill"><b id="dia-n">—</b> peers up</span></div><div class="panelbody"><div class="metaline"><span>Peers connected</span><b id="dia-peers">—</b></div></div></div>
@@ -346,6 +349,7 @@
     if (view === 'overview') charts.forEach(function(c){ c.resize(); });
     if (view === 'registrations') loadRegistrations();
     if (view === 'security') loadBans();
+    if (view === 'integrations') loadGateways();
   }
   $('nav').addEventListener('click', function(e){ var it = e.target.closest('.navitem'); if (!it) return; e.preventDefault(); go(it.getAttribute('data-view')); });
   document.querySelectorAll('[data-goto]').forEach(function(a){ a.addEventListener('click', function(){ go(a.getAttribute('data-goto')); }); });
@@ -545,6 +549,30 @@
       if (r.ok){ say('Ban lifted for '+ip); loadBans(); } else { say('Failed ('+r.status+')', true); }
     }).catch(function(){ say('Request failed', true); });
   });
+
+  // ---- gateways ----
+  async function loadGateways(){
+    var groups;
+    try {
+      var r = await api('/admin/gateways');
+      if (r.status === 401){ $('gw-groups').innerHTML = '<div class="card"><div class="panelbody empty">read access is protected — Unlock with an admin token</div></div>'; return; }
+      groups = await r.json();
+    } catch(e){ $('gw-groups').innerHTML = '<div class="card"><div class="panelbody empty">failed to load</div></div>'; return; }
+    if (!groups.length){ $('gw-groups').innerHTML = '<div class="card"><div class="panelbody empty">no gateway groups configured</div></div>'; return; }
+    $('gw-groups').innerHTML = groups.map(function(g){
+      var rows = (g.destinations||[]).map(function(d){
+        var attrs = Object.keys(d.attrs||{}).map(function(k){ return k+'='+d.attrs[k]; }).join(' ');
+        return '<tr><td class="aor">'+esc(d.uri)+'</td><td class="contact">'+esc(d.address)+' '+esc(d.transport)+'</td>'
+          + '<td>'+(d.healthy?'<span class="spill up">● up</span>':'<span class="spill down">● down</span>')+'</td>'
+          + '<td class="q">'+d.weight+'</td><td class="q">'+d.priority+'</td><td class="contact">'+esc(attrs)+'</td></tr>';
+      }).join('');
+      var col = g.up === g.total ? 'var(--up)' : (g.up > 0 ? 'var(--warn)' : 'var(--crit)');
+      return '<div class="card" style="margin-bottom:14px"><div class="panelhead">'
+        + '<span class="t">'+esc(g.name)+' <span class="count-pill" style="margin-left:8px">'+esc(g.algorithm)+'</span></span>'
+        + '<span class="count-pill"><b style="color:'+col+'">'+g.up+' / '+g.total+'</b> up</span></div>'
+        + '<div class="tblscroll"><table class="tbl"><thead><tr><th>Destination</th><th>Address</th><th>Health</th><th>Weight</th><th>Priority</th><th>Attrs</th></tr></thead><tbody>'+rows+'</tbody></table></div></div>';
+    }).join('');
+  }
 
   // ---- overview recent-registrations preview ----
   async function loadOverviewRegs(){

--- a/ui/index.html
+++ b/ui/index.html
@@ -192,6 +192,7 @@
   <div class="main">
     <header class="topbar">
       <div class="crumb" id="crumb">Overview</div>
+      <span class="badge" title="The web dashboard is an experimental feature and may change" style="color:var(--warn);border-color:color-mix(in srgb,var(--warn) 45%,var(--border));background:color-mix(in srgb,var(--warn) 10%,transparent)">experimental</span>
       <div class="spacer"></div>
       <div class="badges" id="badges">
         <span class="badge" id="b-live"><span class="led"></span>LIVE</span>


### PR DESCRIPTION
## What

Adds an **embedded operator web dashboard** to the admin HTTP listener, plus the
two pieces of plumbing it needs:

- **`GET /admin/metrics.json`** — a curated JSON snapshot of the live gauges and
  counters (SIP, memory, Python executor, Diameter, rtpengine, SBI, security).
  Cumulative counters are exposed raw so a client diffs them over time to derive
  rates — no server-side time series. Useful on its own for custom tooling that
  would rather not parse the Prometheus text format.
- **Bearer-token auth for the admin API** (`admin.auth.token`). The admin API can
  force-unregister AoRs and lift auto-bans; today that's protected only by
  network placement. When a token is set, the mutating `DELETE` routes require
  `Authorization: Bearer <token>` (constant-time compared); `protect_reads: true`
  extends it to the read routes and `/metrics`. Unset = open, exactly as before.
- **The dashboard itself** — a single-page UI baked into the binary and served
  same-origin at the admin listener root: Overview (live tiles + canvas charts
  for dialogs, SIP request rate, memory), Registrations (searchable, with
  force-unregister), Security (threat counters + active bans, with lift-ban),
  System (jemalloc/glibc memory, Python executor pool, runtime facts), and
  Integrations (Diameter / rtpengine / SBI). Write actions sit behind an
  **Unlock** control that takes the admin token.

## Why

The recent CORS work (#98) existed so a browser dashboard on *another* origin
could reach `/metrics` and the admin API. Serving the UI same-origin from siphon
removes that need entirely and gives operators a built-in view with zero extra
moving parts.

## Feature gating (keeps the library path clean)

The dashboard is behind a **non-default `ui` cargo feature** (`rust-embed` +
`mime_guess`, compiled only under `--features ui`). The default binary and any
project embedding siphon as a library pull none of it. A binary built without
`--features ui` logs a warning and serves nothing when `admin.ui.enabled` is set
— same "config still parses, feature off = loud warn" contract as `sctp`.

The auth layer and `/admin/metrics.json` are **not** feature-gated — they harden
and extend the admin API in every build.

## Delivery

The dashboard is a single self-contained `ui/index.html` (inline CSS/JS, no
external fetch), embedded with `rust-embed` — **no Node/Vite build step**, so
`--all-features` builds and the crate package stay self-contained. If the UI
grows past what one hand-written file wants to be, migrating to a Vite/React
build behind the same feature is a mechanical follow-up.

## Config

```yaml
admin:
  listen: "127.0.0.1:9091"
  auth:
    token: "${ADMIN_TOKEN}"
    protect_reads: false
  ui:
    enabled: true          # requires a binary built with --features ui
```

## Tests

- New unit tests (admin): `/admin/metrics.json` shape, bearer auth (401 without /
  with / wrong token, reads open by default, `protect_reads` gates GET),
  constant-time compare, and (under `--features ui`) the dashboard is served at
  `/` as `text/html` when enabled and 404s when disabled.
- New unit tests (metrics): `sum_int_counter_vec`, `gauge_vec_by_label`.
- Full suite green on default features and `--features ui`; `cargo clippy
  --all-targets --all-features -D warnings` clean.

## Validation status

Backend (endpoints, auth, feature gating) is covered by tests end-to-end via the
tower service. The browser rendering against a live node is best validated by
running `--features ui` with `admin.ui.enabled` and opening the admin port — the
data contract matches the endpoints, but the live render hasn't been exercised in
CI (there's no headless browser in the pipeline).

## Follow-ups (not in this PR)

- Per-peer / per-instance detail for the Integrations page (needs new admin read
  endpoints; today it shows the counts from `metrics.json`).
- Optional Vite/React migration if the UI grows.
