### PR TITLE
fix(b2bua): route in-dialog re-INVITE/UPDATE/BYE by dialog identity, not source socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Fixed
+- **In-dialog re-INVITE / UPDATE / BYE are now routed by SIP dialog identity, not
+  by source socket.** A B2BUA decided which leg an in-dialog request belonged to
+  by comparing the request's source address against that leg's original INVITE
+  socket. A peer that opens a fresh connection per transaction (a new TLS
+  connection has a new source port, as some carrier SBCs do) or rebinds its NAT
+  port therefore looked like it came from the wrong leg: the request was
+  reflected back at the leg it arrived on instead of being bridged to the far
+  leg. The consequence was a re-INVITE that never reached the other side, media
+  that was never renegotiated, and the call being torn down seconds later.
+  Direction is now taken from the Call-ID (with the From-tag as a tie-breaker for
+  `preserve_call_id` dialogs); an in-dialog request whose Call-ID matches no live
+  dialog leg is answered `481 Call/Transaction Does Not Exist`. The originating
+  leg's flow is refreshed on every in-dialog request so the response and later
+  requests reach the peer's live connection, and a B-to-A forward reuses that
+  live connection (falling back to the remote-target Contact when a TLS
+  connection has closed) instead of dialing the peer's dead ephemeral source
+  port.
+
+### Changed
+- **Bound to a wildcard address with no `advertised_address`, Via/Contact now use
+  the host's auto-detected routable local IP instead of `127.0.0.1`.** An
+  instance listening on `0.0.0.0` / `[::]` without `advertised_address` used to
+  advertise loopback, which no remote peer can reach and from which no new
+  outbound TLS connection can be opened. It now performs a dependency-free route
+  lookup to pick the primary local address; loopback remains only as a last
+  resort on a host with no default route. Setting `advertised_address`
+  explicitly is still recommended behind NAT, where the auto-detected address is
+  the private one.
+
 ## [1.4.0] — 2026-07-14
 
 _Codename: bjorn._

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -457,6 +457,20 @@ impl Leg {
             auth_challenged: false,
         }
     }
+
+    /// True for the re-INVITE/UPDATE response-tracking pseudo-legs the
+    /// dispatcher inserts as B-legs. Their `target_uri` is a direction marker
+    /// (`reinvite:`/`update:`/`…_done:`) and they deliberately reuse another
+    /// leg's Call-ID for response routing, so they must be excluded from
+    /// dialog-identity direction matching.
+    pub fn is_tracking_leg(&self) -> bool {
+        self.dialog.target_uri.as_deref().is_some_and(|target| {
+            target.starts_with("reinvite:")
+                || target.starts_with("reinvite_done:")
+                || target.starts_with("update:")
+                || target.starts_with("update_done:")
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -730,6 +744,60 @@ impl CallActor {
             auth_retry_count: 0,
             answer_deadline: None,
             auth_passthrough: false,
+        }
+    }
+
+    /// Which leg an in-dialog request (re-INVITE / UPDATE / BYE) arrived on,
+    /// determined by SIP dialog identity (RFC 3261 §12 — Call-ID, with the
+    /// From-tag only as a tie-breaker), never by source socket.
+    ///
+    /// A peer that reconnects per transaction (TLS) or rebinds its NAT port
+    /// sends the in-dialog request from a *different* source address than its
+    /// original INVITE, so comparing sockets misroutes the request (it gets
+    /// reflected back at the leg it came from). The Call-ID is stable across
+    /// the dialog, so it is the correct discriminator.
+    ///
+    /// Returns `None` when the Call-ID matches no live dialog on this call —
+    /// the caller answers 481 Call/Transaction Does Not Exist.
+    pub fn request_direction(&self, sip_call_id: &str, from_tag: Option<&str>) -> Option<LegSide> {
+        let a_match = self.a_leg.dialog.call_id == sip_call_id;
+        let winner_b = self.winner.and_then(|index| self.b_legs.get(index));
+        let b_match = winner_b.is_some_and(|leg| leg.dialog.call_id == sip_call_id);
+
+        match (a_match, b_match) {
+            (true, false) => Some(LegSide::A),
+            (false, true) => Some(LegSide::B),
+            (true, true) => {
+                // Both legs carry the same Call-ID — `preserve_call_id` copies
+                // the A-leg Call-ID onto the B-leg. Disambiguate by From-tag:
+                // an in-dialog request's From-tag is the *peer's* own tag,
+                // which is what we stored as each leg's `remote_tag`.
+                let from_tag = from_tag?;
+                if self.a_leg.dialog.remote_tag.as_deref() == Some(from_tag) {
+                    Some(LegSide::A)
+                } else if winner_b.and_then(|leg| leg.dialog.remote_tag.as_deref())
+                    == Some(from_tag)
+                {
+                    Some(LegSide::B)
+                } else {
+                    None
+                }
+            }
+            (false, false) => {
+                // No winner yet (early dialog): an UPDATE (RFC 3311 §5.2) may
+                // arrive on a not-yet-won fork leg. Match any real
+                // (non-tracking) B-leg's Call-ID.
+                if self.winner.is_none()
+                    && self
+                        .b_legs
+                        .iter()
+                        .any(|leg| !leg.is_tracking_leg() && leg.dialog.call_id == sip_call_id)
+                {
+                    Some(LegSide::B)
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -425,6 +425,37 @@ impl DispatcherState {
     }
 }
 
+/// Resolve the address SIPhon advertises in Via/Contact (and uses as its
+/// `local_addr`) when the listener is bound to a wildcard address.
+///
+/// Precedence: an explicit `advertised_address` IP literal wins; otherwise, for
+/// a wildcard bind, the host's auto-detected routable local IP
+/// ([`crate::transport::detect_routable_local_ip`]); loopback is the last resort
+/// (a truly loopback-only host, or an advertised hostname that isn't an IP
+/// literal on a host with no default route). A non-wildcard bind is returned
+/// unchanged.
+///
+/// `advertised_address` may be a hostname (used verbatim for the Via/Contact
+/// host via `via_host`); it does not parse to an IP here, so this falls through
+/// to auto-detect for `local_addr` — still routable, unlike the old loopback.
+fn resolve_via_addr(local_addr: SocketAddr, advertised_address: Option<&str>) -> SocketAddr {
+    if !local_addr.ip().is_unspecified() {
+        return local_addr;
+    }
+    if let Some(ip) = advertised_address.and_then(|host| host.parse::<std::net::IpAddr>().ok()) {
+        return SocketAddr::new(ip, local_addr.port());
+    }
+    if let Some(ip) = crate::transport::detect_routable_local_ip(local_addr.is_ipv6()) {
+        return SocketAddr::new(ip, local_addr.port());
+    }
+    let loopback = if local_addr.is_ipv6() {
+        std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
+    } else {
+        std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+    };
+    SocketAddr::new(loopback, local_addr.port())
+}
+
 /// Run the core dispatcher loop.
 ///
 /// Reads inbound messages from transport, parses, invokes Python handlers,
@@ -460,34 +491,28 @@ pub async fn run(
     product_name: &'static str,
     product_version: &'static str,
 ) {
-    // Resolve the local address for Via insertion.
-    // If bound to 0.0.0.0 / [::], use advertised_address from config, or loopback.
-    let via_addr = if local_addr.ip().is_unspecified() {
-        let fallback = if local_addr.is_ipv6() { "::1" } else { "127.0.0.1" };
-        let host = config
-            .advertised_address
-            .as_deref()
-            .unwrap_or(fallback);
-        if config.advertised_address.is_none() {
+    // Resolve the local address for Via insertion. When bound to a wildcard
+    // (0.0.0.0 / [::]), prefer an explicit `advertised_address`, else the host's
+    // auto-detected routable IP, else loopback (see resolve_via_addr).
+    let via_addr = resolve_via_addr(local_addr, config.advertised_address.as_deref());
+    if local_addr.ip().is_unspecified() && config.advertised_address.is_none() {
+        if via_addr.ip().is_loopback() {
             warn!(
                 bind = %local_addr,
-                "binding to unspecified address with no `advertised_address` configured — \
-                 Via/Contact will use {fallback}; remote peers will not be able to reach this instance"
+                "bound to an unspecified address with no `advertised_address` and no routable \
+                 local IP detected — Via/Contact will use loopback; remote peers cannot reach \
+                 this instance. Set `advertised_address`."
+            );
+        } else {
+            warn!(
+                bind = %local_addr,
+                advertised = %via_addr.ip(),
+                "bound to an unspecified address with no `advertised_address` — using the \
+                 auto-detected local IP for Via/Contact. Behind NAT, set `advertised_address` \
+                 to the public address."
             );
         }
-        let ip: std::net::IpAddr = host
-            .parse()
-            .unwrap_or_else(|_| {
-                if local_addr.is_ipv6() {
-                    std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
-                } else {
-                    std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
-                }
-            });
-        SocketAddr::new(ip, local_addr.port())
-    } else {
-        local_addr
-    };
+    }
 
     let default_server = format!("{product_name}/{product_version}");
     let server_header = Some(
@@ -4940,6 +4965,45 @@ fn resolve_candidates_inner(
 /// weighted-random / shuffled pick on every call.
 fn resolve_target(uri_string: &str, resolver: &SipResolver) -> Option<RelayTarget> {
     resolve_candidates(uri_string, resolver).into_iter().next()
+}
+
+/// For a B→A in-dialog forward over **TLS**, decide whether to dial the remote
+/// target Contact instead of the target leg's cached socket.
+///
+/// A peer that opens a fresh TLS connection per transaction (e.g. a Teams
+/// Direct Routing SBC) closes its old connection; the leg's cached
+/// `remote_addr` is then the peer's dead *source* port and its cached
+/// `connection_id` is gone from the connection map, so both the reuse path and
+/// the cached-socket fallback would time out. In that case dial the remote
+/// target Contact's resolved host:port (RFC 3261 §12.2.1.1 — e.g. the SBC's
+/// `…pstnhub…:443`), carrying the SNI needed for the new TLS handshake.
+///
+/// Returns `None` (keep the default reuse / cached-socket path) unless: the
+/// forward is B→A, over TLS, there is no dialog route set to follow, and the
+/// leg's TLS connection is no longer registered as alive. Scoped to TLS
+/// because only the TLS listener registers inbound connections in
+/// `stream_connections` (a TCP inbound connection is invisible there, so its
+/// liveness can't be judged this way, and a NAT'd peer must keep its cached
+/// source socket).
+fn contact_fallback_target(
+    from_a_leg: bool,
+    send_dest: SocketAddr,
+    send_transport: Transport,
+    target_connection_id: ConnectionId,
+    route_set_empty: bool,
+    remote_contact: Option<&str>,
+    state: &DispatcherState,
+) -> Option<RelayTarget> {
+    if from_a_leg
+        || send_transport != Transport::Tls
+        || !route_set_empty
+        || state
+            .stream_connections
+            .is_alive(send_dest, send_transport, target_connection_id)
+    {
+        return None;
+    }
+    resolve_target(remote_contact?, &state.dns_resolver)
 }
 
 /// Send a relayed request to a resolved target, using the connection pool for
@@ -12088,18 +12152,42 @@ fn handle_b2bua_bye(
         }
     };
 
-    // Extract everything from the DashMap ref and drop it before entering Python
-    let (from_a_leg, a_leg_invite, a_leg_source_ip, a_leg_transport) =
+    // In-dialog direction by dialog identity (RFC 3261 §12 — Call-ID + From-tag),
+    // never by source socket: a peer that reconnects per transaction (TLS) or
+    // rebinds its NAT port sends the BYE from a different address than its
+    // INVITE. A Call-ID that matches no live dialog leg is answered 481 here,
+    // before the Python on_bye handlers + CDR finalize below, so a stray BYE
+    // can't close a CDR with a bogus direction.
+    let from_tag = message.typed_from().ok().flatten().and_then(|na| na.tag);
+    let from_a_leg = match state
+        .call_actors
+        .get_call(&call_id)
+        .and_then(|call| call.request_direction(&sip_call_id, from_tag.as_deref()))
+    {
+        Some(crate::b2bua::actor::LegSide::A) => true,
+        Some(crate::b2bua::actor::LegSide::B) => false,
+        None => {
+            warn!(sip_call_id = %sip_call_id, "B2BUA BYE: Call-ID matches no dialog leg — 481");
+            let response = build_response(
+                &message, 481, "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(), &[],
+            );
+            send_message_from(
+                response, inbound.transport, inbound.remote_addr,
+                inbound.connection_id, Some(inbound.local_addr), state,
+            );
+            return;
+        }
+    };
+
+    // Extract the rest from the DashMap ref and drop it before entering Python
+    let (a_leg_invite, a_leg_source_ip, a_leg_transport) =
         match state.call_actors.get_call(&call_id) {
-            Some(call) => {
-                let from_a = inbound.remote_addr == call.a_leg.transport.remote_addr;
-                (
-                    from_a,
-                    call.a_leg_invite.clone(),
-                    call.a_leg.transport.remote_addr.ip().to_string(),
-                    format!("{}", call.a_leg.transport.transport).to_lowercase(),
-                )
-            }
+            Some(call) => (
+                call.a_leg_invite.clone(),
+                call.a_leg.transport.remote_addr.ip().to_string(),
+                format!("{}", call.a_leg.transport.transport).to_lowercase(),
+            ),
             None => return,
         };
 
@@ -12422,7 +12510,9 @@ fn b2bua_send_refresh_reinvite(call_id: &str, state: &DispatcherState) {
         branch.clone(),
         LegTransport {
             remote_addr: b_leg.transport.remote_addr,
-            connection_id: ConnectionId::default(),
+            // Track the B-leg's live connection (consistent with the in-dialog
+            // re-INVITE/UPDATE forward reuse) rather than a placeholder.
+            connection_id: b_leg.transport.connection_id,
             transport: b_leg.transport.transport,
             local_addr: None,
         },
@@ -12967,12 +13057,71 @@ fn handle_b2bua_reinvite(
         }
     };
 
-    // Determine direction and extract routing info + per-leg contacts
-    let (from_a_leg, a_leg, winner_b_leg) = match state.call_actors.get_call(&call_id) {
+    // In-dialog direction by dialog identity (RFC 3261 §12 — Call-ID + From-tag),
+    // never by source socket: a Teams-style peer opens a NEW TLS connection (new
+    // source port) for its re-INVITE, so a socket comparison misclassifies the
+    // direction and reflects the re-INVITE back at the leg it came from.
+    let from_tag = message.typed_from().ok().flatten().and_then(|na| na.tag);
+    let from_a_leg = match state
+        .call_actors
+        .get_call(&call_id)
+        .and_then(|call| call.request_direction(&sip_call_id, from_tag.as_deref()))
+    {
+        Some(crate::b2bua::actor::LegSide::A) => true,
+        Some(crate::b2bua::actor::LegSide::B) => false,
+        None => {
+            warn!(sip_call_id = %sip_call_id, "B2BUA re-INVITE: Call-ID matches no dialog leg — 481");
+            let response = build_response(
+                &message, 481, "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(), &[],
+            );
+            send_message_from(
+                response, inbound.transport, inbound.remote_addr,
+                inbound.connection_id, Some(inbound.local_addr), state,
+            );
+            return;
+        }
+    };
+
+    // Flow refresh (RFC 5626 / RFC 3261 §12.2.2): the peer may have sent this
+    // in-dialog re-INVITE on a new flow (TLS reconnect / NAT rebind). Re-anchor
+    // the originating leg's transport + remote target on the arrival flow so the
+    // 200 OK toward that peer — and later in-dialog requests — reach the live
+    // connection instead of the peer's dead original socket. Done before the
+    // snapshot below so the clones carry the live flow.
+    let refreshed_contact = message
+        .headers
+        .get("Contact")
+        .or_else(|| message.headers.get("m"))
+        .map(|value| crate::b2bua::actor::extract_contact_uri(value));
+    if let Some(mut call) = state.call_actors.get_call_mut(&call_id) {
+        let winner_index = call.winner;
+        let origin_leg: Option<&mut Leg> = if from_a_leg {
+            Some(&mut call.a_leg)
+        } else if let Some(index) = winner_index {
+            call.b_legs.get_mut(index)
+        } else {
+            None
+        };
+        if let Some(leg) = origin_leg {
+            if leg.transport.remote_addr != inbound.remote_addr
+                || leg.transport.connection_id != inbound.connection_id
+            {
+                leg.transport.remote_addr = inbound.remote_addr;
+                leg.transport.connection_id = inbound.connection_id;
+                leg.transport.local_addr = Some(inbound.local_addr);
+            }
+            if let Some(ref contact) = refreshed_contact {
+                leg.dialog.remote_contact = Some(contact.clone());
+            }
+        }
+    }
+
+    // Snapshot routing info + per-leg contacts AFTER the flow refresh.
+    let (a_leg, winner_b_leg) = match state.call_actors.get_call(&call_id) {
         Some(call) => {
-            let from_a = inbound.remote_addr == call.a_leg.transport.remote_addr;
             let b_leg = call.winner.and_then(|i| call.b_legs.get(i).cloned());
-            (from_a, call.a_leg.clone(), b_leg)
+            (call.a_leg.clone(), b_leg)
         }
         None => return,
     };
@@ -13065,7 +13214,7 @@ fn handle_b2bua_reinvite(
                 &b_leg.dialog.local_tag,
                 b_leg.dialog.remote_tag.as_deref(),
             );
-            Some((b_leg.transport.remote_addr, b_leg.transport.transport, b_leg.transport.local_addr, b_leg.dialog.call_id.clone(), b_leg.dialog.local_tag.clone()))
+            Some((b_leg.transport.remote_addr, b_leg.transport.transport, b_leg.transport.local_addr, b_leg.transport.connection_id, b_leg.dialog.call_id.clone(), b_leg.dialog.local_tag.clone()))
         } else {
             warn!(call_id = %call_id, "B2BUA re-INVITE: no winning B-leg");
             return;
@@ -13081,10 +13230,10 @@ fn handle_b2bua_reinvite(
                 Some(&a_leg.dialog.local_tag),
             );
         }
-        Some((a_leg.transport.remote_addr, a_leg.transport.transport, a_leg.transport.local_addr, a_leg.dialog.call_id.clone(), a_leg.dialog.remote_tag.clone().unwrap_or_default()))
+        Some((a_leg.transport.remote_addr, a_leg.transport.transport, a_leg.transport.local_addr, a_leg.transport.connection_id, a_leg.dialog.call_id.clone(), a_leg.dialog.remote_tag.clone().unwrap_or_default()))
     };
 
-    if let Some((destination, transport, target_local_addr, leg_call_id, leg_from_tag)) = reinvite_target {
+    if let Some((destination, transport, target_local_addr, target_connection_id, leg_call_id, leg_from_tag)) = reinvite_target {
         // Set Via with correct transport for the target leg
         let transport_str = format!("{}", transport).to_uppercase();
         let via_value = format!(
@@ -13261,7 +13410,10 @@ fn handle_b2bua_reinvite(
             branch.clone(),
             LegTransport {
                 remote_addr: send_dest,
-                connection_id: ConnectionId::default(),
+                // Reuse the target leg's live connection (mirrors the framework
+                // BYE) so a B→A forward writes on the connection the peer is on
+                // rather than dialing its dead ephemeral source port.
+                connection_id: target_connection_id,
                 transport: send_transport,
                 // Anchor the tracking leg on the target's socket (the A-leg's arrival
                 // listener for B→A) so a post-teardown zombie re-ACK to this leg
@@ -13273,19 +13425,32 @@ fn handle_b2bua_reinvite(
         reinvite_leg.stored_cseq = message.headers.cseq().map(|c| c.to_string());
         state.call_actors.add_b_leg(&call_id, reinvite_leg);
 
-        // Forward B→A on the A-leg's anchored socket (multi-homed source-port
-        // parity — pins the UDP egress; connection selection is unchanged, same as
-        // send_b2bua_to_bleg). A→B (target_local_addr None) egresses as before.
-        if let Some(source) = target_local_addr {
-            let data = Bytes::from(forwarded.to_bytes());
-            let target = RelayTarget {
-                address: send_dest,
-                transport: Some(send_transport),
-                server_name: None,
-            };
-            send_to_target(data, &target, send_transport, ConnectionId::default(), Some(source), state);
-        } else {
+        // Forward to the target leg. A→B: destination-keyed reuse via
+        // stream_connections + pool/SNI. B→A: reuse the target leg's live
+        // connection via the connection_map exactly like the framework BYE
+        // (send_message_from → OutboundRouter → TLS/TCP distributor connection_map
+        // lookup, dialing only on a miss); target_local_addr keeps the UDP egress
+        // pinned for multi-homed source-port parity. If the target's TLS
+        // connection is dead, dial its remote-target Contact instead of the dead
+        // cached socket (RFC 3261 §12.2.1.1).
+        let contact_fallback = contact_fallback_target(
+            from_a_leg, send_dest, send_transport, target_connection_id,
+            target_route_set.is_empty(), target_remote_contact.as_deref(), state,
+        );
+        if from_a_leg {
             send_b2bua_to_bleg(forwarded, send_transport, send_dest, state);
+        } else if let Some(target) = contact_fallback {
+            warn!(
+                call_id = %call_id, dest = %target.address,
+                "B2BUA re-INVITE B→A: stored TLS connection dead — dialing remote target Contact"
+            );
+            let data = Bytes::from(forwarded.to_bytes());
+            send_to_target(data, &target, send_transport, ConnectionId::default(), target_local_addr, state);
+        } else {
+            send_message_from(
+                forwarded, send_transport, send_dest,
+                target_connection_id, target_local_addr, state,
+            );
         }
 
         // Increment the target leg's local CSeq after sending the re-INVITE
@@ -13338,11 +13503,67 @@ fn handle_b2bua_update(
         }
     };
 
-    let (from_a_leg, a_leg, winner_b_leg) = match state.call_actors.get_call(&call_id) {
+    // In-dialog direction by dialog identity (RFC 3261 §12 — Call-ID + From-tag),
+    // never by source socket (RFC 3311 UPDATE; same reconnect/NAT hazard as the
+    // re-INVITE path). A Call-ID matching no live dialog leg is answered 481.
+    let from_tag = message.typed_from().ok().flatten().and_then(|na| na.tag);
+    let from_a_leg = match state
+        .call_actors
+        .get_call(&call_id)
+        .and_then(|call| call.request_direction(&sip_call_id, from_tag.as_deref()))
+    {
+        Some(crate::b2bua::actor::LegSide::A) => true,
+        Some(crate::b2bua::actor::LegSide::B) => false,
+        None => {
+            warn!(sip_call_id = %sip_call_id, "B2BUA UPDATE: Call-ID matches no dialog leg — 481");
+            let response = build_response(
+                &message, 481, "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(), &[],
+            );
+            send_message_from(
+                response, inbound.transport, inbound.remote_addr,
+                inbound.connection_id, Some(inbound.local_addr), state,
+            );
+            return;
+        }
+    };
+
+    // Flow refresh (RFC 5626 / RFC 3261 §12.2.2): re-anchor the originating leg
+    // on the arrival flow so the UPDATE 200 OK and later in-dialog requests reach
+    // the live connection. Done before the snapshot so the clones carry it.
+    let refreshed_contact = message
+        .headers
+        .get("Contact")
+        .or_else(|| message.headers.get("m"))
+        .map(|value| crate::b2bua::actor::extract_contact_uri(value));
+    if let Some(mut call) = state.call_actors.get_call_mut(&call_id) {
+        let winner_index = call.winner;
+        let origin_leg: Option<&mut Leg> = if from_a_leg {
+            Some(&mut call.a_leg)
+        } else if let Some(index) = winner_index {
+            call.b_legs.get_mut(index)
+        } else {
+            None
+        };
+        if let Some(leg) = origin_leg {
+            if leg.transport.remote_addr != inbound.remote_addr
+                || leg.transport.connection_id != inbound.connection_id
+            {
+                leg.transport.remote_addr = inbound.remote_addr;
+                leg.transport.connection_id = inbound.connection_id;
+                leg.transport.local_addr = Some(inbound.local_addr);
+            }
+            if let Some(ref contact) = refreshed_contact {
+                leg.dialog.remote_contact = Some(contact.clone());
+            }
+        }
+    }
+
+    // Snapshot routing info + per-leg contacts AFTER the flow refresh.
+    let (a_leg, winner_b_leg) = match state.call_actors.get_call(&call_id) {
         Some(call) => {
-            let from_a = inbound.remote_addr == call.a_leg.transport.remote_addr;
             let b_leg = call.winner.and_then(|i| call.b_legs.get(i).cloned());
-            (from_a, call.a_leg.clone(), b_leg)
+            (call.a_leg.clone(), b_leg)
         }
         None => return,
     };
@@ -13390,7 +13611,7 @@ fn handle_b2bua_update(
                 &b_leg.dialog.local_tag,
                 b_leg.dialog.remote_tag.as_deref(),
             );
-            Some((b_leg.transport.remote_addr, b_leg.transport.transport, b_leg.transport.local_addr, b_leg.dialog.call_id.clone(), b_leg.dialog.local_tag.clone()))
+            Some((b_leg.transport.remote_addr, b_leg.transport.transport, b_leg.transport.local_addr, b_leg.transport.connection_id, b_leg.dialog.call_id.clone(), b_leg.dialog.local_tag.clone()))
         } else {
             warn!(call_id = %call_id, "B2BUA UPDATE: no winning B-leg");
             return;
@@ -13405,10 +13626,10 @@ fn handle_b2bua_update(
                 Some(&a_leg.dialog.local_tag),
             );
         }
-        Some((a_leg.transport.remote_addr, a_leg.transport.transport, a_leg.transport.local_addr, a_leg.dialog.call_id.clone(), a_leg.dialog.remote_tag.clone().unwrap_or_default()))
+        Some((a_leg.transport.remote_addr, a_leg.transport.transport, a_leg.transport.local_addr, a_leg.transport.connection_id, a_leg.dialog.call_id.clone(), a_leg.dialog.remote_tag.clone().unwrap_or_default()))
     };
 
-    if let Some((destination, transport, target_local_addr, leg_call_id, leg_from_tag)) = update_target {
+    if let Some((destination, transport, target_local_addr, target_connection_id, leg_call_id, leg_from_tag)) = update_target {
         let transport_str = format!("{}", transport).to_uppercase();
         let via_value = format!(
             "SIP/2.0/{} {}:{};branch={}",
@@ -13573,7 +13794,10 @@ fn handle_b2bua_update(
             branch.clone(),
             LegTransport {
                 remote_addr: send_dest,
-                connection_id: ConnectionId::default(),
+                // Reuse the target leg's live connection (mirrors the framework
+                // BYE) so a B→A forward writes on the connection the peer is on
+                // rather than dialing its dead ephemeral source port.
+                connection_id: target_connection_id,
                 transport: send_transport,
                 // Anchor the tracking leg on the target's socket (the A-leg's arrival
                 // listener for B→A) so a post-teardown zombie re-ACK to this leg
@@ -13585,19 +13809,32 @@ fn handle_b2bua_update(
         update_leg.stored_cseq = message.headers.cseq().map(|c| c.to_string());
         state.call_actors.add_b_leg(&call_id, update_leg);
 
-        // Forward B→A on the A-leg's anchored socket (multi-homed source-port
-        // parity — pins the UDP egress; connection selection is unchanged, same as
-        // send_b2bua_to_bleg). A→B (target_local_addr None) egresses as before.
-        if let Some(source) = target_local_addr {
-            let data = Bytes::from(forwarded.to_bytes());
-            let target = RelayTarget {
-                address: send_dest,
-                transport: Some(send_transport),
-                server_name: None,
-            };
-            send_to_target(data, &target, send_transport, ConnectionId::default(), Some(source), state);
-        } else {
+        // Forward to the target leg. A→B: destination-keyed reuse via
+        // stream_connections + pool/SNI. B→A: reuse the target leg's live
+        // connection via the connection_map exactly like the framework BYE
+        // (send_message_from → OutboundRouter → TLS/TCP distributor connection_map
+        // lookup, dialing only on a miss); target_local_addr keeps the UDP egress
+        // pinned for multi-homed source-port parity. If the target's TLS
+        // connection is dead, dial its remote-target Contact instead of the dead
+        // cached socket (RFC 3261 §12.2.1.1).
+        let contact_fallback = contact_fallback_target(
+            from_a_leg, send_dest, send_transport, target_connection_id,
+            target_route_set.is_empty(), target_remote_contact.as_deref(), state,
+        );
+        if from_a_leg {
             send_b2bua_to_bleg(forwarded, send_transport, send_dest, state);
+        } else if let Some(target) = contact_fallback {
+            warn!(
+                call_id = %call_id, dest = %target.address,
+                "B2BUA UPDATE B→A: stored TLS connection dead — dialing remote target Contact"
+            );
+            let data = Bytes::from(forwarded.to_bytes());
+            send_to_target(data, &target, send_transport, ConnectionId::default(), target_local_addr, state);
+        } else {
+            send_message_from(
+                forwarded, send_transport, send_dest,
+                target_connection_id, target_local_addr, state,
+            );
         }
 
         // Bump local CSeq on the target leg after sending.
@@ -16803,6 +17040,39 @@ a=rtpmap:8 PCMA/8000\r\n";
     fn clear_media_session_on_timeout_no_store_is_noop() {
         // Media backend not configured (rtpengine_sessions is None) → false.
         assert!(!clear_media_session_on_timeout(None, "1-1354742@host"));
+    }
+
+    #[test]
+    fn resolve_via_addr_explicit_ip_wins() {
+        let bind: SocketAddr = "0.0.0.0:5060".parse().unwrap();
+        // Explicit advertised IP literal is used verbatim (port from the bind).
+        let got = resolve_via_addr(bind, Some("203.0.113.9"));
+        assert_eq!(got, "203.0.113.9:5060".parse().unwrap());
+    }
+
+    #[test]
+    fn resolve_via_addr_specific_bind_unchanged() {
+        // A non-wildcard bind is returned as-is, advertised_address irrelevant.
+        let bind: SocketAddr = "198.51.100.5:5060".parse().unwrap();
+        assert_eq!(resolve_via_addr(bind, None), bind);
+        assert_eq!(resolve_via_addr(bind, Some("203.0.113.9")), bind);
+    }
+
+    #[test]
+    fn resolve_via_addr_wildcard_never_loopback_when_route_exists() {
+        // Wildcard bind, no advertised_address: auto-detect. Never loopback when
+        // a routable IP is available; falls back to loopback only otherwise.
+        let bind: SocketAddr = "0.0.0.0:5060".parse().unwrap();
+        let got = resolve_via_addr(bind, None);
+        assert_eq!(got.port(), 5060);
+        if crate::transport::detect_routable_local_ip(false).is_some() {
+            assert!(!got.ip().is_loopback(), "expected a routable IP, got {got}");
+        }
+        // A hostname (not an IP literal) falls through to auto-detect, not loopback.
+        let host = resolve_via_addr(bind, Some("sip.example.com"));
+        if crate::transport::detect_routable_local_ip(false).is_some() {
+            assert!(!host.ip().is_loopback(), "hostname should auto-detect, got {host}");
+        }
     }
 
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -31,6 +31,37 @@ pub fn next_connection_id() -> ConnectionId {
     ConnectionId(NEXT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed))
 }
 
+/// Best-effort detection of the host's primary routable local IP for the given
+/// address family.
+///
+/// Uses a UDP "route lookup": bind a wildcard socket, `connect()` it to a
+/// documentation-range reference address, and read back the source IP the
+/// kernel selected. `connect()` on a UDP socket performs no network I/O — it
+/// only sets the default peer and triggers the routing-table lookup — so no
+/// packets are sent and the reference address need not be reachable. Returns
+/// `None` on a host with no matching route (e.g. loopback-only), so callers can
+/// fall back.
+///
+/// This is what lets an instance bound to `0.0.0.0` / `[::]` with no
+/// `advertised_address` emit a routable Via/Contact instead of a loopback
+/// placeholder.
+pub fn detect_routable_local_ip(ipv6: bool) -> Option<IpAddr> {
+    // RFC 5737 TEST-NET-1 / RFC 3849 documentation prefix — never real peers.
+    let (bind, reference) = if ipv6 {
+        ("[::]:0", "[2001:db8::1]:9")
+    } else {
+        ("0.0.0.0:0", "192.0.2.1:9")
+    };
+    let socket = std::net::UdpSocket::bind(bind).ok()?;
+    socket.connect(reference).ok()?;
+    let ip = socket.local_addr().ok()?.ip();
+    if ip.is_unspecified() || ip.is_loopback() {
+        None
+    } else {
+        Some(ip)
+    }
+}
+
 /// Default idle timeout for connection-oriented transports (TCP/TLS/WS/WSS).
 /// Connections with no activity for this duration are closed to prevent
 /// zombie connections from accumulating (especially behind NAT).
@@ -440,6 +471,23 @@ impl StreamConnections {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detect_routable_local_ip_never_loopback_or_unspecified() {
+        // On a host with a default route this returns the primary egress IP; on a
+        // loopback-only host it returns None. It must never return a loopback or
+        // unspecified address — that placeholder (127.0.0.1) was the foot-gun this
+        // replaced. Guarded on Some() so a CI host without a default route passes.
+        if let Some(ip) = detect_routable_local_ip(false) {
+            assert!(!ip.is_loopback(), "IPv4 detect returned loopback: {ip}");
+            assert!(!ip.is_unspecified(), "IPv4 detect returned unspecified: {ip}");
+            assert!(ip.is_ipv4(), "requested IPv4, got {ip}");
+        }
+        if let Some(ip) = detect_routable_local_ip(true) {
+            assert!(!ip.is_loopback(), "IPv6 detect returned loopback: {ip}");
+            assert!(!ip.is_unspecified(), "IPv6 detect returned unspecified: {ip}");
+        }
+    }
 
     #[tokio::test]
     async fn configure_tcp_socket_sets_nodelay_and_keepalive() {

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -4,7 +4,7 @@
 //! registrar lookups for routing B2BUA calls, and transaction key handling.
 
 use siphon::b2bua::actor::{
-    CallActor, CallActorStore, CallEvent, CallState, Leg, LegActor, TransportInfo,
+    CallActor, CallActorStore, CallEvent, CallState, Leg, LegActor, LegSide, TransportInfo,
     SessionTimerState, generate_call_id, generate_tag,
 };
 use siphon::b2bua::header_policy::{
@@ -2008,4 +2008,117 @@ fn validator_accepts_intra_trust_with_per_call_authorization_copy() {
     apply_to_request(&mut invite, &policy, &test_ctx());
     // Authorization copied through (case-c transparent auth)
     assert!(invite.headers.has("Authorization"));
+}
+
+// ---------------------------------------------------------------------------
+// In-dialog direction detection (re-INVITE / UPDATE / BYE) by SIP dialog
+// identity, NOT by source socket. A peer that reconnects per transaction (TLS)
+// or rebinds its NAT port sends the in-dialog request from a *different* source
+// address than its INVITE; a socket comparison misroutes it (reflecting it back
+// at the leg it came from). `request_direction` takes no socket input, so these
+// state-level tests encode exactly that regression.
+// ---------------------------------------------------------------------------
+
+/// Build a winning-B-leg call and return (store, call_id, b_call_id, b_tag).
+fn make_answered_call(a_call_id: &str) -> (CallActorStore, String, String, String) {
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg(a_call_id));
+    let mut b_leg = make_b_leg("198.51.100.20:5060");
+    let b_call_id = b_leg.dialog.call_id.clone();
+    let b_tag = "bob-tag".to_string();
+    b_leg.dialog.remote_tag = Some(b_tag.clone());
+    store.add_b_leg(&call_id, b_leg);
+    store.set_winner(&call_id, 0);
+    (store, call_id, b_call_id, b_tag)
+}
+
+#[test]
+fn direction_from_a_ignores_source_socket() {
+    // The A-leg's stored socket is 10.0.0.1:5060 (make_a_leg). The re-INVITE in
+    // the real trace arrived from a *new* TLS source port — but direction is
+    // decided by the A-leg Call-ID + From-tag, which are stable, so no socket is
+    // consulted at all.
+    let (store, call_id, _b_call_id, _b_tag) = make_answered_call("teams-cid");
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(
+        call.request_direction("teams-cid", Some("alice-tag")),
+        Some(LegSide::A),
+    );
+}
+
+#[test]
+fn direction_from_b() {
+    let (store, call_id, b_call_id, b_tag) = make_answered_call("teams-cid");
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(
+        call.request_direction(&b_call_id, Some(&b_tag)),
+        Some(LegSide::B),
+    );
+}
+
+#[test]
+fn direction_unknown_call_id_is_none() {
+    // A Call-ID that matches neither leg → None (the handler answers 481 rather
+    // than bridging to a guessed leg).
+    let (store, call_id, _b_call_id, _b_tag) = make_answered_call("teams-cid");
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(call.request_direction("stranger-cid", Some("who-tag")), None);
+}
+
+#[test]
+fn preserve_call_id_disambiguates_by_from_tag() {
+    // With preserve_call_id both legs carry the same Call-ID, so the From-tag
+    // (the peer's own tag = our stored remote_tag for that leg) breaks the tie.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("shared-cid"));
+    let mut b_leg = make_b_leg("198.51.100.20:5060");
+    b_leg.dialog.call_id = "shared-cid".to_string();
+    b_leg.dialog.remote_tag = Some("bob-tag".to_string());
+    store.add_b_leg(&call_id, b_leg);
+    store.set_winner(&call_id, 0);
+    let call = store.get_call(&call_id).unwrap();
+
+    assert_eq!(call.request_direction("shared-cid", Some("alice-tag")), Some(LegSide::A));
+    assert_eq!(call.request_direction("shared-cid", Some("bob-tag")), Some(LegSide::B));
+    // Unknown tag or missing tag can't be disambiguated → None (safe 481).
+    assert_eq!(call.request_direction("shared-cid", Some("ghost-tag")), None);
+    assert_eq!(call.request_direction("shared-cid", None), None);
+}
+
+#[test]
+fn tracking_leg_call_id_never_flips_direction() {
+    // The dispatcher inserts response-tracking pseudo-legs that reuse the A-leg
+    // Call-ID with a "reinvite:"/"update:" target_uri. They must be excluded
+    // from direction matching, so an A-leg Call-ID still resolves to A.
+    let (store, call_id, _b_call_id, _b_tag) = make_answered_call("teams-cid");
+    let mut tracking = make_b_leg("198.51.100.20:5060");
+    tracking.dialog.call_id = "teams-cid".to_string();
+    tracking.dialog.target_uri = Some("reinvite:b2a".to_string());
+    store.add_b_leg(&call_id, tracking);
+
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(
+        call.request_direction("teams-cid", Some("alice-tag")),
+        Some(LegSide::A),
+    );
+}
+
+#[test]
+fn early_update_from_unanswered_b_leg_is_from_b() {
+    // Before a winner is chosen (RFC 3311 §5.2 UPDATE), match any real B-leg's
+    // Call-ID; a co-resident tracking leg with the same Call-ID must be skipped.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("a-cid"));
+    let mut b_leg = make_b_leg("198.51.100.20:5060");
+    b_leg.dialog.call_id = "b-early-cid".to_string();
+    store.add_b_leg(&call_id, b_leg);
+    let mut tracking = make_b_leg("198.51.100.20:5060");
+    tracking.dialog.call_id = "b-early-cid".to_string();
+    tracking.dialog.target_uri = Some("update:a2b".to_string());
+    store.add_b_leg(&call_id, tracking);
+    // No set_winner — call is still early.
+
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(call.request_direction("b-early-cid", None), Some(LegSide::B));
+    assert_eq!(call.request_direction("a-cid", Some("alice-tag")), Some(LegSide::A));
 }


### PR DESCRIPTION
## Problem

A B2BUA call drops seconds after an in-dialog re-INVITE when the A-leg peer reconnects per transaction. All three in-dialog handlers (BYE, re-INVITE, UPDATE) decided which leg an in-dialog request belonged to by comparing its source socket against that leg's original INVITE socket:

```rust
let from_a = inbound.remote_addr == call.a_leg.transport.remote_addr;
```

A peer that opens a fresh TLS connection per transaction (a new connection has a new source port) or rebinds its NAT port fails that comparison, so the request is classified as coming from the *other* leg and **reflected back at the leg it arrived on** instead of being bridged across. The far leg never sees the re-INVITE, media is never renegotiated, and the call is torn down. A carrier SBC that opens a new connection per transaction reproduces this deterministically over TLS. The BYE variant only avoided it when the peer's socket happened not to move.

## Fix

**A — direction by dialog identity (the actual bug).**
- New `CallActor::request_direction(call_id, from_tag)` decides direction from the Call-ID (RFC 3261 §12), with the From-tag only as a tie-breaker for `preserve_call_id` dialogs, and excludes response-tracking pseudo-legs (`is_tracking_leg`). Transport- and port-agnostic.
- Wired into `handle_b2bua_bye` / `_reinvite` / `_update`. An in-dialog request whose Call-ID matches no live dialog leg is answered `481 Call/Transaction Does Not Exist` instead of being mis-bridged.
- The originating leg's transport (remote_addr + connection_id + local_addr) and remote-target Contact are refreshed from the arrival flow on every in-dialog request (RFC 5626 / §12.2.2). This is required, not optional: without it the re-INVITE's own 200 OK still targets the stale cached socket and misses the peer.
- The B→A forward reuses the target leg's live connection via the connection map (mirrors the framework BYE) instead of source-binding a fresh dial to the peer's dead ephemeral port.

**B — Contact fallback (follow-up hardening).**
- When a B→A forward over **TLS** finds the target leg's connection dead and there is no dialog route set, it dials the remote-target Contact's resolved host:port (RFC 3261 §12.2.1.1) with the correct SNI instead of the dead cached socket. Scoped to TLS because only the TLS listener registers inbound connections in `stream_connections`; a NAT'd UDP peer must keep its cached source socket.

**C — routable local IP for Via/Contact.**
- Bound to a wildcard (`0.0.0.0` / `[::]`) with no `advertised_address`, Via/Contact previously fell back to `127.0.0.1`, which no remote peer can reach and from which no new outbound TLS connection can be opened. It now auto-detects the host's primary routable IP via a dependency-free UDP route lookup (`detect_routable_local_ip`), with loopback only as a last resort. Setting `advertised_address` explicitly is still recommended behind NAT (the auto-detected address is the private one there).

## Tests

- `tests/integration/b2bua_tests.rs`: six state-level direction tests, including the exact regression (an in-dialog request classified with zero knowledge of the source socket), the `preserve_call_id` From-tag tie-break, tracking-leg exclusion, and early-dialog UPDATE.
- `src/transport/mod.rs`: `detect_routable_local_ip` invariant (never loopback/unspecified).
- `src/dispatcher.rs`: `resolve_via_addr` precedence (explicit IP wins / specific bind unchanged / wildcard auto-detects, never loopback when a route exists).
- Connection reuse (A) is already covered by the existing bidirectional TCP round-trip + pool-fallback transport tests (connection-map hit and miss); the full wire-level INVITE → re-INVITE-from-a-new-socket → bridged-to-far-leg path needs the dispatcher booted with a Python `@b2bua` script and is left as a follow-up `#[ignore]` test.
- Full suite green (3378 passed, 0 failed); `clippy --all-targets --all-features -D warnings` clean.

No scripting-API change, so no SDK change. A full SIPp / perf / mem baseline on the reference box is recommended before the release cut.
