### PR TITLE
fix(b2bua): race-free answer/provisional transitions under concurrent dispatch + local advertised_address default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `checks_missed` and each group gains `failure_threshold`.
 
 ### Changed
+- **The example `siphon.yaml` now defaults `advertised_address` to `127.0.0.1`**
+  so it works out of the box for local use (a softphone on the same host,
+  loopback SIPp, the scale-test harness). **Set it to your public / LAN address
+  for any real deployment** — a wildcard-bound siphon with no `advertised_address`
+  auto-detects a routable interface, which on a multi-homed host (LAN + docker +
+  VPN) can be the wrong one.
 - **B2BUA answer-timeout is now honored within ~0.5s of the deadline** (was up to
   30s late). The `call.fork`/`call.dial`/`call.route` `timeout=` check moved off
   the 30s orphan sweep onto a dedicated 500ms interval, so a short per-carrier LCR
@@ -138,6 +144,19 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   pseudo-legs, so a plain call that re-INVITEd no longer reports two B-legs.
 
 ### Fixed
+- **B2BUA answer / provisional handling is now race-free under concurrent
+  dispatch.** Two check-then-set decisions read a `call_state` snapshot taken
+  early in response handling but committed the new state only ~1600 lines later,
+  so under multi-worker dispatch two responses for the same call — a `200` and
+  its retransmit, or a `180` and its `200` (received in order over one flow but
+  processed on different workers) — could both act on a stale "not answered"
+  view: (1) two B-leg `200`s both forwarded to the A-leg, delivering a duplicate
+  `200` to a caller that already ACKed; (2) a `180` processed behind its `200`
+  forwarded to the A-leg after the final response, downgrading the confirmed
+  dialog back to Ringing. Both are now claimed atomically under the per-call
+  lock (`try_win` / `try_mark_ringing`). Loopback is too fast to expose these,
+  but a real TCP trunk with network latency at high call rates widens exactly
+  that window.
 - **B2BUA auto-PRACK now carries the early-dialog To-tag** (RFC 3262 §4 / RFC 3261
   §12.1.2). When the B-leg sent a reliable provisional (`18x` with `Require:
   100rel`), siphon built the PRACK's `To` from the dialog's remote tag — but that

--- a/scripts/scale_test.sh
+++ b/scripts/scale_test.sh
@@ -110,6 +110,8 @@ echo "[+] build ok"
 # --- Pick config: MODE=proxy (default) or MODE=b2bua ---
 # B2BUA mode rewrites the Python script path in a temp config copy so the
 # proxy_default.py routing logic is replaced by b2bua_default.py.
+# (siphon.yaml pins advertised_address: 127.0.0.1 for loopback testing — the
+# reason the loopback SIPp peers can reach siphon's Via/Contact.)
 MODE="${MODE:-proxy}"
 case "$MODE" in
     proxy)

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -68,9 +68,14 @@ domain:
     - "127.0.0.1"       # Local IP for loop detection
 
 # Public IP advertised in Via / Contact / SDP when binding 0.0.0.0 or [::].
-# Needed on cloud instances (EC2, GCE) where the bound IP is private.
-# advertised_address: "1.2.3.4"
-# advertised_address: "2001:db8::1"  # IPv6 public address
+# Defaults to 127.0.0.1 so this example config works out of the box for LOCAL
+# use — a softphone on the same host, loopback SIPp, the scale-test harness.
+# >>> CHANGE THIS to your public / LAN address for any real deployment. <<<
+# (Without it, a wildcard-bound siphon auto-detects a routable interface, which
+# on a multi-homed host — LAN + docker + VPN — can be the wrong one.)
+advertised_address: "127.0.0.1"
+# advertised_address: "1.2.3.4"        # <- your public IPv4 for real traffic
+# advertised_address: "2001:db8::1"    # <- your public IPv6
 
 # ---------------------------------------------------------------------------
 # TLS certificate (required when listen.tls or listen.wss is set)

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -1249,6 +1249,19 @@ pub struct ZombieCancelledLeg {
     pub byed: bool,
 }
 
+/// Outcome of an atomic answer claim ([`CallActorStore::try_win`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WinOutcome {
+    /// This 2xx is the first to answer the call: the winner and `Answered`
+    /// state were set under the per-call lock.
+    FirstWin,
+    /// The call was already answered — this 2xx is a retransmit of the winning
+    /// B-leg's answer (or a losing fork branch). `b_leg_acked` reports whether
+    /// the winning B-leg's ACK has already gone out, so the caller can re-ACK
+    /// to stop the retransmit vs. absorb silently while awaiting the A-leg ACK.
+    AlreadyAnswered { b_leg_acked: bool },
+}
+
 /// Manages all active B2BUA calls.
 ///
 /// Stores `CallActor` instances in a concurrent map, indexed by internal
@@ -1555,6 +1568,62 @@ impl CallActorStore {
         if let Some(mut call) = self.calls.get_mut(call_id) {
             call.set_winner(index);
         }
+    }
+
+    /// Atomically claim the answer for the B-leg at `index`.
+    ///
+    /// If the call is not yet `Answered`, sets the winner (which also flips the
+    /// state to `Answered`) and returns [`WinOutcome::FirstWin`]. Otherwise the
+    /// call was already answered — this 2xx is a retransmit of the winning
+    /// B-leg's answer (or a losing fork branch) — and it returns
+    /// [`WinOutcome::AlreadyAnswered`] with the winning B-leg's `initial_acked`.
+    ///
+    /// The check-and-set runs under the DashMap per-key lock, closing the race
+    /// where two concurrent B-leg 200s both observe a stale "not answered"
+    /// snapshot and both forward to the A-leg, delivering a duplicate 200 to a
+    /// call the caller already ACKed.
+    pub fn try_win(&self, call_id: &str, index: usize) -> WinOutcome {
+        let Some(mut call) = self.calls.get_mut(call_id) else {
+            return WinOutcome::AlreadyAnswered { b_leg_acked: false };
+        };
+        if call.state == CallState::Answered {
+            let b_leg_acked = call
+                .winner
+                .and_then(|w| call.b_legs.get(w))
+                .map(|leg| leg.initial_acked)
+                .unwrap_or(false);
+            WinOutcome::AlreadyAnswered { b_leg_acked }
+        } else {
+            call.set_winner(index);
+            WinOutcome::FirstWin
+        }
+    }
+
+    /// Atomically decide whether a 1xx provisional should be forwarded to the
+    /// A-leg, moving the call `Calling -> Ringing` when it is.
+    ///
+    /// Returns `false` (drop the provisional) when the call is already
+    /// `Answered`: a 1xx that arrives after the final response must not be
+    /// forwarded, nor may it downgrade the confirmed dialog back to `Ringing`
+    /// (RFC 3261 §12.1). Under multi-worker dispatch a B-leg's 180 and 200 —
+    /// received in order but processed on different workers — can be handled
+    /// concurrently; checking the call state under the per-call lock here (not
+    /// a stale snapshot read ~1600 lines earlier) is what stops a late 180 from
+    /// being forwarded behind its 200 and aborting the A-leg UAC.
+    ///
+    /// Returns `false` too when the call is gone (a provisional for a call that
+    /// no longer exists is dropped).
+    pub fn try_mark_ringing(&self, call_id: &str) -> bool {
+        let Some(mut call) = self.calls.get_mut(call_id) else {
+            return false;
+        };
+        if call.state == CallState::Answered {
+            return false;
+        }
+        if call.state == CallState::Calling {
+            call.state = CallState::Ringing;
+        }
+        true
     }
 
     /// Begin a sequential route/failover sequence for a call.
@@ -2722,6 +2791,79 @@ mod tests {
         assert!(store.set_pending_reinvite(&call_id, /*on_a_leg=*/ false, false));
         // Now a new re-INVITE can start.
         assert!(!store.set_pending_reinvite(&call_id, /*on_a_leg=*/ false, true));
+    }
+
+    /// The 2xx answer must be claimed atomically: the first `try_win` wins
+    /// (sets the winner + `Answered`), and every subsequent 2xx (retransmit or
+    /// losing fork branch) reports `AlreadyAnswered`. This is what stops two
+    /// concurrent B-leg 200s from both forwarding to the A-leg and delivering a
+    /// duplicate 200 to a caller that already ACKed.
+    #[test]
+    fn try_win_claims_the_answer_exactly_once() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.add_b_leg(&call_id, make_b_leg(0));
+        store.add_b_leg(&call_id, make_b_leg(1));
+
+        // First 200 (B-leg 0) wins, setting winner + state atomically.
+        assert_eq!(store.try_win(&call_id, 0), WinOutcome::FirstWin);
+        {
+            let call = store.get_call(&call_id).unwrap();
+            assert_eq!(call.winner, Some(0));
+            assert_eq!(call.state, CallState::Answered);
+        }
+
+        // A retransmit of the winner's 200 before the B-leg ACK went out:
+        // already answered, absorb silently.
+        assert_eq!(
+            store.try_win(&call_id, 0),
+            WinOutcome::AlreadyAnswered { b_leg_acked: false }
+        );
+        // A losing fork branch's 200 (B-leg 1): also already answered, not a win.
+        assert_eq!(
+            store.try_win(&call_id, 1),
+            WinOutcome::AlreadyAnswered { b_leg_acked: false }
+        );
+        // The winner is unchanged (still B-leg 0).
+        assert_eq!(store.get_call(&call_id).unwrap().winner, Some(0));
+
+        // Once the winner's ACK has gone out, a further retransmit reports
+        // acked=true so the caller re-ACKs to stop the UAS retransmitting.
+        store.get_call_mut(&call_id).unwrap().b_legs[0].initial_acked = true;
+        assert_eq!(
+            store.try_win(&call_id, 0),
+            WinOutcome::AlreadyAnswered { b_leg_acked: true }
+        );
+    }
+
+    /// A 1xx provisional is forwarded (and moves Calling -> Ringing) until the
+    /// call is answered; a late provisional reordered behind its 200 is then
+    /// dropped and must NOT downgrade the confirmed dialog back to Ringing.
+    /// This is the atomic guard that stops a late 180 processed on another
+    /// worker from being forwarded to the A-leg after the final response.
+    #[test]
+    fn try_mark_ringing_drops_provisional_after_answer() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.add_b_leg(&call_id, make_b_leg(0));
+
+        // First 180: Calling -> Ringing, forward it.
+        assert!(store.try_mark_ringing(&call_id));
+        assert_eq!(store.get_call(&call_id).unwrap().state, CallState::Ringing);
+        // A second 180 while Ringing: still forwarded, stays Ringing.
+        assert!(store.try_mark_ringing(&call_id));
+        assert_eq!(store.get_call(&call_id).unwrap().state, CallState::Ringing);
+
+        // Answer the call.
+        store.set_winner(&call_id, 0);
+        assert_eq!(store.get_call(&call_id).unwrap().state, CallState::Answered);
+
+        // A late 180 reordered behind the 200: dropped, dialog NOT downgraded.
+        assert!(!store.try_mark_ringing(&call_id));
+        assert_eq!(store.get_call(&call_id).unwrap().state, CallState::Answered);
+
+        // A provisional for a call that no longer exists is dropped.
+        assert!(!store.try_mark_ringing("nonexistent"));
     }
 
     /// RFC 3891 §3 dialog lookup: find a call where one of its legs has

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11623,16 +11623,35 @@ fn handle_b2bua_response(
     match class { ResponseClass::Answered => {
     // --- 2xx answer handling ---
     if (200..300).contains(&status_code) {
-        // Absorb 200 OK retransmissions: if the call is already answered,
-        // this is a retransmit from the B-leg (it hasn't received our ACK yet).
-        // Only re-ACK if the B-leg has been ACKed (late ACK complete).
-        // If still waiting for A-leg ACK, absorb silently.
-        if call_state == CallState::Answered {
-            // Check if B-leg has been ACKed yet (late ACK pattern)
-            let b_leg_acked = b_leg_index
-                .and_then(|idx| state.call_actors.get_call(call_id)
-                    .and_then(|call| call.b_legs.get(idx).map(|b| b.initial_acked)))
-                .unwrap_or(false);
+        // Atomically claim the answer. Under load, two B-leg 200s for the same
+        // call (the answer plus a retransmit, or a fork glare) can be processed
+        // concurrently; `call_state` is snapshotted at the top of this function
+        // and only flipped to Answered below, so both could pass a stale
+        // "not answered" check and both forward to the A-leg — delivering a
+        // duplicate 200 to a caller that already ACKed (the "Dead call
+        // (successful)" the UAC logs, and an occasional failed call when a
+        // forward lands after the A-leg freed its state). Claim under the
+        // per-call lock so exactly one 2xx wins and forwards; the rest are
+        // absorbed here. A FirstWin also sets the winner + Answered (replacing
+        // the set_winner below). `None` = no matched B-leg (defensive) — fall
+        // back to the pre-atomic snapshot check.
+        let already_answered: Option<bool> =
+            match b_leg_index.map(|idx| state.call_actors.try_win(call_id, idx)) {
+                Some(crate::b2bua::actor::WinOutcome::FirstWin) => None,
+                Some(crate::b2bua::actor::WinOutcome::AlreadyAnswered { b_leg_acked }) => {
+                    Some(b_leg_acked)
+                }
+                None if call_state == CallState::Answered => Some(true),
+                None => {
+                    state.call_actors.set_state(call_id, CallState::Answered);
+                    None
+                }
+            };
+        if let Some(b_leg_acked) = already_answered {
+            // Retransmit of the winning B-leg's 200 (it hasn't received our ACK
+            // yet), or a losing fork branch. Re-ACK only once the B-leg ACK has
+            // gone out (late-ACK complete); while still awaiting the A-leg ACK,
+            // absorb silently.
             if !b_leg_acked {
                 debug!(
                     call_id = %call_id,
@@ -11700,11 +11719,8 @@ fn handle_b2bua_response(
         // (siphon-terminated transfer-target responses are intercepted earlier,
         // before the class match, so they never reach this normal-answer path.)
 
-        // 2xx — call answered; record the winning B-leg
-        state.call_actors.set_state(call_id, CallState::Answered);
-        if let Some(idx) = b_leg_index {
-            state.call_actors.set_winner(call_id, idx);
-        }
+        // 2xx — this is the winning answer; the winner + Answered state were
+        // claimed atomically above (try_win), so there is nothing to set here.
 
         // Record the winning B-leg's own raw endpoint SDP (its 200 answer,
         // captured before the @b2bua.on_answer script / rtpengine rewrite below)
@@ -12236,20 +12252,21 @@ fn handle_b2bua_response(
     // --- 1xx provisional handling ---
     {
         // Drop a stray provisional that arrives after the call is already
-        // answered — e.g. a carrier's 180 reordered behind its 200 under the
-        // multi-worker UDP receive (seen on an LCR reroute where the winning
-        // carrier's 180/200 land in a tight window), or a losing fork branch's
-        // late 18x. A B2BUA must not forward a provisional after the final
-        // response, nor downgrade the confirmed dialog back to Ringing
-        // (RFC 3261 §12.1). Absorb it.
-        if call_state == CallState::Answered {
+        // answered — e.g. a carrier's 180 reordered behind its 200, or a losing
+        // fork branch's late 18x. A B2BUA must not forward a provisional after
+        // the final response, nor downgrade the confirmed dialog back to Ringing
+        // (RFC 3261 §12.1). This MUST be an atomic check-and-set, not the
+        // `call_state` snapshot taken ~1600 lines earlier: under multi-worker
+        // dispatch a B-leg's 180 and 200 (received in order over one TCP/UDP
+        // flow) are processed on different workers concurrently, so a late 180
+        // that reads a stale "not answered" snapshot would be forwarded behind
+        // its 200 and abort the A-leg UAC (which already ACKed/BYE'd). Deciding
+        // under the per-call lock drops the provisional that lost the race.
+        if !state.call_actors.try_mark_ringing(call_id) {
             debug!(call_id = %call_id, status = status_code,
                 "B2BUA: dropping provisional received after answer");
             return;
         }
-
-        // 1xx provisional — forward to A-leg
-        state.call_actors.set_state(call_id, CallState::Ringing);
 
         // Invoke @b2bua.on_early_media handlers when provisional has SDP body.
         // This lets scripts process early media through RTPEngine before forwarding.


### PR DESCRIPTION
## What & why

Two check-then-set decisions in the B2BUA response path acted on a `call_state` **snapshot** taken early in `handle_b2bua_response`, but the new state was only committed ~1600 lines later. Under multi-worker dispatch, two responses for the same call — a `200` and its retransmit, or a `180` and its `200` (received in order over one TCP/UDP flow but processed on different workers) — can both observe the stale "not answered" view:

1. **Duplicate 200 to the A-leg** — two B-leg `200`s both forwarded, so a caller that already ACKed gets a second `200` ("Dead call (successful)" / "can't map" on the UAC).
2. **Late provisional after answer** — a `180` processed behind its `200` forwarded to the A-leg *after* the final response, and the confirmed dialog downgraded back to `Ringing` (RFC 3261 §12.1).

Both are now claimed **atomically under the per-call lock**: `CallActorStore::try_win` (answer) and `try_mark_ringing` (provisional). Exactly one 2xx wins and forwards; a provisional that lost the race to the 200 is dropped and never downgrades a confirmed dialog.

## How it surfaced

Chasing an intermittent b2bua/TCP failure in a **containerised** scale harness. On the real baseline (host loopback, this reference machine) b2bua/TCP is **clean 0-fail to 30k cps** (the machine's ceiling) — the container failures were docker-bridge timing artifacts, not this. So these are framed as **hardening**, not a perf fix: loopback is too fast to hit the window, but a real TCP trunk with network latency at high call rates widens exactly it.

## Also

- **`siphon.yaml` now defaults `advertised_address` to `127.0.0.1`** so the example config works out of the box for local use (softphone on the same host, loopback SIPp, `scale_test.sh`) instead of auto-detecting a routable interface that a multi-homed host can pick wrong. Loudly commented: **change it for any real deployment.** (`scale_test.sh` no longer needs to special-case this.)

## Verification

- `cargo test` **3455/0** (two new atomic-claim unit tests: `try_win_claims_the_answer_exactly_once`, `try_mark_ringing_drops_provisional_after_answer`), clippy `-D warnings` clean.
- Host loopback b2bua/TCP: 4× 40000/40000 at 10k cps, then 0-fail to 30k cps (100000/100000 @ 20k, 150000/150000 @ 30k).