### PR TITLE
feat(b2bua): in-dialog REFER on tracked calls (terminate/transparent/reject/outbound + proxy passthrough) + rtpengine-anchored transfer media + per-leg o= ownership

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,6 +223,13 @@ jobs:
       - name: SIPp REGISTER test
         run: docker compose -f sipp/docker-compose.yaml run --rm sipp-register
 
+      - name: Proxy REFER passthrough (in-dialog REFER loose-routed once, no loop)
+        run: docker compose -f sipp/docker-compose.yaml --profile proxy-refer up --abort-on-container-exit --exit-code-from sipp-proxy-refer-uac sipp-proxy-refer-uac sipp-proxy-refer-uas
+
+      - name: Cleanup proxy-refer containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile proxy-refer rm -sf sipp-proxy-refer-uac sipp-proxy-refer-uas sipp-proxy-refer-register 2>/dev/null || true
+
       - name: Collect siphon logs
         if: always()
         run: docker compose -f sipp/docker-compose.yaml logs siphon > siphon.log 2>&1 || true
@@ -301,6 +308,72 @@ jobs:
           name: sipp-b2bua-logs
           path: |
             siphon-b2bua.log
+            *.log
+
+  # ── B2BUA REFER / call-transfer functional tests ────────────────────────
+  # In-dialog REFER on a tracked B2BUA call: transparent forward, loop-safe
+  # 603 reject, siphon-terminated transfer (non-anchored), and the terminated
+  # transfer re-anchored through a REAL rtpengine (offer/answer on a fresh
+  # media session + delete of the old anchor).
+  sipp-b2bua-refer:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build B2BUA / refer-modes / anchored siphon images
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer-terminate --profile b2bua-rtpengine-refer build siphon-b2bua siphon-b2bua-refer-modes siphon-b2bua-rtpengine-refer
+
+      - name: Start siphon-b2bua
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua up -d --wait siphon-b2bua
+
+      - name: B2BUA REFER transparent (RFC 3515 blind transfer, forwarded on the far leg's dialog)
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-uac sipp-b2bua-refer-uac sipp-b2bua-refer-uas
+
+      - name: Cleanup transparent containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer rm -sf sipp-b2bua-refer-uac sipp-b2bua-refer-uas 2>/dev/null || true
+
+      - name: Start siphon-b2bua-refer-modes
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-reject up -d --wait siphon-b2bua-refer-modes
+
+      - name: B2BUA REFER reject (loop-safe 603 default, zero egress)
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-reject up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-reject-uac sipp-b2bua-refer-reject-uac sipp-b2bua-refer-reject-uas
+
+      - name: Cleanup reject containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-reject rm -sf sipp-b2bua-refer-reject-uac sipp-b2bua-refer-reject-uas 2>/dev/null || true
+
+      - name: B2BUA REFER siphon-terminated (dial target + promote + BYE)
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-terminate up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-terminate-uac sipp-b2bua-refer-terminate-uac sipp-b2bua-refer-terminate-bob-uas sipp-b2bua-refer-terminate-carol-uas
+
+      - name: Cleanup terminate containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-terminate rm -sf sipp-b2bua-refer-terminate-uac sipp-b2bua-refer-terminate-bob-uas sipp-b2bua-refer-terminate-carol-uas 2>/dev/null || true
+
+      - name: B2BUA REFER terminate + REAL rtpengine (media re-anchor offer/answer/delete)
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-rtpengine-refer up --abort-on-container-exit --exit-code-from sipp-anchored-refer-uac sipp-anchored-refer-uac sipp-anchored-refer-bob-uas sipp-anchored-refer-carol-uas
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-b2bua > siphon-b2bua-refer.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs siphon-b2bua-refer-modes >> siphon-b2bua-refer.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs siphon-b2bua-rtpengine-refer >> siphon-b2bua-refer.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs rtpengine-real > rtpengine-real.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer --profile b2bua-refer-reject --profile b2bua-refer-terminate --profile b2bua-rtpengine-refer down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-b2bua-refer-logs
+          path: |
+            siphon-b2bua-refer.log
+            rtpengine-real.log
             *.log
 
   # ── rtpproxy functional test ───────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,62 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `from`/`to`, and the B-leg count excludes the re-INVITE/UPDATE response-tracking
   pseudo-legs, so a plain call that re-INVITEd no longer reports two B-legs.
 
+### Fixed
+- **in-dialog REFER on a tracked B2BUA call no longer proxy-relays and can no
+  longer loop.** a REFER arriving inside a bridged B2BUA dialog used to fall
+  through to the proxy relay path, which could bounce it back through the same
+  B2BUA and loop. it is now intercepted at the B2BUA and dispatched to
+  `@b2bua.on_refer`. with no `@b2bua.on_refer` handler registered siphon rejects
+  it locally with `603 Decline` and relays nothing (loop-safe default).
+
+### Added
+- **B2BUA call transfer (REFER, RFC 3515 / 3891 / 5589) with three modes.**
+  `@b2bua.on_refer(call)` handles an in-dialog REFER on a tracked call (single
+  arg, no reply object, REFER is a request). read the target off `call.refer_to`
+  and, for attended transfers, `call.refer_replaces` (Replaces dict:
+  `call_id` / `from_tag` / `to_tag` / `early_only`).
+- **`call.accept_refer(target=None, next_hop=None, mode=None)`** accepts a
+  transfer in one of three modes: `"terminate"` (siphon-terminated, the default)
+  answers `202` and the sipfrag NOTIFYs itself, re-resolves `Refer-To` through the
+  dial plan as a new leg, re-bridges the surviving party, and BYEs the
+  referred-away leg; `"transparent"` re-emits the REFER on the far leg's own
+  dialog and relays its `202` + `message/sipfrag` NOTIFYs back to the referrer;
+  `None` uses `b2bua.default_refer_mode`. `target=` rewrites the destination and
+  `next_hop=` steers egress. `call.reject_refer(code, reason)` declines.
+- **siphon-originated (outbound) REFER.** `call.refer(target, replaces=None)`
+  sends a REFER deferred from a `@b2bua.*` handler that holds a `call`;
+  `b2bua.refer(call_id, target, replaces=None)` is the imperative twin for event
+  callbacks that only have a `call_id` (e.g. `@rtpengine.on_dtmf`). use for
+  IVR / TAS offload: answer, play a prompt, then hand the caller off.
+- **`b2bua.default_refer_mode` config knob** (`terminate` | `transparent`,
+  default `terminate`) sets the mode used when `accept_refer(mode=None)`.
+- **proxy-mode REFER passthrough** is documented and covered by a SIPp test: in
+  proxy mode an in-dialog REFER is loose-routed to the far end (record-route
+  required) and its `202` + sipfrag NOTIFYs relay straight back, so the transfer
+  runs endpoint-to-endpoint with no siphon-side state. no code change (the generic
+  in-dialog branch already handled it); the loop fix above is B2BUA-only.
+
+- **terminate-mode transfer now re-anchors media correctly.** the transfer target
+  is offered the **surviving** party's media (not the referrer's, who is being
+  dropped), and the survivor is re-INVITEd with the target's answer, so RTP is
+  aimed correctly end to end. when the call is media-anchored (rtpengine /
+  siphon-rtp) siphon re-anchors the survivor↔target pair on a fresh media session
+  and tears down the old survivor↔referrer anchor, keeping the anchor in the media
+  path across the transfer (LI / transcoding / NAT preserved).
+- **siphon now owns the SDP `o=` line per leg** (a stable session-id with a
+  monotonic version) on every offer/answer it emits into a B2BUA dialog. a
+  re-anchor (transfer, hold) presents a strictly greater version under the same
+  session identity, so a strict RFC 3264 §8 answerer re-negotiates cleanly rather
+  than reading a changed offer as unchanged. previously the peer's `o=` was passed
+  through with only the username masked.
+
+### Fixed
+- **B2BUA rtpengine session cleanup on a B-leg-originated BYE.** the media-session
+  safety-net delete keyed on the incoming BYE's Call-ID, which is not the store
+  key (the A-leg Call-ID) when the BYE comes from the callee (or from the
+  survivor / target after a terminate-transfer re-anchor); it now keys on the
+  A-leg Call-ID so the session is always cleaned up.
+
 ## [1.4.1] — 2026-07-15
 
 ### Added

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -1,0 +1,382 @@
+# Call transfer (REFER)
+
+A B2BUA sits between two dialogs, so when one party asks to transfer the call
+(a `REFER`, RFC 3515 / 3891 / 5589) siphon has to decide what that means for the
+*other* leg. SIPhon gives you three modes, picked per call from a single
+`@b2bua.on_refer` handler:
+
+| Mode | What siphon does | Use it for |
+|---|---|---|
+| **siphon-terminated** *(default)* | Answers `202` + sends the sipfrag `NOTIFY`s itself, re-resolves `Refer-To` through the dial plan as a **new** leg, re-bridges the surviving party, and BYEs the referred-away leg. | Trunk-facing SBCs and media-anchored calls — the endpoints never see the transfer, media stays anchored on siphon. |
+| **transparent** | Re-emits the `REFER` on the far leg's own dialog and relays the far end's `202` + `message/sipfrag` `NOTIFY`s back to the referrer. | UA-to-UA / PBX transfers where you want the endpoints to run the transfer themselves. |
+| **siphon-originated** | siphon *sends* a `REFER` to a leg — `call.refer(target)` (deferred, from a handler) or `b2bua.refer(call_id, target)` (imperative, from an event callback). | IVR / TAS offload — answer, play a prompt, then hand the caller off. |
+
+With **no** `@b2bua.on_refer` handler registered, siphon rejects every in-dialog
+`REFER` on a tracked call locally with `603 Decline` and relays nothing. That is
+the loop-safe default: an in-dialog `REFER` on a bridged call must never be blind
+proxy-relayed (it can loop back through the B2BUA), so you opt in to transfer
+handling by registering the handler.
+
+!!! warning "`@b2bua.on_refer` takes ONE argument"
+    The handler is `def on_refer(call):` — **one argument, no `reply` object**. A
+    `REFER` is a *request*, not a response, so there is nothing to answer with
+    `rtpengine.answer(reply)`. Writing `def on_refer(call, reply):` and calling
+    `rtpengine.answer(reply)` — the reflex from the `@b2bua.on_early_media` /
+    `@b2bua.on_answer` handlers — is wrong here and will fail at call time. Read
+    the transfer target off the `call` object (`call.refer_to`,
+    `call.refer_replaces`) and act with `call.accept_refer()` /
+    `call.reject_refer()`.
+
+## The `call` object during a REFER
+
+```python
+call.refer_to        # str | None  — the Refer-To URI
+call.refer_replaces  # dict | None — attended-transfer Replaces target, keys:
+                     #   {"call_id": str, "from_tag": str,
+                     #    "to_tag": str, "early_only": bool}
+
+call.accept_refer(target=None, next_hop=None, mode=None)
+    # Accept the transfer.
+    #   target=   rewrite the destination (default: call.refer_to verbatim)
+    #   next_hop= steer egress without changing the R-URI shape
+    #   mode=     "terminate" | "transparent" | None
+    #             None -> b2bua.default_refer_mode (config; default "terminate")
+call.reject_refer(code, reason)      # decline the transfer (e.g. 603 Decline)
+```
+
+Config default for `mode=None`:
+
+```yaml
+# siphon.yaml
+b2bua:
+  default_refer_mode: terminate    # terminate | transparent  (default terminate)
+```
+
+Throughout the ladders below: **Alice** `sip:alice@example.com` (A-leg),
+**Bob** `sip:bob@example.com` (B-leg), transfer target **Carol**
+`sip:+15550142@example.com`, siphon at `198.51.100.1`.
+
+## 1. Inbound blind transfer, siphon-terminated
+
+Alice and Bob are bridged by siphon with media anchored. Alice's phone starts a
+blind transfer to Carol — it sends a `REFER` (`Refer-To: Carol`) inside the
+Alice-leg dialog. siphon answers it itself, dials Carol as a fresh leg, bridges
+Bob onto Carol, and drops Alice.
+
+```python
+from siphon import b2bua, log
+
+@b2bua.on_refer
+def on_refer(call):
+    log.info(f"[{call.id}] blind transfer to {call.refer_to}")
+    call.accept_refer()          # siphon-terminated (the config default)
+```
+
+!!! warning "One argument, no reply"
+    The handler is `def on_refer(call):` — one argument, no reply object
+    (`REFER` is a request).
+
+```text
+Alice (A-leg)            siphon 198.51.100.1            Bob (B-leg)      Carol (target)
+     |                          |                            |                |
+     |<===== bridged, media anchored on siphon =============>|                |
+     |                          |                            |                |
+     |  REFER Refer-To:Carol    |                            |                |
+     |------------------------->|                            |                |
+     |  202 Accepted            |                            |                |
+     |<-------------------------|                            |                |
+     |  NOTIFY sipfrag 100      |   (accept_refer default)   |                |
+     |<-------------------------|                            |                |
+     |                          |  INVITE (new leg)          |                |
+     |                          |------------------------------------------->|
+     |                          |            200 OK                          |
+     |                          |<-------------------------------------------|
+     |                          |  ACK                                       |
+     |                          |------------------------------------------->|
+     |                          |  re-INVITE (re-bridge)     |                |
+     |                          |<==========================>|                |
+     |  NOTIFY sipfrag 200 OK   |                            |                |
+     |<-------------------------|                            |                |
+     |  BYE (referred away)     |                            |                |
+     |<-------------------------|                            |                |
+     |  200 OK                  |         Bob <===== bridged =====> Carol     |
+     |------------------------->|                            |                |
+```
+
+Rewrite the destination or steer egress without touching what the endpoints see:
+
+```python
+@b2bua.on_refer
+def on_refer(call):
+    # Send the new leg to a specific trunk, keep the dialled URI shape intact.
+    call.accept_refer(target="sip:+15550142@example.com",
+                      next_hop="sip:trunk.example.com:5060")
+```
+
+### Media anchoring (terminate mode)
+
+Terminate mode re-bridges the media plane by offering the **surviving** party's
+media to the transfer target and re-INVITEing the survivor with the target's
+answer (RFC 3261 §14), so both directions of RTP follow the transfer:
+
+- **Media-anchored** (the call was anchored with rtpengine or siphon-rtp): siphon
+  re-anchors the survivor↔target pair on a fresh media session — it offers the
+  survivor's media to the target through the anchor, answers with the target's
+  SDP, re-INVITEs the survivor onto the anchored session, and tears down the old
+  survivor↔referrer anchor. The anchor stays in the media path across the
+  transfer (LI, transcoding, NAT preserved). This is the normal production shape.
+- **Not anchored** (a raw B2BUA where the endpoints exchange their own SDP): siphon
+  offers the survivor's real SDP to the target and re-INVITEs the survivor with
+  the target's answer, so media is aimed correctly end to end.
+
+siphon also owns the SDP `o=` line per leg (a stable session-id with a monotonic
+version), so a re-anchor presents a strictly greater version under the same
+session identity and a strict RFC 3264 §8 answerer re-negotiates cleanly rather
+than treating a changed offer as unchanged.
+
+> The signalling plane (202, sipfrag NOTIFYs, dialog identity, teardown) is
+> correct in every mode. In-repo tests cover the signalling and — for anchored
+> transfers — that the media-control commands are issued; that RTP actually
+> bridges survivor↔target through the anchor is validated against a real media
+> engine.
+
+## 2. Inbound attended transfer (Replaces)
+
+Attended transfer: Alice consults Carol on a second call first, then transfers
+Bob into the Alice-Carol call with a `REFER` carrying a `Replaces` header
+(RFC 3891) that names the Alice-Carol dialog. siphon reads it off
+`call.refer_replaces`, matches the dialog it is **already tracking**, bridges Bob
+onto it, and BYEs the now-redundant old legs.
+
+```python
+from siphon import b2bua, log
+
+@b2bua.on_refer
+def on_refer(call):
+    replaces = call.refer_replaces
+    if replaces:
+        log.info(f"[{call.id}] attended transfer replacing "
+                 f"call_id={replaces['call_id']} "
+                 f"from_tag={replaces['from_tag']} to_tag={replaces['to_tag']} "
+                 f"early_only={replaces['early_only']}")
+    call.accept_refer()          # siphon matches the replaced dialog + re-bridges
+```
+
+!!! warning "One argument, no reply"
+    The handler is `def on_refer(call):` — one argument, no reply object
+    (`REFER` is a request).
+
+```text
+Alice                    siphon 198.51.100.1            Bob            Carol
+  |                          |                           |               |
+  |<==== call 1: Alice <-> Bob (bridged) ===============>|               |
+  |<==== call 2: Alice <-> Carol (consult, tracked) =====================>|
+  |                          |                           |               |
+  |  REFER Refer-To:Carol    |                           |               |
+  |  Replaces=call2 dialog   |                           |               |
+  |------------------------->|                           |               |
+  |  202 Accepted            |  match Replaces -> call 2 |               |
+  |<-------------------------|                           |               |
+  |                          |  re-bridge Bob <-> Carol  |               |
+  |                          |<==========================|==============>|
+  |  NOTIFY sipfrag 200 OK   |                           |               |
+  |<-------------------------|                           |               |
+  |  BYE (call 1, Alice)     |     BYE (call 2, Alice)   |               |
+  |<-------------------------|-------------------------->|               |
+  |                          |         Bob <==== bridged ====> Carol     |
+```
+
+`early_only` is set when the `Replaces` header carried the `early-only`
+parameter — the transfer must only match a dialog still in an early (pre-2xx)
+state (RFC 3891 §3). siphon honours it when matching.
+
+## 3. Inbound transparent transfer
+
+Let the endpoints run the transfer. siphon re-emits the `REFER` on the far leg's
+own dialog and relays the far end's `202` and `message/sipfrag` `NOTIFY`s back to
+the referrer. Nothing is re-resolved locally — good for UA-to-UA or PBX
+deployments where the far side owns the transfer logic.
+
+```python
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(mode="transparent")
+```
+
+!!! warning "One argument, no reply"
+    The handler is `def on_refer(call):` — one argument, no reply object
+    (`REFER` is a request).
+
+```text
+Alice (A-leg)            siphon 198.51.100.1            Bob (B-leg)
+     |                          |                            |
+     |<===== bridged ==========>|<========= bridged =========>|
+     |                          |                            |
+     |  REFER Refer-To:Carol    |                            |
+     |------------------------->|  REFER (re-emit on B dialog)|
+     |                          |--------------------------->|
+     |                          |  202 Accepted              |
+     |  202 Accepted            |<---------------------------|
+     |<-------------------------|                            |
+     |                          |  NOTIFY sipfrag 100/200    |
+     |  NOTIFY sipfrag 100/200  |<---------------------------|
+     |<-------------------------|                            |
+     |          (Bob's UA now places the call to Carol itself)
+```
+
+## 4. No handler, or an explicit reject
+
+With **no** `@b2bua.on_refer` handler registered, siphon answers every in-dialog
+`REFER` on a tracked call with `603 Decline` locally and egresses nothing — the
+loop-safe default. You never have to write anything to be safe.
+
+To allow transfers only from a trusted source and decline the rest, register a
+handler and call `reject_refer`:
+
+```python
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    if not call.from_gateway("trusted-pbx"):
+        call.reject_refer(603, "Decline")     # same wire result as no handler
+        return
+    call.accept_refer()
+```
+
+!!! warning "One argument, no reply"
+    The handler is `def on_refer(call):` — one argument, no reply object
+    (`REFER` is a request).
+
+```text
+Alice (A-leg)            siphon 198.51.100.1
+     |                          |
+     |  REFER Refer-To:Carol    |
+     |------------------------->|
+     |  603 Decline             |   (no handler, or reject_refer(603,...))
+     |<-------------------------|     nothing egresses to the far leg
+     |  ACK                     |
+     |------------------------->|
+```
+
+## 5. Outbound: IVR / TAS offload
+
+siphon can also *originate* a `REFER`. Answer the call, play a prompt, then hand
+the caller off to Carol by REFER-ing the caller's own leg — siphon drops out and
+the caller reaches Carol directly.
+
+Two entry points:
+
+- `call.refer(target, replaces=None)` — **deferred**, from a `@b2bua.*` handler
+  where you hold a `call`. siphon sends the REFER when the handler returns.
+- `b2bua.refer(call_id, target, replaces=None)` — **imperative twin**, for event
+  callbacks that get a `call_id` but no `call` object, e.g. `@rtpengine.on_dtmf`.
+
+!!! warning "Still no reply object"
+    This is the outbound path — siphon *sends* the REFER, so there is no inbound
+    `@b2bua.on_refer` here. When you *do* handle an inbound REFER (scenarios 1-4),
+    remember the handler is `def on_refer(call):` — one argument, no reply object
+    (REFER is a request).
+
+```python
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    call.answer(200, "OK")                                    # siphon owns the leg
+    await rtpengine.play_media(call, file="/var/lib/siphon/prompts/menu.wav")
+
+@rtpengine.on_dtmf
+def on_dtmf(call_id, from_tag, digit, duration_ms, volume):
+    if digit == "1":
+        # Imperative — no `call` in scope here, only a call_id.
+        b2bua.refer(call_id, "sip:+15550142@example.com")
+```
+
+```text
+Caller (Alice)           siphon 198.51.100.1            Carol (target)
+     |                          |                            |
+     |  INVITE                  |                            |
+     |------------------------->|                            |
+     |  200 OK (siphon answers) |                            |
+     |<-------------------------|                            |
+     |<===== prompt / IVR media (rtpengine.play_media) ======|
+     |                          |                            |
+     |  RTP DTMF "1"            |                            |
+     |------------------------->|  b2bua.refer(call_id, Carol)|
+     |  REFER Refer-To:Carol    |                            |
+     |<-------------------------|                            |
+     |  202 Accepted            |                            |
+     |------------------------->|                            |
+     |          (Alice's UA now places the call to Carol itself)
+     |  INVITE ------------------------------------------------>|
+```
+
+The **deferred** form reads the same but fires from a handler that already holds
+the `call`. Use it when a transfer decision is made at answer time rather than on
+a later event:
+
+```python
+@b2bua.on_answer
+def on_answer(call, reply):
+    # Deferred: siphon sends the REFER once the leg is up and the handler returns.
+    call.refer("sip:+15550142@example.com")
+```
+
+Pass `replaces=` (a dict with `call_id` / `from_tag` / `to_tag`, optionally
+`early_only`) to originate an **attended** transfer that replaces a specific
+dialog.
+
+## 6. Proxy mode (passthrough)
+
+Everything above is B2BUA (`@b2bua.*`). In **proxy** mode there is nothing to do:
+a REFER is an ordinary in-dialog request, so as long as siphon record-routed the
+dialog-forming INVITE it loose-routes the REFER to the far end and relays the far
+end's `202` + `message/sipfrag` NOTIFYs straight back. The transfer subscription
+lives directly between the two endpoints; siphon owns no transfer state and the
+`@b2bua.on_refer` handler never fires. The default proxy script already does this
+with the generic in-dialog branch:
+
+```python
+@proxy.on_request
+def route(request):
+    # ... out-of-dialog handling (auth, registrar lookup, record_route) ...
+    if request.in_dialog:
+        if request.loose_route():
+            request.relay()       # REFER, NOTIFY, BYE all take this path
+        else:
+            request.reply(404, "Not Here")
+        return
+```
+
+```
+  Alice (referrer)            siphon (proxy)              Bob (transferee)
+     |  INVITE (record-route)    |                            |
+     |-------------------------->|--------------------------->|
+     |         200 OK / ACK      |     200 OK / ACK           |
+     |<========================>|<==========================>|
+     |  REFER (Route: siphon)    |                            |
+     |-------------------------->|  loose-route to Bob        |
+     |                           |--------------------------->|
+     |         202 Accepted      |         202 Accepted       |
+     |<--------------------------|<---------------------------|
+     |     NOTIFY sipfrag ...     |     NOTIFY sipfrag ...      |
+     |<--------------------------|<---------------------------|
+     |          BYE / 200        |          BYE / 200         |
+     |<========================>|<==========================>|
+```
+
+The REFER is loose-routed to the far end **exactly once** and never proxy-relayed
+by Request-URI, so it cannot loop (this is the failure that motivated intercepting
+REFER on tracked B2BUA calls in the first place). siphon does not re-anchor media
+or re-resolve `Refer-To` in proxy mode; if you need any of that, run the call
+through the B2BUA and use one of the modes above.
+
+## See also
+
+- [SBC (B2BUA)](sbc.md) — the `@b2bua.*` handlers and the `call` object.
+- [Media & RTP profiles](media-rtp.md) — anchoring media so a siphon-terminated
+  transfer keeps the media path on siphon, and `@rtpengine.on_dtmf`.
+- [Call reference](../reference/call.md) — the full `call` API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Stateful proxy: cookbook/proxy.md
       - Load balancer: cookbook/load-balancer.md
       - SBC (B2BUA): cookbook/sbc.md
+      - Call transfer (REFER): cookbook/call-transfer.md
       - Number normalization: cookbook/number-normalization.md
       - Media & RTP profiles: cookbook/media-rtp.md
       - Hardening & security: cookbook/security.md

--- a/scripts/b2bua_default.py
+++ b/scripts/b2bua_default.py
@@ -57,6 +57,16 @@ def call_answered(call, reply):
     log.info(f"Call {call.id} answered ({reply.status_code})")
 
 
+@b2bua.on_refer
+def call_transfer(call):
+    # A connected party asked to transfer the call (RFC 3515). In this
+    # residential B2BUA both legs are real user agents, so forward the REFER
+    # transparently on the far leg and let the endpoints complete the transfer
+    # between themselves — siphon relays the 202 and the sipfrag NOTIFY progress.
+    log.info(f"Call {call.id} REFER -> {call.refer_to}")
+    call.accept_refer(mode="transparent")
+
+
 @b2bua.on_failure
 def call_failed(call, code, reason):
     log.warn(f"All B legs failed {code} {reason} for call {call.id}")

--- a/scripts/b2bua_refer_modes.py
+++ b/scripts/b2bua_refer_modes.py
@@ -1,0 +1,62 @@
+"""
+SIPhon B2BUA REFER mode-dispatch script (functional-test fixture).
+
+Same bridging as the default B2BUA script, but on_refer picks the transfer mode
+from an optional X-Refer-Mode header on the REFER (transparent | terminate |
+reject), defaulting to transparent. This lets the SIPp REFER acceptance
+scenarios exercise every inbound mode against a single running siphon.
+"""
+from siphon import b2bua, proxy, registrar, auth, log
+
+DOMAIN = "siphon.test"
+
+
+@proxy.on_request
+def route(request):
+    if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+        return
+    if request.method == "REGISTER":
+        if not auth.require_digest(request, realm=DOMAIN):
+            return
+        registrar.save(request)
+        return
+
+
+@b2bua.on_invite
+def new_call(call):
+    contacts = registrar.lookup(call.ruri)
+    if not contacts:
+        call.reject(404, "Not Found")
+        return
+    call.fork(contacts, strategy="parallel", timeout=30)
+
+
+@b2bua.on_answer
+def answered(call, reply):
+    log.info(f"Call {call.id} answered ({reply.status_code})")
+    # Outbound (siphon-originated) transfer: when the caller asked for it via an
+    # X-Outbound-Refer header, send a REFER back to the caller (A-leg) once the
+    # call is up — the IVR / TAS offload pattern.
+    target = call.get_header("X-Outbound-Refer")
+    if target:
+        log.info(f"Call {call.id} outbound REFER -> {target}")
+        call.refer(target)
+
+
+@b2bua.on_refer
+def on_refer(call):
+    mode = (call.get_header("X-Refer-Mode") or "transparent").strip().lower()
+    log.info(f"Call {call.id} REFER -> {call.refer_to} (mode={mode})")
+    if mode == "reject":
+        call.reject_refer(603, "Decline")
+    elif mode == "terminate":
+        call.accept_refer(mode="terminate")
+    else:
+        call.accept_refer(mode="transparent")
+
+
+@b2bua.on_bye
+def ended(call, initiator):
+    log.info(f"Call {call.id} ended (initiator: {initiator.side})")
+    call.terminate()

--- a/scripts/b2bua_rtpengine_refer.py
+++ b/scripts/b2bua_rtpengine_refer.py
@@ -1,0 +1,52 @@
+"""
+B2BUA + media anchoring + REFER terminate — anchored terminate-transfer test.
+
+Anchors media through the media engine (rtpengine) on the initial call, then
+accepts an in-dialog REFER in siphon-terminated mode. The dispatcher re-anchors
+the surviving party to the transfer target on a fresh media session and tears
+down the old anchor (the media-plane recipe under test). Runs against a REAL
+rtpengine so the offer/answer/delete command sequence is exercised end to end.
+"""
+from siphon import b2bua, proxy, registrar, rtpengine, auth, log
+
+DOMAIN = "siphon.test"
+PROFILE = "rtp_passthrough"
+
+
+@proxy.on_request("REGISTER")
+def register(request):
+    if not auth.require_www_digest(request, realm=DOMAIN):
+        return
+    registrar.save(request)
+
+
+@b2bua.on_invite
+async def new_call(call):
+    contacts = registrar.lookup(call.ruri)
+    if not contacts:
+        call.reject(404, "Not Found")
+        return
+    # Anchor media (offer direction) before dialling the callee.
+    await rtpengine.offer(call, profile=PROFILE)
+    log.info(f"rtpengine offer done for call {call.call_id}")
+    call.fork(contacts, strategy="parallel", timeout=30)
+
+
+@b2bua.on_answer
+async def answered(call, reply):
+    log.info(f"Call {call.id} answered ({reply.status_code})")
+    # Pass `call` so the answer reuses the A-leg Call-ID that matched the offer.
+    await rtpengine.answer(reply, profile=PROFILE, call=call)
+    log.info(f"rtpengine answer done for call {call.call_id}")
+
+
+@b2bua.on_refer
+def on_refer(call):
+    log.info(f"Call {call.id} REFER -> {call.refer_to} (terminate)")
+    call.accept_refer(mode="terminate")
+
+
+@b2bua.on_bye
+async def on_bye(call, initiator):
+    log.info(f"B2BUA BYE: call {call.call_id}, initiator={initiator.side}")
+    await rtpengine.delete(call)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -104,6 +104,10 @@ run_sipp docker compose -f "$COMPOSE_FILE" run --rm sipp-register
 if [[ "$RUN_CALL" == true ]]; then
   echo "=== SIPp call test (UAC + UAS) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile call up --abort-on-container-exit sipp-uac sipp-uas
+
+  echo "=== Proxy REFER passthrough test (in-dialog REFER loose-routed, no loop) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile proxy-refer up --abort-on-container-exit --exit-code-from sipp-proxy-refer-uac sipp-proxy-refer-uac sipp-proxy-refer-uas
+  docker compose -f "$COMPOSE_FILE" --profile proxy-refer rm -sf sipp-proxy-refer-uac sipp-proxy-refer-uas sipp-proxy-refer-register 2>/dev/null || true
 fi
 
 # ── Step 6: Presence/event tests (optional) ─────────────────────────────────
@@ -184,6 +188,23 @@ if [[ "$RUN_B2BUA" == true ]]; then
   echo "=== B2BUA UPDATE test (RFC 3311 in-dialog UPDATE bridging) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-update up --abort-on-container-exit --exit-code-from sipp-b2bua-update-uac sipp-b2bua-update-uac sipp-b2bua-update-uas
   docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-update rm -sf sipp-b2bua-update-uac sipp-b2bua-update-uas 2>/dev/null || true
+
+  echo "=== B2BUA REFER test (RFC 3515 transparent blind transfer) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-refer up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-uac sipp-b2bua-refer-uac sipp-b2bua-refer-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-refer rm -sf sipp-b2bua-refer-uac sipp-b2bua-refer-uas 2>/dev/null || true
+
+  echo "=== B2BUA REFER reject test (loop-safe 603 default, no egress) ==="
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-refer-reject up -d --wait siphon-b2bua-refer-modes
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua-refer-reject up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-reject-uac sipp-b2bua-refer-reject-uac sipp-b2bua-refer-reject-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-refer-reject rm -sf sipp-b2bua-refer-reject-uac sipp-b2bua-refer-reject-uas 2>/dev/null || true
+
+  echo "=== B2BUA REFER siphon-terminated test (dial target + promote + BYE) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua-refer-terminate up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-terminate-uac sipp-b2bua-refer-terminate-uac sipp-b2bua-refer-terminate-bob-uas sipp-b2bua-refer-terminate-carol-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-refer-terminate down 2>/dev/null || true
+
+  echo "=== B2BUA REFER terminate + REAL rtpengine (media re-anchor: offer/answer/delete) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua-rtpengine-refer up --abort-on-container-exit --exit-code-from sipp-anchored-refer-uac sipp-anchored-refer-uac sipp-anchored-refer-bob-uas sipp-anchored-refer-carol-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-rtpengine-refer down 2>/dev/null || true
 
   echo "=== B2BUA CANCEL test (INVITE → CANCEL → 487) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-cancel up --abort-on-container-exit --exit-code-from sipp-b2bua-cancel-uac sipp-b2bua-cancel-uac sipp-b2bua-cancel-uas

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -15,6 +15,24 @@ from siphon_sdk.types import Action, Contact, Flow, MediaHandle, SipUri
 from siphon_sdk.request import _parse_uri, _validate_send_socket
 
 
+def _validate_replaces(replaces: Optional[dict]) -> None:
+    """Validate an attended-transfer ``replaces`` dict (RFC 3891).
+
+    ``None`` (a blind transfer) is always valid.  A dict must carry
+    ``call_id``, ``from_tag`` and ``to_tag`` (``early_only`` is optional).
+    Raises :class:`ValueError` otherwise.
+    """
+    if replaces is None:
+        return
+    required = ("call_id", "from_tag", "to_tag")
+    missing = [key for key in required if key not in replaces]
+    if missing:
+        raise ValueError(
+            f"replaces dict must contain {', '.join(required)} "
+            f"(missing: {', '.join(missing)})"
+        )
+
+
 class Call:
     """A B2BUA call with two legs (A-leg = caller, B-leg = callee).
 
@@ -221,9 +239,11 @@ class Call:
     def refer_replaces(self) -> Optional[dict]:
         """Parsed Replaces parameter from the Refer-To header.
 
-        Returns a dict with ``call_id``, ``from_tag``, and ``to_tag`` if
-        the REFER includes a Replaces header (attended transfer), or
-        ``None`` for a blind transfer.
+        Returns a dict with **four** keys — ``call_id``, ``from_tag``,
+        ``to_tag`` and ``early_only`` (a ``bool``) — if the REFER includes a
+        Replaces header (attended transfer, RFC 3891), or ``None`` for a blind
+        transfer.  ``early_only`` is ``True`` when the Replaces carried the
+        ``early-only`` flag (match only a dialog still in the early state).
 
         Example::
 
@@ -231,7 +251,10 @@ class Call:
             def handle_refer(call):
                 repl = call.refer_replaces
                 if repl:
-                    log.info(f"Attended transfer, replaces {repl['call_id']}")
+                    log.info(
+                        f"Attended transfer, replaces {repl['call_id']} "
+                        f"(early_only={repl['early_only']})"
+                    )
         """
         return self._refer_replaces
 
@@ -535,20 +558,66 @@ class Call:
         self._state = "terminated"
         self._actions.append(Action(kind="terminate"))
 
-    def accept_refer(self) -> None:
-        """Accept an incoming REFER and initiate the transfer.
+    def accept_refer(self, target: Optional[str] = None,
+                     next_hop: Optional[str] = None,
+                     mode: Optional[str] = None) -> None:
+        """Accept an incoming REFER and honour the transfer.
 
         Call this from a ``@b2bua.on_refer`` handler to proceed with the
-        call transfer.  The B2BUA will send 202 Accepted to the REFER
-        originator and initiate a new INVITE to the Refer-To target.
+        transfer the remote party asked for.
+
+        Args:
+            target: Optionally rewrite the transfer destination before
+                honouring it.  Defaults to :attr:`refer_to` (the URI carried
+                in the incoming Refer-To header).
+            next_hop: Optionally steer egress to a specific next-hop, exactly
+                like ``dial(next_hop=...)`` — the R-URI is still built from
+                ``target`` (so the referred-to identity is preserved on the
+                wire) but the message is sent to ``next_hop``.
+            mode: How siphon honours the REFER:
+
+                - ``"terminate"`` — siphon **terminates** the transfer: it
+                  answers ``202 Accepted`` locally, re-resolves ``target``
+                  (the Refer-To) through the dial plan as a brand-new leg,
+                  re-bridges the surviving leg to it, and sends BYE to the
+                  referred-away leg.  The transferor drops out; siphon owns
+                  both new legs.  The transferee never sees the REFER.
+                - ``"transparent"`` — siphon **re-emits** the REFER on the far
+                  leg and relays the far leg's ``202 Accepted`` plus the
+                  sipfrag ``NOTIFY`` progress reports back to the transferor,
+                  staying out of the transfer decision.
+                - ``None`` (default) — use the configured
+                  ``b2bua.default_refer_mode`` from ``siphon.yaml`` (which
+                  itself defaults to ``"terminate"``).
+
+        Raises:
+            ValueError: if ``mode`` is not one of ``None``, ``"terminate"``,
+                or ``"transparent"``.
 
         Example::
 
             @b2bua.on_refer
             def handle_refer(call):
+                # Blind transfer — let siphon terminate + re-bridge (default).
                 call.accept_refer()
+
+            @b2bua.on_refer
+            def handle_refer(call):
+                # Steer the referred-to leg out a specific trunk, transparently.
+                call.accept_refer(next_hop="sip:trunk.example.com:5060",
+                                  mode="transparent")
         """
-        self._actions.append(Action(kind="accept_refer"))
+        if mode not in (None, "terminate", "transparent"):
+            raise ValueError(
+                f"accept_refer(mode=...) must be None, 'terminate', or "
+                f"'transparent' (got {mode!r})"
+            )
+        self._actions.append(Action(
+            kind="accept_refer",
+            targets=[target] if target else None,
+            next_hop=next_hop,
+            extras={"mode": mode},
+        ))
 
     def reject_refer(self, code: int, reason: str) -> None:
         """Reject an incoming REFER.
@@ -564,6 +633,58 @@ class Call:
                 call.reject_refer(403, "Forbidden")
         """
         self._actions.append(Action(kind="reject_refer", status_code=code, reason=reason))
+
+    def refer(self, target: str, replaces: Optional[dict] = None) -> None:
+        """Originate an outbound REFER — siphon is the *referrer*.
+
+        Use this when siphon itself drives the transfer, e.g. a UAS/IVR
+        offload that answers the call, plays a menu, then transfers the caller
+        onward.  This is the mirror of :meth:`accept_refer` (which honours a
+        REFER siphon *received*).
+
+        Args:
+            target: The Refer-To URI — where the remote party should be
+                transferred to.
+            replaces: For an **attended** transfer, a dict identifying the
+                dialog to replace (RFC 3891) with keys ``call_id``,
+                ``from_tag`` and ``to_tag`` (and an optional ``early_only``
+                bool).  Omit / ``None`` for a **blind** transfer.
+
+        Raises:
+            ValueError: if ``replaces`` is given but is missing any of
+                ``call_id`` / ``from_tag`` / ``to_tag``.
+
+        Note:
+            This is a **deferred** call action — it is honoured after the
+            handler returns, so it works from a call-scoped handler like
+            ``@b2bua.on_answer``.  From an out-of-band event callback
+            (``@rtpengine.on_dtmf``, a timer) where no ``call`` is in scope and
+            deferred actions are no-ops, use the imperative
+            :func:`b2bua.refer` (keyed by Call-ID) instead.
+
+        Example::
+
+            @b2bua.on_answer
+            def on_answer(call, reply):
+                # Blind transfer the freshly answered call onward.
+                call.refer("sip:+15550142@example.com")
+
+            @b2bua.on_answer
+            def attended(call, reply):
+                call.refer(
+                    "sip:+15550142@example.com",
+                    replaces={"call_id": "held-dialog@example.com",
+                              "from_tag": "ft-held",
+                              "to_tag": "tt-held"},
+                )
+        """
+        _validate_replaces(replaces)
+        self._actions.append(Action(
+            kind="refer",
+            targets=[target],
+            next_hop=None,
+            extras={"replaces": replaces},
+        ))
 
     def session_timer(self, expires: int, min_se: int = 90,
                       refresher: str = "uac") -> None:

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -576,15 +576,20 @@ class MockB2bua:
     Imperative:
         - ``b2bua.terminate(call_id)`` — end a call by SIP Call-ID from any
           context (records onto ``terminates`` for test assertions)
+        - ``b2bua.refer(call_id, target)`` — transfer a call by SIP Call-ID
+          from any context (records onto ``refers`` for test assertions)
     """
 
     def __init__(self) -> None:
         # Records b2bua.terminate(...) calls for test assertions.
         self.terminates: list[dict] = []
+        # Records b2bua.refer(...) calls for test assertions.
+        self.refers: list[dict] = []
 
     def clear(self) -> None:
         """Reset recorded imperative calls (called by ``reset()``)."""
         self.terminates.clear()
+        self.refers.clear()
 
     def terminate(self, call_id: str, reason: str = "Normal Clearing") -> bool:
         """Imperatively end a B2BUA call by its SIP Call-ID.
@@ -613,6 +618,52 @@ class MockB2bua:
                     b2bua.terminate(call_id)
         """
         self.terminates.append({"call_id": call_id, "reason": reason})
+        return True
+
+    def refer(self, call_id: str, target: str,
+              replaces: Optional[dict] = None) -> bool:
+        """Imperatively transfer a B2BUA call by its SIP Call-ID.
+
+        The imperative twin of :meth:`Call.refer`.  Unlike ``call.refer()``
+        (a deferred call action, honoured after its handler returns), this
+        acts immediately and is keyed by SIP Call-ID, so it works from an
+        out-of-band event callback (``@rtpengine.on_dtmf``, a timer) where
+        no ``call`` object is in scope and deferred actions are no-ops — the
+        same reason :meth:`terminate` exists alongside ``call.terminate()``.
+
+        Args:
+            call_id: the SIP Call-ID of the call to transfer.
+            target: the Refer-To URI (transfer destination).
+            replaces: optional attended-transfer dict (RFC 3891) with
+                ``call_id`` / ``from_tag`` / ``to_tag`` (and an optional
+                ``early_only``); ``None`` for a blind transfer.
+
+        Returns:
+            bool: True if a matching call was found and the REFER was
+            originated, False if the Call-ID is unknown / already gone.
+            Never raises for a missing call.
+
+        Raises:
+            ValueError: if ``replaces`` is given but missing any of
+                ``call_id`` / ``from_tag`` / ``to_tag``.
+
+        In the mock, records ``{"call_id", "target", "replaces"}`` on
+        ``refers`` and returns True. Inspect via
+        ``siphon.get_b2bua().refers``.
+
+        Usage::
+
+            @rtpengine.on_dtmf
+            def on_ivr_dtmf(call_id, from_tag, digit, duration_ms, volume):
+                if digit == "*":
+                    b2bua.refer(call_id, "sip:+15550142@example.com")
+        """
+        from siphon_sdk.call import _validate_replaces
+
+        _validate_replaces(replaces)
+        self.refers.append(
+            {"call_id": call_id, "target": target, "replaces": replaces}
+        )
         return True
 
     @staticmethod
@@ -682,7 +733,19 @@ class MockB2bua:
     def on_refer(fn: Callable) -> Callable:
         """Register handler for REFER (call transfer, RFC 3515).
 
-        Handler signature: ``(call) -> None``
+        Handler signature is **single-arg** ``(call) -> None``.  A REFER is a
+        SIP *request*, not a response, so there is **no** ``reply`` object —
+        do NOT write ``(call, reply)`` and do NOT call ``rtpengine.answer()``
+        here.  Read the transfer target off :attr:`Call.refer_to` (and
+        :attr:`Call.refer_replaces` for an attended transfer), then decide
+        with :meth:`Call.accept_refer` or :meth:`Call.reject_refer`.
+
+        Example::
+
+            @b2bua.on_refer
+            def handle_refer(call):
+                log.info(f"Transfer requested to {call.refer_to}")
+                call.accept_refer()
         """
         is_async = asyncio.iscoroutinefunction(fn)
         _registry.register("b2bua.on_refer", None, fn, is_async)

--- a/sdk/siphon_sdk/testing.py
+++ b/sdk/siphon_sdk/testing.py
@@ -618,6 +618,59 @@ class SipTestHarness:
 
         return CallResult(call=call, actions=list(call.actions))
 
+    def send_refer(
+        self,
+        call: Optional[Call] = None,
+        refer_to: str = "sip:+15550111@example.com",
+        refer_replaces: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> CallResult:
+        """Dispatch a REFER (call transfer) to ``@b2bua.on_refer`` handlers.
+
+        Mirrors :meth:`send_invite` for the transfer path.  Builds an answered
+        :class:`Call` carrying the transfer target on :attr:`Call.refer_to`
+        (and :attr:`Call.refer_replaces` for an attended transfer), then
+        dispatches it to the registered ``@b2bua.on_refer`` handler with a
+        **single** ``(call,)`` argument — a REFER is a request, so there is no
+        reply object.  Supports both sync and async handlers.
+
+        Note:
+            With **no** registered handler this returns an empty
+            :class:`CallResult` (no action recorded).  In production the
+            Rust dispatcher locally rejects an un-handled REFER (501 / 603) —
+            that default is a dispatcher concern, out of scope for the mock.
+
+        Args:
+            call: Call object (auto-created answered if ``None``).
+            refer_to: The Refer-To URI (transfer target).
+            refer_replaces: Optional attended-transfer dict with ``call_id`` /
+                ``from_tag`` / ``to_tag`` (and optional ``early_only``);
+                ``None`` for a blind transfer.
+            **kwargs: Passed to the :class:`Call` constructor when
+                auto-creating.
+
+        Returns:
+            :class:`CallResult` with the actions the handler took.
+        """
+        if call is None:
+            call = Call(
+                state="answered",
+                refer_to=refer_to,
+                refer_replaces=refer_replaces,
+                **kwargs,
+            )
+
+        registry = mock_module.get_registry()
+        handlers = registry.get("b2bua.on_refer")
+
+        for fn, is_async in handlers:
+            if is_async:
+                self._loop.run_until_complete(fn(call))
+            else:
+                fn(call)
+
+        return CallResult(call=call, actions=list(call.actions))
+
     @property
     def diameter(self) -> mock_module.MockDiameter:
         """Access the mock Diameter namespace (Cx/Rx operations)."""

--- a/sdk/tests/test_b2bua_refer.py
+++ b/sdk/tests/test_b2bua_refer.py
@@ -1,0 +1,261 @@
+"""Tests for the B2BUA REFER / call-transfer API.
+
+Covers both the call-scoped handler path (``@b2bua.on_refer`` +
+``call.accept_refer`` / ``call.reject_refer`` / ``call.refer``) and the
+imperative ``b2bua.refer(call_id, target)`` used from out-of-band event
+callbacks (``@rtpengine.on_dtmf``, timers) where no ``call`` object is in
+scope and deferred call actions are no-ops — the twin of ``b2bua.terminate``.
+
+A REFER is a SIP *request*, so ``@b2bua.on_refer`` is single-arg ``(call)``
+with no ``reply`` object.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from siphon_sdk.testing import SipTestHarness
+
+
+@pytest.fixture
+def harness():
+    h = SipTestHarness(local_domains=["example.com"])
+    yield h
+    h.reset()
+    h.close()
+
+
+class TestOnReferHandler:
+    def test_single_arg_and_blind_refer_to_readable(self, harness):
+        # Handler is single-arg (call). If it were (call, reply) the harness'
+        # fn(call) dispatch would raise TypeError, so a clean run proves the
+        # single-arg contract.  Blind transfer => refer_replaces is None.
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    assert call.refer_replaces is None
+    call.set_header("X-Seen-Refer-To", call.refer_to)
+    call.accept_refer()
+"""
+        )
+
+        result = harness.send_refer(refer_to="sip:+15550142@example.com")
+        assert result.call.refer_to == "sip:+15550142@example.com"
+        assert result.call.get_header("X-Seen-Refer-To") == "sip:+15550142@example.com"
+        assert result.action == "accept_refer"
+
+    def test_attended_replaces_passes_all_four_keys(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    repl = call.refer_replaces
+    call.set_header("X-Repl-CallId", repl["call_id"])
+    call.set_header("X-Repl-FromTag", repl["from_tag"])
+    call.set_header("X-Repl-ToTag", repl["to_tag"])
+    call.set_header("X-Repl-EarlyOnly", str(repl["early_only"]))
+    call.accept_refer()
+"""
+        )
+
+        result = harness.send_refer(
+            refer_to="sip:+15550142@example.com",
+            refer_replaces={
+                "call_id": "held-dialog@example.com",
+                "from_tag": "ft-held",
+                "to_tag": "tt-held",
+                "early_only": True,
+            },
+        )
+        repl = result.call.refer_replaces
+        assert set(repl) == {"call_id", "from_tag", "to_tag", "early_only"}
+        assert repl["early_only"] is True
+        assert result.call.get_header("X-Repl-CallId") == "held-dialog@example.com"
+        assert result.call.get_header("X-Repl-EarlyOnly") == "True"
+
+
+class TestAcceptRefer:
+    def test_default_mode_is_none_and_no_target(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer()
+"""
+        )
+
+        result = harness.send_refer()
+        action = result.call.last_action
+        assert action.kind == "accept_refer"
+        assert action.extras["mode"] is None
+        assert action.targets is None
+        assert action.next_hop is None
+
+    def test_target_and_transparent_mode_recorded(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(target="sip:+15550142@example.com",
+                      next_hop="sip:trunk.example.com:5060",
+                      mode="transparent")
+"""
+        )
+
+        result = harness.send_refer()
+        action = result.call.last_action
+        assert action.kind == "accept_refer"
+        assert action.extras["mode"] == "transparent"
+        assert action.targets == ["sip:+15550142@example.com"]
+        assert action.next_hop == "sip:trunk.example.com:5060"
+
+    def test_invalid_mode_raises_value_error(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(mode="bridge")
+"""
+        )
+
+        with pytest.raises(ValueError):
+            harness.send_refer()
+
+
+class TestRejectRefer:
+    def test_reject_recorded(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.reject_refer(603, "Decline")
+"""
+        )
+
+        result = harness.send_refer()
+        action = result.call.last_action
+        assert action.kind == "reject_refer"
+        assert action.status_code == 603
+        assert action.reason == "Decline"
+
+
+class TestOutboundCallRefer:
+    def test_blind_refer_from_on_answer(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_answer
+def on_answer(call, reply):
+    call.refer("sip:+15550142@example.com")
+"""
+        )
+
+        result = harness.send_answer()
+        action = result.call.last_action
+        assert action.kind == "refer"
+        assert action.targets == ["sip:+15550142@example.com"]
+        assert action.extras["replaces"] is None
+
+    def test_attended_refer_records_replaces(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_answer
+def on_answer(call, reply):
+    call.refer(
+        "sip:+15550142@example.com",
+        replaces={"call_id": "held@example.com",
+                  "from_tag": "ft", "to_tag": "tt"},
+    )
+"""
+        )
+
+        result = harness.send_answer()
+        action = result.call.last_action
+        assert action.kind == "refer"
+        assert action.extras["replaces"] == {
+            "call_id": "held@example.com",
+            "from_tag": "ft",
+            "to_tag": "tt",
+        }
+
+    def test_refer_bad_replaces_raises(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_answer
+def on_answer(call, reply):
+    call.refer("sip:+15550142@example.com",
+               replaces={"call_id": "held@example.com"})
+"""
+        )
+
+        with pytest.raises(ValueError):
+            harness.send_answer()
+
+
+class TestImperativeB2buaRefer:
+    def test_refer_from_on_dtmf_star_digit(self, harness):
+        # Cross-worker-safe transfer by Call-ID from an out-of-band DTMF
+        # callback — no stashed `call` object.
+        harness.load_source(
+            """
+from siphon import rtpengine, b2bua
+
+XFER_DIGIT = "*"
+
+@rtpengine.on_dtmf
+def on_ivr_dtmf(call_id, from_tag, digit, duration_ms, volume):
+    if digit == XFER_DIGIT:
+        b2bua.refer(call_id, "sip:+15550142@example.com")
+"""
+        )
+
+        # A non-transfer digit does nothing.
+        harness.rtpengine.fire_dtmf("call-abc@example.com", "ft", "5")
+        assert harness.b2bua.refers == []
+
+        # The transfer digit refers by call-id.
+        fired = harness.rtpengine.fire_dtmf("call-abc@example.com", "ft", "*")
+        assert fired == 1
+        assert harness.b2bua.refers == [
+            {
+                "call_id": "call-abc@example.com",
+                "target": "sip:+15550142@example.com",
+                "replaces": None,
+            }
+        ]
+
+    def test_direct_call_returns_true_and_records(self, harness):
+        import siphon
+
+        assert siphon.b2bua.refer("x@example.com", "sip:+15550111@example.com") is True
+        assert harness.b2bua.refers[-1] == {
+            "call_id": "x@example.com",
+            "target": "sip:+15550111@example.com",
+            "replaces": None,
+        }
+
+    def test_reset_clears_recorded_refers(self, harness):
+        import siphon
+
+        siphon.b2bua.refer("x@example.com", "sip:+15550111@example.com")
+        assert harness.b2bua.refers
+        harness.reset()
+        assert harness.b2bua.refers == []

--- a/sipp/b2bua_refer_carol_uas.xml
+++ b/sipp/b2bua_refer_carol_uas.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated — Carol, the transfer target:
+  Receive INVITE (siphon dials carol after the terminate REFER) → 180 → 200 → ACK
+  → (bridged to bob) → send BYE → 200
+
+  Carol is dialed directly by the Refer-To URI (not registered). After she
+  answers she is bridged to the surviving party (bob); she then hangs up, and
+  siphon tears down the far leg.
+-->
+<scenario name="B2BUA REFER terminate Carol UAS">
+
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="(.*)" search_in="hdr" header="Call-ID:" assign_to="dialog_callid" />
+      <ereg regexp="tag=([^;>\r\n ]+)" search_in="hdr" header="From:" assign_to="junk,remote_tag" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="From:" assign_to="junk,remote_from_uri" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="Contact:" assign_to="junk,remote_contact" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=carol 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" timeout="5000" />
+
+  <!-- Carol hangs up; siphon tears down the surviving far leg. -->
+  <send retrans="500">
+    <![CDATA[
+BYE [$remote_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:carol@[local_ip]>;tag=[pid]SIPpTag02[call_number]
+To: <[$remote_from_uri]>;tag=[$remote_tag]
+Call-ID: [$dialog_callid]
+CSeq: 1 BYE
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-terminate-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+</scenario>

--- a/sipp/b2bua_refer_outbound_uac.xml
+++ b/sipp/b2bua_refer_outbound_uac.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA siphon-originated (outbound) REFER UAC scenario — Alice, the referee:
+  INVITE (X-Outbound-Refer: carol) → 200 → ACK
+  → receive siphon's REFER (Refer-To: carol) → 202
+  → send sipfrag NOTIFY (200 OK) → 200
+  → BYE → 200
+
+  The script's @b2bua.on_answer calls call.refer(target) once the call is up, so
+  siphon originates an in-dialog REFER to the caller (the IVR / TAS offload
+  pattern). This validates the outbound path (CallAction::SendRefer) end to end.
+-->
+<scenario name="B2BUA outbound REFER UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+X-Outbound-Refer: sip:+15550142@example.com
+User-Agent: SIPp/b2bua-refer-outbound-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- siphon originates the REFER (from @b2bua.on_answer → call.refer). -->
+  <recv request="REFER" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 202 Accepted
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!-- Report the transfer complete: sipfrag NOTIFY back to siphon (which absorbs
+       it — siphon owns this subscription as the referrer). From/To are the
+       received REFER's To/From (dialog roles reversed). -->
+  <send retrans="500">
+    <![CDATA[
+NOTIFY sip:[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 NOTIFY
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Event: refer
+Subscription-State: terminated;reason=noresource
+User-Agent: SIPp/b2bua-refer-outbound-test
+Content-Type: message/sipfrag
+Content-Length: [len]
+
+SIP/2.0 200 OK
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/b2bua_refer_reject_uac.xml
+++ b/sipp/b2bua_refer_reject_uac.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER reject UAC scenario — Alice, the referrer:
+  INVITE → 200 → ACK
+  → REFER (X-Refer-Mode: reject) → 603 Decline (local, NOT forwarded)
+  → BYE → 200
+
+  Validates the loop-safe default: an in-dialog REFER the script declines is
+  answered locally by siphon and never egresses to the far leg (no loop).
+-->
+<scenario name="B2BUA REFER reject UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-reject-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <!-- REFER the script is configured to decline. -->
+  <send retrans="500">
+    <![CDATA[
+REFER sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 REFER
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Refer-To: <sip:+15550142@example.com>
+X-Refer-Mode: reject
+User-Agent: SIPp/b2bua-refer-reject-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- siphon answers the REFER locally; nothing is forwarded to the far leg. -->
+  <recv response="603" crlf="true" />
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/b2bua_refer_terminate_bob_uas.xml
+++ b/sipp/b2bua_refer_terminate_bob_uas.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated — Bob, the surviving far leg:
+  Receive INVITE → 180 → 200 → ACK
+  → receive the media re-INVITE (siphon re-points Bob's media at the transfer
+    target Carol, RFC 3261 §14) → 200 → ACK
+  → receive BYE (Carol hung up) → 200
+
+  After the transfer completes, siphon re-INVITEs the surviving party with the
+  transfer target's SDP so media flows Bob <-> Carol.
+-->
+<scenario name="B2BUA REFER terminate Bob UAS">
+
+  <recv request="INVITE" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <!-- siphon re-INVITEs Bob with the transfer target's SDP (media re-anchor). -->
+  <recv request="INVITE" crlf="true" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687638 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/b2bua_refer_terminate_uac.xml
+++ b/sipp/b2bua_refer_terminate_uac.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated UAC scenario — Alice, the referrer:
+  INVITE → 200 → ACK
+  → REFER (X-Refer-Mode: terminate, Refer-To: carol) → 202
+  → NOTIFY (sipfrag 100 Trying) → 200
+  → NOTIFY (sipfrag 200 OK, terminated) → 200
+  → BYE (siphon tears down the referrer leg once carol answers) → 200
+
+  siphon answers the 202 + sipfrag NOTIFYs itself, dials carol as a new leg,
+  promotes it into the surviving pair (bob stays), and BYEs this referrer leg.
+-->
+<scenario name="B2BUA REFER terminate UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-terminate-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+REFER sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 REFER
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Refer-To: <sip:carol@172.20.0.54:5060>
+X-Refer-Mode: terminate
+User-Agent: SIPp/b2bua-refer-terminate-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="202" crlf="true" />
+
+  <!-- sipfrag NOTIFY 100 Trying (siphon-originated). -->
+  <recv request="NOTIFY" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!--
+    The final sipfrag NOTIFY (200 OK, subscription terminated) and the
+    referrer-leg BYE are two independent transactions siphon fires back to
+    back (µs apart). Over UDP there is NO cross-transaction ordering
+    guarantee (RFC 3261 §18), so either can hit the wire first. A real UAC
+    must accept both orderings — so do we. Both branches answer 200 to the
+    NOTIFY and 200 to the BYE, then the call completes.
+  -->
+
+  <!-- If the NOTIFY arrives first, branch to label 10; otherwise fall through
+       to the BYE-first ordering below. -->
+  <recv request="NOTIFY" optional="true" next="10" crlf="true" />
+
+  <!-- ===== BYE arrived before the final NOTIFY ===== -->
+  <recv request="BYE" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+  <recv request="NOTIFY" crlf="true" next="20" />
+
+  <!-- ===== NOTIFY arrived first ===== -->
+  <label id="10" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+  <recv request="BYE" crlf="true" />
+
+  <!-- ===== converge: answer whichever request (NOTIFY or BYE) was last ===== -->
+  <label id="20" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/b2bua_refer_uac.xml
+++ b/sipp/b2bua_refer_uac.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER (transparent blind transfer) UAC scenario — Alice, the referrer:
+  INVITE → 200 → ACK
+  → REFER (Refer-To: carol) → 202
+  → NOTIFY (message/sipfrag) → 200
+  → BYE → 200
+
+  Validates that an in-dialog REFER on a tracked B2BUA call is NOT proxy-relayed
+  (the loop), but handled by @b2bua.on_refer: in transparent mode siphon forwards
+  the REFER to the far leg and relays the far end's 202 + sipfrag NOTIFY back to
+  the referrer. All addresses/numbers are sanitized test values.
+-->
+<scenario name="B2BUA REFER transparent UAC">
+
+  <!-- Initial INVITE -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <!-- Blind transfer: REFER the call to carol. -->
+  <send retrans="500">
+    <![CDATA[
+REFER sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 REFER
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Refer-To: <sip:+15550142@example.com>
+Referred-By: <sip:alice@[local_ip]>
+User-Agent: SIPp/b2bua-refer-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="202" crlf="true" />
+
+  <!-- Far end's sipfrag NOTIFY, relayed transparently by siphon. -->
+  <recv request="NOTIFY" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!-- BYE -->
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/b2bua_refer_uas.xml
+++ b/sipp/b2bua_refer_uas.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER (transparent blind transfer) UAS scenario — Bob, the far leg:
+  Receive INVITE → 180 → 200 → ACK
+  → receive the forwarded REFER → 202
+  → send sipfrag NOTIFY (200 OK) → 200
+  → receive BYE → 200
+
+  In transparent mode siphon re-emits Alice's REFER on this (the far) leg's own
+  dialog, and bridges Bob's sipfrag NOTIFY back to Alice. This UAS plays a peer
+  that accepts REFER and reports the transfer complete.
+-->
+<scenario name="B2BUA REFER transparent UAS">
+
+  <!-- Receive the B-leg INVITE from siphon; capture the dialog for the NOTIFY. -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="(.*)" search_in="hdr" header="Call-ID:" assign_to="dialog_callid" />
+      <ereg regexp="tag=([^;>\r\n ]+)" search_in="hdr" header="From:" assign_to="junk,remote_tag" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="From:" assign_to="junk,remote_from_uri" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="Contact:" assign_to="junk,remote_contact" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <!-- siphon forwards Alice's REFER onto this leg (transparent mode). -->
+  <recv request="REFER" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 202 Accepted
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!-- Report the transfer complete: a message/sipfrag NOTIFY back to siphon,
+       which bridges it to Alice. -->
+  <send retrans="500">
+    <![CDATA[
+NOTIFY [$remote_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:bob@[local_ip]>;tag=[pid]SIPpTag01[call_number]
+To: <[$remote_from_uri]>;tag=[$remote_tag]
+Call-ID: [$dialog_callid]
+CSeq: 1 NOTIFY
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Event: refer
+Subscription-State: terminated;reason=noresource
+User-Agent: SIPp/b2bua-refer-test
+Content-Type: message/sipfrag
+Content-Length: [len]
+
+SIP/2.0 200 OK
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/configs/siphon.b2bua-refer-modes-test.yaml
+++ b/sipp/configs/siphon.b2bua-refer-modes-test.yaml
@@ -1,0 +1,37 @@
+# siphon.b2bua-refer-modes-test.yaml — B2BUA REFER acceptance configuration
+#
+# Used with: sipp/docker-compose.yaml (b2bua-refer-modes profile)
+# Script:    scripts/b2bua_refer_modes.py (dispatches on X-Refer-Mode)
+# Tests:     REFER reject (603) and siphon-terminated transfer
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.60"
+    - "127.0.0.1"
+
+script:
+  path: "scripts/b2bua_refer_modes.py"
+  reload: auto
+
+advertised_address: "172.20.0.60"
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/configs/siphon.b2bua-rtpengine-refer.yaml
+++ b/sipp/configs/siphon.b2bua-rtpengine-refer.yaml
@@ -1,0 +1,44 @@
+# siphon.b2bua-rtpengine-refer.yaml — anchored B2BUA REFER-terminate test config
+#
+# Used with: sipp/docker-compose.yaml (b2bua-rtpengine-refer profile)
+# Script:    scripts/b2bua_rtpengine_refer.py (anchors media + on_refer terminate)
+# Media:     REAL rtpengine (drachtio/rtpengine) at 172.20.0.44:22222
+# Proves:    the terminate-transfer media recipe (rtpengine offer/answer/delete)
+#            against a real media engine, not the SDP-echo mock.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.61"
+    - "127.0.0.1"
+
+script:
+  path: "scripts/b2bua_rtpengine_refer.py"
+  reload: auto
+
+advertised_address: "172.20.0.61"
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+media:
+  rtpengine:
+    address: "172.20.0.44:22222"
+    timeout_ms: 2000
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -862,6 +862,7 @@ services:
       - b2bua-cancel
       - b2bua-early-media
       - b2bua-topology
+      - b2bua-refer
 
   # Register bob with Contact pointing to the basic UAS IP (172.20.0.52)
   sipp-b2bua-register:
@@ -906,6 +907,7 @@ services:
       - b2bua-cancel
       - b2bua-early-media
       - b2bua-topology
+      - b2bua-refer
 
   # --- B2BUA basic call test ---
 
@@ -1312,6 +1314,297 @@ services:
       - -trace_err
     profiles:
       - b2bua-update
+
+  # --- B2BUA REFER test (RFC 3515 transparent blind transfer) ---
+
+  sipp-b2bua-refer-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer
+
+  sipp-b2bua-refer-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua:
+        condition: service_healthy
+      sipp-b2bua-refer-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.50:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer
+
+  # --- B2BUA REFER acceptance modes (reject 603 + siphon-terminated) ---
+  # A separate siphon (172.20.0.60) running the mode-dispatch script; on_refer
+  # picks the mode from the X-Refer-Mode header.
+
+  siphon-b2bua-refer-modes:
+    build:
+      context: ..
+    container_name: siphon-b2bua-refer-modes-test
+    volumes:
+      - ./configs/siphon.b2bua-refer-modes-test.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.60
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - b2bua-refer-reject
+      - b2bua-refer-terminate
+      - b2bua-refer-outbound
+
+  sipp-b2bua-refer-modes-register:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - "172.20.0.60:5060"
+      - -sf
+      - /sipp/scenarios/register_alice_contact.xml
+      - -inf
+      - /sipp/scenarios/b2bua_bob_contact.csv
+      - -s
+      - bob
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+    profiles:
+      - b2bua-refer-reject
+      - b2bua-refer-terminate
+      - b2bua-refer-outbound
+
+  sipp-b2bua-refer-reject-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-refer-modes-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-reject
+
+  sipp-b2bua-refer-reject-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+      sipp-b2bua-refer-reject-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.60:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_reject_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-reject
+
+  # siphon-terminated transfer: bob is the surviving far leg, carol the target.
+
+  sipp-b2bua-refer-terminate-bob-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-refer-modes-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_bob_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-terminate
+
+  sipp-b2bua-refer-terminate-carol-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.54
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_carol_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-terminate
+
+  sipp-b2bua-refer-terminate-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+      sipp-b2bua-refer-terminate-bob-uas:
+        condition: service_started
+      sipp-b2bua-refer-terminate-carol-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.60:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-terminate
+
+  # siphon-originated (outbound) REFER: siphon REFERs the caller after answer.
+
+  sipp-b2bua-refer-outbound-bob-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-refer-modes-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-outbound
+
+  sipp-b2bua-refer-outbound-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+      sipp-b2bua-refer-outbound-bob-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.60:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_outbound_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-outbound
 
   # --- B2BUA failure test ---
 
@@ -2431,6 +2724,245 @@ services:
         ipv4_address: 172.20.0.83
     profiles:
       - webrtc
+
+  # ── Proxy-mode REFER (passthrough via loose-routing) ─────────────────────
+  # Reuses the base `siphon` proxy (172.20.0.10, proxy_default.py, which
+  # record-routes and loose-routes in-dialog requests). Proves an in-dialog
+  # REFER on a proxy dialog is loose-routed to the far end exactly once
+  # (never proxy-relayed by R-URI into a loop) and the far end's 202 + sipfrag
+  # NOTIFYs relay straight back. No B2BUA, no siphon-side subscription state.
+
+  # Register bob from the UAS IP so the proxy routes the INVITE to him.
+  sipp-proxy-refer-register:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.70
+    entrypoint:
+      - sipp
+      - "172.20.0.10:5060"
+      - -sf
+      - /sipp/scenarios/register.xml
+      - -s
+      - bob
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+    profiles:
+      - proxy-refer
+
+  # Bob, the transferee/far end.
+  sipp-proxy-refer-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-proxy-refer-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.70
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/proxy_refer_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - proxy-refer
+
+  # Alice, the referrer.
+  sipp-proxy-refer-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon:
+        condition: service_healthy
+      sipp-proxy-refer-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.71
+    entrypoint:
+      - sipp
+      - "172.20.0.10:5060"
+      - -sf
+      - /sipp/scenarios/proxy_refer_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - proxy-refer
+
+  # ── Anchored REFER-terminate against a REAL rtpengine ────────────────────
+  # Proves the terminate-transfer media recipe (siphon issues rtpengine
+  # offer/answer/delete to re-anchor survivor↔target on a fresh media session
+  # and tears down the old anchor) end-to-end against a real media engine, not
+  # the SDP-echo mock. Alice(.53) calls bob(.52) through the anchored B2BUA
+  # siphon(.61); the SDP is rewritten to rtpengine(.44); Alice REFERs to
+  # carol(.54); siphon re-anchors bob↔carol and BYEs alice.
+
+  rtpengine-real:
+    image: drachtio/rtpengine:latest
+    container_name: rtpengine-real
+    # Entrypoint auto-detects the container IP → interface + listen-ng=IP:22222.
+    # --table=-1 forces userspace forwarding (no kernel module in the container).
+    command: ["rtpengine", "--table=-1", "--log-level=6"]
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.44
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'hc d7:command4:pinge', ('172.20.0.44',22222)); d=s.recv(1024); s.close(); exit(0 if b'pong' in d else 1)\" || nc -zu 172.20.0.44 22222"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+      start_period: 3s
+    profiles:
+      - b2bua-rtpengine-refer
+
+  siphon-b2bua-rtpengine-refer:
+    build:
+      context: ..
+    container_name: siphon-b2bua-rtpengine-refer-test
+    depends_on:
+      rtpengine-real:
+        condition: service_started
+    volumes:
+      - ./configs/siphon.b2bua-rtpengine-refer.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.61
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - b2bua-rtpengine-refer
+
+  sipp-anchored-refer-register:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-rtpengine-refer:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - "172.20.0.61:5060"
+      - -sf
+      - /sipp/scenarios/register.xml
+      - -s
+      - bob
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+    profiles:
+      - b2bua-rtpengine-refer
+
+  sipp-anchored-refer-bob-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-anchored-refer-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_bob_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-rtpengine-refer
+
+  sipp-anchored-refer-carol-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-anchored-refer-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.54
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_carol_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-rtpengine-refer
+
+  sipp-anchored-refer-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-rtpengine-refer:
+        condition: service_healthy
+      sipp-anchored-refer-bob-uas:
+        condition: service_started
+      sipp-anchored-refer-carol-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.61:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-rtpengine-refer
 
 # ── Network ────────────────────────────────────────────────────────────────
 networks:

--- a/sipp/proxy_refer_uac.xml
+++ b/sipp/proxy_refer_uac.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Proxy-mode REFER (passthrough) UAC scenario — Alice, the referrer:
+  INVITE → 200 → ACK
+  → REFER (Refer-To: carol) → 202
+  → NOTIFY (sipfrag 100 Trying) → 200
+  → NOTIFY (sipfrag 200 OK, terminated) → 200
+  → BYE → 200
+
+  In PROXY mode siphon does not terminate the transfer: it record-routes the
+  INVITE, then loose-routes the in-dialog REFER to the far end (bob) and relays
+  bob's 202 + sipfrag NOTIFYs straight back. The transfer subscription lives
+  between Alice and Bob; siphon owns no state. Alice tears her own leg down with
+  a BYE once the transfer is reported complete.
+
+  This is the regression proof that an in-dialog REFER on a proxy dialog is
+  loose-routed exactly once (never proxy-relayed by R-URI into a loop).
+-->
+<scenario name="Proxy REFER passthrough UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/proxy-refer-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <!-- Capture the route set (Record-Route) from the 200 OK for in-dialog requests. -->
+  <recv response="200" rtd="true" crlf="true" rrs="true" />
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <!-- In-dialog REFER: loose-routed by siphon to bob (never proxy-relayed by
+       R-URI, so never looped). -->
+  <send retrans="500">
+    <![CDATA[
+REFER [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 REFER
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+[routes]
+Max-Forwards: 70
+Refer-To: <sip:carol@example.com>
+Referred-By: <sip:alice@[remote_ip]>
+User-Agent: SIPp/proxy-refer-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="202" crlf="true" />
+
+  <!-- sipfrag NOTIFY 100 Trying (from bob, relayed by siphon). -->
+  <recv request="NOTIFY" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- sipfrag NOTIFY 200 OK (transfer complete, subscription terminated). -->
+  <recv request="NOTIFY" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Alice tears her own leg down (she transferred bob away). -->
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/proxy_refer_uas.xml
+++ b/sipp/proxy_refer_uas.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Proxy-mode REFER (passthrough) UAS scenario — Bob, the transferee/far end:
+  Receive INVITE → 180 → 200 → ACK
+  → receive the loose-routed REFER → 202
+  → send sipfrag NOTIFY (100 Trying) → 200
+  → send sipfrag NOTIFY (200 OK, terminated) → 200
+  → receive BYE → 200
+
+  siphon is a record-routing proxy here, not a B2BUA: the REFER arrives on the
+  same dialog Alice and Bob established (single Record-Route = siphon), and Bob
+  sends his sipfrag NOTIFYs back through siphon via the captured route set
+  ([routes] — one hop, so no reversal needed). Bob plays the transferee that
+  accepts the REFER and reports the transfer complete.
+-->
+<scenario name="Proxy REFER passthrough UAS">
+
+  <!-- Receive the INVITE from siphon; capture Alice's dialog + the route set. -->
+  <recv request="INVITE" crlf="true" rrs="true">
+    <action>
+      <ereg regexp="(.*)" search_in="hdr" header="Call-ID:" assign_to="dialog_callid" />
+      <ereg regexp="tag=([^;>\r\n ]+)" search_in="hdr" header="From:" assign_to="junk,alice_tag" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="From:" assign_to="junk,alice_from_uri" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="Contact:" assign_to="junk,alice_contact" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_Record-Route:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_Record-Route:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <!-- siphon loose-routes Alice's in-dialog REFER to this leg. -->
+  <recv request="REFER" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 202 Accepted
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!-- Progress NOTIFY (100 Trying) back through siphon to Alice. -->
+  <send retrans="500">
+    <![CDATA[
+NOTIFY [$alice_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:bob@[local_ip]>;tag=[pid]SIPpTag01[call_number]
+To: <[$alice_from_uri]>;tag=[$alice_tag]
+Call-ID: [$dialog_callid]
+CSeq: 1 NOTIFY
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+[routes]
+Max-Forwards: 70
+Event: refer
+Subscription-State: active;expires=60
+User-Agent: SIPp/proxy-refer-test
+Content-Type: message/sipfrag
+Content-Length: [len]
+
+SIP/2.0 100 Trying
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+  <pause milliseconds="200" />
+
+  <!-- Final NOTIFY (200 OK, subscription terminated). -->
+  <send retrans="500">
+    <![CDATA[
+NOTIFY [$alice_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:bob@[local_ip]>;tag=[pid]SIPpTag01[call_number]
+To: <[$alice_from_uri]>;tag=[$alice_tag]
+Call-ID: [$dialog_callid]
+CSeq: 2 NOTIFY
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+[routes]
+Max-Forwards: 70
+Event: refer
+Subscription-State: terminated;reason=noresource
+User-Agent: SIPp/proxy-refer-test
+Content-Type: message/sipfrag
+Content-Length: [len]
+
+SIP/2.0 200 OK
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+  <!-- Alice tears the leg down. -->
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -124,6 +124,22 @@ pub struct Dialog {
     pub local_from_uri: Option<String>,
     /// Remote To URI for this dialog (for mid-dialog requests like BYE).
     pub remote_to_uri: Option<String>,
+    /// siphon's owned SDP `o=` session-id for SDP it emits toward this leg's
+    /// peer (RFC 4566 §5.2). Stable for the dialog's life — generated once at
+    /// creation — so every offer/answer siphon sends this peer shares one
+    /// session identity (RFC 3264 §8).
+    pub sdp_session_id: u64,
+    /// Monotonic SDP `o=` version for SDP siphon emits toward this leg's peer.
+    /// Incremented on every emit so a re-INVITE that changes the media (e.g. a
+    /// transfer re-anchor) presents a strictly greater version than the last
+    /// SDP the peer saw — otherwise a strict RFC 3264 §8 answerer may treat the
+    /// changed offer as unchanged and skip re-answering.
+    pub sdp_version: u64,
+}
+
+/// Generate a fresh SDP `o=` session-id (RFC 4566 §5.2 — a numeric identifier).
+pub fn generate_sdp_session_id() -> u64 {
+    uuid::Uuid::new_v4().as_u128() as u64
 }
 
 impl Dialog {
@@ -142,6 +158,8 @@ impl Dialog {
             route_set: vec![],
             local_from_uri: None,
             remote_to_uri: None,
+            sdp_session_id: generate_sdp_session_id(),
+            sdp_version: 0,
         }
     }
 
@@ -161,6 +179,8 @@ impl Dialog {
             route_set: vec![],
             local_from_uri: None,
             remote_to_uri: None,
+            sdp_session_id: generate_sdp_session_id(),
+            sdp_version: 0,
         }
     }
 
@@ -370,6 +390,22 @@ pub struct Leg {
     pub stored_vias: Vec<String>,
     /// Stored CSeq from re-INVITE originator (for response CSeq restoration).
     pub stored_cseq: Option<String>,
+    /// Stored From header of the request that created this (pseudo-)leg, kept
+    /// verbatim so a response relayed back to the originator echoes it exactly
+    /// (RFC 3261 §8.2.6.2). Used by the transparent REFER/NOTIFY relay: the
+    /// dialog-derived URI can differ from what the peer actually sent (e.g. a
+    /// `:5060` the peer omitted), so reconstructing From/To from dialog state
+    /// would break the verbatim-echo MUST. `None` for legs that don't need it.
+    pub stored_from: Option<String>,
+    /// Stored To header of the request that created this (pseudo-)leg. See
+    /// [`Leg::stored_from`].
+    pub stored_to: Option<String>,
+    /// This leg's own most-recent endpoint SDP, stored **raw** (the peer's true
+    /// media address, before any rtpengine rewrite or topology masking). Kept so
+    /// a siphon-terminated transfer can offer the *surviving* leg's real media
+    /// to the transfer target (or feed it to an rtpengine re-anchor) instead of
+    /// the referrer's SDP. `None` until the leg has negotiated a body.
+    pub last_sdp: Option<Vec<u8>>,
     /// Whether the initial INVITE on this leg has been ACKed.
     pub initial_acked: bool,
     /// Whether a re-INVITE toward this leg is currently in flight
@@ -424,6 +460,9 @@ impl Leg {
             branch,
             stored_vias: Vec::new(),
             stored_cseq: None,
+            stored_from: None,
+            stored_to: None,
+            last_sdp: None,
             initial_acked: false,
             pending_reinvite: false,
             prack_acked_rseq: None,
@@ -449,6 +488,9 @@ impl Leg {
             branch,
             stored_vias: Vec::new(),
             stored_cseq: None,
+            stored_from: None,
+            stored_to: None,
+            last_sdp: None,
             initial_acked: false,
             pending_reinvite: false,
             prack_acked_rseq: None,
@@ -458,17 +500,23 @@ impl Leg {
         }
     }
 
-    /// True for the re-INVITE/UPDATE response-tracking pseudo-legs the
-    /// dispatcher inserts as B-legs. Their `target_uri` is a direction marker
-    /// (`reinvite:`/`update:`/`…_done:`) and they deliberately reuse another
-    /// leg's Call-ID for response routing, so they must be excluded from
-    /// dialog-identity direction matching.
+    /// True for the re-INVITE/UPDATE/REFER/NOTIFY response-tracking pseudo-legs
+    /// the dispatcher inserts as B-legs. Their `target_uri` is a direction
+    /// marker (`reinvite:`/`update:`/`refer:`/`notify:`/`refer_out:`/`…_done:`)
+    /// and they deliberately reuse another leg's Call-ID for response routing,
+    /// so they must be excluded from dialog-identity direction matching.
     pub fn is_tracking_leg(&self) -> bool {
         self.dialog.target_uri.as_deref().is_some_and(|target| {
             target.starts_with("reinvite:")
                 || target.starts_with("reinvite_done:")
                 || target.starts_with("update:")
                 || target.starts_with("update_done:")
+                || target.starts_with("refer:")
+                || target.starts_with("refer_done:")
+                || target.starts_with("notify:")
+                || target.starts_with("notify_done:")
+                || target.starts_with("refer_out:")
+                || target.starts_with("refer_out_done:")
         })
     }
 }
@@ -590,6 +638,45 @@ pub enum CallState {
 // CallActor — per-call supervisor
 // ---------------------------------------------------------------------------
 
+/// A REFER subscription (RFC 3515) that siphon owns for a transfer in progress
+/// on a B2BUA call.
+///
+/// Two roles:
+/// - **notifier** (`siphon_notifies == true`) — the siphon-terminated inbound
+///   path: a UA sent siphon a REFER, siphon answered `202`, and now sends the
+///   `message/sipfrag` NOTIFY progress to that referrer as the new leg it dialed
+///   makes progress.
+/// - **subscriber** (`siphon_notifies == false`) — the siphon-originated path
+///   (`call.refer()`): siphon sent a REFER to a connected UA and receives that
+///   UA's sipfrag NOTIFYs, which it `200 OK`s and reads for teardown.
+///
+/// The transparent-forward path owns no subscription — it bridges the peers'
+/// own NOTIFYs across the two dialogs.
+#[derive(Debug, Clone)]
+pub struct ReferSubscription {
+    /// Which leg of this call carries the subscription dialog (the leg the REFER
+    /// was received on for a terminated transfer, or sent on for an originated
+    /// one).
+    pub on_a_leg: bool,
+    /// True when siphon is the notifier, false when siphon is the subscriber.
+    pub siphon_notifies: bool,
+    /// The subscription `id` token — the CSeq number of the REFER that created
+    /// it (RFC 3515 §2.4.4) — surfaced as `Event: refer;id=<n>` to disambiguate
+    /// concurrent transfers on one dialog.
+    pub event_id: u32,
+    /// Next CSeq for a siphon-originated NOTIFY on this subscription (notifier
+    /// role only).
+    pub notify_cseq: u32,
+    /// Current transfer progress (drives the sipfrag body and teardown).
+    pub state: super::transfer::TransferState,
+    /// For a siphon-terminated inbound transfer: the dialog Call-ID of the leg
+    /// siphon dialed to the transfer target. The response path matches an
+    /// answering b_leg against this exact Call-ID (not just "a non-winner leg")
+    /// so an unrelated leg dialed while a transfer is pending can't be mistaken
+    /// for the transfer target. `None` for the subscriber (outbound) role.
+    pub target_leg_call_id: Option<String>,
+}
+
 /// Per-call supervisor managing A-leg + B-leg(s).
 ///
 /// Each call actor owns its legs as independent entities. The dispatcher
@@ -644,6 +731,14 @@ pub struct CallActor {
     pub session_timer_override: Option<crate::script::api::call::SessionTimerOverride>,
     /// Active transfer context (REFER handling).
     pub transfer: Option<super::transfer::TransferContext>,
+    /// REFER subscriptions siphon owns for transfers in progress (RFC 3515).
+    /// Present for the siphon-terminated inbound path (siphon is the notifier,
+    /// sending `message/sipfrag` NOTIFYs to the referrer) and the
+    /// siphon-originated path (`call.refer()`, siphon is the subscriber,
+    /// receiving them from the referee). The transparent-forward path owns none
+    /// — it bridges the peers' own NOTIFYs. A `Vec` so concurrent transfers on
+    /// one dialog are disambiguated by the `Event: refer;id` token.
+    pub refer_subscriptions: Vec<ReferSubscription>,
     /// Outbound digest credentials for B-leg 401/407 retry.
     pub outbound_credentials: Option<(String, String)>,
     /// Per-call digest nonce-count tracker (RFC 7616 §3.3). Resets to 1 when
@@ -730,6 +825,7 @@ impl CallActor {
             session_timer: None,
             session_timer_override: None,
             transfer: None,
+            refer_subscriptions: Vec::new(),
             outbound_credentials: None,
             digest_nc: crate::auth::NonceCounter::new(),
             li_record: false,
@@ -1393,6 +1489,167 @@ impl CallActorStore {
         }
     }
 
+    /// Record a siphon-owned REFER subscription for a transfer in progress.
+    pub fn push_refer_subscription(&self, call_id: &str, subscription: ReferSubscription) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            call.refer_subscriptions.push(subscription);
+        }
+    }
+
+    /// True if the call carries a siphon-owned *subscriber* REFER subscription
+    /// on the given leg (siphon-originated transfer: siphon sent the REFER and
+    /// receives the referee's sipfrag NOTIFYs, rather than sending them).
+    pub fn has_subscriber_refer_subscription(&self, call_id: &str, on_a_leg: bool) -> bool {
+        self.calls
+            .get(call_id)
+            .map(|call| {
+                call.refer_subscriptions
+                    .iter()
+                    .any(|subscription| !subscription.siphon_notifies && subscription.on_a_leg == on_a_leg)
+            })
+            .unwrap_or(false)
+    }
+
+    /// Drop any REFER subscriptions recorded on the given leg (e.g. on the
+    /// terminating NOTIFY of a siphon-owned subscription).
+    pub fn clear_refer_subscriptions_on_leg(&self, call_id: &str, on_a_leg: bool) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            call.refer_subscriptions
+                .retain(|subscription| subscription.on_a_leg != on_a_leg);
+        }
+    }
+
+    /// Reserve the next local CSeq for one leg of a call (increments the stored
+    /// value and returns the number to use). Returns `None` if the call or the
+    /// requested leg is not present. Used for siphon-originated in-dialog
+    /// requests on a leg (REFER-subscription NOTIFYs, outbound REFER).
+    pub fn reserve_leg_cseq(&self, call_id: &str, on_a_leg: bool) -> Option<u32> {
+        let mut call = self.calls.get_mut(call_id)?;
+        let winner = call.winner;
+        let leg = if on_a_leg {
+            Some(&mut call.a_leg)
+        } else {
+            winner.and_then(|index| call.b_legs.get_mut(index))
+        }?;
+        let cseq = leg.dialog.local_cseq;
+        leg.dialog.local_cseq += 1;
+        Some(cseq)
+    }
+
+    /// Reserve siphon's owned SDP `o=` identity for the next SDP emitted toward
+    /// one leg of a call: returns `(sdp_session_id, sdp_version)` and
+    /// post-increments the stored version so the next emit is strictly greater
+    /// (RFC 3264 §8). Returns `None` if the call or the requested leg is absent.
+    /// The session-id is stable for the dialog's life; only the version advances.
+    pub fn reserve_leg_sdp_version(&self, call_id: &str, on_a_leg: bool) -> Option<(u64, u64)> {
+        let mut call = self.calls.get_mut(call_id)?;
+        let winner = call.winner;
+        let leg = if on_a_leg {
+            Some(&mut call.a_leg)
+        } else {
+            winner.and_then(|index| call.b_legs.get_mut(index))
+        }?;
+        let identity = (leg.dialog.sdp_session_id, leg.dialog.sdp_version);
+        leg.dialog.sdp_version += 1;
+        Some(identity)
+    }
+
+    /// Reserve the SDP `o=` identity for a specific B-leg by index (used for a
+    /// freshly-dialed leg — e.g. a transfer target — that is not the winner).
+    pub fn reserve_b_leg_sdp_version_by_index(
+        &self,
+        call_id: &str,
+        index: usize,
+    ) -> Option<(u64, u64)> {
+        let mut call = self.calls.get_mut(call_id)?;
+        let leg = call.b_legs.get_mut(index)?;
+        let identity = (leg.dialog.sdp_session_id, leg.dialog.sdp_version);
+        leg.dialog.sdp_version += 1;
+        Some(identity)
+    }
+
+    /// Record one leg's own most-recent endpoint SDP (raw). Stored so a
+    /// siphon-terminated transfer can offer the surviving leg's real media to
+    /// the transfer target. `on_a_leg` selects the A-leg or the winning B-leg;
+    /// a no-op if the call or leg is absent, or if `sdp` is empty.
+    pub fn set_leg_last_sdp(&self, call_id: &str, on_a_leg: bool, sdp: &[u8]) {
+        if sdp.is_empty() {
+            return;
+        }
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            let winner = call.winner;
+            let leg = if on_a_leg {
+                Some(&mut call.a_leg)
+            } else {
+                winner.and_then(|index| call.b_legs.get_mut(index))
+            };
+            if let Some(leg) = leg {
+                leg.last_sdp = Some(sdp.to_vec());
+            }
+        }
+    }
+
+    /// Clone one leg of a call (the A-leg, or the winning B-leg). Used to build
+    /// siphon-originated in-dialog requests off a snapshot without holding the
+    /// call lock across the send.
+    pub fn clone_leg(&self, call_id: &str, on_a_leg: bool) -> Option<Leg> {
+        let call = self.calls.get(call_id)?;
+        if on_a_leg {
+            Some(call.a_leg.clone())
+        } else {
+            call.winner.and_then(|index| call.b_legs.get(index).cloned())
+        }
+    }
+
+    /// Complete a siphon-terminated transfer: promote the just-answered transfer
+    /// target (`target_idx` in `b_legs`) to be the surviving party's new peer,
+    /// and return the referrer leg (the party being transferred away) so the
+    /// caller can BYE it.
+    ///
+    /// - `referrer_on_a_leg == true` — the referrer is the A-leg and the
+    ///   surviving party is the winning B-leg: the target replaces the A-leg (it
+    ///   becomes the new `a_leg`, the winner is preserved, the old A-leg is
+    ///   returned). This is the Microsoft Teams blind-transfer shape.
+    /// - `referrer_on_a_leg == false` — the referrer is the winning B-leg and the
+    ///   surviving party is the A-leg: the target becomes the new winner and the
+    ///   old winning B-leg is returned.
+    ///
+    /// The parallel per-B-leg vectors are kept aligned when a slot is removed.
+    pub fn promote_transfer_target(
+        &self,
+        call_id: &str,
+        target_idx: usize,
+        referrer_on_a_leg: bool,
+    ) -> Option<Leg> {
+        let mut call = self.calls.get_mut(call_id)?;
+        if target_idx >= call.b_legs.len() {
+            return None;
+        }
+        if referrer_on_a_leg {
+            let target = call.b_legs.remove(target_idx);
+            if target_idx < call.b_leg_status.len() {
+                call.b_leg_status.remove(target_idx);
+            }
+            if target_idx < call.b_leg_handles.len() {
+                call.b_leg_handles.remove(target_idx);
+            }
+            // Removing the slot shifts higher indices down by one — fix the
+            // winner pointer (the surviving B-leg) accordingly.
+            match call.winner {
+                Some(winner) if winner == target_idx => call.winner = None,
+                Some(winner) if winner > target_idx => call.winner = Some(winner - 1),
+                _ => {}
+            }
+            let old_referrer = std::mem::replace(&mut call.a_leg, target);
+            Some(old_referrer)
+        } else {
+            let old_winner_idx = call.winner?;
+            let old_referrer = call.b_legs.get(old_winner_idx).cloned()?;
+            call.winner = Some(target_idx);
+            Some(old_referrer)
+        }
+    }
+
     /// Remove a call and clean up all registry entries.
     ///
     /// Sends `Shutdown` to all active B-leg actor handles before removing.
@@ -1813,6 +2070,106 @@ mod tests {
         let id1 = LegId::new();
         let id2 = LegId::new();
         assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn dialog_has_stable_sdp_session_id_and_zero_version() {
+        // Each dialog is born with a stable siphon-owned SDP session-id and a
+        // version starting at 0 (RFC 4566 §5.2 / RFC 3264 §8).
+        let a = Dialog::from_inbound("c@h".to_string(), "rt".to_string());
+        assert_eq!(a.sdp_version, 0);
+        let b = Dialog::new_outbound("c@h".to_string(), "lt".to_string(), "sip:x@h".to_string());
+        assert_eq!(b.sdp_version, 0);
+        // Distinct dialogs get distinct session-ids (overwhelmingly — u64 from a
+        // v4 UUID).
+        assert_ne!(a.sdp_session_id, b.sdp_session_id);
+    }
+
+    #[test]
+    fn reserve_leg_sdp_version_is_monotonic_and_session_stable() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.add_b_leg(&call_id, make_b_leg(0));
+        store.set_winner(&call_id, 0);
+
+        // A-leg: same session-id across reservations, version steps 0,1,2.
+        let (a_sess0, v0) = store.reserve_leg_sdp_version(&call_id, true).unwrap();
+        let (a_sess1, v1) = store.reserve_leg_sdp_version(&call_id, true).unwrap();
+        let (a_sess2, v2) = store.reserve_leg_sdp_version(&call_id, true).unwrap();
+        assert_eq!((v0, v1, v2), (0, 1, 2));
+        assert_eq!(a_sess0, a_sess1);
+        assert_eq!(a_sess1, a_sess2);
+
+        // Winning B-leg counts independently under its own session-id.
+        let (b_sess, bv0) = store.reserve_leg_sdp_version(&call_id, false).unwrap();
+        let (_, bv1) = store.reserve_leg_sdp_version(&call_id, false).unwrap();
+        assert_eq!((bv0, bv1), (0, 1));
+        assert_ne!(a_sess0, b_sess, "each leg owns a distinct SDP session-id");
+
+        // By-index variant advances the same B-leg counter.
+        let (b_sess_idx, bv2) = store.reserve_b_leg_sdp_version_by_index(&call_id, 0).unwrap();
+        assert_eq!(bv2, 2);
+        assert_eq!(b_sess_idx, b_sess);
+
+        // Unknown call / index → None.
+        assert!(store.reserve_leg_sdp_version("nope", true).is_none());
+        assert!(store.reserve_b_leg_sdp_version_by_index(&call_id, 99).is_none());
+    }
+
+    #[test]
+    fn set_leg_last_sdp_records_per_leg_raw_body() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.add_b_leg(&call_id, make_b_leg(0));
+        store.set_winner(&call_id, 0);
+
+        // Default: no SDP captured.
+        assert!(store.get_call(&call_id).unwrap().a_leg.last_sdp.is_none());
+
+        store.set_leg_last_sdp(&call_id, true, b"v=0\r\no=alice 1 1 IN IP4 192.0.2.1\r\n");
+        store.set_leg_last_sdp(&call_id, false, b"v=0\r\no=bob 2 2 IN IP4 192.0.2.2\r\n");
+        let call = store.get_call(&call_id).unwrap();
+        assert_eq!(
+            call.a_leg.last_sdp.as_deref(),
+            Some(&b"v=0\r\no=alice 1 1 IN IP4 192.0.2.1\r\n"[..])
+        );
+        assert_eq!(
+            call.b_legs[0].last_sdp.as_deref(),
+            Some(&b"v=0\r\no=bob 2 2 IN IP4 192.0.2.2\r\n"[..])
+        );
+
+        // Empty SDP is a no-op (does not clobber a stored body).
+        store.set_leg_last_sdp(&call_id, true, b"");
+        assert!(store.get_call(&call_id).unwrap().a_leg.last_sdp.is_some());
+    }
+
+    #[test]
+    fn leg_stored_request_from_to_default_none_and_round_trip() {
+        // Both constructors leave the verbatim request From/To capture empty —
+        // only the transparent REFER/NOTIFY pseudo-legs populate it (RFC 3261
+        // §8.2.6.2 verbatim echo). A leg that never captures them keeps the
+        // dialog-reconstruction fallback.
+        let mut a_leg = make_a_leg();
+        assert_eq!(a_leg.stored_from, None);
+        assert_eq!(a_leg.stored_to, None);
+        let mut b_leg = make_b_leg(1);
+        assert_eq!(b_leg.stored_from, None);
+        assert_eq!(b_leg.stored_to, None);
+
+        a_leg.stored_from = Some("<sip:bob@192.0.2.52>;tag=abc".to_string());
+        a_leg.stored_to = Some("<sip:alice@192.0.2.50>;tag=xyz".to_string());
+        assert_eq!(
+            a_leg.stored_from.as_deref(),
+            Some("<sip:bob@192.0.2.52>;tag=abc")
+        );
+        assert_eq!(
+            a_leg.stored_to.as_deref(),
+            Some("<sip:alice@192.0.2.50>;tag=xyz")
+        );
+        // A clone preserves the capture (the dispatcher clones legs when
+        // snapshotting the call actor before relaying a response).
+        b_leg.stored_from = a_leg.stored_from.clone();
+        assert_eq!(b_leg.clone().stored_from, a_leg.stored_from);
     }
 
     #[test]

--- a/src/b2bua/transfer.rs
+++ b/src/b2bua/transfer.rs
@@ -82,11 +82,32 @@ impl fmt::Display for TransferSide {
     }
 }
 
-/// Build a NOTIFY body with `message/sipfrag` content (RFC 3515 §2.4).
+/// Build a NOTIFY body with `message/sipfrag` content (RFC 3515 §2.4 / RFC
+/// 3420).
 ///
-/// The body is a SIP status line, e.g. `SIP/2.0 200 OK`.
+/// The body is a SIP Status-Line, e.g. `SIP/2.0 200 OK`. Per RFC 3261 §25 the
+/// Status-Line is CRLF-terminated, and message/sipfrag inherits that grammar
+/// (RFC 3420), so the trailing CRLF is included.
 pub fn build_sipfrag_body(status_code: u16, reason: &str) -> String {
-    format!("SIP/2.0 {status_code} {reason}")
+    format!("SIP/2.0 {status_code} {reason}\r\n")
+}
+
+/// Build a `Subscription-State` header value for a REFER-subscription NOTIFY
+/// (RFC 3515 §2.4.4 / RFC 6665 §4.1.3).
+///
+/// While the transfer is still pending or trying the subscription is
+/// `active;expires=<n>`; once it reaches a final state (success or failure) the
+/// implicit subscription is `terminated;reason=noresource` and the dialog is
+/// torn down.
+pub fn subscription_state_header(state: &TransferState, expires_secs: u32) -> String {
+    match state {
+        TransferState::Pending | TransferState::Trying => {
+            format!("active;expires={expires_secs}")
+        }
+        TransferState::Succeeded | TransferState::Failed { .. } => {
+            "terminated;reason=noresource".to_string()
+        }
+    }
 }
 
 /// Determine which NOTIFY status to send based on an INVITE response.
@@ -161,19 +182,19 @@ mod tests {
     #[test]
     fn build_sipfrag_100_trying() {
         let body = build_sipfrag_body(100, "Trying");
-        assert_eq!(body, "SIP/2.0 100 Trying");
+        assert_eq!(body, "SIP/2.0 100 Trying\r\n");
     }
 
     #[test]
     fn build_sipfrag_200_ok() {
         let body = build_sipfrag_body(200, "OK");
-        assert_eq!(body, "SIP/2.0 200 OK");
+        assert_eq!(body, "SIP/2.0 200 OK\r\n");
     }
 
     #[test]
     fn build_sipfrag_503() {
         let body = build_sipfrag_body(503, "Service Unavailable");
-        assert_eq!(body, "SIP/2.0 503 Service Unavailable");
+        assert_eq!(body, "SIP/2.0 503 Service Unavailable\r\n");
     }
 
     #[test]
@@ -208,6 +229,36 @@ mod tests {
             }
             other => panic!("Expected Failed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn subscription_state_active_while_pending_or_trying() {
+        assert_eq!(
+            subscription_state_header(&TransferState::Pending, 60),
+            "active;expires=60"
+        );
+        assert_eq!(
+            subscription_state_header(&TransferState::Trying, 120),
+            "active;expires=120"
+        );
+    }
+
+    #[test]
+    fn subscription_state_terminated_on_final() {
+        assert_eq!(
+            subscription_state_header(&TransferState::Succeeded, 60),
+            "terminated;reason=noresource"
+        );
+        assert_eq!(
+            subscription_state_header(
+                &TransferState::Failed {
+                    code: 486,
+                    reason: "Busy Here".to_string()
+                },
+                60
+            ),
+            "terminated;reason=noresource"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,34 @@ pub struct B2buaConfig {
     /// Names an entry in the top-level `number_policies:` map.  When `None`,
     /// no number normalization is applied unless a call opts in explicitly.
     pub default_number_policy: Option<String>,
+
+    /// Default REFER transfer mode applied when an `@b2bua.on_refer` handler
+    /// calls `accept_refer()` without an explicit `mode=`.
+    ///
+    /// - `"terminate"` (default) — siphon terminates the transfer: answer 202
+    ///   locally, re-resolve the Refer-To through the dial plan as a new leg,
+    ///   re-bridge the media, and BYE the referred-away leg. Correct for
+    ///   trunk-facing SBCs (the far end need not support REFER) and keeps media
+    ///   anchored.
+    /// - `"transparent"` — siphon re-emits the REFER on the far leg's own dialog
+    ///   and relays the far end's 202 + `message/sipfrag` NOTIFYs back. Correct
+    ///   for UA-to-UA (PBX / softphone) topologies.
+    ///
+    /// Unset → `"terminate"`.
+    pub default_refer_mode: Option<String>,
+}
+
+impl B2buaConfig {
+    /// Resolve the configured default REFER mode. `None`, empty, or an
+    /// unrecognized value fall back to the safe trunk-facing default
+    /// (`Terminate`); only an explicit `"transparent"` selects transparent
+    /// forwarding.
+    pub fn resolved_default_refer_mode(&self) -> crate::script::api::call::ReferMode {
+        match self.default_refer_mode.as_deref().map(str::trim) {
+            Some("transparent") => crate::script::api::call::ReferMode::Transparent,
+            _ => crate::script::api::call::ReferMode::Terminate,
+        }
+    }
 }
 
 /// Configuration for ``proxy.subscribe_state`` — generic SUBSCRIBE

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -134,6 +134,10 @@ struct DispatcherState {
     /// `config.b2bua.default_header_policy`, falling back to
     /// `"transparent-b2bua@2026"` if unset.
     default_header_policy: Arc<crate::b2bua::header_policy::Preset>,
+    /// Default REFER transfer mode applied when an `@b2bua.on_refer` handler
+    /// calls `accept_refer()` without an explicit `mode=`.  Resolved from
+    /// `config.b2bua.default_refer_mode` (defaults to `Terminate`).
+    default_refer_mode: crate::script::api::call::ReferMode,
     /// Outbound registration manager (None when registrant is not configured).
     registrant_manager: Option<Arc<crate::registrant::RegistrantManager>>,
     /// SIPREC recording manager (SRC role — sends recordings to external SRS).
@@ -594,6 +598,7 @@ pub async fn run(
         session_timer_config: config.session_timer.clone(),
         header_policy_registry,
         default_header_policy,
+        default_refer_mode: config.b2bua.resolved_default_refer_mode(),
         registrant_manager,
         recording_manager: Arc::new(crate::siprec::RecordingManager::new(product_name, product_version)),
         li_siprec_srs_uri: config.lawful_intercept.as_ref()
@@ -2546,6 +2551,39 @@ fn handle_request(
             if state.call_actors.find_by_sip_call_id(sip_call_id).is_some() {
                 drop(engine_state);
                 handle_b2bua_update(inbound, message, state);
+                return;
+            }
+        }
+    }
+    if method == "REFER" && engine_state.has_b2bua_handlers() {
+        // RFC 3515 in-dialog REFER belonging to a B2BUA call: siphon owns the
+        // transfer (fire @b2bua.on_refer, then terminate / forward / reject).
+        // This intercept MUST run before the generic proxy path below — an
+        // in-dialog REFER routed by Request-URI would be relayed straight back
+        // at siphon's advertised address and loop (the storm this fixes). A
+        // REFER on a Call-ID that matches no tracked B2BUA call falls through
+        // (out-of-dialog REFER handled by proxy scripts, unchanged).
+        let sip_call_id = message.headers.get("Call-ID").map(|s| s.to_string());
+        if let Some(ref sip_call_id) = sip_call_id {
+            if state.call_actors.find_by_sip_call_id(sip_call_id).is_some() {
+                drop(engine_state);
+                handle_b2bua_refer(inbound, message, state);
+                return;
+            }
+        }
+    }
+    if method == "NOTIFY" && engine_state.has_b2bua_handlers() {
+        // In-dialog NOTIFY belonging to a B2BUA call — the sipfrag progress of a
+        // REFER subscription (RFC 3515 §2.4). Either a subscription siphon owns
+        // (siphon-originated transfer: 200 OK + read the sipfrag) or the far
+        // end's NOTIFY on a transparent transfer (bridge it to the referrer).
+        // A NOTIFY on a Call-ID matching no tracked call falls through to the
+        // proxy path (presence/reg-event etc., unchanged).
+        let sip_call_id = message.headers.get("Call-ID").map(|s| s.to_string());
+        if let Some(ref sip_call_id) = sip_call_id {
+            if state.call_actors.find_by_sip_call_id(sip_call_id).is_some() {
+                drop(engine_state);
+                handle_b2bua_notify(inbound, message, state);
                 return;
             }
         }
@@ -6223,6 +6261,63 @@ fn sanitize_sdp_identity(body: &mut Vec<u8>, name: &str, addr: Option<&str>) {
     }
 }
 
+/// Stamp siphon's owned `o=` identity onto an SDP body: rewrite the origin
+/// line's username to `name`, its `<sess-id>` to `sess_id`, its `<sess-version>`
+/// to `version`, and (when `addr` is `Some`) its unicast-address to `addr`. The
+/// `<nettype>`/`<addrtype>` tokens are preserved.
+///
+/// This is the piece [`sanitize_sdp_identity`] deliberately leaves alone: it
+/// lets siphon own a stable per-leg session identity with a monotonic version
+/// (RFC 4566 §5.2 / RFC 3264 §8) instead of passing the peer's through, so a
+/// siphon-originated re-INVITE that changes the media presents a strictly
+/// greater version than the last SDP the peer saw. Must be the LAST SDP
+/// mutation before the message goes on the wire (after any rtpengine rewrite),
+/// so siphon's `o=` is what the peer actually sees. A malformed `o=` line (not
+/// the RFC-mandated six fields) is left untouched.
+fn stamp_sdp_origin(body: &mut Vec<u8>, name: &str, sess_id: u64, version: u64, addr: Option<&str>) {
+    if body.is_empty() {
+        return;
+    }
+    let Ok(text) = std::str::from_utf8(body) else {
+        return;
+    };
+    let o_line_name = sanitize_o_username(name);
+    let mut changed = false;
+    let mut result = String::with_capacity(text.len());
+    for line in text.split_inclusive('\n') {
+        if let Some(rest) = line.strip_prefix("o=") {
+            // o=<username> <sess-id> <sess-version> <nettype> <addrtype> <addr>[\r\n]
+            let value = rest.trim_end_matches(['\r', '\n']);
+            let line_ending = &rest[value.len()..];
+            let fields: Vec<&str> = value.split(' ').collect();
+            if fields.len() == 6 {
+                let unicast_addr = addr.unwrap_or(fields[5]);
+                result.push_str("o=");
+                result.push_str(&o_line_name);
+                result.push(' ');
+                result.push_str(&sess_id.to_string());
+                result.push(' ');
+                result.push_str(&version.to_string());
+                result.push(' ');
+                result.push_str(fields[3]);
+                result.push(' ');
+                result.push_str(fields[4]);
+                result.push(' ');
+                result.push_str(unicast_addr);
+                result.push_str(line_ending);
+                changed = true;
+                continue;
+            }
+            result.push_str(line);
+        } else {
+            result.push_str(line);
+        }
+    }
+    if changed {
+        *body = result.into_bytes();
+    }
+}
+
 /// Flip SDP direction attributes for an SRS answer.
 ///
 /// The SRC offers `a=sendonly` (it sends forked media to the SRS).  The SRS
@@ -8634,7 +8729,7 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
         if let Some(session) = media_sessions.remove(&a_sip_call_id) {
             let set = Arc::clone(rtpengine_set);
             tokio::spawn(async move {
-                if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
+                if let Err(error) = set.delete(session.rtpengine_id(), &session.from_tag).await {
                     if error.is_call_not_found() {
                         debug!(call_id = %session.call_id, "safety-net RTPEngine delete (timeout): call already gone ({error})");
                     } else {
@@ -8835,6 +8930,13 @@ fn handle_b2bua_invite(
     }
     if let Some(from) = message.headers.from() {
         a_leg.dialog.remote_to_uri = Some(from.clone());
+    }
+
+    // Record the A-leg's own raw endpoint SDP (the caller's offer, before any
+    // script/rtpengine rewrite) so a later siphon-terminated transfer where the
+    // A-leg is the survivor can offer its real media to the transfer target.
+    if !message.body.is_empty() {
+        a_leg.last_sdp = Some(message.body.clone());
     }
 
     let call_id = state.call_actors.create_call(a_leg);
@@ -9068,6 +9170,7 @@ fn handle_b2bua_invite(
                 flow.as_ref(),
                 &route,
                 send_socket.as_ref(),
+                None,
                 &message_guard,
                 &inbound,
                 state,
@@ -9085,6 +9188,7 @@ fn handle_b2bua_invite(
                     flows.get(index).and_then(|f| f.as_ref()),
                     &[],
                     send_socket.as_ref(),
+                    None,
                     &message_guard,
                     &inbound,
                     state,
@@ -9097,11 +9201,14 @@ fn handle_b2bua_invite(
             state.call_actors.remove_call(&call_id);
             state.call_event_receivers.remove(&call_id);
         }
-        CallAction::AcceptRefer => {
-            debug!(call_id = %call_id, "B2BUA: AcceptRefer during INVITE (no-op)");
+        CallAction::AcceptRefer { .. } => {
+            debug!(call_id = %call_id, "B2BUA: accept_refer() during on_invite has no effect — it only applies inside @b2bua.on_refer");
         }
         CallAction::RejectRefer { code, reason } => {
-            debug!(call_id = %call_id, code, reason = %reason, "B2BUA: RejectRefer during INVITE (no-op)");
+            debug!(call_id = %call_id, code, reason = %reason, "B2BUA: reject_refer() during on_invite has no effect — it only applies inside @b2bua.on_refer");
+        }
+        CallAction::SendRefer { .. } => {
+            debug!(call_id = %call_id, "B2BUA: call.refer() during on_invite has no effect — the call is not yet established; use it from @b2bua.on_answer or the imperative b2bua.refer()");
         }
         CallAction::Answered => {
             // The script called call.answer() imperatively — the 2xx has already
@@ -9166,6 +9273,11 @@ fn b2bua_send_b_leg_invite(
     flow: Option<&crate::script::api::registrar::PyFlow>,
     b_leg_route: &[String],
     send_socket: Option<&crate::transport::SendSocket>,
+    // When `Some`, forces the new B-leg's SIP Call-ID (and therefore the
+    // MediaSessionStore key for a re-anchor). Used by the REFER-terminate
+    // transfer so the fresh survivor↔target anchor is keyed on a Call-ID the
+    // caller pre-generated. `None` → the normal preserve/generate logic.
+    forced_call_id: Option<&str>,
     original_request: &SipMessage,
     _inbound: &InboundMessage,
     state: &DispatcherState,
@@ -9310,7 +9422,9 @@ fn b2bua_send_b_leg_invite(
         None => (None, false, String::new(), String::new(), None, None, None, None),
     };
 
-    let b_leg_call_id = if preserve_call_id {
+    let b_leg_call_id = if let Some(forced) = forced_call_id {
+        forced.to_string()
+    } else if preserve_call_id {
         a_leg_call_id
     } else {
         crate::b2bua::actor::generate_call_id()
@@ -9499,6 +9613,24 @@ fn b2bua_send_b_leg_invite(
         } else {
             target_parsed.host.clone()
         });
+    }
+    // Stamp siphon's owned o= identity for this new B-leg (RFC 3264 §8): this is
+    // the first SDP siphon emits toward the callee, so it fixes the leg's stable
+    // session-id at version 0; the stored leg starts at version 1 for the next
+    // emit. Keeps the o= address = siphon's advertised address (as the sanitize
+    // above does) for topology hiding. Empty body → no-op.
+    if !b_leg_invite.body.is_empty() {
+        stamp_sdp_origin(
+            &mut b_leg_invite.body,
+            &state.sdp_name,
+            b_leg.dialog.sdp_session_id,
+            b_leg.dialog.sdp_version,
+            Some(&sdp_addr),
+        );
+        b_leg.dialog.sdp_version += 1;
+        b_leg_invite
+            .headers
+            .set("Content-Length", b_leg_invite.body.len().to_string());
     }
     state.call_actors.add_b_leg(call_id, b_leg.clone());
     spawn_b_leg_actor(call_id, &b_leg, state);
@@ -10023,7 +10155,7 @@ fn handle_b2bua_response(
 
     // Get the A-leg info and stored INVITE for handler reconstruction.
     // Extract everything we need then drop the DashMap ref before entering Python.
-    let (a_leg, a_leg_invite, b_leg_target, b_leg_remote_contact, _b_leg_local_contact, b_leg_dialog, b_leg_dest, b_leg_connection_id, b_leg_index, b_leg_stored_vias, b_leg_stored_cseq, call_state, outbound_credentials, li_record, b_leg_handle_tx, b_leg_stored_invite, b_leg_local_cseq, a_leg_supports_100rel, a_leg_local_addr) = match state.call_actors.get_call(call_id) {
+    let (a_leg, a_leg_invite, b_leg_target, b_leg_remote_contact, _b_leg_local_contact, b_leg_dialog, b_leg_dest, b_leg_connection_id, b_leg_index, b_leg_stored_vias, b_leg_stored_cseq, b_leg_stored_from, b_leg_stored_to, call_state, outbound_credentials, li_record, b_leg_handle_tx, b_leg_stored_invite, b_leg_local_cseq, a_leg_supports_100rel, a_leg_local_addr) = match state.call_actors.get_call(call_id) {
         Some(call) => {
             let matching_b_idx = call.b_legs.iter().position(|b| b.branch == branch);
             let matching_b = matching_b_idx.map(|i| &call.b_legs[i]);
@@ -10038,13 +10170,15 @@ fn handle_b2bua_response(
             let connection_id = matching_b.map(|b| b.transport.connection_id).unwrap_or_default();
             let stored_vias = matching_b.map(|b| b.stored_vias.clone()).unwrap_or_default();
             let stored_cseq = matching_b.and_then(|b| b.stored_cseq.clone());
+            let stored_from = matching_b.and_then(|b| b.stored_from.clone());
+            let stored_to = matching_b.and_then(|b| b.stored_to.clone());
             let handle_tx = matching_b_idx
                 .and_then(|i| call.b_leg_handles.get(i))
                 .and_then(|h| h.as_ref())
                 .map(|h| h.tx.clone());
             let stored_invite = matching_b.and_then(|b| b.b_leg_invite.clone());
             let local_cseq = matching_b.map(|b| b.dialog.local_cseq).unwrap_or(2);
-            (call.a_leg.clone(), call.a_leg_invite.clone(), target, remote_contact, local_contact, dialog, dest, connection_id, matching_b_idx, stored_vias, stored_cseq, call.state.clone(), call.outbound_credentials.clone(), call.li_record, handle_tx, stored_invite, local_cseq, call.a_leg_supports_100rel, call.a_leg_local_addr)
+            (call.a_leg.clone(), call.a_leg_invite.clone(), target, remote_contact, local_contact, dialog, dest, connection_id, matching_b_idx, stored_vias, stored_cseq, stored_from, stored_to, call.state.clone(), call.outbound_credentials.clone(), call.li_record, handle_tx, stored_invite, local_cseq, call.a_leg_supports_100rel, call.a_leg_local_addr)
         }
         None => {
             warn!(call_id = %call_id, "B2BUA: response for unknown call");
@@ -10314,7 +10448,14 @@ fn handle_b2bua_response(
             }
         };
 
-        if is_a2b {
+        // A siphon-originated re-INVITE (session-timer refresh / transfer media
+        // re-anchor) has no originator leg — its tracking entry carries empty
+        // stored Vias. Its response is absorbed (only used to ACK the responder),
+        // so it must NOT be rewritten to the a_leg identity nor Contact-sanitized:
+        // the ACK is built from the responder's own 200. Only a bridged re-INVITE
+        // (a real originator leg) rewrites the response identity.
+        let is_bridged_reinvite = !b_leg_stored_vias.is_empty();
+        if is_bridged_reinvite && is_a2b {
             // A→B: response from B-leg → rewrite B-leg identifiers back to A-leg
             if let Some((ref _b_cid, ref b_ftag)) = b_leg_dialog {
                 crate::b2bua::actor::Dialog::rewrite_headers(
@@ -10325,7 +10466,7 @@ fn handle_b2bua_response(
                     Some(&a_leg.dialog.local_tag),
                 );
             }
-        } else {
+        } else if is_bridged_reinvite {
             // B→A: response from A-leg → rewrite A-leg identifiers back to B-leg
             if let Some(call) = state.call_actors.get_call(call_id) {
                 if let Some(winner) = call.winner.and_then(|i| call.b_legs.get(i)) {
@@ -10358,8 +10499,12 @@ fn handle_b2bua_response(
         }
 
         // A-facing (is_a2b) response: anchor Contact to the A-leg's arrival socket;
-        // B-facing: leave it to via_port (the B-side advertised address).
-        sanitize_b2bua_response(message, state, resp_transport, if is_a2b { a_leg_local_addr } else { None }, a_leg_supports_100rel, call_id);
+        // B-facing: leave it to via_port (the B-side advertised address). Skipped
+        // for a siphon-originated re-INVITE — its response is absorbed, not
+        // forwarded, and the ACK needs the responder's own Contact intact.
+        if is_bridged_reinvite {
+            sanitize_b2bua_response(message, state, resp_transport, if is_a2b { a_leg_local_addr } else { None }, a_leg_supports_100rel, call_id);
+        }
 
         // RTPEngine: rewrite re-INVITE 2xx response SDP through answer.
         // Mirrors the offer processing done on the request side.
@@ -10382,7 +10527,7 @@ fn handle_b2bua_response(
                         let answer_flags = profile.answer.clone();
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(
-                                rtpengine_set.answer(&session.call_id, answer_from, answer_to, &message.body, &answer_flags)
+                                rtpengine_set.answer(session.rtpengine_id(), answer_from, answer_to, &message.body, &answer_flags)
                             )
                         }) {
                             Ok(rewritten_sdp) => {
@@ -10396,6 +10541,22 @@ fn handle_b2bua_response(
                         }
                     }
                 }
+            }
+        }
+
+        // Own the o= identity toward the re-INVITE originator on the relayed
+        // answer (RFC 3264 §8): the offerer is the A-leg when is_a2b, else the
+        // winning B-leg. Stamped after any rtpengine rewrite. Only for bridged
+        // re-INVITEs — a siphon-originated re-INVITE response is absorbed, not
+        // forwarded.
+        if is_bridged_reinvite && (200..300).contains(&status_code) && !message.body.is_empty() {
+            if let Some((sess_id, version)) =
+                state.call_actors.reserve_leg_sdp_version(call_id, is_a2b)
+            {
+                stamp_sdp_origin(&mut message.body, &state.sdp_name, sess_id, version, None);
+                message
+                    .headers
+                    .set("Content-Length", message.body.len().to_string());
             }
         }
 
@@ -10513,8 +10674,19 @@ fn handle_b2bua_response(
             state.call_actors.set_pending_reinvite(call_id, /*on_a_leg=*/ !is_a2b, false);
         }
 
-        // Forward response to the originator
-        if is_a2b {
+        // Forward the response to the originator — but ONLY for a bridged
+        // re-INVITE (one leg originated it, the other must see the response). A
+        // siphon-originated re-INVITE (session-timer refresh, transfer media
+        // re-anchor) has no originator leg — its tracking entry carries no
+        // stored Via — so the responder is already ACKed above and the response
+        // is absorbed rather than forwarded as a spurious one to the far leg.
+        if b_leg_stored_vias.is_empty() {
+            debug!(
+                call_id = %call_id,
+                direction = direction,
+                "B2BUA: absorbing siphon-originated re-INVITE response (no originator to forward to)"
+            );
+        } else if is_a2b {
             // A→B re-INVITE: the response goes to the A-leg — pin its arrival socket.
             send_message_from(message.clone(), resp_transport, resp_dest, resp_conn_id, a_leg_local_addr, state);
         } else {
@@ -10606,7 +10778,7 @@ fn handle_b2bua_response(
                         let answer_flags = profile.answer.clone();
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(
-                                rtpengine_set.answer(&session.call_id, answer_from, answer_to, &message.body, &answer_flags)
+                                rtpengine_set.answer(session.rtpengine_id(), answer_from, answer_to, &message.body, &answer_flags)
                             )
                         }) {
                             Ok(rewritten_sdp) => {
@@ -10620,6 +10792,19 @@ fn handle_b2bua_response(
                         }
                     }
                 }
+            }
+        }
+
+        // Own the o= identity toward the UPDATE originator on the relayed answer
+        // (RFC 3264 §8), after any rtpengine rewrite. Offerer = A-leg when is_a2b.
+        if (200..300).contains(&status_code) && !message.body.is_empty() {
+            if let Some((sess_id, version)) =
+                state.call_actors.reserve_leg_sdp_version(call_id, is_a2b)
+            {
+                stamp_sdp_origin(&mut message.body, &state.sdp_name, sess_id, version, None);
+                message
+                    .headers
+                    .set("Content-Length", message.body.len().to_string());
             }
         }
 
@@ -10654,6 +10839,143 @@ fn handle_b2bua_response(
             direction = direction,
             "B2BUA: forwarded UPDATE response"
         );
+        return;
+    }
+
+    // Detect transparent-transfer REFER / NOTIFY responses: target_uri starts
+    // with "refer:" or "notify:". Relayed back to the originator like the UPDATE
+    // arm — no ACK (non-INVITE) and no media handling (REFER is bodyless, a
+    // NOTIFY sipfrag body is opaque and rides back untouched).
+    let transfer_response = b_leg_target.as_deref().and_then(|t| {
+        t.strip_prefix("refer:")
+            .map(|direction| ("refer", direction))
+            .or_else(|| t.strip_prefix("notify:").map(|direction| ("notify", direction)))
+    });
+    if let Some((marker, direction)) = transfer_response {
+        let is_a2b = direction == "a2b";
+        let (resp_dest, resp_transport, resp_conn_id) = if is_a2b {
+            (
+                a_leg.transport.remote_addr,
+                a_leg.transport.transport,
+                a_leg.transport.connection_id,
+            )
+        } else {
+            match state.call_actors.get_call(call_id) {
+                Some(call) => match call.winner.and_then(|i| call.b_legs.get(i)) {
+                    Some(b) => (b.transport.remote_addr, b.transport.transport, ConnectionId::default()),
+                    None => {
+                        warn!(call_id = %call_id, marker, "B2BUA transfer response: no winning B-leg");
+                        return;
+                    }
+                },
+                None => return,
+            }
+        };
+
+        if is_a2b {
+            if let Some((ref _b_cid, ref b_ftag)) = b_leg_dialog {
+                crate::b2bua::actor::Dialog::rewrite_headers(
+                    message,
+                    &a_leg.dialog.call_id,
+                    b_ftag,
+                    a_leg.dialog.remote_tag.as_deref().unwrap_or(""),
+                    Some(&a_leg.dialog.local_tag),
+                );
+            }
+            // RFC 3261 §8.2.6.2: echo the originator's request From/To verbatim.
+            // The pseudo-leg captured the exact request headers at creation; that
+            // is the precise thing this response is answering, so it beats
+            // reconstructing from the A-leg INVITE / dialog (which can differ by a
+            // port, param, or display name the peer never sent). Fall back to the
+            // A-leg INVITE only if the capture is somehow absent.
+            if let Some(ref from) = b_leg_stored_from {
+                message.headers.set("From", from.clone());
+            } else if let Some(invite_arc) = &a_leg_invite {
+                if let Ok(invite) = invite_arc.lock() {
+                    if let Some(from) = invite.headers.from() {
+                        message.headers.set("From", from.clone());
+                    }
+                }
+            }
+            if let Some(ref to) = b_leg_stored_to {
+                message.headers.set("To", to.clone());
+            } else if let Some(invite_arc) = &a_leg_invite {
+                if let Ok(invite) = invite_arc.lock() {
+                    if let Some(to) = invite.headers.to() {
+                        message.headers.set(
+                            "To",
+                            crate::b2bua::actor::ensure_tag(to, Some(&a_leg.dialog.local_tag)),
+                        );
+                    }
+                }
+            }
+        } else if let Some(call) = state.call_actors.get_call(call_id) {
+            if let Some(winner) = call.winner.and_then(|i| call.b_legs.get(i)) {
+                crate::b2bua::actor::Dialog::rewrite_headers(
+                    message,
+                    &winner.dialog.call_id,
+                    a_leg.dialog.remote_tag.as_deref().unwrap_or(""),
+                    &winner.dialog.local_tag,
+                    winner.dialog.remote_tag.as_deref(),
+                );
+                // RFC 3261 §8.2.6.2: echo the far leg's request From/To verbatim
+                // from the pseudo-leg capture (the exact NOTIFY/REFER this answers),
+                // not the dialog URIs — those reconstruct From = far end / To =
+                // siphon's B-leg identity but can carry a `:5060` (or param) the
+                // peer omitted. Dialog reconstruction is the fallback only.
+                if let Some(ref from) = b_leg_stored_from {
+                    message.headers.set("From", from.clone());
+                } else if let Some(ref from_uri) = winner.dialog.remote_to_uri {
+                    message.headers.set(
+                        "From",
+                        crate::b2bua::actor::ensure_tag(from_uri, winner.dialog.remote_tag.as_deref()),
+                    );
+                }
+                if let Some(ref to) = b_leg_stored_to {
+                    message.headers.set("To", to.clone());
+                } else if let Some(ref to_uri) = winner.dialog.local_from_uri {
+                    message.headers.set(
+                        "To",
+                        crate::b2bua::actor::ensure_tag(to_uri, Some(&winner.dialog.local_tag)),
+                    );
+                }
+            }
+        }
+
+        // Restore the originator's Via and CSeq (RFC 3261 §8.2.6.2).
+        message.headers.set_all("Via", b_leg_stored_vias.clone());
+        if let Some(ref cseq) = b_leg_stored_cseq {
+            message.headers.set("CSeq", cseq.clone());
+        }
+        sanitize_b2bua_response(
+            message,
+            state,
+            resp_transport,
+            if is_a2b { a_leg_local_addr } else { None },
+            a_leg_supports_100rel,
+            call_id,
+        );
+
+        if (200..300).contains(&status_code) {
+            if let Some(idx) = b_leg_index {
+                state.call_actors.set_b_leg_target_uri(
+                    call_id,
+                    idx,
+                    format!("{marker}_done:{direction}"),
+                );
+            }
+        } else if status_code >= 300 {
+            if let Some(idx) = b_leg_index {
+                state.call_actors.remove_b_leg(call_id, idx);
+            }
+        }
+
+        if is_a2b {
+            send_message_from(message.clone(), resp_transport, resp_dest, resp_conn_id, a_leg_local_addr, state);
+        } else {
+            send_b2bua_to_bleg(message.clone(), resp_transport, resp_dest, state);
+        }
+        debug!(call_id = %call_id, status = status_code, marker, direction, "B2BUA: forwarded transparent transfer response");
         return;
     }
 
@@ -10757,6 +11079,42 @@ fn handle_b2bua_response(
         }
     };
 
+    // siphon-terminated transfer: intercept EVERY response from a newly-dialed
+    // transfer-target leg before the normal answer / provisional / retransmit
+    // handling. The referrer's call is already `Answered`, so (a) a provisional
+    // here must NOT be forwarded to the referrer (it would look like a fresh
+    // call-setup 18x and confuse them) and (b) the 2xx must drive the transfer
+    // completion rather than being swallowed by the "200 OK retransmission"
+    // absorber below. A transfer target is a b_leg that is not the winner while
+    // a siphon-owned REFER subscription is pending.
+    if let Some(target_idx) = b_leg_index {
+        let is_transfer_target = state
+            .call_actors
+            .get_call(call_id)
+            .and_then(|call| {
+                let leg_call_id = &call.b_legs.get(target_idx)?.dialog.call_id;
+                Some(call.refer_subscriptions.iter().any(|subscription| {
+                    subscription.siphon_notifies
+                        && subscription.target_leg_call_id.as_deref() == Some(leg_call_id.as_str())
+                }))
+            })
+            .unwrap_or(false);
+        if is_transfer_target {
+            if (200..300).contains(&status_code) {
+                b2bua_complete_terminated_transfer(call_id, target_idx, message, state);
+            } else if status_code >= 300 {
+                b2bua_fail_terminated_transfer(call_id, target_idx, status_code, state);
+            } else {
+                debug!(
+                    call_id = %call_id,
+                    status = status_code,
+                    "B2BUA REFER (terminate): absorbing transfer-target provisional (not forwarded to the referrer)"
+                );
+            }
+            return;
+        }
+    }
+
     match class { ResponseClass::Answered => {
     // --- 2xx answer handling ---
     if (200..300).contains(&status_code) {
@@ -10834,10 +11192,21 @@ fn handle_b2bua_response(
             return;
         }
 
+        // (siphon-terminated transfer-target responses are intercepted earlier,
+        // before the class match, so they never reach this normal-answer path.)
+
         // 2xx — call answered; record the winning B-leg
         state.call_actors.set_state(call_id, CallState::Answered);
         if let Some(idx) = b_leg_index {
             state.call_actors.set_winner(call_id, idx);
+        }
+
+        // Record the winning B-leg's own raw endpoint SDP (its 200 answer,
+        // captured before the @b2bua.on_answer script / rtpengine rewrite below)
+        // so a later siphon-terminated transfer where this leg is the survivor
+        // can offer its real media to the transfer target.
+        if !message.body.is_empty() {
+            state.call_actors.set_leg_last_sdp(call_id, false, &message.body);
         }
 
         // CDR: stamp the answer time (cdr.auto_emit).
@@ -10870,19 +11239,19 @@ fn handle_b2bua_response(
                         response_source.port(),
                     );
 
-                Python::attach(|python| {
+                let answer_action = Python::attach(|python| -> Option<CallAction> {
                     let call_obj = match Py::new(python, py_call) {
                         Ok(obj) => obj,
                         Err(error) => {
                             error!("failed to create PyCall for on_answer: {error}");
-                            return;
+                            return None;
                         }
                     };
                     let reply_obj = match Py::new(python, py_reply) {
                         Ok(obj) => obj,
                         Err(error) => {
                             error!("failed to create PyReply for on_answer: {error}");
-                            return;
+                            return None;
                         }
                     };
 
@@ -10901,7 +11270,17 @@ fn handle_b2bua_response(
                             }
                         }
                     }
+                    let borrowed = call_obj.borrow(python);
+                    Some(borrowed.action().clone())
                 });
+
+                // Deferred call.refer() from @b2bua.on_answer: send an outbound
+                // REFER to the A-leg (the connected caller). Other deferred
+                // actions on on_answer are not applicable (the call is already
+                // answered) and are ignored.
+                if let Some(CallAction::SendRefer { refer_to }) = answer_action {
+                    b2bua_send_outbound_refer(state, call_id, /*on_a_leg=*/ true, &refer_to);
+                }
             } else {
                 warn!(call_id = %call_id, "B2BUA: no stored A-leg INVITE for on_answer");
             }
@@ -10955,17 +11334,42 @@ fn handle_b2bua_response(
             Err(arc) => arc.lock().unwrap_or_else(|error| error.into_inner()).clone(),
         };
 
-        // Inject session timer headers into response forwarded to A-leg
+        // Inject session timer headers into the response forwarded to the A-leg.
+        // RFC 4028 §7.4/§9: a UAS MUST NOT drive a session timer (least of all
+        // `refresher=uac`) toward a UAC that did not advertise `Supported: timer`
+        // (or `Require: timer`) — the refresh it would expect never comes and the
+        // call is torn down at expiry. So only inject when the A-leg INVITE
+        // advertised timer support; otherwise leave the response untouched.
         if let Some(ref timer_config) = state.session_timer_config {
             if timer_config.enabled {
-                if response.headers.get("Supported").is_none() {
-                    response.headers.add("Supported", "timer".to_string());
-                }
-                if response.headers.get("Session-Expires").is_none() {
-                    response.headers.add(
-                        "Session-Expires",
-                        format!("{};refresher=uac", timer_config.session_expires),
-                    );
+                let a_leg_supports_timer = a_leg_invite
+                    .as_ref()
+                    .and_then(|arc| arc.lock().ok())
+                    .map(|invite| {
+                        let has = |name: &str| {
+                            invite
+                                .headers
+                                .get_all(name)
+                                .map(|values| {
+                                    values
+                                        .iter()
+                                        .any(|v| v.to_ascii_lowercase().contains("timer"))
+                                })
+                                .unwrap_or(false)
+                        };
+                        has("Supported") || has("Require")
+                    })
+                    .unwrap_or(false);
+                if a_leg_supports_timer {
+                    if response.headers.get("Supported").is_none() {
+                        response.headers.add("Supported", "timer".to_string());
+                    }
+                    if response.headers.get("Session-Expires").is_none() {
+                        response.headers.add(
+                            "Session-Expires",
+                            format!("{};refresher=uac", timer_config.session_expires),
+                        );
+                    }
                 }
             }
         }
@@ -11002,6 +11406,22 @@ fn handle_b2bua_response(
                 if let Some(cseq) = invite.headers.cseq() {
                     response.headers.set("CSeq", cseq.clone());
                 }
+                // RFC 3261 §8.2.6.2: the response From MUST equal the request
+                // From, and the response To MUST equal the request To plus the
+                // dialog tag. The cloned B-leg 2xx carries the B-leg dialog's
+                // From/To URIs (siphon's B-leg identity and the B-leg contact
+                // host) — restore the A-leg caller's own From verbatim and its
+                // To with siphon's A-leg tag (the rewrite_headers tag-swap above
+                // only fixed the tags, not the URIs).
+                if let Some(from) = invite.headers.from() {
+                    response.headers.set("From", from.clone());
+                }
+                if let Some(to) = invite.headers.to() {
+                    response.headers.set(
+                        "To",
+                        crate::b2bua::actor::ensure_tag(to, Some(&a_leg.dialog.local_tag)),
+                    );
+                }
             }
         }
 
@@ -11013,6 +11433,21 @@ fn handle_b2bua_response(
 
         // Sanitize B-leg headers before forwarding to A-leg
         sanitize_b2bua_response(&mut response, state, a_leg.transport.transport, a_leg_local_addr, a_leg_supports_100rel, call_id);
+
+        // Own the o= identity toward the A-leg on the answer it receives (RFC
+        // 3264 §8): the first SDP siphon emits toward the caller fixes the leg's
+        // stable session-id; a later re-anchor (transfer, hold) then presents a
+        // strictly greater version under the same session-id.
+        if !response.body.is_empty() {
+            if let Some((sess_id, version)) =
+                state.call_actors.reserve_leg_sdp_version(call_id, true)
+            {
+                stamp_sdp_origin(&mut response.body, &state.sdp_name, sess_id, version, None);
+                response
+                    .headers
+                    .set("Content-Length", response.body.len().to_string());
+            }
+        }
 
         // Restore A-leg Record-Route from the stored INVITE (same pattern as Via).
         // sanitize_b2bua_response strips all Record-Route (B-leg path). The A-leg
@@ -11371,6 +11806,25 @@ fn handle_b2bua_response(
                 }
                 if let Some(cseq) = invite.headers.cseq() {
                     message.headers.set("CSeq", cseq.clone());
+                }
+                // RFC 3261 §8.2.6.2: response From/To URIs MUST echo the A-leg
+                // request's, not the cloned B-leg dialog's. Restore the A-leg
+                // From verbatim; restore the A-leg To URI while preserving
+                // whatever early-dialog To-tag the rewrite above established (a
+                // plain 180 has none, an early-dialog 18x carries siphon's tag).
+                if let Some(from) = invite.headers.from() {
+                    message.headers.set("From", from.clone());
+                }
+                if let Some(to) = invite.headers.to() {
+                    let existing_tag = message
+                        .headers
+                        .to()
+                        .and_then(|value| crate::sip::headers::nameaddr::NameAddr::parse(value).ok())
+                        .and_then(|name_addr| name_addr.tag);
+                    message.headers.set(
+                        "To",
+                        crate::b2bua::actor::ensure_tag(to, existing_tag.as_deref()),
+                    );
                 }
             }
         }
@@ -11946,7 +12400,7 @@ fn handle_b2bua_response(
                 if let Some(session) = media_sessions.remove(&a_sip_call_id) {
                     let set = Arc::clone(rtpengine_set);
                     tokio::spawn(async move {
-                        if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
+                        if let Err(error) = set.delete(session.rtpengine_id(), &session.from_tag).await {
                             if error.is_call_not_found() {
                                 debug!(call_id = %session.call_id, "safety-net RTPEngine delete: call already gone ({error})");
                             } else {
@@ -12310,6 +12764,11 @@ fn handle_b2bua_bye(
         }
     }
 
+    // The rtpengine session is keyed by the A-leg Call-ID (the store key), which
+    // is NOT the incoming BYE's Call-ID when the BYE comes from the B-leg (or from
+    // the survivor/target after a terminate-transfer re-anchor). Capture it before
+    // dropping the call so the safety-net delete below hits the right key.
+    let media_key = call.a_leg.dialog.call_id.clone();
     drop(call);
 
     // Safety-net: if an RTPEngine media session exists for this call but the
@@ -12317,10 +12776,10 @@ fn handle_b2bua_bye(
     if let (Some(rtpengine_set), Some(media_sessions)) =
         (&state.rtpengine_set, &state.rtpengine_sessions)
     {
-        if let Some(session) = media_sessions.remove(&sip_call_id) {
+        if let Some(session) = media_sessions.remove(&media_key) {
             let set = Arc::clone(rtpengine_set);
             tokio::spawn(async move {
-                if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
+                if let Err(error) = set.delete(session.rtpengine_id(), &session.from_tag).await {
                     if error.is_call_not_found() {
                         debug!(call_id = %session.call_id, "safety-net RTPEngine delete: call already gone ({error})");
                     } else {
@@ -12505,6 +12964,27 @@ fn b2bua_send_refresh_reinvite(call_id: &str, state: &DispatcherState) {
     // Reset timer preemptively (will be confirmed on 200 OK)
     state.call_actors.reset_session_timer(call_id);
 
+    // Own the o= identity toward the B-leg on the refresh (RFC 3264 §8) so a
+    // session-timer keepalive shares this leg's stable session-id + a monotonic
+    // version rather than re-presenting the caller's forwarded o= (which would
+    // read as a session change relative to the initial B-leg INVITE).
+    if !reinvite.body.is_empty() {
+        if let Some((sess_id, version)) =
+            state.call_actors.reserve_leg_sdp_version(call_id, false)
+        {
+            stamp_sdp_origin(
+                &mut reinvite.body,
+                &state.sdp_name,
+                sess_id,
+                version,
+                Some(&b2bua_host),
+            );
+            reinvite
+                .headers
+                .set("Content-Length", reinvite.body.len().to_string());
+        }
+    }
+
     debug!(call_id = %call_id, "B2BUA: sending session timer refresh re-INVITE");
     send_b2bua_to_bleg(reinvite, b_leg.transport.transport, b_leg.transport.remote_addr, state);
 
@@ -12516,6 +12996,110 @@ fn b2bua_send_refresh_reinvite(call_id: &str, state: &DispatcherState) {
             }
         }
     }
+}
+
+/// Re-INVITE the surviving leg of a siphon-terminated transfer with the transfer
+/// target's SDP, so the surviving party's media re-points at the target instead
+/// of the departed referrer (RFC 3261 §14). `surviving_on_a_leg` selects the
+/// A-leg (referrer was the B-leg) or the winning B-leg (referrer was the A-leg).
+///
+/// Tracked as a `reinvite:` leg keyed on the re-INVITE's Via branch so the
+/// re-INVITE response arm ACKs the 200 — a bare re-INVITE would leave the 200
+/// unACKed and the leg retransmitting.
+fn b2bua_send_media_reinvite(
+    call_id: &str,
+    surviving_on_a_leg: bool,
+    sdp_body: Vec<u8>,
+    state: &DispatcherState,
+) {
+    let Some(cseq) = state.call_actors.reserve_leg_cseq(call_id, surviving_on_a_leg) else {
+        return;
+    };
+    let Some(surviving) = state.call_actors.clone_leg(call_id, surviving_on_a_leg) else {
+        return;
+    };
+    // Re-originate the offered SDP under siphon's o= identity (RFC 3264 §5 /
+    // RFC 4566 §5.2) — the target's answer SDP still carries the target's o=
+    // owner, which a B2BUA must not leak to the surviving leg. The connection
+    // address is left untouched (`None`) so, absent a media anchor, the surviving
+    // leg still learns the target's media address.
+    let mut sdp_body = sdp_body;
+    sanitize_sdp_identity(&mut sdp_body, &state.sdp_name, None);
+    // Own the o= session-id/version toward the surviving leg so this re-anchor
+    // offer carries a strictly greater version than the last SDP that leg saw
+    // (RFC 3264 §8) under a stable session-id — otherwise a strict answerer may
+    // treat the changed media as unchanged. Connection address left untouched.
+    if let Some((sess_id, version)) = state
+        .call_actors
+        .reserve_leg_sdp_version(call_id, surviving_on_a_leg)
+    {
+        stamp_sdp_origin(&mut sdp_body, &state.sdp_name, sess_id, version, None);
+    }
+    let Some(reinvite) = build_b2bua_in_dialog_request(
+        &surviving,
+        state,
+        Method::Invite,
+        cseq,
+        &[],
+        Some(("application/sdp", sdp_body)),
+    ) else {
+        return;
+    };
+
+    // Register a tracking leg keyed on the re-INVITE's Via branch so the
+    // `reinvite:` response arm handles + ACKs the surviving leg's 200.
+    let branch = reinvite
+        .headers
+        .get("Via")
+        .and_then(|via| via.split(";branch=").nth(1))
+        .map(|rest| {
+            rest.split([';', ',', ' '])
+                .next()
+                .unwrap_or("")
+                .to_string()
+        })
+        .unwrap_or_default();
+    if branch.is_empty() {
+        warn!(call_id = %call_id, "B2BUA REFER (terminate): media re-INVITE has no Via branch");
+        return;
+    }
+    let direction = if surviving_on_a_leg { "reinvite:b2a" } else { "reinvite:a2b" };
+    let mut tracking = Leg::new_b_leg(
+        surviving.dialog.call_id.clone(),
+        surviving.dialog.local_tag.clone(),
+        direction.to_string(),
+        branch,
+        LegTransport {
+            remote_addr: surviving.transport.remote_addr,
+            connection_id: surviving.transport.connection_id,
+            transport: surviving.transport.transport,
+            local_addr: surviving.transport.local_addr,
+        },
+    );
+    // No originator leg (siphon-originated) — empty stored Vias tells the
+    // re-INVITE response arm to absorb the 200 rather than forward it.
+    tracking.stored_vias = vec![];
+    state.call_actors.add_b_leg(call_id, tracking);
+
+    let (dest, transport) = resolve_in_dialog_destination(
+        &surviving.dialog.route_set,
+        state,
+        surviving.transport.remote_addr,
+        surviving.transport.transport,
+    );
+    send_message_from(
+        reinvite,
+        transport,
+        dest,
+        surviving.transport.connection_id,
+        surviving.transport.local_addr,
+        state,
+    );
+    debug!(
+        call_id = %call_id,
+        surviving_on_a_leg,
+        "B2BUA REFER (terminate): re-INVITE surviving leg with transfer-target SDP"
+    );
 }
 
 /// Stop and tear down any SIPREC recording sessions for a B2BUA call: send the
@@ -12647,7 +13231,7 @@ fn b2bua_terminate_call_inner(
         if let Some(session) = media_sessions.remove(&sip_call_id) {
             let set = Arc::clone(rtpengine_set);
             tokio::spawn(async move {
-                if let Err(error) = set.delete(&session.call_id, &session.from_tag).await {
+                if let Err(error) = set.delete(session.rtpengine_id(), &session.from_tag).await {
                     if error.is_call_not_found() {
                         debug!(call_id = %session.call_id, "safety-net RTPEngine delete: call already gone ({error})");
                     } else {
@@ -12721,6 +13305,96 @@ pub fn b2bua_terminate_call(sip_call_id: &str, reason: Option<&str>) -> bool {
         "b2bua",
         &control.state,
     )
+}
+
+/// Send a siphon-originated in-dialog REFER on one leg of a B2BUA call
+/// (`call.refer()` / `b2bua.refer()`).
+///
+/// Siphon is the referrer: it builds the REFER on the chosen leg's own dialog
+/// identity, sends it, and records a *subscriber* REFER subscription so the
+/// referee's `message/sipfrag` NOTIFYs are absorbed (200 OK'd + read) by
+/// [`handle_b2bua_notify`] rather than bridged. Returns `false` if the call or
+/// leg is gone.
+fn b2bua_send_outbound_refer(
+    state: &DispatcherState,
+    internal_call_id: &str,
+    on_a_leg: bool,
+    refer_to: &crate::sip::headers::refer::ReferTo,
+) -> bool {
+    let Some(cseq) = state.call_actors.reserve_leg_cseq(internal_call_id, on_a_leg) else {
+        warn!(call_id = %internal_call_id, "b2bua.refer: no such call/leg");
+        return false;
+    };
+    let Some(leg) = state.call_actors.clone_leg(internal_call_id, on_a_leg) else {
+        warn!(call_id = %internal_call_id, "b2bua.refer: leg vanished");
+        return false;
+    };
+
+    let extra_headers = [("Refer-To", refer_to.to_string())];
+    let Some(refer) = build_b2bua_in_dialog_request(
+        &leg,
+        state,
+        Method::Refer,
+        cseq,
+        &extra_headers,
+        None,
+    ) else {
+        return false;
+    };
+
+    let (destination, transport) = resolve_in_dialog_destination(
+        &leg.dialog.route_set,
+        state,
+        leg.transport.remote_addr,
+        leg.transport.transport,
+    );
+    send_message_from(
+        refer,
+        transport,
+        destination,
+        leg.transport.connection_id,
+        leg.transport.local_addr,
+        state,
+    );
+
+    state.call_actors.push_refer_subscription(
+        internal_call_id,
+        crate::b2bua::actor::ReferSubscription {
+            on_a_leg,
+            siphon_notifies: false,
+            event_id: cseq,
+            notify_cseq: cseq,
+            state: crate::b2bua::transfer::TransferState::Trying,
+            target_leg_call_id: None,
+        },
+    );
+    info!(
+        call_id = %internal_call_id,
+        target = %refer_to.uri,
+        on_a_leg,
+        attended = refer_to.replaces.is_some(),
+        "B2BUA: sent siphon-originated REFER"
+    );
+    true
+}
+
+/// Imperative `b2bua.refer(call_id, target, replaces=None)` — send an outbound
+/// REFER on a live B2BUA call from any context (event callbacks like
+/// `@rtpengine.on_dtmf`, timers), keyed by SIP Call-ID. Refers the A-leg (the
+/// caller / IVR-connected party). Returns `false` if the Call-ID is unknown or
+/// the dispatcher is not running. Mirrors [`b2bua_terminate_call`].
+pub fn b2bua_refer_call(
+    sip_call_id: &str,
+    refer_to: crate::sip::headers::refer::ReferTo,
+) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let Some(internal_call_id) = control.state.call_actors.find_by_sip_call_id(sip_call_id) else {
+        return false;
+    };
+    let _enter = control.runtime.enter();
+    b2bua_send_outbound_refer(&control.state, &internal_call_id, /*on_a_leg=*/ true, &refer_to)
 }
 
 /// Build and send a UAS response (final 2xx or provisional 1xx) for a B2BUA call
@@ -13065,6 +13739,15 @@ fn handle_b2bua_reinvite(
         }
     };
 
+    // Track the offerer's own new endpoint SDP (its re-INVITE offer, raw —
+    // before any topology/rtpengine rewrite) so a later siphon-terminated
+    // transfer offers this leg's *current* media if it is the survivor.
+    if !message.body.is_empty() {
+        state
+            .call_actors
+            .set_leg_last_sdp(&call_id, from_a_leg, &message.body);
+    }
+
     // Flow refresh (RFC 5626 / RFC 3261 §12.2.2): the peer may have sent this
     // in-dialog re-INVITE on a new flow (TLS reconnect / NAT rebind). Re-anchor
     // the originating leg's transport + remote target on the arrival flow so the
@@ -13331,7 +14014,7 @@ fn handle_b2bua_reinvite(
                         let offer_flags = profile.offer.clone();
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(
-                                rtpengine_set.offer(&session.call_id, offer_tag, &forwarded.body, &offer_flags)
+                                rtpengine_set.offer(session.rtpengine_id(), offer_tag, &forwarded.body, &offer_flags)
                             )
                         }) {
                             Ok(rewritten_sdp) => {
@@ -13344,6 +14027,19 @@ fn handle_b2bua_reinvite(
                         }
                     }
                 }
+            }
+        }
+
+        // Own the o= identity toward the leg this re-INVITE is sent to (RFC 3264
+        // §8): stable per-leg session-id + monotonic version, applied AFTER any
+        // rtpengine rewrite so siphon's o= is final on the wire (address left as
+        // rtpengine/sanitize set it — §8 keys on the session-id, not the address).
+        if !forwarded.body.is_empty() {
+            if let Some((sess_id, version)) = state
+                .call_actors
+                .reserve_leg_sdp_version(&call_id, !from_a_leg)
+            {
+                stamp_sdp_origin(&mut forwarded.body, &state.sdp_name, sess_id, version, None);
             }
         }
 
@@ -13509,6 +14205,15 @@ fn handle_b2bua_update(
             return;
         }
     };
+
+    // Track the offerer's own new endpoint SDP (its UPDATE offer, raw) so a
+    // later siphon-terminated transfer offers this leg's current media if it is
+    // the survivor.
+    if !message.body.is_empty() {
+        state
+            .call_actors
+            .set_leg_last_sdp(&call_id, from_a_leg, &message.body);
+    }
 
     // Flow refresh (RFC 5626 / RFC 3261 §12.2.2): re-anchor the originating leg
     // on the arrival flow so the UPDATE 200 OK and later in-dialog requests reach
@@ -13721,7 +14426,7 @@ fn handle_b2bua_update(
                         let offer_flags = profile.offer.clone();
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(
-                                rtpengine_set.offer(&session.call_id, offer_tag, &forwarded.body, &offer_flags)
+                                rtpengine_set.offer(session.rtpengine_id(), offer_tag, &forwarded.body, &offer_flags)
                             )
                         }) {
                             Ok(rewritten_sdp) => {
@@ -13734,6 +14439,13 @@ fn handle_b2bua_update(
                         }
                     }
                 }
+            }
+            // Own the o= identity toward the leg this UPDATE is sent to (RFC 3264
+            // §8), after any rtpengine rewrite.
+            if let Some((sess_id, version)) =
+                state.call_actors.reserve_leg_sdp_version(&call_id, !from_a_leg)
+            {
+                stamp_sdp_origin(&mut forwarded.body, &state.sdp_name, sess_id, version, None);
             }
             forwarded.headers.set("Content-Length", forwarded.body.len().to_string());
         }
@@ -13832,6 +14544,1411 @@ fn handle_b2bua_update(
             }
         }
     }
+}
+
+/// Build an in-dialog request (NOTIFY, REFER, …) toward a leg, using that
+/// leg's own dialog identity (Call-ID / tags / Route set / remote target).
+///
+/// Generalization of [`build_b2bua_bye`]: same From/To/Contact/Route/Via
+/// construction, but the caller chooses the method, the CSeq number, any extra
+/// headers, and an optional body. Used for siphon-originated `message/sipfrag`
+/// NOTIFYs on a REFER subscription and for the outbound `call.refer()` REFER.
+///
+/// `cseq` is used as-is — the caller must have reserved (incremented) the leg's
+/// `local_cseq` for this request first.
+fn build_b2bua_in_dialog_request(
+    leg: &crate::b2bua::actor::Leg,
+    state: &DispatcherState,
+    method: Method,
+    cseq: u32,
+    extra_headers: &[(&str, String)],
+    body: Option<(&str, Vec<u8>)>,
+) -> Option<SipMessage> {
+    let dialog = &leg.dialog;
+    let method_str = method.as_str().to_string();
+
+    // R-URI: the remote target (Contact), RFC 3261 §12.2.1.1.
+    let ruri = dialog
+        .remote_contact
+        .as_deref()
+        .and_then(|uri_str| parse_uri_standalone(uri_str).ok())
+        .unwrap_or_else(|| {
+            dialog
+                .target_uri
+                .as_deref()
+                .and_then(|uri_str| parse_uri_standalone(uri_str).ok())
+                .unwrap_or_else(|| SipUri::new("invalid".to_string()))
+        });
+
+    let transport_str = format!("{}", leg.transport.transport).to_uppercase();
+    let branch = TransactionKey::generate_branch();
+    let via = format!(
+        "SIP/2.0/{} {}:{};branch={}",
+        transport_str,
+        state.via_host(&leg.transport.transport),
+        a_leg_advertised_port(leg.transport.local_addr, state.via_port(&leg.transport.transport)),
+        branch,
+    );
+
+    let from_header = match &dialog.local_from_uri {
+        Some(uri) => crate::b2bua::actor::ensure_tag(uri, Some(&dialog.local_tag)),
+        None => format!(
+            "<{}>;tag={}",
+            dialog.local_contact.as_deref().unwrap_or("sip:invalid"),
+            dialog.local_tag,
+        ),
+    };
+    let to_header = match &dialog.remote_to_uri {
+        Some(uri) => crate::b2bua::actor::ensure_tag(uri, dialog.remote_tag.as_deref()),
+        None => {
+            let to_uri = dialog
+                .remote_contact
+                .as_deref()
+                .unwrap_or(dialog.target_uri.as_deref().unwrap_or("sip:invalid"));
+            match &dialog.remote_tag {
+                Some(tag) => format!("<{}>;tag={}", to_uri, tag),
+                None => format!("<{}>", to_uri),
+            }
+        }
+    };
+
+    let mut builder = SipMessageBuilder::new()
+        .request(method, ruri)
+        .via(via)
+        .from(from_header)
+        .to(to_header)
+        .call_id(dialog.call_id.clone())
+        .cseq(format!("{cseq} {method_str}"))
+        .header("Max-Forwards", "70".to_string());
+
+    if let Some(ref contact) = dialog.local_contact {
+        builder = builder.header("Contact", contact.clone());
+    }
+    if let Some(ref ua) = state.user_agent_header {
+        builder = builder.header("User-Agent", ua.clone());
+    } else if let Some(ref srv) = state.server_header {
+        builder = builder.header("User-Agent", srv.clone());
+    }
+    for route in &dialog.route_set {
+        builder = builder.header("Route", route.clone());
+    }
+    for (name, value) in extra_headers {
+        builder = builder.header(name, value.clone());
+    }
+
+    let builder = match body {
+        Some((content_type, bytes)) => builder
+            .content_type(content_type.to_string())
+            .content_length(bytes.len())
+            .body(bytes),
+        None => builder.content_length(0),
+    };
+
+    match builder.build() {
+        Ok(message) => Some(message),
+        Err(error) => {
+            warn!("B2BUA: failed to build in-dialog {method_str}: {error}");
+            None
+        }
+    }
+}
+
+/// Handle an in-dialog REFER (RFC 3515) belonging to a tracked B2BUA call.
+///
+/// This is the intercept that stops the REFER loop: without it, an in-dialog
+/// REFER whose Request-URI names siphon is proxy-relayed by R-URI back at
+/// siphon's advertised address and ping-pongs against the trunk until
+/// Max-Forwards drains. Here siphon owns the transfer instead.
+///
+/// Flow: resolve the dialog leg the REFER arrived on (by dialog identity, never
+/// source socket — Teams reconnects per transaction over TLS), parse Refer-To,
+/// fire `@b2bua.on_refer(call)`, then act on the deferred action:
+///   - no `@b2bua.on_refer` handler registered → local `603 Decline` (siphon
+///     *does* implement REFER, so `501 Not Implemented` would be untruthful),
+///   - `reject_refer(code, reason)` → that final response,
+///   - `accept_refer(...)` → run the transfer in the resolved mode
+///     (siphon-terminated by default, transparent forward when selected).
+///
+/// Every path answers the REFER — never a silent drop, never a proxy relay.
+fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &DispatcherState) {
+    let sip_call_id = message
+        .headers
+        .get("Call-ID")
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+
+    let call_id = match state.call_actors.find_by_sip_call_id(&sip_call_id) {
+        Some(id) => id,
+        None => {
+            warn!(sip_call_id = %sip_call_id, "B2BUA REFER: no matching call");
+            return;
+        }
+    };
+
+    // In-dialog direction by dialog identity (RFC 3261 §12), never source
+    // socket — a Call-ID matching no live dialog leg is answered 481.
+    let from_tag = message.typed_from().ok().flatten().and_then(|na| na.tag);
+    let from_a_leg = match state
+        .call_actors
+        .get_call(&call_id)
+        .and_then(|call| call.request_direction(&sip_call_id, from_tag.as_deref()))
+    {
+        Some(crate::b2bua::actor::LegSide::A) => true,
+        Some(crate::b2bua::actor::LegSide::B) => false,
+        None => {
+            warn!(sip_call_id = %sip_call_id, "B2BUA REFER: Call-ID matches no dialog leg — 481");
+            let response = build_response(
+                &message,
+                481,
+                "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(),
+                &[],
+            );
+            send_message_from(
+                response,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
+            return;
+        }
+    };
+
+    // Parse Refer-To (+ any embedded Replaces). A missing/malformed Refer-To is
+    // a client error (RFC 3515 §2.4.1) — 400, don't relay.
+    let refer_to = match message
+        .headers
+        .get("Refer-To")
+        .or_else(|| message.headers.get("r"))
+        .map(|value| crate::sip::headers::refer::parse_refer_to(value))
+    {
+        Some(Ok(refer_to)) => refer_to,
+        _ => {
+            warn!(call_id = %call_id, "B2BUA REFER: missing or malformed Refer-To — 400");
+            let response = build_response(
+                &message,
+                400,
+                "Bad Request",
+                state.server_header.as_deref(),
+                &[],
+            );
+            send_message_from(
+                response,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
+            return;
+        }
+    };
+
+    // Fire @b2bua.on_refer(call). No handler → local 603 Decline (loop killer for
+    // scripts that don't handle REFER at all).
+    let engine_state = state.engine.state();
+    let handlers = engine_state.handlers_for(&HandlerKind::B2buaRefer);
+    if handlers.is_empty() {
+        debug!(call_id = %call_id, "B2BUA REFER: no @b2bua.on_refer handler — 603 Decline");
+        let response = build_response(
+            &message,
+            603,
+            "Decline",
+            state.server_header.as_deref(),
+            &[],
+        );
+        send_message_from(
+            response,
+            inbound.transport,
+            inbound.remote_addr,
+            inbound.connection_id,
+            Some(inbound.local_addr),
+            state,
+        );
+        return;
+    }
+
+    let mut py_call = PyCall::new(
+        call_id.clone(),
+        Arc::new(std::sync::Mutex::new(message.clone())),
+        inbound.remote_addr.ip().to_string(),
+        format!("{}", inbound.transport).to_lowercase(),
+    );
+    py_call.set_refer_to(refer_to.uri.clone(), refer_to.replaces.clone());
+
+    let action = Python::attach(|python| {
+        let call_obj = match Py::new(python, py_call) {
+            Ok(obj) => obj,
+            Err(error) => {
+                error!("failed to create PyCall for on_refer: {error}");
+                return CallAction::RejectRefer {
+                    code: 500,
+                    reason: "Script Error".to_string(),
+                };
+            }
+        };
+        for handler in &handlers {
+            let callable = handler.callable.bind(python);
+            match callable.call1((call_obj.bind(python),)) {
+                Ok(ret) => {
+                    if handler.is_async {
+                        if let Err(error) = run_coroutine(python, &ret) {
+                            error!("async B2BUA on_refer handler error: {error}");
+                            return CallAction::RejectRefer {
+                                code: 500,
+                                reason: "Script Error".to_string(),
+                            };
+                        }
+                    }
+                }
+                Err(error) => {
+                    error!("B2BUA on_refer handler error: {error}");
+                    return CallAction::RejectRefer {
+                        code: 500,
+                        reason: "Script Error".to_string(),
+                    };
+                }
+            }
+        }
+        let borrowed = call_obj.borrow(python);
+        borrowed.action().clone()
+    });
+
+    match action {
+        CallAction::RejectRefer { code, reason } => {
+            debug!(call_id = %call_id, code, "B2BUA REFER: script rejected");
+            let response =
+                build_response(&message, code, &reason, state.server_header.as_deref(), &[]);
+            send_message_from(
+                response,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
+        }
+        CallAction::AcceptRefer {
+            target,
+            next_hop,
+            mode,
+        } => {
+            let mode = mode.unwrap_or(state.default_refer_mode);
+            let target_uri = target.unwrap_or_else(|| refer_to.uri.clone());
+            b2bua_refer_accept(
+                inbound,
+                message,
+                &call_id,
+                from_a_leg,
+                &target_uri,
+                next_hop.as_deref(),
+                refer_to.replaces.clone(),
+                mode,
+                state,
+            );
+        }
+        // Any other (or no) action from the handler: the script neither accepted
+        // nor rejected. Decline locally rather than leave the referrer hanging or
+        // fall through to a relay (RFC 3515 — the recipient must answer).
+        other => {
+            debug!(call_id = %call_id, ?other, "B2BUA REFER: handler took no accept/reject action — 603 Decline");
+            let response = build_response(
+                &message,
+                603,
+                "Decline",
+                state.server_header.as_deref(),
+                &[],
+            );
+            send_message_from(
+                response,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
+        }
+    }
+}
+
+/// Execute an accepted REFER transfer (`accept_refer()`), in the resolved mode.
+///
+/// rtpengine `offer` for a siphon-terminated transfer (Phase 1): anchor the
+/// survivor's media (`survivor_sdp`, offered under `survivor_tag`) on the FRESH
+/// rtpengine call-id `cid_new` using `profile_name`'s offer flags, and return
+/// the SDP to place in the transfer target's INVITE. `None` if media control is
+/// not configured or the offer failed (the caller then dials with the survivor's
+/// raw SDP). Awaited with the same `block_in_place` idiom as the bridged
+/// re-INVITE path.
+fn b2bua_transfer_rtpengine_offer(
+    state: &DispatcherState,
+    cid_new: &str,
+    survivor_tag: &str,
+    survivor_sdp: &[u8],
+    profile_name: &str,
+) -> Option<Vec<u8>> {
+    let backend = state.rtpengine_set.as_ref()?;
+    let profiles = state.rtpengine_profiles.as_ref()?;
+    let profile = profiles.get(profile_name)?;
+    let offer_flags = profile.offer.clone();
+    match tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(backend.offer(
+            cid_new,
+            survivor_tag,
+            survivor_sdp,
+            &offer_flags,
+        ))
+    }) {
+        Ok(rewritten) => Some(rewritten),
+        Err(error) => {
+            warn!(rtpengine_call_id = %cid_new, "REFER terminate: rtpengine offer failed: {error}");
+            None
+        }
+    }
+}
+
+/// rtpengine `answer` for a siphon-terminated transfer (Phase 2): complete the
+/// survivor↔target media on the fresh rtpengine call-id `cid_new` with the
+/// target's answer SDP (`target_sdp`, under `target_tag`) against the offerer
+/// (`survivor_tag`), and return the SDP to re-INVITE the survivor with. `None`
+/// if media control is not configured or the answer failed.
+fn b2bua_transfer_rtpengine_answer(
+    state: &DispatcherState,
+    cid_new: &str,
+    survivor_tag: &str,
+    target_tag: &str,
+    target_sdp: &[u8],
+    profile_name: &str,
+) -> Option<Vec<u8>> {
+    let backend = state.rtpengine_set.as_ref()?;
+    let profiles = state.rtpengine_profiles.as_ref()?;
+    let profile = profiles.get(profile_name)?;
+    let answer_flags = profile.answer.clone();
+    match tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(backend.answer(
+            cid_new,
+            survivor_tag,
+            target_tag,
+            target_sdp,
+            &answer_flags,
+        ))
+    }) {
+        Ok(rewritten) => Some(rewritten),
+        Err(error) => {
+            warn!(rtpengine_call_id = %cid_new, "REFER terminate: rtpengine answer failed: {error}");
+            None
+        }
+    }
+}
+
+/// rtpengine `delete` for the OLD anchor of a siphon-terminated transfer: tears
+/// down the survivor↔referrer media once the survivor has been re-anchored to
+/// the target. A `call-not-found` is benign (the call may already be gone).
+fn b2bua_transfer_rtpengine_delete(state: &DispatcherState, cid_old: &str, from_tag: &str) {
+    let Some(backend) = state.rtpengine_set.as_ref() else {
+        return;
+    };
+    match tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(backend.delete(cid_old, from_tag))
+    }) {
+        Ok(()) => {}
+        Err(error) if error.is_call_not_found() => {}
+        Err(error) => {
+            warn!(rtpengine_call_id = %cid_old, "REFER terminate: rtpengine delete of old anchor failed: {error}");
+        }
+    }
+}
+
+/// Siphon-terminated (default): answer `202 Accepted` to the referrer, open the
+/// implicit REFER subscription, and start feeding it `message/sipfrag` NOTIFY
+/// progress (RFC 3515 §2.4.4). Siphon re-resolves the Refer-To through the dial
+/// plan as a new leg, re-bridges the surviving party to it, then BYEs the
+/// referred-away leg and sends the terminating `NOTIFY 200`.
+///
+/// The `202 + NOTIFY 100 Trying + subscription` opening is done here; the
+/// new-leg dial and the transfer-aware bridge/BYE completion are driven off the
+/// dialed leg's 2xx in the response path.
+#[allow(clippy::too_many_arguments)]
+fn b2bua_refer_accept(
+    inbound: InboundMessage,
+    message: SipMessage,
+    call_id: &str,
+    from_a_leg: bool,
+    target_uri: &str,
+    next_hop: Option<&str>,
+    replaces: Option<crate::sip::headers::refer::Replaces>,
+    mode: crate::script::api::call::ReferMode,
+    state: &DispatcherState,
+) {
+    use crate::script::api::call::ReferMode;
+
+    // The subscription `id` token (RFC 3515 §2.4.4) is the REFER's CSeq number.
+    let refer_cseq = message
+        .headers
+        .get("CSeq")
+        .and_then(|value| value.split_whitespace().next())
+        .and_then(|number| number.parse::<u32>().ok())
+        .unwrap_or(1);
+
+    match mode {
+        ReferMode::Transparent => {
+            // Re-emit the REFER on the far leg's own dialog. Siphon owns no
+            // subscription here — the far end answers 202 (relayed back by the
+            // `refer:` response arm) and its sipfrag NOTIFYs are bridged back by
+            // handle_b2bua_notify. The referrer's Refer-To rides across intact
+            // (a script that rewrote the target did so via `target=`, already
+            // applied to the message's Refer-To by the caller when set).
+            info!(
+                call_id = %call_id,
+                target = %target_uri,
+                attended = replaces.is_some(),
+                "B2BUA REFER: accepting (transparent) — forwarding on the far leg"
+            );
+            b2bua_forward_indialog_request(
+                &inbound,
+                &message,
+                call_id,
+                from_a_leg,
+                Method::Refer,
+                "refer",
+                state,
+            );
+        }
+        ReferMode::Terminate => {
+            let attended = replaces.is_some();
+            info!(
+                call_id = %call_id,
+                target = %target_uri,
+                next_hop = ?next_hop,
+                attended,
+                "B2BUA REFER: accepting (siphon-terminated) — 202 + NOTIFY 100 Trying"
+            );
+
+            // 202 Accepted to the referrer, on the flow the REFER arrived on.
+            let accepted = build_response(
+                &message,
+                202,
+                "Accepted",
+                state.server_header.as_deref(),
+                &[],
+            );
+            send_message_from(
+                accepted,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
+
+            // Open the subscription and send the first NOTIFY (sipfrag 100
+            // Trying) toward the referrer on the same flow.
+            let notify_cseq = state.call_actors.reserve_leg_cseq(call_id, from_a_leg);
+            let origin_leg = state.call_actors.clone_leg(call_id, from_a_leg);
+            if let (Some(cseq), Some(leg)) = (notify_cseq, origin_leg) {
+                let extra_headers = [
+                    ("Event", "refer".to_string()),
+                    (
+                        "Subscription-State",
+                        crate::b2bua::transfer::subscription_state_header(
+                            &crate::b2bua::transfer::TransferState::Trying,
+                            60,
+                        ),
+                    ),
+                ];
+                if let Some(notify) = build_b2bua_in_dialog_request(
+                    &leg,
+                    state,
+                    Method::Notify,
+                    cseq,
+                    &extra_headers,
+                    Some((
+                        "message/sipfrag",
+                        crate::b2bua::transfer::build_sipfrag_body(100, "Trying").into_bytes(),
+                    )),
+                ) {
+                    send_message_from(
+                        notify,
+                        inbound.transport,
+                        inbound.remote_addr,
+                        inbound.connection_id,
+                        Some(inbound.local_addr),
+                        state,
+                    );
+                }
+            }
+
+            // Dial the transfer target as a new leg, then record the
+            // subscription tagged with that leg's Call-ID. The leg's 2xx is
+            // intercepted in the response path (b2bua_complete_terminated_transfer)
+            // to promote it into the surviving pair, BYE the referrer, and send
+            // the terminating sipfrag NOTIFY 200.
+            let a_leg_invite = state
+                .call_actors
+                .get_call(call_id)
+                .and_then(|call| call.a_leg_invite.clone());
+
+            // The transfer target must be offered the SURVIVING party's media,
+            // not the referrer's (the referrer is being dropped). The survivor is
+            // the non-referrer leg.
+            let survivor_on_a_leg = !from_a_leg;
+            let survivor = state.call_actors.clone_leg(call_id, survivor_on_a_leg);
+            let survivor_tag = survivor
+                .as_ref()
+                .and_then(|leg| leg.dialog.remote_tag.clone());
+            let survivor_sdp = survivor.as_ref().and_then(|leg| leg.last_sdp.clone());
+
+            // If the call is media-anchored, re-anchor the survivor on a FRESH
+            // rtpengine call-id so the survivor↔target media stays on the anchor;
+            // the target's INVITE then carries the anchored offer, and this fresh
+            // id is forced onto the target leg's Call-ID so the post-promotion
+            // store key lines up (see b2bua_complete_terminated_transfer). Absent
+            // an anchor, offer the survivor's raw SDP directly.
+            let anchored_profile = state
+                .call_actors
+                .get_call(call_id)
+                .map(|c| c.a_leg.dialog.call_id.clone())
+                .and_then(|key| {
+                    state
+                        .rtpengine_sessions
+                        .as_ref()
+                        .and_then(|store| store.get(&key))
+                        .map(|session| session.profile.clone())
+                });
+            let fresh_cid = crate::b2bua::actor::generate_call_id();
+            let (target_offer_sdp, forced_cid) =
+                match (&anchored_profile, &survivor_sdp, &survivor_tag) {
+                    (Some(profile), Some(sdp), Some(tag)) => {
+                        // Anchored: rtpengine-offer the survivor's media on the
+                        // fresh call-id → the SDP to put in the target's INVITE.
+                        match b2bua_transfer_rtpengine_offer(state, &fresh_cid, tag, sdp, profile) {
+                            Some(anchored) => (Some(anchored), Some(fresh_cid.as_str())),
+                            None => {
+                                warn!(call_id = %call_id, "REFER terminate: rtpengine offer for transfer target failed — falling back to raw survivor SDP");
+                                (Some(sdp.clone()), None)
+                            }
+                        }
+                    }
+                    // Not anchored, but we have the survivor's SDP: offer it raw.
+                    (None, Some(sdp), _) => (Some(sdp.clone()), None),
+                    // No survivor SDP captured (pre-existing call, or capture
+                    // missed): fall back to the referrer's INVITE body below.
+                    _ => (None, None),
+                };
+
+            // Clone the A-leg INVITE as the dial template, but point its To at
+            // the Refer-To target (not the original callee). The generic B-leg
+            // builder rewrites only the To host, so without this the dialed
+            // INVITE would carry the original callee's userpart on the target's
+            // host (e.g. To: <sip:bob@carol-host>) — wrong for a transfer
+            // (RFC 3261 §8.1.1.2). Cloning also lets the lock drop before the send.
+            let dial_template = match a_leg_invite {
+                Some(invite_arc) => match invite_arc.lock() {
+                    Ok(invite) => {
+                        let mut template = invite.clone();
+                        template.headers.set("To", format!("<{target_uri}>"));
+                        // Offer the survivor's media (anchored or raw) instead of
+                        // the referrer's; leave the referrer's body only when no
+                        // survivor SDP was available.
+                        if let Some(ref sdp) = target_offer_sdp {
+                            template.body = sdp.clone();
+                            template
+                                .headers
+                                .set("Content-Length", template.body.len().to_string());
+                        } else {
+                            warn!(call_id = %call_id, "REFER terminate: no survivor SDP — dialling target with the referrer's SDP (media may be misaimed until re-negotiated)");
+                        }
+                        Some(template)
+                    }
+                    Err(_) => {
+                        error!(call_id = %call_id, "REFER terminate: a_leg_invite lock poisoned");
+                        None
+                    }
+                },
+                None => {
+                    warn!(call_id = %call_id, "REFER terminate: no stored A-leg INVITE to dial the target");
+                    None
+                }
+            };
+            let dialed = if let Some(template) = dial_template {
+                b2bua_send_b_leg_invite(
+                    call_id, target_uri, next_hop, None, &[], None, forced_cid, &template, &inbound,
+                    state,
+                );
+                true
+            } else {
+                false
+            };
+
+            // The dialed target is the last b_leg; capture its Call-ID so the
+            // response path matches only THIS leg as the transfer target.
+            let target_leg_call_id = if dialed {
+                state
+                    .call_actors
+                    .get_call(call_id)
+                    .and_then(|call| call.b_legs.last().map(|leg| leg.dialog.call_id.clone()))
+            } else {
+                None
+            };
+            state.call_actors.push_refer_subscription(
+                call_id,
+                crate::b2bua::actor::ReferSubscription {
+                    on_a_leg: from_a_leg,
+                    siphon_notifies: true,
+                    event_id: refer_cseq,
+                    notify_cseq: refer_cseq,
+                    state: crate::b2bua::transfer::TransferState::Trying,
+                    target_leg_call_id,
+                },
+            );
+        }
+    }
+}
+
+/// Complete a siphon-terminated transfer when the dialed transfer-target leg
+/// answers (2xx): ACK it, send the terminating `NOTIFY 200 OK` sipfrag to the
+/// referrer, promote the target into the surviving pair, and BYE the referrer.
+///
+/// The signaling here (ACK / NOTIFY / promote / BYE) is what makes the transfer
+/// visible on the wire and is covered by the integration tests. The rtpengine
+/// media re-anchor (re-bridging the surviving party's media to the transfer
+/// target) needs a live rtpengine session to validate and is intentionally left
+/// to the standard re-negotiation path rather than reconstructed blind here.
+fn b2bua_complete_terminated_transfer(
+    call_id: &str,
+    target_idx: usize,
+    response: &SipMessage,
+    state: &DispatcherState,
+) {
+    // Snapshot the referrer side + the target (Z) leg before mutating.
+    let (referrer_on_a_leg, target_leg) = match state.call_actors.get_call(call_id) {
+        Some(call) => {
+            let Some(on_a_leg) = call
+                .refer_subscriptions
+                .iter()
+                .find(|subscription| subscription.siphon_notifies)
+                .map(|subscription| subscription.on_a_leg)
+            else {
+                return;
+            };
+            (on_a_leg, call.b_legs.get(target_idx).cloned())
+        }
+        None => return,
+    };
+    let Some(target_leg) = target_leg else {
+        return;
+    };
+
+    // Media re-anchor inputs, snapshotted BEFORE any mutation — promotion changes
+    // a_leg.dialog.call_id, which is the old anchor's store key. Meaningful only
+    // when the call is media-anchored (an old session exists); otherwise the
+    // transfer re-INVITE below relays the target's raw answer SDP.
+    let survivor_on_a_leg = !referrer_on_a_leg;
+    let survivor_tag = state
+        .call_actors
+        .clone_leg(call_id, survivor_on_a_leg)
+        .and_then(|leg| leg.dialog.remote_tag.clone());
+    let target_answer_tag = response
+        .headers
+        .to()
+        .and_then(|to| to.split(";tag=").nth(1))
+        .map(|rest| {
+            rest.split([';', ' ', '>', '\r', '\n'])
+                .next()
+                .unwrap_or("")
+                .to_string()
+        })
+        .filter(|tag| !tag.is_empty());
+    let old_anchor = state
+        .call_actors
+        .get_call(call_id)
+        .map(|call| call.a_leg.dialog.call_id.clone())
+        .and_then(|key| {
+            state
+                .rtpengine_sessions
+                .as_ref()
+                .and_then(|store| store.get(&key))
+                .map(|session| (key, session))
+        });
+    // The transfer target leg's Call-ID doubles as the fresh rtpengine call-id
+    // for the survivor↔target anchor (forced in Phase 1 when anchored).
+    let cid_new = target_leg.dialog.call_id.clone();
+
+    // ACK the target's 2xx — siphon is the UAC for this leg (RFC 3261 §13.2.2.4).
+    let ack_ruri = response
+        .headers
+        .get("Contact")
+        .map(|value| crate::b2bua::actor::extract_contact_uri(value))
+        .or_else(|| target_leg.dialog.remote_contact.clone())
+        .and_then(|uri| parse_uri_standalone(&uri).ok())
+        .or_else(|| {
+            target_leg
+                .dialog
+                .target_uri
+                .as_deref()
+                .and_then(|uri| parse_uri_standalone(uri).ok())
+        });
+    if let Some(ruri) = ack_ruri {
+        let transport_str = format!("{}", target_leg.transport.transport).to_uppercase();
+        let cseq_num = response
+            .headers
+            .cseq()
+            .and_then(|c| c.split_whitespace().next().map(|s| s.to_string()))
+            .unwrap_or_else(|| "1".to_string());
+        if let Ok(ack) = SipMessageBuilder::new()
+            .request(Method::Ack, ruri)
+            .via(format!(
+                "SIP/2.0/{} {}:{};branch={}",
+                transport_str,
+                state.via_host(&target_leg.transport.transport),
+                a_leg_advertised_port(
+                    target_leg.transport.local_addr,
+                    state.via_port(&target_leg.transport.transport)
+                ),
+                TransactionKey::generate_branch(),
+            ))
+            .from(response.headers.from().cloned().unwrap_or_default())
+            .to(response.headers.to().cloned().unwrap_or_default())
+            .call_id(target_leg.dialog.call_id.clone())
+            .cseq(format!("{cseq_num} ACK"))
+            .header("Max-Forwards", "70".to_string())
+            .content_length(0)
+            .build()
+        {
+            let (dest, transport) = resolve_in_dialog_destination(
+                &target_leg.dialog.route_set,
+                state,
+                target_leg.transport.remote_addr,
+                target_leg.transport.transport,
+            );
+            send_message_from(
+                ack,
+                transport,
+                dest,
+                target_leg.transport.connection_id,
+                target_leg.transport.local_addr,
+                state,
+            );
+        }
+    }
+
+    // Terminating NOTIFY (sipfrag 200 OK) to the referrer on its subscription.
+    if let Some(cseq) = state.call_actors.reserve_leg_cseq(call_id, referrer_on_a_leg) {
+        if let Some(referrer_leg) = state.call_actors.clone_leg(call_id, referrer_on_a_leg) {
+            let extra_headers = [
+                ("Event", "refer".to_string()),
+                (
+                    "Subscription-State",
+                    crate::b2bua::transfer::subscription_state_header(
+                        &crate::b2bua::transfer::TransferState::Succeeded,
+                        0,
+                    ),
+                ),
+            ];
+            if let Some(notify) = build_b2bua_in_dialog_request(
+                &referrer_leg,
+                state,
+                Method::Notify,
+                cseq,
+                &extra_headers,
+                Some((
+                    "message/sipfrag",
+                    crate::b2bua::transfer::build_sipfrag_body(200, "OK").into_bytes(),
+                )),
+            ) {
+                let (dest, transport) = resolve_in_dialog_destination(
+                    &referrer_leg.dialog.route_set,
+                    state,
+                    referrer_leg.transport.remote_addr,
+                    referrer_leg.transport.transport,
+                );
+                send_message_from(
+                    notify,
+                    transport,
+                    dest,
+                    referrer_leg.transport.connection_id,
+                    referrer_leg.transport.local_addr,
+                    state,
+                );
+            }
+        }
+    }
+
+    // Promote the target into the surviving pair, then BYE the referrer leg.
+    if let Some(referrer_leg) =
+        state
+            .call_actors
+            .promote_transfer_target(call_id, target_idx, referrer_on_a_leg)
+    {
+        if let Some(bye) = build_b2bua_bye(&referrer_leg, state) {
+            let (dest, transport) = resolve_in_dialog_destination(
+                &referrer_leg.dialog.route_set,
+                state,
+                referrer_leg.transport.remote_addr,
+                referrer_leg.transport.transport,
+            );
+            send_message_from(
+                bye,
+                transport,
+                dest,
+                referrer_leg.transport.connection_id,
+                referrer_leg.transport.local_addr,
+                state,
+            );
+        }
+    }
+
+    state
+        .call_actors
+        .clear_refer_subscriptions_on_leg(call_id, referrer_on_a_leg);
+    state.call_actors.set_state(call_id, CallState::Answered);
+
+    // Re-point the surviving party's media at the transfer target (RFC 3261 §14).
+    // The referrer is gone, so without this the surviving leg still holds the
+    // referrer's SDP and sends RTP nowhere.
+    //   Anchored: rtpengine-answer the survivor↔target media on the fresh call-id
+    //     (the survivor was offered onto it in Phase 1), re-INVITE the survivor
+    //     with the anchored SDP, register the fresh session under the
+    //     (post-promotion) A-leg Call-ID, and tear down the old anchor.
+    //   Non-anchored: re-INVITE the survivor with the target's raw answer SDP.
+    if !response.body.is_empty() {
+        let reanchored = match (&old_anchor, &survivor_tag, &target_answer_tag) {
+            (Some((_, old_session)), Some(surv_tag), Some(tgt_tag)) => {
+                b2bua_transfer_rtpengine_answer(
+                    state,
+                    &cid_new,
+                    surv_tag,
+                    tgt_tag,
+                    &response.body,
+                    &old_session.profile,
+                )
+            }
+            _ => None,
+        };
+        let reinvite_sdp = reanchored.clone().unwrap_or_else(|| response.body.clone());
+        b2bua_send_media_reinvite(call_id, survivor_on_a_leg, reinvite_sdp, state);
+
+        // On a successful re-anchor: register the fresh session keyed by the
+        // (post-promotion) A-leg Call-ID — so later re-INVITEs/teardown resolve
+        // it — and delete the old survivor↔referrer anchor.
+        if reanchored.is_some() {
+            if let (Some((old_key, old_session)), Some(surv_tag), Some(tgt_tag)) =
+                (&old_anchor, &survivor_tag, &target_answer_tag)
+            {
+                if let Some(store) = state.rtpengine_sessions.as_ref() {
+                    let new_store_key = state
+                        .call_actors
+                        .get_call(call_id)
+                        .map(|call| call.a_leg.dialog.call_id.clone())
+                        .unwrap_or_else(|| cid_new.clone());
+                    store.insert(crate::rtpengine::session::MediaSession {
+                        call_id: new_store_key,
+                        rtpengine_call_id: cid_new.clone(),
+                        // a_leg/b_leg role order after promotion: the target is
+                        // the offerer for future role-based lookups.
+                        from_tag: tgt_tag.clone(),
+                        to_tag: Some(surv_tag.clone()),
+                        profile: old_session.profile.clone(),
+                        created_at: std::time::Instant::now(),
+                    });
+                    store.remove(old_key);
+                }
+                b2bua_transfer_rtpengine_delete(
+                    state,
+                    old_session.rtpengine_id(),
+                    &old_session.from_tag,
+                );
+                info!(
+                    call_id = %call_id,
+                    rtpengine_call_id = %cid_new,
+                    "B2BUA REFER (terminate): media re-anchored survivor↔target, old anchor deleted"
+                );
+            }
+        }
+    }
+
+    info!(
+        call_id = %call_id,
+        referrer_on_a_leg,
+        "B2BUA REFER (terminate): transfer completed — target active, referrer BYE'd"
+    );
+}
+
+/// The dialed transfer target failed (non-2xx). Notify the referrer that the
+/// transfer failed (terminating sipfrag NOTIFY), drop the failed target leg, and
+/// keep the original call intact. The failed INVITE is ACKed by the client
+/// transaction layer (RFC 3261 §17.1.1.3).
+fn b2bua_fail_terminated_transfer(
+    call_id: &str,
+    target_idx: usize,
+    status_code: u16,
+    state: &DispatcherState,
+) {
+    let Some(referrer_on_a_leg) = state.call_actors.get_call(call_id).and_then(|call| {
+        call.refer_subscriptions
+            .iter()
+            .find(|subscription| subscription.siphon_notifies)
+            .map(|subscription| subscription.on_a_leg)
+    }) else {
+        return;
+    };
+
+    let failure = crate::b2bua::transfer::transfer_result_from_response(status_code);
+    let (code, reason) = match &failure {
+        crate::b2bua::transfer::TransferState::Failed { code, reason } => (*code, reason.clone()),
+        _ => (status_code, "Failure".to_string()),
+    };
+    if let Some(cseq) = state.call_actors.reserve_leg_cseq(call_id, referrer_on_a_leg) {
+        if let Some(referrer_leg) = state.call_actors.clone_leg(call_id, referrer_on_a_leg) {
+            let extra_headers = [
+                ("Event", "refer".to_string()),
+                (
+                    "Subscription-State",
+                    crate::b2bua::transfer::subscription_state_header(&failure, 0),
+                ),
+            ];
+            if let Some(notify) = build_b2bua_in_dialog_request(
+                &referrer_leg,
+                state,
+                Method::Notify,
+                cseq,
+                &extra_headers,
+                Some((
+                    "message/sipfrag",
+                    crate::b2bua::transfer::build_sipfrag_body(code, &reason).into_bytes(),
+                )),
+            ) {
+                let (dest, transport) = resolve_in_dialog_destination(
+                    &referrer_leg.dialog.route_set,
+                    state,
+                    referrer_leg.transport.remote_addr,
+                    referrer_leg.transport.transport,
+                );
+                send_message_from(
+                    notify,
+                    transport,
+                    dest,
+                    referrer_leg.transport.connection_id,
+                    referrer_leg.transport.local_addr,
+                    state,
+                );
+            }
+        }
+    }
+
+    // Drop the failed transfer-target leg; the original call is untouched.
+    state.call_actors.remove_b_leg(call_id, target_idx);
+    state
+        .call_actors
+        .clear_refer_subscriptions_on_leg(call_id, referrer_on_a_leg);
+    info!(
+        call_id = %call_id,
+        status = status_code,
+        "B2BUA REFER (terminate): transfer target failed — referrer call kept, subscription terminated"
+    );
+}
+
+/// Forward an in-dialog REFER or NOTIFY across to the far leg of a B2BUA call,
+/// on that leg's own dialog identity — the transparent-transfer primitive.
+///
+/// This is the UPDATE bridge (`handle_b2bua_update`) stripped to the parts a
+/// bodyless/opaque-body request needs: no 100 Trying, no SDP/rtpengine (the body,
+/// e.g. a NOTIFY `message/sipfrag`, is forwarded verbatim). `method` is the
+/// request method; `marker` is the tracking-leg `target_uri` prefix (`"refer"` /
+/// `"notify"`) whose response arm relays the far end's reply back to the
+/// originator. The caller has already resolved `from_a_leg` by dialog identity.
+fn b2bua_forward_indialog_request(
+    inbound: &InboundMessage,
+    message: &SipMessage,
+    call_id: &str,
+    from_a_leg: bool,
+    method: Method,
+    marker: &str,
+    state: &DispatcherState,
+) {
+    let method_str = method.as_str().to_string();
+
+    // Flow refresh (RFC 5626 / RFC 3261 §12.2.2): re-anchor the originating leg
+    // on the arrival flow (TLS reconnect / NAT rebind) before snapshotting.
+    let refreshed_contact = message
+        .headers
+        .get("Contact")
+        .or_else(|| message.headers.get("m"))
+        .map(|value| crate::b2bua::actor::extract_contact_uri(value));
+    if let Some(mut call) = state.call_actors.get_call_mut(call_id) {
+        let winner_index = call.winner;
+        let origin_leg: Option<&mut Leg> = if from_a_leg {
+            Some(&mut call.a_leg)
+        } else if let Some(index) = winner_index {
+            call.b_legs.get_mut(index)
+        } else {
+            None
+        };
+        if let Some(leg) = origin_leg {
+            if leg.transport.remote_addr != inbound.remote_addr
+                || leg.transport.connection_id != inbound.connection_id
+            {
+                leg.transport.remote_addr = inbound.remote_addr;
+                leg.transport.connection_id = inbound.connection_id;
+                leg.transport.local_addr = Some(inbound.local_addr);
+            }
+            if let Some(ref contact) = refreshed_contact {
+                leg.dialog.remote_contact = Some(contact.clone());
+            }
+        }
+    }
+
+    let (a_leg, winner_b_leg) = match state.call_actors.get_call(call_id) {
+        Some(call) => {
+            let b_leg = call.winner.and_then(|i| call.b_legs.get(i).cloned());
+            (call.a_leg.clone(), b_leg)
+        }
+        None => return,
+    };
+
+    let (target_remote_contact, target_local_contact) = if from_a_leg {
+        winner_b_leg
+            .as_ref()
+            .map(|b| (b.dialog.remote_contact.clone(), b.dialog.local_contact.clone()))
+            .unwrap_or((None, None))
+    } else {
+        (
+            a_leg.dialog.remote_contact.clone(),
+            a_leg.dialog.local_contact.clone(),
+        )
+    };
+
+    let branch = TransactionKey::generate_branch();
+    let mut forwarded = message.clone();
+
+    let target = if from_a_leg {
+        if let Some(b_leg) = &winner_b_leg {
+            crate::b2bua::actor::Dialog::rewrite_headers(
+                &mut forwarded,
+                &b_leg.dialog.call_id,
+                a_leg.dialog.remote_tag.as_deref().unwrap_or(""),
+                &b_leg.dialog.local_tag,
+                b_leg.dialog.remote_tag.as_deref(),
+            );
+            Some((
+                b_leg.transport.remote_addr,
+                b_leg.transport.transport,
+                b_leg.transport.local_addr,
+                b_leg.transport.connection_id,
+                b_leg.dialog.call_id.clone(),
+                b_leg.dialog.local_tag.clone(),
+            ))
+        } else {
+            warn!(call_id = %call_id, "B2BUA {method_str}: no winning B-leg to forward to");
+            return;
+        }
+    } else {
+        crate::b2bua::actor::Dialog::rewrite_headers(
+            &mut forwarded,
+            &a_leg.dialog.call_id,
+            &winner_b_leg
+                .as_ref()
+                .map(|b| b.dialog.local_tag.clone())
+                .unwrap_or_default(),
+            a_leg.dialog.remote_tag.as_deref().unwrap_or(""),
+            Some(&a_leg.dialog.local_tag),
+        );
+        Some((
+            a_leg.transport.remote_addr,
+            a_leg.transport.transport,
+            a_leg.transport.local_addr,
+            a_leg.transport.connection_id,
+            a_leg.dialog.call_id.clone(),
+            a_leg.dialog.remote_tag.clone().unwrap_or_default(),
+        ))
+    };
+
+    let Some((destination, transport, target_local_addr, target_connection_id, leg_call_id, leg_from_tag)) =
+        target
+    else {
+        return;
+    };
+
+    let transport_str = format!("{}", transport).to_uppercase();
+    let via_value = format!(
+        "SIP/2.0/{} {}:{};branch={}",
+        transport_str,
+        state.via_host(&transport),
+        a_leg_advertised_port(target_local_addr, state.via_port(&transport)),
+        branch,
+    );
+    forwarded.headers.set("Via", via_value);
+
+    // Strip cross-leg headers (same hygiene set as the UPDATE bridge). Refer-To,
+    // Referred-By, Event and Subscription-State are NOT in this set, so they ride
+    // across intact — exactly what the transparent transfer needs.
+    if let Some(ref ua) = state.user_agent_header {
+        forwarded.headers.set("User-Agent", ua.clone());
+    } else {
+        forwarded.headers.remove("User-Agent");
+    }
+    forwarded.headers.remove("Server");
+    forwarded.headers.remove("Allow");
+    forwarded.headers.remove("Supported");
+    forwarded.headers.remove("Require");
+    forwarded.headers.remove("Proxy-Require");
+    forwarded.headers.remove("P-Access-Network-Info");
+    forwarded.headers.remove("Security-Verify");
+    forwarded.headers.remove("Security-Client");
+    forwarded.headers.remove("Authorization");
+    forwarded.headers.remove("Proxy-Authorization");
+    forwarded.headers.remove("Record-Route");
+    forwarded.headers.remove("Route");
+
+    let target_route_set = if from_a_leg {
+        winner_b_leg
+            .as_ref()
+            .map(|b| b.dialog.route_set.clone())
+            .unwrap_or_default()
+    } else {
+        a_leg.dialog.route_set.clone()
+    };
+    for route in &target_route_set {
+        forwarded.headers.add("Route", route.clone());
+    }
+
+    let (target_from_uri, target_from_tag, target_to_uri, target_to_tag) = if from_a_leg {
+        let b = winner_b_leg.as_ref();
+        (
+            b.and_then(|b| b.dialog.local_from_uri.clone()),
+            b.map(|b| b.dialog.local_tag.clone()),
+            b.and_then(|b| b.dialog.remote_to_uri.clone()),
+            b.and_then(|b| b.dialog.remote_tag.clone()),
+        )
+    } else {
+        (
+            a_leg.dialog.local_from_uri.clone(),
+            Some(a_leg.dialog.local_tag.clone()),
+            a_leg.dialog.remote_to_uri.clone(),
+            a_leg.dialog.remote_tag.clone(),
+        )
+    };
+    if let Some(uri) = target_from_uri {
+        forwarded.headers.set(
+            "From",
+            crate::b2bua::actor::ensure_tag(&uri, target_from_tag.as_deref()),
+        );
+    }
+    if let Some(uri) = target_to_uri {
+        forwarded.headers.set(
+            "To",
+            crate::b2bua::actor::ensure_tag(&uri, target_to_tag.as_deref()),
+        );
+    }
+
+    let target_cseq = if from_a_leg {
+        winner_b_leg.as_ref().map(|b| b.dialog.local_cseq).unwrap_or(1)
+    } else {
+        a_leg.dialog.local_cseq
+    };
+    forwarded.headers.set("CSeq", format!("{target_cseq} {method_str}"));
+
+    let _ = crate::proxy::core::decrement_max_forwards(&mut forwarded.headers);
+
+    // Opaque body forwarded verbatim (NOTIFY message/sipfrag; REFER has none).
+    forwarded
+        .headers
+        .set("Content-Length", forwarded.body.len().to_string());
+
+    if let Some(ref uri_str) = target_remote_contact {
+        if let Ok(parsed) = parse_uri_standalone(uri_str) {
+            forwarded.start_line = StartLine::Request(crate::sip::message::RequestLine {
+                method,
+                request_uri: parsed,
+                version: crate::sip::message::Version::sip_2_0(),
+            });
+        }
+    }
+    if let Some(ref contact) = target_local_contact {
+        forwarded.headers.set("Contact", contact.clone());
+    }
+
+    let (send_dest, send_transport) =
+        resolve_in_dialog_destination(&target_route_set, state, destination, transport);
+
+    let direction = if from_a_leg {
+        format!("{marker}:a2b")
+    } else {
+        format!("{marker}:b2a")
+    };
+    let originator_vias = message
+        .headers
+        .get_all("Via")
+        .map(|v| v.to_vec())
+        .unwrap_or_default();
+    let mut tracking_leg = Leg::new_b_leg(
+        leg_call_id,
+        leg_from_tag,
+        direction,
+        branch.clone(),
+        LegTransport {
+            remote_addr: send_dest,
+            connection_id: target_connection_id,
+            transport: send_transport,
+            local_addr: target_local_addr,
+        },
+    );
+    tracking_leg.stored_vias = originator_vias;
+    tracking_leg.stored_cseq = message.headers.cseq().map(|c| c.to_string());
+    // Keep the originator's From/To verbatim so the relayed response echoes them
+    // exactly (RFC 3261 §8.2.6.2) instead of reconstructing from dialog URIs,
+    // which can carry a `:5060` (or params/display) the peer never sent.
+    tracking_leg.stored_from = message.headers.from().map(|f| f.to_string());
+    tracking_leg.stored_to = message.headers.to().map(|t| t.to_string());
+    state.call_actors.add_b_leg(call_id, tracking_leg);
+
+    let contact_fallback = contact_fallback_target(
+        from_a_leg,
+        send_dest,
+        send_transport,
+        target_connection_id,
+        target_route_set.is_empty(),
+        target_remote_contact.as_deref(),
+        state,
+    );
+    if from_a_leg {
+        send_b2bua_to_bleg(forwarded, send_transport, send_dest, state);
+    } else if let Some(fallback) = contact_fallback {
+        let data = Bytes::from(forwarded.to_bytes());
+        send_to_target(
+            data,
+            &fallback,
+            send_transport,
+            ConnectionId::default(),
+            target_local_addr,
+            state,
+        );
+    } else {
+        send_message_from(
+            forwarded,
+            send_transport,
+            send_dest,
+            target_connection_id,
+            target_local_addr,
+            state,
+        );
+    }
+
+    // Bump the target leg's local CSeq after sending.
+    if let Some(mut call) = state.call_actors.get_call_mut(call_id) {
+        if from_a_leg {
+            if let Some(winner_idx) = call.winner {
+                if let Some(b_leg) = call.b_legs.get_mut(winner_idx) {
+                    b_leg.dialog.local_cseq += 1;
+                }
+            }
+        } else {
+            call.a_leg.dialog.local_cseq += 1;
+        }
+    }
+}
+
+/// Handle an in-dialog NOTIFY on a tracked B2BUA call — the sipfrag progress of
+/// a REFER subscription (RFC 3515 §2.4).
+///
+/// Two cases:
+///   - **siphon owns the subscription** (siphon-originated transfer: siphon sent
+///     the REFER and is the subscriber): answer `200 OK` locally, read the
+///     `Subscription-State`, and drop the subscription on `terminated`. Not
+///     bridged — the subscription lives only between siphon and the referee.
+///   - **transparent transfer** (siphon forwarded the REFER; the far end is
+///     notifying): bridge the NOTIFY across to the referrer's leg so it sees the
+///     transfer progress, exactly like the far end intended.
+fn handle_b2bua_notify(inbound: InboundMessage, message: SipMessage, state: &DispatcherState) {
+    let sip_call_id = message
+        .headers
+        .get("Call-ID")
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+    let call_id = match state.call_actors.find_by_sip_call_id(&sip_call_id) {
+        Some(id) => id,
+        None => {
+            warn!(sip_call_id = %sip_call_id, "B2BUA NOTIFY: no matching call");
+            return;
+        }
+    };
+
+    let from_tag = message.typed_from().ok().flatten().and_then(|na| na.tag);
+    let from_a_leg = match state
+        .call_actors
+        .get_call(&call_id)
+        .and_then(|call| call.request_direction(&sip_call_id, from_tag.as_deref()))
+    {
+        Some(crate::b2bua::actor::LegSide::A) => true,
+        Some(crate::b2bua::actor::LegSide::B) => false,
+        None => {
+            warn!(sip_call_id = %sip_call_id, "B2BUA NOTIFY: Call-ID matches no dialog leg — 481");
+            let response = build_response(
+                &message,
+                481,
+                "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(),
+                &[],
+            );
+            send_message_from(
+                response,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
+            return;
+        }
+    };
+
+    if state
+        .call_actors
+        .has_subscriber_refer_subscription(&call_id, from_a_leg)
+    {
+        // siphon owns this subscription (it sent the REFER). Absorb: 200 OK and
+        // read the sipfrag progress; on terminated, drop the subscription.
+        let response = build_response(&message, 200, "OK", state.server_header.as_deref(), &[]);
+        send_message_from(
+            response,
+            inbound.transport,
+            inbound.remote_addr,
+            inbound.connection_id,
+            Some(inbound.local_addr),
+            state,
+        );
+
+        let terminated = message
+            .headers
+            .get("Subscription-State")
+            .map(|value| value.to_ascii_lowercase().contains("terminated"))
+            .unwrap_or(false);
+        debug!(
+            call_id = %call_id,
+            terminated,
+            body = %String::from_utf8_lossy(&message.body),
+            "B2BUA NOTIFY: siphon-owned REFER subscription progress"
+        );
+        if terminated {
+            state
+                .call_actors
+                .clear_refer_subscriptions_on_leg(&call_id, from_a_leg);
+        }
+        return;
+    }
+
+    // Transparent transfer: bridge the far end's NOTIFY to the referrer's leg.
+    b2bua_forward_indialog_request(
+        &inbound,
+        &message,
+        &call_id,
+        from_a_leg,
+        Method::Notify,
+        "notify",
+        state,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -16837,6 +18954,73 @@ a=rtpmap:8 PCMA/8000\r\n";
         assert_eq!(sanitize_o_username(""), "");
     }
 
+    #[test]
+    fn stamp_sdp_origin_owns_session_id_and_version() {
+        let sdp = "v=0\r\no=alice 111 222 IN IP4 10.0.0.1\r\ns=call\r\nt=0 0\r\nm=audio 8000 RTP/AVP 0\r\n";
+        let mut body = sdp.as_bytes().to_vec();
+        // addr=None → nettype/addrtype/address preserved, only username+ids owned.
+        stamp_sdp_origin(&mut body, "SIPhon", 9999, 7, None);
+        let result = std::str::from_utf8(&body).unwrap();
+        assert!(
+            result.contains("o=SIPhon 9999 7 IN IP4 10.0.0.1\r\n"),
+            "got: {result}",
+        );
+        // A malformed username still collapses whitespace (RFC 4566 §5.2).
+        let o_line = result.lines().find(|l| l.starts_with("o=")).unwrap();
+        assert_eq!(o_line.split(' ').count(), 6);
+    }
+
+    #[test]
+    fn stamp_sdp_origin_rewrites_address_when_given() {
+        let sdp = "v=0\r\no=carol 5 6 IN IP4 198.51.100.9\r\ns=-\r\nt=0 0\r\n";
+        let mut body = sdp.as_bytes().to_vec();
+        stamp_sdp_origin(&mut body, "SIPhon", 42, 1, Some("203.0.113.7"));
+        let result = std::str::from_utf8(&body).unwrap();
+        assert!(
+            result.contains("o=SIPhon 42 1 IN IP4 203.0.113.7\r\n"),
+            "got: {result}",
+        );
+        assert!(!result.contains("198.51.100.9"));
+    }
+
+    /// The whole point of siphon-owned o=: a re-emit toward the same peer keeps
+    /// the session-id stable and presents a strictly greater version, even when
+    /// the underlying SDP came from a different party (a transfer re-anchor).
+    #[test]
+    fn stamp_sdp_origin_monotonic_across_reemits() {
+        let first =
+            "v=0\r\no=bob 1 1 IN IP4 10.0.0.2\r\ns=-\r\nt=0 0\r\nm=audio 9000 RTP/AVP 0\r\n";
+        let mut a = first.as_bytes().to_vec();
+        stamp_sdp_origin(&mut a, "SIPhon", 5000, 0, None);
+        // A later re-anchor carries a *different* party's SDP but siphon's same
+        // session-id with an incremented version.
+        let second =
+            "v=0\r\no=carol 7 7 IN IP4 10.0.0.9\r\ns=-\r\nt=0 0\r\nm=audio 9100 RTP/AVP 0\r\n";
+        let mut b = second.as_bytes().to_vec();
+        stamp_sdp_origin(&mut b, "SIPhon", 5000, 1, None);
+        let ra = std::str::from_utf8(&a).unwrap();
+        let rb = std::str::from_utf8(&b).unwrap();
+        assert!(ra.contains("o=SIPhon 5000 0 IN IP4 10.0.0.2\r\n"), "got: {ra}");
+        assert!(rb.contains("o=SIPhon 5000 1 IN IP4 10.0.0.9\r\n"), "got: {rb}");
+    }
+
+    #[test]
+    fn stamp_sdp_origin_leaves_malformed_o_line_untouched() {
+        // Fewer than the RFC-mandated six fields → left alone (defensive).
+        let sdp = "v=0\r\no=broken 1 2\r\ns=-\r\nt=0 0\r\n";
+        let mut body = sdp.as_bytes().to_vec();
+        stamp_sdp_origin(&mut body, "SIPhon", 1, 2, None);
+        let result = std::str::from_utf8(&body).unwrap();
+        assert!(result.contains("o=broken 1 2\r\n"), "got: {result}");
+    }
+
+    #[test]
+    fn stamp_sdp_origin_no_op_on_empty_body() {
+        let mut body = Vec::new();
+        stamp_sdp_origin(&mut body, "SIPhon", 1, 1, None);
+        assert!(body.is_empty());
+    }
+
     /// Verify that fork targets DO update the R-URI (each branch gets its Contact).
     #[test]
     fn fork_branch_updates_request_uri() {
@@ -16982,6 +19166,7 @@ a=rtpmap:8 PCMA/8000\r\n";
     fn media_session_fixture(call_id: &str) -> crate::rtpengine::session::MediaSession {
         crate::rtpengine::session::MediaSession {
             call_id: call_id.to_string(),
+            rtpengine_call_id: call_id.to_string(),
             from_tag: "a-tag".to_string(),
             to_tag: None,
             profile: "srtp_to_rtp".to_string(),

--- a/src/rtpengine/session.rs
+++ b/src/rtpengine/session.rs
@@ -7,8 +7,16 @@ use dashmap::DashMap;
 /// An active RTPEngine media session associated with a SIP dialog.
 #[derive(Debug, Clone)]
 pub struct MediaSession {
-    /// SIP Call-ID header value.
+    /// SIP Call-ID header value. This is the **store key** — the dispatcher
+    /// looks sessions up by the A-leg's SIP Call-ID.
     pub call_id: String,
+    /// The opaque call-id used in rtpengine NG commands (`offer`/`answer`/
+    /// `delete`). Normally equal to [`MediaSession::call_id`], but decoupled so
+    /// a siphon-terminated transfer can re-anchor the surviving pair on a
+    /// **fresh** rtpengine call-id while the store key stays the (post-promotion)
+    /// SIP Call-ID that later re-INVITEs/teardown look up. Use
+    /// [`MediaSession::rtpengine_id`] rather than reading this directly.
+    pub rtpengine_call_id: String,
     /// SIP From-tag (A leg).
     pub from_tag: String,
     /// SIP To-tag (B leg) — set after the answer.
@@ -17,6 +25,20 @@ pub struct MediaSession {
     pub profile: String,
     /// When this session was created.
     pub created_at: Instant,
+}
+
+impl MediaSession {
+    /// The call-id to address rtpengine with. Falls back to the SIP `call_id`
+    /// when `rtpengine_call_id` was left empty (back-compat for sessions created
+    /// before the decoupling), so all existing anchored calls talk to rtpengine
+    /// on their SIP Call-ID exactly as before.
+    pub fn rtpengine_id(&self) -> &str {
+        if self.rtpengine_call_id.is_empty() {
+            &self.call_id
+        } else {
+            &self.rtpengine_call_id
+        }
+    }
 }
 
 /// Thread-safe store of active media sessions, keyed by SIP Call-ID.
@@ -89,6 +111,7 @@ mod tests {
     fn make_session(call_id: &str) -> MediaSession {
         MediaSession {
             call_id: call_id.to_string(),
+            rtpengine_call_id: call_id.to_string(),
             from_tag: "tag-a".to_string(),
             to_tag: None,
             profile: "srtp_to_rtp".to_string(),
@@ -199,5 +222,22 @@ mod tests {
     fn default_trait() {
         let store = MediaSessionStore::default();
         assert!(store.is_empty());
+    }
+
+    #[test]
+    fn rtpengine_id_uses_field_then_falls_back_to_call_id() {
+        // Normal session: rtpengine_call_id == call_id → both agree.
+        let mut session = make_session("sip-cid");
+        assert_eq!(session.rtpengine_id(), "sip-cid");
+
+        // Decoupled (transfer re-anchor): store key stays the SIP Call-ID, but
+        // rtpengine is addressed on the fresh id.
+        session.rtpengine_call_id = "b2b-fresh-anchor".to_string();
+        assert_eq!(session.call_id, "sip-cid");
+        assert_eq!(session.rtpengine_id(), "b2b-fresh-anchor");
+
+        // Back-compat: an empty rtpengine_call_id falls back to the SIP Call-ID.
+        session.rtpengine_call_id = String::new();
+        assert_eq!(session.rtpengine_id(), "sip-cid");
     }
 }

--- a/src/script/api/b2bua.rs
+++ b/src/script/api/b2bua.rs
@@ -43,4 +43,29 @@ impl PyB2buaControl {
     fn terminate(&self, call_id: &str, reason: &str) -> bool {
         crate::dispatcher::b2bua_terminate_call(call_id, Some(reason))
     }
+
+    /// Imperatively send an outbound REFER on a live B2BUA call by SIP Call-ID.
+    ///
+    /// Refers the A-leg (the caller / IVR-connected party) to `target`.
+    /// `replaces` is an attended-transfer Replaces dict (keys `call_id` /
+    /// `from_tag` / `to_tag`, optional `early_only`) or `None` for a blind
+    /// transfer. Works from any context — including event callbacks like
+    /// `@rtpengine.on_dtmf` and timers — where the deferred `call.refer()` is a
+    /// silent no-op (no handler-return to act on). Returns True if the call was
+    /// found and the REFER emitted, False if the Call-ID is unknown / already
+    /// gone. Never raises (except on a malformed `replaces` dict).
+    #[pyo3(signature = (call_id, target, replaces=None))]
+    fn refer(
+        &self,
+        call_id: &str,
+        target: &str,
+        replaces: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> PyResult<bool> {
+        let replaces = crate::script::api::call::parse_replaces_dict(replaces)?;
+        let refer_to = crate::sip::headers::refer::ReferTo {
+            uri: target.to_string(),
+            replaces,
+        };
+        Ok(crate::dispatcher::b2bua_refer_call(call_id, refer_to))
+    }
 }

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -68,15 +68,77 @@ pub enum CallAction {
     },
     /// Terminate the call (BYE both legs).
     Terminate,
-    /// Accept a REFER (call transfer).
-    AcceptRefer,
+    /// Accept a REFER (call transfer). `mode` selects siphon-terminated
+    /// (`Terminate`) vs transparent forward (`Transparent`); `None` defers to
+    /// the configured `b2bua.default_refer_mode`. `target` optionally rewrites
+    /// the transfer destination before it is honored; `next_hop` steers egress.
+    AcceptRefer {
+        target: Option<String>,
+        next_hop: Option<String>,
+        mode: Option<ReferMode>,
+    },
     /// Reject a REFER with a status code.
     RejectRefer { code: u16, reason: String },
+    /// Originate an outbound REFER on a connected leg (`call.refer(...)`) —
+    /// siphon is the referrer (IVR / UAS-mode offload). Carries the target and
+    /// an optional Replaces (attended transfer).
+    SendRefer {
+        refer_to: crate::sip::headers::refer::ReferTo,
+    },
     /// UAS-mode answer already sent imperatively by `call.answer()` — the final
     /// 2xx went on the wire during the handler (see `dispatcher::b2bua_answer_call`).
     /// This marker only tells the dispatcher the call was answered so it keeps
     /// the actor alive instead of removing it as a silent (no-action) drop.
     Answered,
+}
+
+/// REFER transfer mode selected by `call.accept_refer(mode=...)` (and the
+/// configured `b2bua.default_refer_mode` fallback).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferMode {
+    /// siphon terminates the transfer: answer 202 locally, re-resolve the
+    /// Refer-To through the dial plan as a new leg, re-bridge the media, and BYE
+    /// the referred-away leg. Correct for trunk-facing SBCs (the far end need not
+    /// support REFER) and keeps media anchored.
+    Terminate,
+    /// siphon forwards the REFER transparently on the far leg's own dialog and
+    /// relays the far end's 202 + `message/sipfrag` NOTIFYs back to the referrer.
+    /// Correct for UA-to-UA (PBX / softphone) topologies where both ends handle
+    /// REFER themselves.
+    Transparent,
+}
+
+/// Parse a Python Replaces dict (`{call_id, from_tag, to_tag, early_only?}`)
+/// into the internal [`Replaces`](crate::sip::headers::refer::Replaces). Shared
+/// by `call.refer(replaces=…)` and the imperative `b2bua.refer(...)`. Returns
+/// `None` when `dict` is `None` (a blind transfer).
+pub(crate) fn parse_replaces_dict(
+    dict: Option<&Bound<'_, pyo3::types::PyDict>>,
+) -> PyResult<Option<crate::sip::headers::refer::Replaces>> {
+    let Some(dict) = dict else {
+        return Ok(None);
+    };
+    let required = |key: &str| -> PyResult<String> {
+        match dict.get_item(key)? {
+            Some(value) => value.extract::<String>(),
+            None => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "replaces dict requires a '{key}' key"
+            ))),
+        }
+    };
+    let call_id = required("call_id")?;
+    let from_tag = required("from_tag")?;
+    let to_tag = required("to_tag")?;
+    let early_only = match dict.get_item("early_only")? {
+        Some(value) => value.extract::<bool>()?,
+        None => false,
+    };
+    Ok(Some(crate::sip::headers::refer::Replaces {
+        call_id,
+        from_tag,
+        to_tag,
+        early_only,
+    }))
 }
 
 /// Which side initiated a BYE.
@@ -1517,8 +1579,48 @@ impl PyCall {
     }
 
     /// Accept the REFER and proceed with the transfer.
-    fn accept_refer(&mut self) {
-        self.action = CallAction::AcceptRefer;
+    ///
+    /// `mode` selects how siphon honors the transfer:
+    ///   - `"terminate"`   — siphon terminates the transfer: answer 202 locally,
+    ///     re-resolve the Refer-To through the dial plan as a new leg, re-bridge
+    ///     the media, and BYE the referred-away leg. Works even when the far end
+    ///     cannot handle REFER; keeps media anchored.
+    ///   - `"transparent"` — siphon re-emits the REFER on the far leg's own
+    ///     dialog and relays the far end's 202 + sipfrag NOTIFYs back.
+    ///   - `None` (default) — use the configured `b2bua.default_refer_mode`.
+    ///
+    /// `target` optionally rewrites the transfer destination (e.g. E.164
+    /// canonicalization or gateway selection) before it is honored; it defaults
+    /// to `call.refer_to`. `next_hop` steers egress without changing the target
+    /// URI shape (same semantics as `call.dial(next_hop=...)`).
+    ///
+    /// Usage in Python:
+    ///   call.accept_refer()
+    ///   call.accept_refer(mode="transparent")
+    ///   call.accept_refer(target="sip:+15550142@example.com", mode="terminate")
+    #[pyo3(signature = (target=None, next_hop=None, mode=None))]
+    fn accept_refer(
+        &mut self,
+        target: Option<String>,
+        next_hop: Option<String>,
+        mode: Option<&str>,
+    ) -> PyResult<()> {
+        let mode = match mode {
+            None => None,
+            Some("terminate") => Some(ReferMode::Terminate),
+            Some("transparent") => Some(ReferMode::Transparent),
+            Some(other) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "accept_refer(mode=…) must be 'terminate' or 'transparent', got {other:?}"
+                )));
+            }
+        };
+        self.action = CallAction::AcceptRefer {
+            target,
+            next_hop,
+            mode,
+        };
+        Ok(())
     }
 
     /// Reject the REFER with a status code and reason.
@@ -1527,6 +1629,37 @@ impl PyCall {
             code,
             reason: reason.to_string(),
         };
+    }
+
+    /// Originate an outbound REFER on this call's connected leg — siphon is the
+    /// referrer (UAS-mode / IVR offload). `target` is the Refer-To URI the peer
+    /// should contact; `replaces` (a dict with keys `call_id` / `from_tag` /
+    /// `to_tag` and optional `early_only`) makes it an attended transfer, or
+    /// `None` for a blind transfer.
+    ///
+    /// Deferred: takes effect when the handler returns (use from
+    /// `@b2bua.on_answer`). For event-callback contexts such as
+    /// `@rtpengine.on_dtmf` — where deferred call actions are silent no-ops —
+    /// use the imperative `b2bua.refer(call_id, target)` instead.
+    ///
+    /// Usage in Python:
+    ///   call.refer("sip:+15550142@example.com")
+    ///   call.refer("sip:carol@example.com",
+    ///              replaces={"call_id": "abc", "from_tag": "a", "to_tag": "b"})
+    #[pyo3(signature = (target, replaces=None))]
+    fn refer(
+        &mut self,
+        target: &str,
+        replaces: Option<&Bound<'_, pyo3::types::PyDict>>,
+    ) -> PyResult<()> {
+        let replaces = parse_replaces_dict(replaces)?;
+        self.action = CallAction::SendRefer {
+            refer_to: crate::sip::headers::refer::ReferTo {
+                uri: target.to_string(),
+                replaces,
+            },
+        };
+        Ok(())
     }
 }
 
@@ -1868,8 +2001,60 @@ mod tests {
     fn call_accept_refer() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        call.accept_refer();
-        assert_eq!(call.action(), &CallAction::AcceptRefer);
+        call.accept_refer(None, None, None).unwrap();
+        assert_eq!(
+            call.action(),
+            &CallAction::AcceptRefer {
+                target: None,
+                next_hop: None,
+                mode: None
+            }
+        );
+    }
+
+    #[test]
+    fn call_accept_refer_transparent_with_target() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.accept_refer(
+            Some("sip:+15550142@example.com".to_string()),
+            Some("sip:198.51.100.1:5060".to_string()),
+            Some("transparent"),
+        )
+        .unwrap();
+        assert_eq!(
+            call.action(),
+            &CallAction::AcceptRefer {
+                target: Some("sip:+15550142@example.com".to_string()),
+                next_hop: Some("sip:198.51.100.1:5060".to_string()),
+                mode: Some(ReferMode::Transparent),
+            }
+        );
+    }
+
+    #[test]
+    fn call_accept_refer_terminate_mode() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.accept_refer(None, None, Some("terminate")).unwrap();
+        assert_eq!(
+            call.action(),
+            &CallAction::AcceptRefer {
+                target: None,
+                next_hop: None,
+                mode: Some(ReferMode::Terminate),
+            }
+        );
+    }
+
+    #[test]
+    fn call_accept_refer_rejects_bad_mode() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        let result = call.accept_refer(None, None, Some("bridge"));
+        assert!(result.is_err());
+        // The invalid call must not have mutated the action.
+        assert_eq!(call.action(), &CallAction::None);
     }
 
     #[test]
@@ -1884,6 +2069,62 @@ mod tests {
                 reason: "Forbidden".to_string()
             }
         );
+    }
+
+    #[test]
+    fn call_refer_blind() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.refer("sip:+15550142@example.com", None).unwrap();
+        match call.action() {
+            CallAction::SendRefer { refer_to } => {
+                assert_eq!(refer_to.uri, "sip:+15550142@example.com");
+                assert!(refer_to.replaces.is_none());
+            }
+            other => panic!("expected SendRefer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn call_refer_attended() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let message = Arc::new(Mutex::new(make_invite()));
+            let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+            let dict = pyo3::types::PyDict::new(py);
+            dict.set_item("call_id", "abc@example.com").unwrap();
+            dict.set_item("from_tag", "a-tag").unwrap();
+            dict.set_item("to_tag", "b-tag").unwrap();
+            dict.set_item("early_only", true).unwrap();
+            call.refer("sip:carol@example.com", Some(&dict)).unwrap();
+            match call.action() {
+                CallAction::SendRefer { refer_to } => {
+                    assert_eq!(refer_to.uri, "sip:carol@example.com");
+                    let replaces = refer_to.replaces.as_ref().expect("attended → Some(Replaces)");
+                    assert_eq!(replaces.call_id, "abc@example.com");
+                    assert_eq!(replaces.from_tag, "a-tag");
+                    assert_eq!(replaces.to_tag, "b-tag");
+                    assert!(replaces.early_only);
+                }
+                other => panic!("expected SendRefer, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn parse_replaces_dict_missing_key_errors() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let dict = pyo3::types::PyDict::new(py);
+            dict.set_item("call_id", "abc@example.com").unwrap();
+            // from_tag / to_tag missing → ValueError
+            assert!(parse_replaces_dict(Some(&dict)).is_err());
+        });
+    }
+
+    #[test]
+    fn parse_replaces_dict_none_is_none() {
+        assert!(parse_replaces_dict(None).unwrap().is_none());
     }
 
     #[test]

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -301,6 +301,7 @@ impl PyRtpEngine {
             replace_body(&message, &rewritten_sdp)?;
 
             sessions.insert(MediaSession {
+                rtpengine_call_id: call_id.clone(),
                 call_id,
                 from_tag,
                 to_tag: None,
@@ -494,6 +495,7 @@ impl PyRtpEngine {
                     // active-session accounting, and a later `rtpengine.answer`
                     // profile-reuse all work.
                     sessions.insert(MediaSession {
+                        rtpengine_call_id: call_id.clone(),
                         call_id,
                         from_tag,
                         to_tag: None,
@@ -1476,6 +1478,7 @@ mod tests {
     fn make_session(call_id: &str, profile: &str) -> MediaSession {
         MediaSession {
             call_id: call_id.to_string(),
+            rtpengine_call_id: call_id.to_string(),
             from_tag: "tag-a".to_string(),
             to_tag: None,
             profile: profile.to_string(),

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -191,6 +191,38 @@ class _B2buaNamespace:
             return False
         return control.terminate(call_id, reason)
 
+    def refer(self, call_id, target, replaces=None):
+        """Imperatively send an outbound REFER on a live B2BUA call by SIP Call-ID.
+
+        Refers the A-leg (the caller / IVR-connected party) to ``target``.
+        ``replaces`` is an attended-transfer Replaces dict (keys ``call_id`` /
+        ``from_tag`` / ``to_tag``, optional ``early_only``) or ``None`` for a
+        blind transfer. Like ``b2bua.terminate``, this acts now and works from an
+        out-of-band event callback (``@rtpengine.on_dtmf``), a timer, or a normal
+        handler — where the deferred ``call.refer()`` is a silent no-op.
+
+        Args:
+            call_id: the SIP Call-ID of the call to transfer.
+            target: the Refer-To URI the connected party should contact.
+            replaces: attended-transfer Replaces dict, or None for a blind
+                transfer.
+
+        Returns:
+            bool: True if a matching call was found and the REFER emitted, False
+            if the Call-ID is unknown / already gone. Never raises (except on a
+            malformed ``replaces`` dict).
+
+        Usage:
+            @rtpengine.on_dtmf
+            def on_ivr_dtmf(call_id, from_tag, digit, duration_ms, volume):
+                if digit == "1":
+                    b2bua.refer(call_id, "sip:+15550142@example.com")
+        """
+        control = object.__getattribute__(self, "__dict__").get("_control")
+        if control is None:
+            return False
+        return control.refer(call_id, target, replaces)
+
     @staticmethod
     def on_invite(fn):
         """Register handler for new INVITE (new call)."""

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -4,9 +4,10 @@
 //! registrar lookups for routing B2BUA calls, and transaction key handling.
 
 use siphon::b2bua::actor::{
-    CallActor, CallActorStore, CallEvent, CallState, Leg, LegActor, LegSide, TransportInfo,
-    SessionTimerState, generate_call_id, generate_tag,
+    CallActor, CallActorStore, CallEvent, CallState, Leg, LegActor, LegSide, ReferSubscription,
+    TransportInfo, SessionTimerState, generate_call_id, generate_tag,
 };
+use siphon::b2bua::transfer::TransferState;
 use siphon::b2bua::header_policy::{
     apply_to_request, apply_to_response, builtin_presets, validate_preset,
     DirectionPolicy, HeaderPattern, PolicyContext, Preset, PresetError,
@@ -823,6 +824,7 @@ fn media_session_store_lifecycle() {
     // Offer: create session (from_tag known, to_tag not yet)
     let session = MediaSession {
         call_id: "media-lifecycle@test".to_string(),
+        rtpengine_call_id: "media-lifecycle@test".to_string(),
         from_tag: "alice-tag".to_string(),
         to_tag: None,
         profile: "srtp_to_rtp".to_string(),
@@ -2121,4 +2123,165 @@ fn early_update_from_unanswered_b_leg_is_from_b() {
     let call = store.get_call(&call_id).unwrap();
     assert_eq!(call.request_direction("b-early-cid", None), Some(LegSide::B));
     assert_eq!(call.request_direction("a-cid", Some("alice-tag")), Some(LegSide::A));
+}
+
+// ---------------------------------------------------------------------------
+// REFER / call-transfer primitives
+// ---------------------------------------------------------------------------
+
+#[test]
+fn refer_call_matched_by_call_id_gates_loop_killer() {
+    // The B2BUA REFER dispatch branch keys on find_by_sip_call_id: an in-dialog
+    // REFER whose Call-ID matches a tracked B2BUA call is intercepted and handled
+    // per @b2bua.on_refer instead of falling through to the proxy relay (the loop).
+    let store = CallActorStore::new();
+    let sip_call_id = "refer-loopkiller@test";
+    let internal = store.create_call(make_a_leg(sip_call_id));
+    assert_eq!(
+        store.find_by_sip_call_id(sip_call_id).as_deref(),
+        Some(internal.as_str()),
+        "a REFER on this Call-ID is intercepted, not proxy-relayed",
+    );
+    // A REFER on an unknown Call-ID doesn't match — it falls through (out-of-dialog).
+    assert!(store.find_by_sip_call_id("someone-elses-call@test").is_none());
+}
+
+#[test]
+fn is_tracking_leg_recognizes_transfer_markers() {
+    for marker in [
+        "refer:a2b",
+        "refer_done:b2a",
+        "notify:a2b",
+        "notify_done:b2a",
+        "refer_out:a",
+    ] {
+        let mut leg = make_b_leg("10.0.0.2:5060");
+        leg.dialog.target_uri = Some(marker.to_string());
+        assert!(leg.is_tracking_leg(), "{marker} must be a tracking leg");
+    }
+    // A real dialed leg (URI target) is NOT a tracking leg — it takes part in
+    // dialog-identity direction matching.
+    let real = make_b_leg("10.0.0.2:5060");
+    assert!(!real.is_tracking_leg());
+}
+
+#[test]
+fn refer_subscription_push_query_clear() {
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("sub@test"));
+    assert!(!store.has_subscriber_refer_subscription(&call_id, true));
+
+    store.push_refer_subscription(
+        &call_id,
+        ReferSubscription {
+            on_a_leg: true,
+            siphon_notifies: false, // subscriber role (siphon-originated REFER)
+            event_id: 4,
+            notify_cseq: 4,
+            state: TransferState::Trying,
+            target_leg_call_id: None,
+        },
+    );
+    assert!(store.has_subscriber_refer_subscription(&call_id, true));
+    // Wrong leg → no match.
+    assert!(!store.has_subscriber_refer_subscription(&call_id, false));
+
+    store.clear_refer_subscriptions_on_leg(&call_id, true);
+    assert!(!store.has_subscriber_refer_subscription(&call_id, true));
+}
+
+#[test]
+fn refer_notifier_subscription_is_not_a_subscriber_one() {
+    // A siphon-terminated transfer records a *notifier* subscription (siphon
+    // sends the sipfrag NOTIFYs). It must not be mistaken for a subscriber one,
+    // or handle_b2bua_notify would absorb the far end's transparent NOTIFYs.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("notifier@test"));
+    store.push_refer_subscription(
+        &call_id,
+        ReferSubscription {
+            on_a_leg: true,
+            siphon_notifies: true,
+            event_id: 2,
+            notify_cseq: 2,
+            state: TransferState::Trying,
+            target_leg_call_id: None,
+        },
+    );
+    assert!(!store.has_subscriber_refer_subscription(&call_id, true));
+}
+
+#[test]
+fn promote_transfer_target_referrer_on_a_leg() {
+    // Microsoft Teams blind-transfer shape: the referrer is the A-leg, the
+    // surviving party is the winning B-leg, and the dialed target replaces the
+    // A-leg. The old A-leg (referrer) is returned so the caller can BYE it.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("teams-referrer@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060")); // idx 0 = surviving party
+    store.set_winner(&call_id, 0);
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.9:5060")); // idx 1 = transfer target Z
+
+    let (old_a_call_id, surviving_call_id, target_call_id) = {
+        let call = store.get_call(&call_id).unwrap();
+        (
+            call.a_leg.dialog.call_id.clone(),
+            call.b_legs[0].dialog.call_id.clone(),
+            call.b_legs[1].dialog.call_id.clone(),
+        )
+    };
+
+    let referrer = store
+        .promote_transfer_target(&call_id, 1, /*referrer_on_a_leg=*/ true)
+        .expect("promotion returns the referrer leg to BYE");
+    assert_eq!(referrer.dialog.call_id, old_a_call_id);
+
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(
+        call.a_leg.dialog.call_id, target_call_id,
+        "the transfer target is promoted into the A-leg slot",
+    );
+    assert_eq!(call.b_legs.len(), 1, "target removed from b_legs");
+    assert_eq!(call.winner, Some(0), "surviving party stays the winner");
+    assert_eq!(
+        call.b_legs[0].dialog.call_id, surviving_call_id,
+        "surviving party is preserved and bridged to the target",
+    );
+}
+
+#[test]
+fn promote_transfer_target_referrer_on_b_leg() {
+    // The referrer is the winning B-leg; the surviving party is the A-leg. The
+    // dialed target becomes the new winner and the old winning B-leg is returned.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("b-referrer@test")); // surviving = A-leg
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060")); // idx 0 = referrer (winner)
+    store.set_winner(&call_id, 0);
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.9:5060")); // idx 1 = transfer target Z
+
+    let (referrer_call_id, target_call_id) = {
+        let call = store.get_call(&call_id).unwrap();
+        (
+            call.b_legs[0].dialog.call_id.clone(),
+            call.b_legs[1].dialog.call_id.clone(),
+        )
+    };
+
+    let referrer = store
+        .promote_transfer_target(&call_id, 1, /*referrer_on_a_leg=*/ false)
+        .expect("promotion returns the referrer leg to BYE");
+    assert_eq!(referrer.dialog.call_id, referrer_call_id);
+
+    let call = store.get_call(&call_id).unwrap();
+    assert_eq!(call.winner, Some(1), "transfer target is the new winner");
+    assert_eq!(call.b_legs[1].dialog.call_id, target_call_id);
+}
+
+#[test]
+fn promote_transfer_target_out_of_range_is_none() {
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("oob@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+    assert!(store.promote_transfer_target(&call_id, 5, true).is_none());
 }

--- a/tests/integration/rtpengine_tests.rs
+++ b/tests/integration/rtpengine_tests.rs
@@ -208,6 +208,7 @@ async fn session_store_tracks_offer_and_answer() {
     // Offer creates a session.
     store.insert(MediaSession {
         call_id: "call-1".to_string(),
+        rtpengine_call_id: "call-1".to_string(),
         from_tag: "tag-a".to_string(),
         to_tag: None,
         profile: "srtp_to_rtp".to_string(),

--- a/tests/rtpengine_tests.rs
+++ b/tests/rtpengine_tests.rs
@@ -219,6 +219,7 @@ async fn session_store_tracks_offer_and_answer() {
     // Offer creates a session.
     store.insert(MediaSession {
         call_id: "call-1".to_string(),
+        rtpengine_call_id: "call-1".to_string(),
         from_tag: "tag-a".to_string(),
         to_tag: None,
         profile: "srtp_to_rtp".to_string(),


### PR DESCRIPTION
## Why

An in-dialog `REFER` arriving on a tracked B2BUA call had no dispatch branch (unlike re-INVITE/UPDATE/BYE), so it fell through to the proxy relay path and was forwarded by Request-URI to the upstream trunk, which reflected it back — the two bounced it back and forth, each hop stacking a Via and decrementing Max-Forwards, until a `483` storm. No `202`, no `NOTIFY`, the transfer never happened. Same class as the earlier re-INVITE-over-TLS fix (#101), which covered re-INVITE/UPDATE/BYE but not REFER.

## What

**REFER is now intercepted at the B2BUA and dispatched to `@b2bua.on_refer(call)`** (single arg — a REFER is a request, there is no reply object). Three modes plus an outbound form and a proxy-mode passthrough:

- **`terminate`** (default) — siphon answers `202` + the sipfrag NOTIFYs itself, re-resolves `Refer-To` through the dial plan as a new leg, re-bridges the surviving party, and BYEs the referred-away leg. Blind + attended (`Replaces`).
- **`transparent`** — re-emit the REFER on the far leg's own dialog and relay its `202` + `message/sipfrag` NOTIFYs back to the referrer.
- **no handler → `603 Decline`** locally, never a relay (loop-safe default).
- **outbound** — `call.refer(target, replaces=None)` (deferred, from a `@b2bua.*` handler) and `b2bua.refer(call_id, ...)` (imperative, e.g. from `@rtpengine.on_dtmf`) for IVR/TAS offload.
- **proxy mode** — an in-dialog REFER is loose-routed to the far end (record-route required) with its `202`/NOTIFYs relayed straight back; no siphon-side state, no code change (the generic in-dialog branch already handled it).

Config knob `b2bua.default_refer_mode: terminate | transparent`.

### Media plane (terminate transfer)

- The transfer target is now offered the **surviving** party's media, not the referrer's (who is being dropped), and the survivor is re-INVITEd with the target's answer — so RTP is aimed correctly end to end.
- When the call is **media-anchored** (rtpengine / siphon-rtp), siphon re-anchors the survivor↔target pair on a fresh media session (offer → answer → re-INVITE the survivor) and deletes the old survivor↔referrer anchor, keeping the anchor in the media path across the transfer (LI / transcoding / NAT preserved). `MediaSession` gains an `rtpengine_call_id` decoupled from the store key (defaults to the SIP Call-ID, so the normal anchored path is unchanged).
- siphon now **owns the SDP `o=` line per leg** (a stable session-id + a monotonic version) on every offer/answer it emits into a B2BUA dialog, applied after any rtpengine rewrite. A re-anchor (transfer, hold) presents a strictly greater version under the same session identity, so a strict RFC 3264 §8 answerer re-negotiates cleanly rather than reading a changed offer as unchanged.
- Fix: the media-session teardown safety-net keyed on the incoming BYE's Call-ID, which is not the store key when the BYE comes from the callee (or the survivor/target after a re-anchor); it now keys on the A-leg Call-ID.

## Validation

- **Non-anchored terminate** (SIPp, on the wire): the target is offered the survivor's real media (`c=` = the survivor's address, not the referrer's); the survivor re-INVITE `o=` has the same session-id as its initial INVITE with version `0 → 1`; 0 retransmits.
- **Anchored terminate against a real rtpengine (9.4.0.0)**: rtpengine's own log shows the exact recipe — `offer`+`answer` on the initial call, `offer`+`answer` on a fresh call-id (survivor↔target), then `delete` of the old call ("Deleting entire call"). The target INVITE and survivor re-INVITE carry rtpengine relay addresses/ports; 0 retransmits, all legs pass. A repeatable acceptance test under the `b2bua-rtpengine-refer` compose profile (wired into `run-tests.sh`).
- All three modes + proxy passthrough have SIPp scenarios; reject is `603` local with zero egress; transparent forwards exactly once (no loop).
- Normal B2BUA paths (basic call, session-timer, re-INVITE, UPDATE) still pass with the `o=` stamping — no regression.
- `cargo test` 3037 lib + 290 integration green; `cargo clippy --all-targets --all-features -- -D warnings` clean; SDK pytest green (mirrors the new `call`/`b2bua` methods). Cookbook page `docs/cookbook/call-transfer.md` + CHANGELOG updated.

The 16-row SIPp perf/mem baseline (the `o=` stamping touches the answer path) will be run before the next release.
