### PR TITLE
docs: docker compose quickstart + getting-started guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **Docker Compose quickstart + Getting started guide.** A root
+  `docker-compose.yaml` runs the published image with your `siphon.yaml` and
+  `scripts/` bind-mounted (host networking, hot-reload, a SIP `OPTIONS`
+  healthcheck), so `git clone && docker compose up -d` starts a working proxy
+  with nothing to build. A new `Getting started` docs page leads with that path
+  and folds in the native/`.deb`/`.rpm` options plus the common Ubuntu build
+  gotchas (old `apt` rustc, missing `python3-dev`).
 - **SDK: `Request.remove_headers_matching(prefix)`** in the `siphon-sip` mock,
   mirroring the production request method (it was only on the `call` mock), so
   script unit tests can exercise header-prefix stripping on a proxy request.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,63 @@
+# docker-compose.yaml — the quickest way to run SIPhon.
+#
+#   docker compose up -d          # start (pulls the published image)
+#   docker compose logs -f        # follow logs
+#   docker compose down           # stop
+#
+# It bind-mounts your config and scripts from this directory, so you edit
+# siphon.yaml / scripts/*.py on the host and SIPhon hot-reloads them — no
+# rebuild, no restart. The repo ships a working siphon.yaml and
+# scripts/proxy_default.py, so a fresh clone runs a working proxy out of the box.
+#
+# See docs/getting-started.md and docs/deployment.md for the full story.
+
+services:
+  siphon:
+    image: ghcr.io/siphon-project/siphon-sip:latest
+    # To run your own build instead of the published image, comment out the
+    # `image:` line above and uncomment this:
+    # build:
+    #   context: .
+    restart: unless-stopped
+
+    # SIP is sensitive to NAT rewriting of Via/Contact addresses, so on Linux
+    # run in the host network namespace — the ports below bind directly on the
+    # host and Via/Contact carry the real addresses.
+    network_mode: host
+    # Docker Desktop (macOS / Windows) has no host networking. There, delete the
+    # `network_mode: host` line above and publish the ports instead:
+    # ports:
+    #   - "5060:5060/udp"
+    #   - "5060:5060/tcp"
+    #   - "5061:5061/tcp"     # SIP over TLS
+
+    volumes:
+      # Your config and routing scripts — edited on the host, hot-reloaded in
+      # the container. Read-only in the container; SIPhon only reads them.
+      - ./siphon.yaml:/etc/siphon/siphon.yaml:ro
+      - ./scripts:/etc/siphon/scripts:ro
+      # Optional: mount TLS certs / persisted state as needed, e.g.
+      # - ./certs:/etc/siphon/certs:ro
+
+    # Answer a SIP OPTIONS ping to prove the datapath is actually up, not just
+    # that the process started.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          python3 -c "import socket;
+          s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2);
+          s.sendto(b'OPTIONS sip:healthcheck SIP/2.0\r\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\r\nFrom: <sip:hc@localhost>;tag=hc\r\nTo: <sip:localhost>\r\nCall-ID: hc@check\r\nCSeq: 1 OPTIONS\r\nMax-Forwards: 1\r\nContent-Length: 0\r\n\r\n', ('127.0.0.1',5060));
+          s.recv(1024); s.close()"
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+  # ── Optional: media anchoring with rtpengine ────────────────────────────────
+  # Uncomment to anchor RTP (SBC / topology hiding). Point `media.rtpengine`
+  # in siphon.yaml at 127.0.0.1:22222. See docs/cookbook/media-rtp.md.
+  # rtpengine:
+  #   image: drachtio/rtpengine:latest
+  #   restart: unless-stopped
+  #   network_mode: host

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,184 @@
+# Getting started
+
+Run SIPhon and confirm it answers a call. The fastest path is Docker Compose —
+no toolchain, no build. If you only read one page before deploying, read this
+one, then head to the [Cookbook](cookbook/index.md) for a working script for your
+role.
+
+## Quickstart (Docker Compose) — recommended
+
+You need [Docker](https://docs.docker.com/engine/install/) with the Compose
+plugin. Nothing else.
+
+```bash
+git clone https://github.com/siphon-project/siphon-sip.git
+cd siphon-sip
+docker compose up -d
+docker compose logs -f
+```
+
+That's it. The repo ships a working [`siphon.yaml`](https://github.com/siphon-project/siphon-sip/blob/main/siphon.yaml)
+and [`scripts/proxy_default.py`](https://github.com/siphon-project/siphon-sip/blob/main/scripts/proxy_default.py),
+so `docker compose up -d` starts a working proxy out of the box, pulling the
+published `ghcr.io/siphon-project/siphon-sip:latest` image.
+
+The [`docker-compose.yaml`](https://github.com/siphon-project/siphon-sip/blob/main/docker-compose.yaml)
+**bind-mounts your config and scripts from the repo directory**:
+
+```yaml
+    volumes:
+      - ./siphon.yaml:/etc/siphon/siphon.yaml:ro
+      - ./scripts:/etc/siphon/scripts:ro
+```
+
+So you edit `siphon.yaml` or `scripts/*.py` on the host and SIPhon
+**hot-reloads** them — no rebuild, no restart. Make it yours by editing those two
+files; jump to [Verify it's up](#verify-its-up) to confirm it's answering.
+
+!!! note "Host networking vs. Docker Desktop"
+    The compose file uses `network_mode: host` because SIP is sensitive to NAT
+    rewriting of the `Via`/`Contact` addresses — on Linux the ports bind
+    directly on the host and the addresses stay real. **Docker Desktop
+    (macOS/Windows) has no host networking**: delete the `network_mode: host`
+    line and uncomment the `ports:` block in `docker-compose.yaml` instead.
+
+To run your own build instead of the published image, comment out `image:` and
+uncomment `build: { context: . }` in the compose file, then
+`docker compose up -d --build`.
+
+## Verify it's up
+
+Send an `OPTIONS` keepalive and expect a `200 OK`. With
+[`sipsak`](https://github.com/nils-ohlmeier/sipsak):
+
+```bash
+sipsak -s sip:ping@127.0.0.1:5060
+```
+
+The compose file also has a built-in healthcheck that pings SIP `OPTIONS`, so:
+
+```bash
+docker compose ps        # STATUS shows "healthy" once it's answering
+```
+
+If you enabled the admin/metrics endpoints in `siphon.yaml`, `curl` them:
+
+```bash
+curl -s http://127.0.0.1:9090/metrics        # Prometheus metrics
+curl -s http://127.0.0.1:8080/admin/health   # liveness
+```
+
+## Other ways to install
+
+Prefer a native binary or a package? All of these produce the same `siphon`
+binary; only the Compose quickstart needs no build toolchain.
+
+### Prerequisites (for the build/package paths)
+
+- **Linux** is the primary target (that's where the transports, `nf_tables`
+  firewall, and IPsec paths are exercised). macOS works fine for development.
+- **Rust 1.80 or newer**, installed with [rustup](https://rustup.rs). Do **not**
+  use the `rustc` from `apt`/`dnf` — the distro package is usually too old to
+  build the crate, and that is the single most common install failure.
+- **Python 3.12+ with dev headers** (`python3-dev` / `python3-devel`). The
+  scripting layer embeds CPython, so the headers and a shared `libpython` must
+  be present at build time. Python 3.12 is enough to run SIPhon; the
+  free-threaded **3.14t** build is a performance option, not a requirement (see
+  [below](#python-312-vs-314t)).
+
+### cargo install (from crates.io)
+
+```bash
+# build toolchain + Python headers
+sudo apt update
+sudo apt install -y build-essential python3-dev pkg-config
+
+# current Rust from rustup (NOT apt's rustc)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# build and install the binary
+PYO3_PYTHON=python3 cargo install siphon-sip
+```
+
+!!! warning "Ubuntu 24.04 / Debian: the two things that trip people up"
+    Almost every failed build is one of these:
+
+    1. **`rustc` is too old.** `apt`'s Rust predates what the crate needs. Install
+       [rustup](https://rustup.rs) and make sure `rustc --version` reports 1.80+
+       (`which rustc` should point into `~/.cargo`, not `/usr/bin`).
+    2. **`python3-dev` is missing.** Without the Python headers and shared
+       library, the build can't link CPython and fails with a PyO3/`libpython`
+       error. `sudo apt install python3-dev` fixes it. Keep `PYO3_PYTHON=python3`
+       set so the build targets the interpreter you expect.
+
+    SIPhon uses **rustls** end-to-end, so you do **not** need OpenSSL headers.
+
+Optional backends and transports are behind cargo features:
+
+```bash
+cargo install siphon-sip --features redis-backend,postgres-backend
+# SIP/Diameter-over-SCTP is Linux-only and off by default:
+sudo apt install -y libsctp-dev
+cargo install siphon-sip --features sctp
+```
+
+### Prebuilt `.deb` / `.rpm`
+
+Prebuilt packages are attached to each
+[GitHub Release](https://github.com/siphon-project/siphon-sip/releases). They
+install the binary to `/usr/bin/siphon`, a default config to
+`/etc/siphon/siphon.yaml`, example scripts to `/etc/siphon/scripts/`, and a
+systemd unit.
+
+```bash
+sudo dpkg -i siphon_*.deb        # Debian / Ubuntu
+sudo rpm -i siphon-*.rpm         # Fedora / RHEL / Rocky
+
+sudo vim /etc/siphon/siphon.yaml # edit to match your network
+sudo systemctl enable --now siphon
+journalctl -u siphon -f
+```
+
+The service runs as an unprivileged `siphon` user and is not auto-enabled on
+install — you enable it explicitly. Building the packages yourself, and the
+from-source path, are covered in the
+[README](https://github.com/siphon-project/siphon-sip#installation).
+
+### Running a native binary directly
+
+```bash
+siphon --config /etc/siphon/siphon.yaml
+# or, from a source checkout:
+PYO3_PYTHON=python3 cargo run --release -- --config siphon.yaml
+```
+
+## Python 3.12 vs 3.14t
+
+SIPhon runs on any Python **3.12 or newer**. Scripts run under a real CPython
+interpreter, so you get the whole standard library (`re`, `json`, `asyncio`, …)
+and any pip package you install. (The prebuilt Docker image already bundles a
+free-threaded 3.14t interpreter, so the Compose quickstart is fast by default.)
+
+The performance numbers in the README are measured on **free-threaded Python
+3.14t**, which removes the GIL so handler threads run in genuine parallel.
+That's what you want for a high-throughput node, but it is not needed to get
+started, and nothing about the scripting API changes between the two. For a
+native build, install a free-threaded interpreter (for example with
+`uv python install 3.14+freethreaded`) and point `PYO3_PYTHON` at it when you're
+tuning for throughput.
+
+## Next steps
+
+- **[Cookbook](cookbook/index.md)** — a complete, working starting point for each
+  role: [registrar](cookbook/registrar.md), [stateful proxy](cookbook/proxy.md),
+  [load balancer](cookbook/load-balancer.md), [SBC / B2BUA](cookbook/sbc.md),
+  [number normalization](cookbook/number-normalization.md), and more.
+- **[Deployment & operations](deployment.md)** — real topologies, graceful drain,
+  health probes, capacity planning.
+- **[Migrating from Kamailio / OpenSIPS](migrating-from-kamailio-opensips.md)** —
+  if you already run one of those, start here.
+
+Stuck on install? Open a
+[Discussion](https://github.com/siphon-project/siphon-sip/discussions) with your
+OS, whether you used Compose or a native build, and the exact error.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ theme:
 
 nav:
   - Home: README.md
+  - Getting started: getting-started.md
   - Cookbook:
       - Overview: cookbook/index.md
       - Registrar: cookbook/registrar.md


### PR DESCRIPTION
Adds an on-site install/run path that was missing — the docs home page only linked out to the GitHub README, so a new user had nothing on siphon-sip.org to follow. Closes the gap behind the recurring "how do I install/run this" questions (#105).

## What's here

- **Root `docker-compose.yaml`** — the operator quickstart that didn't exist (previously only the sipp test stack and the ha-demo shipped compose files). Runs the published `ghcr.io/siphon-project/siphon-sip:latest` image, `restart: unless-stopped`, `network_mode: host` (with a commented `ports:` fallback for Docker Desktop), **bind-mounts `./siphon.yaml` and `./scripts/`** so host edits hot-reload, a real SIP `OPTIONS` healthcheck, and a commented rtpengine add-on. A fresh clone runs a working proxy with nothing to build.
- **`docs/getting-started.md`** — leads with the Compose quickstart (clone → `docker compose up -d`, hot-reload explained inline, host-net vs Docker Desktop note), a Verify step, then the native/`.deb`/`.rpm` options below. Calls out the two real Ubuntu 24.04 build failures (old `apt` rustc, missing `python3-dev`) and the 3.12-vs-3.14t story.
- Wired `Getting started` into the docs nav (first item after Home) and a CHANGELOG entry.

`mkdocs build --strict` is clean and `docker compose config` validates.