### PR TITLE
fix(b2bua): set the early-dialog to-tag on the auto-PRACK (was rejected 481 by strict IMS UAS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   pseudo-legs, so a plain call that re-INVITEd no longer reports two B-legs.
 
 ### Fixed
+- **B2BUA auto-PRACK now carries the early-dialog To-tag** (RFC 3262 §4 / RFC 3261
+  §12.1.2). When the B-leg sent a reliable provisional (`18x` with `Require:
+  100rel`), siphon built the PRACK's `To` from the dialog's remote tag — but that
+  field is only populated from the `200 OK`, which hasn't arrived yet at PRACK
+  time, so the PRACK went out tag-less and a strict UAS (e.g. an IMS S-CSCF)
+  rejected it with `481 Call/Transaction Does Not Exist`, breaking VoLTE calls
+  that use reliable provisionals / preconditions. The reliable provisional
+  establishes the early dialog, so its To-tag (and route set, already handled) is
+  now captured onto the B-leg before the PRACK is built. The SIPp reliable-prov
+  scenario now asserts the PRACK's To-tag, which is why this slipped through.
 - **B2BUA no longer mis-handles a cancelled B-leg during failover** (surfaced by
   LCR ring-timeout reroute; also affects any CANCEL-then-answer-a-different-leg
   flow). Three fixes: (1) a `2xx` to a B-leg CANCEL shares the INVITE's top Via

--- a/sipp/b2bua_reliable_prov_uas.xml
+++ b/sipp/b2bua_reliable_prov_uas.xml
@@ -69,8 +69,19 @@ a=fmtp:101 0-15
 ]]>
   </send>
 
-  <!-- siphon (B2BUA, B-leg side) auto-PRACKs the reliable 183 -->
-  <recv request="PRACK" crlf="true" />
+  <!-- siphon (B2BUA, B-leg side) auto-PRACKs the reliable 183.  The PRACK MUST
+       carry the early-dialog To-tag from the 183 (RFC 3262 §4 — PRACK is
+       in-dialog); a strict IMS UAS 481s a tag-less PRACK.  check_it fails the
+       call if the To header has no matching tag. -->
+  <recv request="PRACK" crlf="true">
+    <action>
+      <ereg regexp="tag=[0-9]+SIPpTag01[0-9]+" search_in="hdr" header="To:"
+            check_it="true" assign_to="prack_to_tag" />
+      <!-- SIPp requires an assigned variable to be referenced; the log both
+           satisfies that and records the matched early-dialog To-tag. -->
+      <log message="PRACK carries early-dialog To-tag [$prack_to_tag]" />
+    </action>
+  </recv>
 
   <send>
     <![CDATA[

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -10721,21 +10721,35 @@ fn handle_b2bua_response(
                 // the 1xx still reaches the A-leg.
             } else {
             // RFC 3262 §4 + RFC 3261 §12.1.2: a reliable provisional response
-            // establishes the early dialog, whose route set is THIS response's
-            // Record-Route reversed (UAC side). The confirmed-dialog route set
-            // isn't captured until the 200 OK, so without this the PRACK is built
-            // with no Route header and sent to the cached INVITE next-hop (e.g. an
-            // IMS I-CSCF that doesn't Record-Route and rejects the in-dialog PRACK
-            // with 406). Establish it once (§12.1.2 — not updated by later
-            // responses), so build_b2bua_prack and resolve_in_dialog_destination
-            // both pick the route-set first hop (the S-CSCF).
+            // establishes the early dialog. Two things must be captured from it
+            // before the PRACK is built, because both are otherwise only filled
+            // from the 200 OK (which hasn't arrived yet at PRACK time):
+            //
+            //   * the early-dialog remote (To) tag — without it the PRACK's To
+            //     header carries no tag, so a strict UAS (e.g. an IMS S-CSCF)
+            //     rejects it with 481 Call/Transaction Does Not Exist;
+            //   * the early-dialog route set (THIS response's Record-Route
+            //     reversed, UAC side) — without it the PRACK is sent to the
+            //     cached INVITE next-hop and an I-CSCF that doesn't Record-Route
+            //     rejects it with 406.
+            //
+            // Establish both once (§12.1.2 — not updated by later responses), so
+            // build_b2bua_prack and resolve_in_dialog_destination see the tagged
+            // To and the route-set first hop (the S-CSCF). The 200 OK re-sets
+            // remote_tag to the same value later (confirmed dialog).
+            let early_to_tag = crate::b2bua::actor::extract_to_tag(message);
             let early_routes = uac_route_set_from_record_routes(
                 &message.headers.get_all("Record-Route").cloned().unwrap_or_default(),
             );
-            if !early_routes.is_empty() {
+            if early_to_tag.is_some() || !early_routes.is_empty() {
                 if let Some(mut call) = state.call_actors.get_call_mut(call_id) {
                     if let Some(leg) = call.b_legs.get_mut(idx) {
-                        if leg.dialog.route_set.is_empty() {
+                        if leg.dialog.remote_tag.is_none() {
+                            if let Some(tag) = early_to_tag {
+                                leg.dialog.remote_tag = Some(tag);
+                            }
+                        }
+                        if leg.dialog.route_set.is_empty() && !early_routes.is_empty() {
                             leg.dialog.route_set = early_routes;
                         }
                     }


### PR DESCRIPTION
## Symptom

A B2BUA auto-PRACK toward a reliable-provisional B-leg went out with a **tag-less `To`** header, and a strict IMS core rejected it:

```
PRACK sip:0101@ims... SIP/2.0
To: <sip:0101@ims...>              <-- no tag
...
SIP/2.0 481 Call/Transaction Does Not Exist
To: <sip:0101@ims...>;tag=4261636528   <-- the core's real early-dialog tag
```

This breaks VoLTE calls that use reliable provisionals / preconditions (RFC 3262 / 3312).

## Root cause

`build_b2bua_prack` builds the `To` from `dialog.remote_tag`, but that field is only populated from the **200 OK** (`handle_b2bua_response`, on the `Answered` event). The auto-PRACK fires on the reliable **18x**, before any 2xx, so `remote_tag` is still `None` → tag-less `To` → `481`.

The code that emits the auto-PRACK already captures the early-dialog **route set** from the reliable 18x's Record-Route (a prior fix for a `406`). It just never captured the early-dialog **To-tag**.

## Fix

RFC 3262 §4 / RFC 3261 §12.1.2 — a reliable provisional establishes the early dialog, so its `To`-tag *is* the early-dialog remote tag. Capture it onto the B-leg alongside the route set, before the PRACK is built. The 200 OK re-sets `remote_tag` to the same value later (confirmed dialog), so nothing downstream changes.

## Why it slipped through

The SIPp `b2bua_reliable_prov_uas` scenario sent a tagged reliable 183 but its `<recv request="PRACK">` accepted the PRACK **without checking the To-tag**, so the functional test passed even tag-less. It now asserts the PRACK carries the early-dialog to-tag (`check_it`), so this can't regress silently.

## Verification

- `cargo test` green (no regression), clippy clean.
- Reliable-prov SIPp scenario (with the new to-tag assertion) **passes** with the fix — and fails without it (the assertion is what catches the tag-less PRACK).