### PR TITLE
docs(cookbook): manipulation, number-routing & quick recipes + business-logic framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **SDK: `Request.remove_headers_matching(prefix)`** in the `siphon-sip` mock,
+  mirroring the production request method (it was only on the `call` mock), so
+  script unit tests can exercise header-prefix stripping on a proxy request.
+- **Cookbook recipes: SIP & SDP manipulation (HMR), Number routing (LNP +
+  redirect server), and Quick recipes** (common-case snippets), plus a runnable
+  `examples/number_routing.py`. The existing Least-Cost Routing recipe is now
+  wired into the docs-site navigation.
 - **Least-Cost Routing (LCR) — B2BUA-only.** A new `lcr` scripting namespace
   (`await lcr.route(call)`) queries an external HTTP JSON API for an ordered
   carrier decision (the API owns cost/order; siphon is not a rating engine),

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -8,12 +8,31 @@ whole thing and adapt it.
 Every recipe is grounded in a real script in the repo (linked at the bottom of each
 page); none of the APIs here are invented.
 
+## What SIPhon does, and what's yours
+
+SIPhon is open source (MIT) and free to run in production. It gives you the
+protocol side: the transports, the RFC 3261 transaction and dialog state
+machines, the registrar, media control. The parts that take years to get right
+and tend to break at 3am.
+
+What it deliberately doesn't do is your business logic. The LCR cost decision,
+the LNP dip, which carrier wins tonight, how your customers map onto trunks. That
+stays yours. That's the whole promise: the hard protocol parts are handled so you
+spend your time on the logic that's actually specific to you. Wherever a recipe
+needs your data, it leaves you a small function to fill in.
+
+If you'd rather not build or run that integration alone, commercial support is
+available from [Real Time Telecom](../support.md).
+
 ## The recipes
 
 | Recipe | What you build | Key ideas |
 |---|---|---|
 | [Registrar](registrar.md) | A SIP registrar with digest auth | `auth.require_digest`, `registrar.save`/`lookup`, NAT fixups |
 | [Stateful proxy](proxy.md) | A residential/edge proxy | `request.fork`, `loose_route`, `record_route`, sanity checks |
+| [SIP & SDP manipulation](manipulation.md) | Header/SDP rewrite at a boundary (HMR) | `set_header`/`remove_headers_matching`, `re`, the `sdp` namespace |
+| [Number routing](number-routing.md) | LNP correction + a redirect (3xx) server | `set_ruri` (`rn`/`npdi`), `add_reply_header`, `reply(3xx)` |
+| [Quick recipes](snippets.md) | Common one-off building blocks | scanner drop, `from_gateway`, `rate_limit`, prefix routing |
 | [Load balancer](load-balancer.md) | A front LB over a backend pool | `gateway.select`, health probing, subscriber affinity |
 | [Least-Cost Routing](least-cost-routing.md) | Carrier LCR driven by an external API | `lcr.route`, `call.route` sequential failover, gateway pools, CDR |
 | [SBC (B2BUA)](sbc.md) | A topology-hiding SBC with media | `@b2bua.*`, `call.dial`/`fork`, **header policies**, RTPEngine |

--- a/docs/cookbook/least-cost-routing.md
+++ b/docs/cookbook/least-cost-routing.md
@@ -214,11 +214,20 @@ The JSON contract is in [the LCR API reference](../reference/lcr-api.md); the
 typed models operators build against ship in the `siphon-sip` SDK
 (`from siphon_sdk.lcr import LcrRequest, LcrResponse, Route`).
 
-## Charging (coming with Ro)
+## Charging
 
-Today the winning carrier flows into the **CDR** via `cdr.write(call,
-extra={...})` (shown above) — `carrier_id`, `rate`, `currency`. Auto-stamping
-the carrier onto the **Rf** offline record (`outgoing-trunk-group-id`) and
-**Ro** online credit teardown (drop the call when the OCS refuses further
-credit) build on the B2BUA teardown hook and land once online charging merges.
-Because LCR is B2BUA-only, that teardown path is available to it when it ships.
+The carrier that won is on `call.active_route` (a `Route`: `carrier_id`,
+`gateway_group`, `rate`, `currency`), so it flows into all three charging paths:
+
+- **CDR.** Stamp it into the record, as in the `@b2bua.on_answer` handler above:
+  `cdr.write(call, extra={"carrier_id": route.carrier_id, "rate": ...})`.
+- **Rf offline.** Stamp the carrier's trunk group onto the offline record with
+  `call.set_charging_param("outgoing-trunk-group-id", route.gateway_group)`. The
+  Rf ACR auto-emit carries it as `Outgoing-Trunk-Group-Id` (TS 32.260).
+- **Ro online.** With the [`ro:` block](online-charging-ocs.md) enabled, SIPhon
+  reserves credit before connect, re-authorises mid-call, and drops the call when
+  the OCS refuses further credit (`4012 CREDIT_LIMIT_REACHED`). Because LCR is
+  B2BUA-only, that mid-call teardown applies to every LCR call.
+
+See the [Online charging (OCS)](online-charging-ocs.md) recipe for the full Ro
+setup (reserve-before-connect gate, re-auth timer, CGRateS).

--- a/docs/cookbook/manipulation.md
+++ b/docs/cookbook/manipulation.md
@@ -1,0 +1,168 @@
+# SIP & SDP manipulation
+
+The classic header-manipulation (HMR) job: rewrite, add, or strip headers and
+SDP as a message crosses a boundary. SIPhon hands you the parsed message and
+gets out of the way. You decide what changes, in Python, with the whole standard
+library (including `re`) available. There is no manipulation DSL to learn; it is
+just code.
+
+## Headers
+
+Every header operation is a method on the `request` (or, on the B2BUA, the
+`call`). Names are case-insensitive.
+
+```python
+from siphon import proxy
+
+@proxy.on_request
+def edit(request):
+    # read
+    ua = request.get_header("User-Agent")        # str | None
+    has_pai = request.has_header("P-Asserted-Identity")
+
+    # strip inbound internal headers by name prefix (case-insensitive), e.g. X-*
+    request.remove_headers_matching("X-")
+
+    # then stamp our own
+    request.set_header("X-Trunk", "wholesale-a")  # replace (or add if absent)
+    request.ensure_header("Max-Forwards", "70")   # set only if not already present
+    request.remove_header("P-Preferred-Identity")
+
+    # one value out of a multi-value header
+    request.remove_from_header_list("Supported", "100rel")
+
+    request.relay()
+```
+
+| Call | What it does |
+|---|---|
+| `get_header(name)` / `header(name)` | Read a header value (`None` if absent). |
+| `has_header(name)` | Presence check. |
+| `set_header(name, value)` | Replace the header, or add it if absent. |
+| `ensure_header(name, value)` | Set only if not already present. |
+| `remove_header(name)` | Remove a header by name. |
+| `remove_headers_matching(prefix)` | Remove every header whose **name starts with** `prefix` (case-insensitive). |
+| `remove_from_header_list(name, value)` | Drop one value from a comma-separated header. |
+
+## Regex
+
+`remove_headers_matching` is a **name-prefix** strip, not a regex. When you need
+a real regular expression, reach for Python's `re` on the value you read. The
+scripts are ordinary Python, so the whole `re` module is there:
+
+```python
+import re
+from siphon import proxy
+
+SCANNERS = re.compile(r"sipvicious|friendly-scanner|sipcli", re.IGNORECASE)
+
+@proxy.on_request
+def drop_scanners(request):
+    # drop known scanners silently (no response = no fingerprint)
+    if SCANNERS.search(request.get_header("User-Agent") or ""):
+        return
+
+    # rewrite inside a header value
+    diversion = request.get_header("Diversion")
+    if diversion:
+        request.set_header("Diversion", re.sub(r"sip:(\d+)@", r"tel:\1;", diversion))
+
+    request.relay()
+```
+
+## SDP
+
+Parse the body, edit it, apply it back. `apply()` sets the body, `Content-Type`,
+and `Content-Length` for you.
+
+```python
+from siphon import proxy, sdp
+
+@proxy.on_request("INVITE")
+def edit(request):
+    if not request.has_body("application/sdp"):
+        request.relay(); return
+
+    s = sdp.parse(request)
+
+    # keep only G.711
+    s.filter_codecs(["PCMU", "PCMA"])
+
+    # strip video
+    s.remove_media("video")
+
+    # put audio on hold
+    for m in s.media:
+        if m.media_type == "audio":
+            m.port = 0
+
+    # session- and media-level a= attributes
+    s.set_attr("ice-lite")                 # flag attribute
+    for m in s.media:
+        m.set_attr("ptime", "20")
+
+    s.apply(request)
+    request.relay()
+```
+
+The full `sdp` surface (media sections, codecs, `a=` attributes, connection
+lines) is in the [SDP reference](../reference/sdp.md).
+
+## On the B2BUA
+
+At an SBC boundary, the same header and SDP methods exist on the `call`, but the
+right tool for *which headers cross the A↔B boundary* is a **header policy**, not
+per-header code. Pick a preset, then apply per-call deltas only for the
+exceptions:
+
+```python
+from siphon import b2bua
+
+@b2bua.on_invite
+def on_invite(call):
+    call.remove_headers_matching("X-")           # strip internal headers
+    call.dial(
+        "sip:+15551234567@carrier.example.net",
+        header_policy="sip-trunk-edge@2026",     # the boundary hygiene preset
+        copy=["X-Account-Id"],                    # let this one through
+        strip=["History-Info"],                   # drop this one
+    )
+```
+
+Script `call.set_header()` / `call.remove_header()` always win over the preset.
+The presets and precedence are covered in the [SBC recipe](sbc.md).
+
+## Test it
+
+Exercise the logic without a running server using the
+[`siphon-sip` mock SDK](https://github.com/siphon-project/siphon-sip/tree/main/sdk):
+
+```python
+from siphon_sdk import mock_module
+from siphon_sdk.request import Request
+
+mock_module.install()
+
+# internal headers are stripped, and the request is relayed
+request = Request(method="INVITE", headers={"X-Internal-Trace": "abc"})
+edit(request)
+assert request.get_header("X-Internal-Trace") is None
+assert request.last_action.kind == "relay"
+
+# a scanner is dropped: no routing action was taken
+scanner = Request(method="INVITE", headers={"User-Agent": "friendly-scanner"})
+drop_scanners(scanner)
+assert scanner.actions == []
+```
+
+## The line
+
+The manipulation is yours to define; SIPhon just gives you a clean, parsed
+message to change and re-serializes it correctly (Via, Content-Length, header
+ordering). What to rewrite, and why, is your policy.
+
+## See also
+
+- Real script: [`examples/teams_sbc.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/teams_sbc.py) (B2BUA header hygiene at a Teams boundary).
+- [Request reference](../reference/request.md) · [SDP reference](../reference/sdp.md).
+- [Number normalization](number-normalization.md) for policy-driven E.164 identity rewriting.

--- a/docs/cookbook/number-routing.md
+++ b/docs/cookbook/number-routing.md
@@ -1,0 +1,107 @@
+# Number routing: LNP and redirect
+
+Two routing jobs that hinge on an external data dip: **LNP** (local number
+portability correction) and running SIPhon as a **redirect server**. SIPhon does
+the SIP. The lookup, your ported-number database or your routing table, is the
+business-logic part. In both recipes it is a small stub function you replace with
+your real data source: an SQL query, an HTTP API, `cache.fetch`, or
+`proxy.enum_lookup`.
+
+!!! tip "Cost-based routing is built in"
+    For carrier **least-cost routing** (cost-ordered failover across gateway
+    pools, per-carrier CDRs, ring-timeout reroute), don't hand-roll a redirect.
+    Use the built-in [LCR feature](least-cost-routing.md): your API owns the cost
+    decision, SIPhon executes it. Same split, more machinery for free.
+
+## LNP: correct the routing number
+
+Dip your ported-number data, and if the number has ported, rewrite the R-URI
+with the routing number (`rn`) and mark the dip as done (`npdi`) per
+[RFC 4694](https://www.rfc-editor.org/rfc/rfc4694). `set_ruri` takes a full URI,
+so the parameters land on the wire verbatim.
+
+```python
+from siphon import proxy, log
+
+CARRIER_HOST = "carrier.example.net"
+
+def lnp_dip(number: str) -> str | None:
+    """Your dip: SS7/SOA query, HTTP API, or a local copy of the LNP database.
+    Returns the LRN for a ported number, else None."""
+    ...
+
+@proxy.on_request("INVITE")
+def route(request):
+    called = request.ruri.user or ""
+
+    lrn = lnp_dip(called)
+    if lrn is not None:
+        request.set_ruri(f"sip:{called};npdi;rn={lrn}@{CARRIER_HOST};user=phone")
+        log.info(f"LNP {called} ported -> rn={lrn}")
+
+    request.relay()
+```
+
+The wire result for a ported number:
+
+```
+INVITE sip:+15551234567;npdi;rn=+15559990000@carrier.example.net;user=phone SIP/2.0
+```
+
+## Redirect server (3xx)
+
+A redirect server answers `3xx` with `Contact` headers and forwards nothing. The
+caller retries the targets itself. Build the contact list from your lookup and
+reply:
+
+```python
+from siphon import proxy
+
+def routes_for(number: str) -> list[str]:
+    """Your routing table. Returns target URIs, most-preferred first."""
+    ...
+
+@proxy.on_request("INVITE")
+def redirect(request):
+    routes = routes_for(request.ruri.user or "")
+    if not routes:
+        request.reply(404, "Not Found")
+        return
+
+    # One Contact per target. 302 for a single move, 300 for a choice.
+    for uri in routes:
+        request.add_reply_header("Contact", f"<{uri}>")
+    request.reply(300 if len(routes) > 1 else 302, "Multiple Choices")
+```
+
+`add_reply_header` appends (so several `Contact` headers stack); `set_reply_header`
+would replace. The transaction layer handles the ACK for your non-2xx response.
+
+## Test it
+
+```python
+from siphon_sdk import mock_module
+from siphon_sdk.request import Request
+
+mock_module.install()
+
+request = Request(method="INVITE", ruri="sip:+15551234567@example.net")
+route(request)                                   # the LNP handler above
+assert "rn=+15559990000" in str(request.ruri)
+assert request.last_action.kind == "relay"
+```
+
+## The line
+
+SIPhon rewrites the R-URI, stacks the `Contact` headers, and answers the
+transaction correctly. Which number ported, and where a number should go, is
+your data and your decision. That lookup is the part that's specific to your
+business, so it stays in your hands (or a
+[commercial engagement](../support.md) if you'd rather not run it yourself).
+
+## See also
+
+- Real script: [`examples/number_routing.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/number_routing.py) — both roles, with the stubs to replace.
+- [Least-Cost Routing](least-cost-routing.md) for cost-ordered carrier failover.
+- [Number normalization](number-normalization.md) to canonicalise E.164 before you route.
+- [Request reference](../reference/request.md) — `set_ruri`, `add_reply_header`, `reply`.

--- a/docs/cookbook/snippets.md
+++ b/docs/cookbook/snippets.md
@@ -1,0 +1,110 @@
+# Quick recipes
+
+Small, common building blocks. Each is a few lines you drop into a
+`@proxy.on_request` (or B2BUA) handler. They use only documented primitives; the
+fuller recipes ([proxy](proxy.md), [SBC](sbc.md),
+[security](security.md)) show them in context.
+
+## Block scanners silently
+
+No response means no fingerprint for the scanner to learn from.
+
+```python
+import re
+from siphon import proxy
+
+SCANNERS = re.compile(r"sipvicious|friendly-scanner|sipcli", re.IGNORECASE)
+
+@proxy.on_request
+def guard(request):
+    if SCANNERS.search(request.get_header("User-Agent") or ""):
+        return                      # drop
+    request.relay()
+```
+
+## Accept only from a trusted gateway
+
+`from_gateway` is IP membership against a configured gateway group (a trust
+signal on TLS/TCP, a direction hint on UDP). `source_ip_in` checks raw CIDRs.
+
+```python
+@proxy.on_request("INVITE")
+def ingress(request):
+    if not request.from_gateway("carriers"):
+        request.reply(403, "Forbidden")
+        return
+    request.relay()
+```
+
+## Rate-limit per source
+
+```python
+@proxy.on_request("REGISTER")
+def limit(request):
+    # max 5 REGISTERs per 10s window from this source
+    if not proxy.rate_limit(request, 10, 5):
+        return                      # over budget: drop
+    request.relay()
+```
+
+## Force a single codec
+
+```python
+from siphon import sdp
+
+@proxy.on_request("INVITE")
+def g711_only(request):
+    if request.has_body("application/sdp"):
+        s = sdp.parse(request)
+        s.filter_codecs(["PCMU", "PCMA"])
+        s.apply(request)
+    request.relay()
+```
+
+## Prefix-route to a gateway
+
+```python
+from siphon import gateway
+
+@proxy.on_request("INVITE")
+def route(request):
+    user = request.ruri.user or ""
+    group = "emergency" if user in ("112", "911") else "carriers"
+    destination = gateway.select(group, key=request.call_id)
+    if not destination:
+        request.reply(503, "Service Unavailable")
+        return
+    request.relay(destination.uri)
+```
+
+## Reject anonymous callers
+
+```python
+@proxy.on_request("INVITE")
+def screen(request):
+    from_uri = request.from_uri
+    if from_uri and (from_uri.host == "anonymous.invalid"
+                     or (from_uri.user or "").lower() == "anonymous"):
+        request.reply(433, "Anonymity Disallowed")   # RFC 5079
+        return
+    request.relay()
+```
+
+## Send to voicemail when everything fails
+
+`@proxy.on_failure` fires once all branches of a relay/fork have failed.
+
+```python
+@proxy.on_failure
+def failover(request, reply):
+    if request.method == "INVITE":
+        request.relay(f"sip:vm-{request.ruri.user}@voicemail.example.net")
+    else:
+        reply.relay()               # forward the original failure
+```
+
+## See also
+
+- [Stateful proxy](proxy.md) and [Hardening & security](security.md) put these together.
+- [SIP & SDP manipulation](manipulation.md) for the full header/SDP surface.
+- [Request reference](../reference/request.md) · [Proxy & B2BUA reference](../reference/proxy.md).

--- a/examples/number_routing.py
+++ b/examples/number_routing.py
@@ -1,0 +1,78 @@
+"""Number routing patterns: LNP correction and a redirect (3xx) server.
+
+SIPhon does the SIP. The lookups here are the business-logic parts, stubbed as
+plain functions you replace with your real data source (an SQL query, an HTTP
+API, ``cache.fetch``, ``proxy.enum_lookup`` ...):
+
+  * ``lnp_dip``     -> your ported-number database / SOA dip
+  * ``routes_for``  -> your redirect routing table
+
+Two roles are shown. The active handler does LNP and relays. To run this as a
+redirect server instead, register ``as_redirect_server`` and drop the relay
+handler (see the note at the bottom).
+
+For carrier least-cost routing (cost-ordered failover across gateway pools),
+use the built-in LCR feature (``lcr.route`` + ``call.route``) rather than a
+hand-rolled redirect. See docs/cookbook/least-cost-routing.md.
+"""
+
+from siphon import proxy, log
+
+CARRIER_HOST = "carrier.example.net"
+
+
+# --- your business logic (replace these two stubs) --------------------------
+
+def lnp_dip(number: str) -> str | None:
+    """Return the LRN for a ported number, or None if not ported / unknown.
+
+    Replace with your real dip: an SS7/SOA query, an HTTP API, or a local copy
+    of the ported-number database.
+    """
+    ported = {"+15551234567": "+15559990000"}   # demo data
+    return ported.get(number)
+
+
+def routes_for(number: str) -> list[str]:
+    """Return redirect target(s) for a number, most-preferred first.
+
+    Replace with your routing table.
+    """
+    return [
+        f"sip:{number}@gw1.example.net",
+        f"sip:{number}@gw2.example.net",
+    ]
+
+
+# --- Role 1: LNP correction, then relay -------------------------------------
+
+@proxy.on_request("INVITE")
+def route(request):
+    called = request.ruri.user or ""
+
+    lrn = lnp_dip(called)
+    if lrn is not None:
+        # RFC 4694: flag the dip as done (npdi) and carry the routing number
+        # (rn). set_ruri takes a full URI, so the params land on the wire as-is.
+        request.set_ruri(f"sip:{called};npdi;rn={lrn}@{CARRIER_HOST};user=phone")
+        log.info(f"LNP {called} ported -> rn={lrn}")
+
+    request.relay()
+
+
+# --- Role 2: redirect server (3xx) ------------------------------------------
+# Not registered above. To run SIPhon as a redirect server, decorate this with
+# @proxy.on_request("INVITE") instead of `route`.
+
+def as_redirect_server(request):
+    called = request.ruri.user or ""
+    routes = routes_for(called)
+    if not routes:
+        request.reply(404, "Not Found")
+        return
+
+    # One Contact per target; the caller retries them in order. Use 302 for a
+    # single move, 300 for a choice of several.
+    for uri in routes:
+        request.add_reply_header("Contact", f"<{uri}>")
+    request.reply(300 if len(routes) > 1 else 302, "Multiple Choices")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,10 +44,14 @@ nav:
       - Overview: cookbook/index.md
       - Registrar: cookbook/registrar.md
       - Stateful proxy: cookbook/proxy.md
+      - SIP & SDP manipulation: cookbook/manipulation.md
+      - Quick recipes: cookbook/snippets.md
       - Load balancer: cookbook/load-balancer.md
+      - Least-Cost Routing: cookbook/least-cost-routing.md
       - SBC (B2BUA): cookbook/sbc.md
       - Call transfer (REFER): cookbook/call-transfer.md
       - Number normalization: cookbook/number-normalization.md
+      - Number routing (LNP / redirect): cookbook/number-routing.md
       - Media & RTP profiles: cookbook/media-rtp.md
       - Online charging (OCS): cookbook/online-charging-ocs.md
       - Hardening & security: cookbook/security.md

--- a/sdk/siphon_sdk/request.py
+++ b/sdk/siphon_sdk/request.py
@@ -933,6 +933,21 @@ class Request:
         if not self.has_header(name):
             self.set_header(name, value)
 
+    def remove_headers_matching(self, prefix: str) -> None:
+        """Remove all headers whose name starts with a prefix (case-insensitive).
+
+        Mirrors the production ``request.remove_headers_matching`` — e.g.
+        ``request.remove_headers_matching("X-")`` strips every custom header.
+
+        Args:
+            prefix: Header-name prefix (e.g. ``"X-"``).
+        """
+        prefix_lower = prefix.lower()
+        self._headers = {
+            k: v for k, v in self._headers.items()
+            if not k.lower().startswith(prefix_lower)
+        }
+
     def remove_from_header_list(self, name: str, value: str) -> None:
         """Remove one value from a comma-separated multi-value header.
 

--- a/sdk/tests/test_remove_headers_matching.py
+++ b/sdk/tests/test_remove_headers_matching.py
@@ -1,0 +1,30 @@
+"""Parity test for Request.remove_headers_matching (mirrors production)."""
+
+from siphon_sdk.request import Request
+
+
+def test_removes_by_prefix_case_insensitive():
+    request = Request(
+        method="INVITE",
+        headers={
+            "X-Trunk": "a",
+            "x-account-id": "42",
+            "Via": "SIP/2.0/UDP host",
+            "P-Asserted-Identity": "sip:alice@example.com",
+        },
+    )
+
+    request.remove_headers_matching("X-")
+
+    # both X-* headers gone regardless of case
+    assert request.get_header("X-Trunk") is None
+    assert request.get_header("x-account-id") is None
+    # non-matching headers untouched
+    assert request.get_header("Via") == "SIP/2.0/UDP host"
+    assert request.has_header("P-Asserted-Identity")
+
+
+def test_no_match_is_noop():
+    request = Request(method="INVITE", headers={"Via": "SIP/2.0/UDP host"})
+    request.remove_headers_matching("X-")
+    assert request.get_header("Via") == "SIP/2.0/UDP host"


### PR DESCRIPTION
Adds the example scenarios asked for in #107, framed around the split that makes SIPhon what it is: **SIPhon owns the protocol, you own the business logic**. Each recipe leaves the business decision (the LNP dip, the routing table) as a small function you fill in.

## New recipes

- **`cookbook/manipulation.md` — SIP & SDP manipulation (HMR).** Header add/replace/remove/ensure, `remove_headers_matching` (a name-prefix strip, *not* a regex — real regex is Python `re` on the value), the `sdp` namespace, and header policies on the B2BUA. With a runnable mock-SDK test.
- **`cookbook/number-routing.md` — LNP + redirect server.** LNP dip → `set_ruri` with `rn`/`npdi` (RFC 4694); a redirect (3xx) server via `add_reply_header("Contact", …)` + `reply(3xx)`. Grounded in the new `examples/number_routing.py`.
- **`cookbook/snippets.md` — Quick recipes.** Seven small common-case building blocks (scanner drop, `from_gateway` gate, `rate_limit`, force codec, prefix route, reject anonymous, voicemail-on-failure).

## Framing + housekeeping

- Cookbook index gains a short **"What SIPhon does, and what's yours"** section (MIT, we do protocol not business logic, commercial support via RTT) and rows for the new recipes.
- **Wired the existing Least-Cost Routing recipe into the site nav** (it shipped in #108 as a nav orphan) and **refreshed its Charging section** — it said "coming with Ro", but Ro online charging has shipped, so it now documents the real `active_route` → CDR / `outgoing-trunk-group-id` (Rf) / Ro credit-teardown paths.
- **SDK parity fix:** production `Request.remove_headers_matching` existed but the mock had it only on `call`. Added it to the SDK `Request` mock (case-insensitive, matching production) with a test — the manipulation recipe's test snippet depends on it.

## Validation

- `mkdocs build --strict` clean (all new nav/links resolve).
- Both recipe test snippets executed against the mock SDK and pass (incl. the `rn=` R-URI param round-trip).
- `examples/number_routing.py` compiles.
- Full SDK suite green from `sdk/`: **478 passed** (includes the new parity test).