### PR TITLE
feat(pcscf): dual-stack (IPv4 + IPv6) P-CSCF — per-family Gm identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   side is unchanged. Default is off (no behaviour change on a bump); IMS
   deployments set `1280` (the IPv6 minimum MTU). Family-agnostic — works for v4
   and v6 next hops. Kamailio analog: `udp_mtu` + `udp_mtu_try_proto=TCP`.
+- **Dual-stack (IPv4 + IPv6) P-CSCF — per-family Gm identity.** A P-CSCF can bind
+  a v4 and a v6 Gm listener set at once and now stamps the family-matching local
+  identity on each UE's signalling instead of collapsing to the first configured
+  listener. Responses, Contact and Record-Route toward the UE carry a v6 host for
+  a v6 UE (v4 for v4); the IPsec sec-agree SA's P-CSCF side is selected to match
+  the UE's family (a mismatch now errors loudly rather than installing a dead
+  mixed-family XFRM selector); the SDP `o=` rewrite emits an unbracketed address
+  with the correct `IN IP4`/`IN IP6` addrtype; the IPsec/flow-relay Via paths and
+  the `force_send_via` target split are IPv6-bracket correct; and DSCP marking now
+  sets `IPV6_TCLASS` on v6 sockets (was IPv4-only, so v6 egress went unmarked).
+  Loop detection checks every configured listener across both families. Configure
+  explicit per-family listeners, each with an optional per-listener `advertise`
+  (see `examples/ims_pcscf.yaml`). Core-side (Mw / outbound) dual-stack is a
+  separate follow-up.
 - **Docker Compose quickstart + Getting started guide.** A root
   `docker-compose.yaml` runs the published image with your `siphon.yaml` and
   `scripts/` bind-mounted (host networking, hot-reload, a SIP `OPTIONS`

--- a/examples/ims_pcscf.yaml
+++ b/examples/ims_pcscf.yaml
@@ -24,7 +24,31 @@ listen:
     - "0.0.0.0:5064"        # IPsec protected client port (ESP-over-TCP, TS 33.203 §7.2)
     - "0.0.0.0:5066"        # IPsec protected server port (ESP-over-TCP)
 
-# Public IP — set to the P-CSCF's routable address
+  # --- Dual-stack Gm (IPv4 + IPv6) ---------------------------------------
+  # A P-CSCF serving VoLTE UEs on both IPv4 and IPv6 bearers binds an
+  # explicit v4 AND v6 Gm listener set (per GSMA IR.92 a UE registers over
+  # one family at a time; this is dual-stack per process, not per UE).
+  # Prefer EXPLICIT per-family binds over a single `[::]` — siphon does not
+  # normalise v4-mapped (`::ffff:`) peers, so an explicit v4 listener keeps
+  # addresses canonical.  siphon then stamps the family-matching local
+  # identity (Via / Record-Route host, IPsec SA local address, SDP o=) for
+  # each UE.  Give each family its own routable identity with a per-listener
+  # `advertise` (an FQDN with both A + AAAA works for either family):
+  #
+  # udp:
+  #   - { address: "192.0.2.10:5060",          advertise: "pcscf.ims.example" }
+  #   - { address: "192.0.2.10:5064",          advertise: "pcscf.ims.example" }
+  #   - { address: "192.0.2.10:5066",          advertise: "pcscf.ims.example" }
+  #   - { address: "[2001:db8:ac10::10]:5060", advertise: "pcscf.ims.example" }
+  #   - { address: "[2001:db8:ac10::10]:5064", advertise: "pcscf.ims.example" }
+  #   - { address: "[2001:db8:ac10::10]:5066", advertise: "pcscf.ims.example" }
+  # tcp:  # ESP-over-TCP mirror (TS 33.203 §7.2), same six entries
+  #   - { address: "192.0.2.10:5060" }
+  #   - { address: "[2001:db8:ac10::10]:5060" }
+  #   # ...
+
+# Public IP — set to the P-CSCF's routable address (per-listener `advertise`
+# above overrides this for dual-stack, so each family gets its own identity)
 advertised_address: "10.0.0.10"
 
 domain:

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -6079,6 +6079,12 @@ class MockIpsec:
     def __init__(self) -> None:
         self.pcscf_port_c = 5064
         self.pcscf_port_s = 5066
+        # Per-family P-CSCF local address (dual-stack).  Both present by default
+        # so a correctly-configured P-CSCF allocates for either family; set one
+        # to ``None`` to model a single-stack P-CSCF and exercise the
+        # family-mismatch error (see ``set_pcscf_families``).
+        self.pcscf_addr_v4: Optional[str] = "10.0.0.10"
+        self.pcscf_addr_v6: Optional[str] = "2001:db8::10"
         self._stash: dict[str, MockPendingSA] = {}
         self._allocate_should_fail: Optional[type[BaseException]] = None
         self._allocate_failure_message = "mock allocate failure"
@@ -6126,6 +6132,19 @@ class MockIpsec:
             sa_protocol = proto_lower
             wire_protocol = "udp" if proto_lower == "any" else proto_lower
         av._take()  # raises ValueError if already consumed
+        # Family-matched P-CSCF address (mirrors the Rust binding, which
+        # consumes ``av`` before this check): the SA's P-CSCF side must be the
+        # same family as the UE, so a UE whose family has no configured P-CSCF
+        # listener raises rather than installing a dead mixed-family selector
+        # (3GPP TS 33.203 §7.2).
+        ue_is_v6 = ":" in offer.ue_addr
+        if (self.pcscf_addr_v6 if ue_is_v6 else self.pcscf_addr_v4) is None:
+            family = "IPv6" if ue_is_v6 else "IPv4"
+            raise ValueError(
+                f"no {family} P-CSCF listener configured for {family} UE "
+                f"{offer.ue_addr}; cannot build a same-family IPsec SA selector "
+                f"(3GPP TS 33.203 §7.2)"
+            )
         if self._allocate_should_fail is not None:
             raise self._allocate_should_fail(self._allocate_failure_message)
         pending = MockPendingSA(
@@ -6155,9 +6174,21 @@ class MockIpsec:
         self._allocate_should_fail = exc_type
         self._allocate_failure_message = message
 
+    def set_pcscf_families(self, v4: bool = True, v6: bool = True) -> None:
+        """Model which address families this P-CSCF has a listener for.
+
+        Both default to available.  Set one to ``False`` to model a
+        single-stack P-CSCF so ``allocate()`` raises for a UE of the missing
+        family, exactly as the Rust binding does.
+        """
+        self.pcscf_addr_v4 = "10.0.0.10" if v4 else None
+        self.pcscf_addr_v6 = "2001:db8::10" if v6 else None
+
     def clear(self) -> None:
         self._stash.clear()
         self._allocate_should_fail = None
+        self.pcscf_addr_v4 = "10.0.0.10"
+        self.pcscf_addr_v6 = "2001:db8::10"
         MockPendingSA._next_spi = 10000
 
 

--- a/sdk/tests/test_ipsec_pending_sa.py
+++ b/sdk/tests/test_ipsec_pending_sa.py
@@ -83,3 +83,45 @@ def test_activate_after_cleanup_rejects_lifetime_kwarg():
 
     with pytest.raises(ValueError, match="cleaned up"):
         pending.activate(hard_lifetime_secs=3632)
+
+
+# -- Dual-stack: the P-CSCF SA side must match the UE's family ---------------
+
+def _allocate_for(ipsec, ue_addr):
+    av = MockAuthVectorHandle(ck=bytes(16), ik=bytes(16))
+    offer = MockSecurityOffer(
+        mechanism="ipsec-3gpp",
+        alg="hmac-sha-1-96",
+        ealg="null",
+        spi_c=11111, spi_s=22222,
+        port_c=50000, port_s=50001,
+        ue_addr=ue_addr,
+    )
+    return asyncio.run(
+        ipsec.allocate(
+            av, offer, _TransformEnum.HmacSha1_96Null,
+            expires_secs=600_000, protocol=None,
+        )
+    )
+
+
+def test_allocate_dual_stack_serves_both_families():
+    ipsec = _fresh_ipsec()  # default mock is dual-stack
+    assert _allocate_for(ipsec, "10.0.0.1") is not None
+    assert _allocate_for(ipsec, "2001:db8::1") is not None
+
+
+def test_allocate_v6_ue_without_v6_listener_raises():
+    ipsec = _fresh_ipsec()
+    ipsec.set_pcscf_families(v4=True, v6=False)  # single-stack (v4-only) P-CSCF
+    assert _allocate_for(ipsec, "10.0.0.1") is not None
+    with pytest.raises(ValueError, match="no IPv6 P-CSCF listener"):
+        _allocate_for(ipsec, "2001:db8::1")
+
+
+def test_allocate_v4_ue_without_v4_listener_raises():
+    ipsec = _fresh_ipsec()
+    ipsec.set_pcscf_families(v4=False, v6=True)  # v6-only P-CSCF
+    assert _allocate_for(ipsec, "2001:db8::1") is not None
+    with pytest.raises(ValueError, match="no IPv4 P-CSCF listener"):
+        _allocate_for(ipsec, "10.0.0.1")

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -4,7 +4,7 @@
 //! Python script handlers, and sends responses back through the transport.
 //! Implements stateless proxy relay with Via-based response routing.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex, RwLock};
 
 use bytes::Bytes;
@@ -31,7 +31,7 @@ use crate::sip::message::{Method, RequestLine, SipMessage, StartLine, StatusLine
 use crate::sip::headers::SipHeaders;
 use crate::sip::uri::SipUri;
 use crate::sip::parser::{parse_sip_message_bytes, parse_uri_standalone};
-use crate::sip::uri::format_sip_host;
+use crate::sip::uri::{format_sip_host, split_host_port, strip_ipv6_brackets};
 use crate::transaction::key::TransactionKey;
 use crate::transaction::state::{
     Action, TimerName,
@@ -350,6 +350,30 @@ impl DispatcherState {
             .unwrap_or(self.local_addr.port())
     }
 
+    /// Family-matched host to advertise to the A-leg (Contact / Via /
+    /// Record-Route), selected from the socket the request arrived on.
+    ///
+    /// Host-side analogue of [`a_leg_advertised_port`].  `via_host` keys only on
+    /// transport and so collapses to the first configured listener's family — on
+    /// a dual-stack P-CSCF a UE that registered over IPv6 would get the IPv4
+    /// advertised host stamped on its responses.  Passing the arrival socket
+    /// (`inbound.local_addr` / `leg.transport.local_addr`) selects the
+    /// family-correct identity.  `None` (arrival socket unknown — e.g. a
+    /// core-facing outbound leg) reproduces the legacy per-transport `via_host`.
+    fn a_leg_advertised_host(
+        &self,
+        a_leg_local_addr: Option<SocketAddr>,
+        transport: &Transport,
+    ) -> String {
+        resolve_advertised_host(
+            &self.listener_registry,
+            &self.advertised_addrs,
+            self.local_addr.ip(),
+            a_leg_local_addr,
+            transport,
+        )
+    }
+
     /// Resolve siphon's own endpoint to report in a HEP capture for `transport`.
     ///
     /// When siphon binds to the wildcard address (`0.0.0.0` / `[::]`, the usual
@@ -415,28 +439,23 @@ impl DispatcherState {
     }
 
     /// Check whether a resolved destination points back to one of our own
-    /// listen addresses (loop detection).  Checks the primary `local_addr`
-    /// AND every per-transport listen address in `listen_addrs`.
+    /// listen addresses (loop detection).  Checks the primary `local_addr` and
+    /// **every** configured listener via `listener_registry` — on a multi-homed
+    /// / dual-stack host `listen_addrs` keeps only the first listener per
+    /// transport, so a destination on the second-family (or second-port)
+    /// listener would otherwise slip through.
     fn is_own_address(&self, destination: &std::net::SocketAddr) -> bool {
         let ip = destination.ip();
         let port = destination.port();
-        let ip_matches = |listen_ip: std::net::IpAddr| {
-            ip == listen_ip || ip.is_loopback()
-        };
 
-        // Check primary listen address
-        if port == self.local_addr.port() && ip_matches(self.local_addr.ip()) {
+        // Check primary listen address (the resolved via_addr, which may not be
+        // an exact registry entry when bound to a wildcard).
+        if port == self.local_addr.port() && (ip == self.local_addr.ip() || ip.is_loopback()) {
             return true;
         }
 
-        // Check all per-transport listen addresses (e.g. TLS on :5061)
-        for addr in self.listen_addrs.values() {
-            if port == addr.port() && ip_matches(addr.ip()) {
-                return true;
-            }
-        }
-
-        false
+        // Check every configured listener (both families, all transports).
+        self.listener_registry.matches_local(destination)
     }
 }
 
@@ -2867,8 +2886,10 @@ fn handle_request(
             if method == "OPTIONS" && (200..300).contains(code) {
                 augment_options_response(
                     &mut response,
-                    &state.via_host(&inbound.transport),
-                    state.via_port(&inbound.transport),
+                    // Family-matched to the socket the OPTIONS arrived on, so a v6
+                    // probe gets a v6 Contact/Via and the exact arrival port.
+                    &state.a_leg_advertised_host(Some(inbound.local_addr), &inbound.transport),
+                    inbound.local_addr.port(),
                     inbound.transport,
                 );
             }
@@ -3317,14 +3338,16 @@ fn relay_request(
         // server port (e.g. 5066) is non-default — using the per-
         // transport via_host would emit a Via with the wrong port and
         // the UE's response would land on the wrong listener
-        // (3GPP TS 33.203 §7.4).
-        (local.ip().to_string(), Some(local.port()))
+        // (3GPP TS 33.203 §7.4).  Bracket a v6 literal — a raw
+        // `local.ip().to_string()` would emit a malformed unbracketed
+        // `SIP/2.0/UDP 2001:db8::10:5066` sent-by.
+        (format_sip_host(&local.ip().to_string()), Some(local.port()))
     } else if let Some(local) = ipsec_source {
         // IPsec auto-source: same correctness invariant as the flow
         // path — the UE's response on SA #4 (UE → port_pc) must land
         // on the Via we advertise, otherwise the kernel selector
         // doesn't match and the response is silently dropped.
-        (local.ip().to_string(), Some(local.port()))
+        (format_sip_host(&local.ip().to_string()), Some(local.port()))
     } else if let Some(pin) = send_socket {
         // Script send_socket= egress pin: advertise the selected listener's
         // sent-by (its configured advertise host, else the bound IP) with the
@@ -3332,12 +3355,12 @@ fn relay_request(
         let (host, port) = pin.via_sent_by();
         (format_sip_host(&host), Some(port))
     } else if let Some(target_str) = send_via_target {
-        // Parse "host:port" or just "host"
-        if let Some((host, port_str)) = target_str.rsplit_once(':') {
-            (host.to_string(), port_str.parse::<u16>().ok())
-        } else {
-            (target_str.to_string(), None)
-        }
+        // Script force_send_via override — bracket-aware split so a bare
+        // bracketed v6 literal (`[2001:db8::1]`, no port) isn't truncated by a
+        // naive rsplit_once(':').  Re-bracket the host so an unbracketed v6
+        // still renders a valid sent-by.
+        let (host, port) = split_host_port(target_str);
+        (format_sip_host(host), port)
     } else {
         (state.via_host(&outbound_transport), Some(state.via_port(&outbound_transport)))
     };
@@ -4070,7 +4093,7 @@ fn handle_response(
                             .via(format!(
                                 "SIP/2.0/{} {}:{};branch={}",
                                 transport_str,
-                                format_sip_host(&state.local_addr.ip().to_string()),
+                                state.a_leg_advertised_host(zombie.local_addr, &zombie.transport),
                                 outbound_port,
                                 TransactionKey::generate_branch(),
                             ))
@@ -6257,6 +6280,93 @@ fn a_leg_advertised_port(a_leg_local_addr: Option<SocketAddr>, default_via_port:
         .unwrap_or(default_via_port)
 }
 
+/// Resolve the family-matched host to advertise to the A-leg, given the socket
+/// the request arrived on.  Backing logic for
+/// [`DispatcherState::a_leg_advertised_host`], factored out as a free function
+/// so it is unit-testable without a `DispatcherState` fixture.
+///
+/// With `a_leg_local_addr = Some(addr)` the resolution, most-specific first:
+///
+/// 1. the per-listener `advertise` configured for that exact socket;
+/// 2. a transport-level advertised host of the **same family** (preserves the
+///    global `advertised_address` / NAT case, but never hands a v4 literal to a
+///    v6 UE or vice-versa; an FQDN is family-agnostic and always accepted);
+/// 3. the exact bound IP, when concrete (explicit per-family listener);
+/// 4. a wildcard bind → a family-matched listener's advertise/bound IP, else a
+///    routable local IP of that family, else that family's loopback.
+///
+/// `None` reproduces the legacy per-transport `via_host` (first advertised host,
+/// else the resolved `default_local_ip`).
+fn resolve_advertised_host(
+    registry: &crate::transport::ListenerRegistry,
+    advertised_addrs: &std::collections::HashMap<Transport, String>,
+    default_local_ip: IpAddr,
+    a_leg_local_addr: Option<SocketAddr>,
+    transport: &Transport,
+) -> String {
+    let Some(addr) = a_leg_local_addr else {
+        return advertised_addrs
+            .get(transport)
+            .map(|host| format_sip_host(host))
+            .unwrap_or_else(|| format_sip_host(&default_local_ip.to_string()));
+    };
+    let ipv6 = addr.is_ipv6();
+
+    // 1. Per-listener advertise for this exact socket.
+    if let Some(advertise) = registry.resolve(*transport, addr).and_then(|s| s.advertise) {
+        return format_sip_host(&advertise);
+    }
+
+    // 2. A transport-level advertised host of the same family (or an FQDN).
+    //    Strip any v6 brackets before parsing so a bracketed literal
+    //    (`[2001:db8::1]`) is still classified as an IP, not an FQDN.
+    if let Some(host) = advertised_addrs.get(transport) {
+        let family_ok = match strip_ipv6_brackets(host).parse::<IpAddr>() {
+            Ok(ip) => ip.is_ipv6() == ipv6,
+            Err(_) => true, // FQDN — resolves to whichever family the UE needs.
+        };
+        if family_ok {
+            return format_sip_host(host);
+        }
+    }
+
+    // 3. The exact bound IP, when concrete.
+    if !addr.ip().is_unspecified() {
+        return format_sip_host(&addr.ip().to_string());
+    }
+
+    // 4. Wildcard bind → family-matched fallback.
+    if let Some(send) = registry.resolve_family(*transport, ipv6) {
+        if let Some(advertise) = send.advertise {
+            return format_sip_host(&advertise);
+        }
+        if !send.addr.ip().is_unspecified() {
+            return format_sip_host(&send.addr.ip().to_string());
+        }
+    }
+    if let Some(ip) = cached_routable_local_ip(ipv6) {
+        return format_sip_host(&ip.to_string());
+    }
+    let loopback = if ipv6 {
+        IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
+    } else {
+        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+    };
+    format_sip_host(&loopback.to_string())
+}
+
+/// Process-lifetime cache of [`crate::transport::detect_routable_local_ip`] per
+/// family.  Only the wildcard-bind, no-advertise fallback of
+/// [`resolve_advertised_host`] reaches the probe, but that path can be
+/// per-message, and the probe does a socket create + `connect` + `getsockname`.
+/// The routable local IP doesn't change at runtime, so memoise it.
+fn cached_routable_local_ip(ipv6: bool) -> Option<IpAddr> {
+    static V4: std::sync::OnceLock<Option<IpAddr>> = std::sync::OnceLock::new();
+    static V6: std::sync::OnceLock<Option<IpAddr>> = std::sync::OnceLock::new();
+    let cache = if ipv6 { &V6 } else { &V4 };
+    *cache.get_or_init(|| crate::transport::detect_routable_local_ip(ipv6))
+}
+
 /// Sanitize a B2BUA response before forwarding it to the A-leg.
 ///
 /// A proper B2BUA terminates and regenerates the dialog, so B-leg-specific
@@ -6284,7 +6394,7 @@ fn sanitize_b2bua_response(
     // Contact advertising the wrong port sends every in-dialog request (ACK, BYE,
     // re-INVITE) to a port the dialog isn't anchored on. Falls back to via_port()
     // when the arrival socket is unknown (single-listener hosts, where they match).
-    let a_leg_host = state.via_host(&a_leg_transport);
+    let a_leg_host = state.a_leg_advertised_host(a_leg_local_addr, &a_leg_transport);
     let a_leg_port =
         a_leg_advertised_port(a_leg_local_addr, state.via_port(&a_leg_transport));
     let contact_value = format!(
@@ -6381,6 +6491,27 @@ fn sanitize_o_username(name: &str) -> String {
     }
 }
 
+/// Resolve a substituted SDP origin address to its `(unicast-address, addrtype)`
+/// pair for the `o=` line.  `via_host()` produces a **bracket-formatted** host
+/// for IPv6, but brackets are illegal in SDP (RFC 4566 §5.2) and the address
+/// family must match the `<addrtype>` token — so strip the brackets and derive
+/// `IP4`/`IP6` from the address family.  Returns `addrtype = None` for a
+/// non-literal host (an FQDN advertise address), signalling the caller to leave
+/// the existing `<addrtype>` untouched.
+fn sdp_origin_address(addr: &str) -> (String, Option<&'static str>) {
+    let bare = strip_ipv6_brackets(addr);
+    if bare.parse::<std::net::Ipv6Addr>().is_ok() {
+        (bare.to_string(), Some("IP6"))
+    } else if bare.parse::<std::net::Ipv4Addr>().is_ok() {
+        (bare.to_string(), Some("IP4"))
+    } else {
+        // FQDN / unparseable (e.g. a zoned link-local) — emit unbracketed and
+        // leave <addrtype> as-is.  For an FQDN `bare == addr`; for a bracketed
+        // non-literal this strips the brackets rather than leak them into SDP.
+        (bare.to_string(), None)
+    }
+}
+
 fn sanitize_sdp_identity(body: &mut Vec<u8>, name: &str, addr: Option<&str>) {
     if body.is_empty() {
         return;
@@ -6399,31 +6530,63 @@ fn sanitize_sdp_identity(body: &mut Vec<u8>, name: &str, addr: Option<&str>) {
     for line in text.split_inclusive('\n') {
         if line.starts_with("o=") {
             // o=<username> <sess-id> <sess-version> <nettype> <addrtype> <addr>[\r\n]
-            // Replace username, and optionally the trailing address.
+            // Replace <username>, and (when addr is Some) the <addrtype>+<addr>.
             if let Some(rest) = line.strip_prefix("o=") {
-                if let Some(space_pos) = rest.find(' ') {
-                    let after_username = &rest[space_pos..];
-                    // Optionally rewrite the address (last field)
-                    if let Some(sdp_addr) = addr {
-                        // Find the last space before the trailing \r\n
-                        let trimmed = after_username.trim_end_matches(['\r', '\n']);
-                        if let Some(last_space) = trimmed.rfind(' ') {
-                            let line_ending = &after_username[trimmed.len()..];
-                            result.push_str("o=");
-                            result.push_str(&o_line_name);
-                            result.push_str(&trimmed[..last_space + 1]);
-                            result.push_str(sdp_addr);
-                            result.push_str(line_ending);
-                        } else {
-                            result.push_str("o=");
-                            result.push_str(&o_line_name);
-                            result.push_str(after_username);
-                        }
-                    } else {
+                if let Some(sdp_addr) = addr {
+                    let value = rest.trim_end_matches(['\r', '\n']);
+                    let line_ending = &rest[value.len()..];
+                    let fields: Vec<&str> = value.split(' ').collect();
+                    if fields.len() == 6 {
+                        // Well-formed origin: rewrite username + address, and
+                        // flip <addrtype> to match the substituted address
+                        // family.  The address is emitted UNbracketed (brackets
+                        // are illegal in SDP) — a v6 via_host() carries them.
+                        let (bare_addr, addrtype) = sdp_origin_address(sdp_addr);
                         result.push_str("o=");
                         result.push_str(&o_line_name);
-                        result.push_str(after_username);
+                        result.push(' ');
+                        result.push_str(fields[1]);
+                        result.push(' ');
+                        result.push_str(fields[2]);
+                        result.push(' ');
+                        result.push_str(fields[3]);
+                        result.push(' ');
+                        result.push_str(addrtype.unwrap_or(fields[4]));
+                        result.push(' ');
+                        result.push_str(&bare_addr);
+                        result.push_str(line_ending);
+                        changed = true;
+                        continue;
                     }
+                    // Malformed o= (not the six RFC fields — doubled spaces, a
+                    // vendor-extended origin): still substitute the trailing
+                    // address for topology hiding, bracket-stripped.  Skipping it
+                    // would leak the peer's real address.  <addrtype> is left
+                    // alone since it can't be reliably located on a malformed
+                    // line.
+                    if let Some(space_pos) = rest.find(' ') {
+                        let (bare_addr, _addrtype) = sdp_origin_address(sdp_addr);
+                        let after_username = &rest[space_pos..];
+                        let trimmed = after_username.trim_end_matches(['\r', '\n']);
+                        result.push_str("o=");
+                        result.push_str(&o_line_name);
+                        if let Some(last_space) = trimmed.rfind(' ') {
+                            result.push_str(&trimmed[..last_space + 1]);
+                            result.push_str(&bare_addr);
+                            result.push_str(&after_username[trimmed.len()..]);
+                        } else {
+                            // Only a username + one token: nothing address-shaped
+                            // to replace — keep the remainder as-is.
+                            result.push_str(after_username);
+                        }
+                        changed = true;
+                        continue;
+                    }
+                } else if let Some(space_pos) = rest.find(' ') {
+                    // No address substitution — replace the username only.
+                    result.push_str("o=");
+                    result.push_str(&o_line_name);
+                    result.push_str(&rest[space_pos..]);
                     changed = true;
                     continue;
                 }
@@ -6456,7 +6619,10 @@ fn sanitize_sdp_identity(body: &mut Vec<u8>, name: &str, addr: Option<&str>) {
 /// Stamp siphon's owned `o=` identity onto an SDP body: rewrite the origin
 /// line's username to `name`, its `<sess-id>` to `sess_id`, its `<sess-version>`
 /// to `version`, and (when `addr` is `Some`) its unicast-address to `addr`. The
-/// `<nettype>`/`<addrtype>` tokens are preserved.
+/// `<nettype>` token is preserved; `<addrtype>` is flipped to `IP4`/`IP6` to
+/// match the substituted address family (and left untouched for an FQDN), and
+/// the substituted address is emitted unbracketed (brackets are illegal in SDP,
+/// RFC 4566 §5.2).
 ///
 /// This is the piece [`sanitize_sdp_identity`] deliberately leaves alone: it
 /// lets siphon own a stable per-leg session identity with a monotonic version
@@ -6483,7 +6649,16 @@ fn stamp_sdp_origin(body: &mut Vec<u8>, name: &str, sess_id: u64, version: u64, 
             let line_ending = &rest[value.len()..];
             let fields: Vec<&str> = value.split(' ').collect();
             if fields.len() == 6 {
-                let unicast_addr = addr.unwrap_or(fields[5]);
+                // When substituting the address, strip any v6 brackets and flip
+                // <addrtype> to the substituted family; otherwise keep the
+                // origin's own address + addrtype verbatim.
+                let (unicast_addr, addrtype) = match addr {
+                    Some(a) => {
+                        let (bare, at) = sdp_origin_address(a);
+                        (bare, at.unwrap_or(fields[4]))
+                    }
+                    None => (fields[5].to_string(), fields[4]),
+                };
                 result.push_str("o=");
                 result.push_str(&o_line_name);
                 result.push(' ');
@@ -6493,9 +6668,9 @@ fn stamp_sdp_origin(body: &mut Vec<u8>, name: &str, sess_id: u64, version: u64, 
                 result.push(' ');
                 result.push_str(fields[3]);
                 result.push(' ');
-                result.push_str(fields[4]);
+                result.push_str(addrtype);
                 result.push(' ');
-                result.push_str(unicast_addr);
+                result.push_str(&unicast_addr);
                 result.push_str(line_ending);
                 changed = true;
                 continue;
@@ -6738,7 +6913,7 @@ fn build_b2bua_bye(
     let via = format!(
         "SIP/2.0/{} {}:{};branch={}",
         transport_str,
-        state.via_host(&leg.transport.transport),
+        state.a_leg_advertised_host(leg.transport.local_addr, &leg.transport.transport),
         a_leg_advertised_port(leg.transport.local_addr, state.via_port(&leg.transport.transport)),
         branch,
     );
@@ -6871,9 +7046,11 @@ fn build_b2bua_prack(
 ) -> Option<SipMessage> {
     // Via sent-by host:port is the listener this leg is anchored on (the A-leg's
     // arrival socket on a multi-homed host) so the response comes back to the
-    // socket the request left from. Falls back to via_port for the B-leg
-    // (local_addr None) and single-listener hosts — no change there.
-    let via_host = state.via_host(&leg.transport.transport);
+    // socket the request left from. The host is resolved per address family
+    // (dual-stack Gm) so a v6 UE's PRACK carries the v6 identity, not the first
+    // configured listener. Falls back to via_port for the B-leg (local_addr
+    // None) and single-listener hosts — no change there.
+    let via_host = state.a_leg_advertised_host(leg.transport.local_addr, &leg.transport.transport);
     let via_port = a_leg_advertised_port(
         leg.transport.local_addr,
         state.via_port(&leg.transport.transport),
@@ -9559,7 +9736,7 @@ fn handle_b2bua_invite(
     // socket the call actually landed on — matches sanitize_b2bua_response's Contact.
     a_leg.dialog.local_contact = Some(format!(
         "<sip:{}:{};transport={}>",
-        state.via_host(&inbound.transport),
+        state.a_leg_advertised_host(Some(inbound.local_addr), &inbound.transport),
         inbound.local_addr.port(),
         inbound.transport.to_string().to_lowercase(),
     ));
@@ -11143,7 +11320,10 @@ fn handle_b2bua_response(
                         .via(format!(
                             "SIP/2.0/{} {}:{};branch={}",
                             transport_str,
-                            format_sip_host(&state.local_addr.ip().to_string()),
+                            state.a_leg_advertised_host(
+                                if is_a2b { None } else { a_leg.transport.local_addr },
+                                &responder_transport,
+                            ),
                             outbound_port,
                             TransactionKey::generate_branch(),
                         ))
@@ -11377,7 +11557,10 @@ fn handle_b2bua_response(
                         .via(format!(
                             "SIP/2.0/{} {}:{};branch={}",
                             transport_str,
-                            format_sip_host(&state.local_addr.ip().to_string()),
+                            state.a_leg_advertised_host(
+                                if is_a2b { None } else { a_leg.transport.local_addr },
+                                &responder_transport,
+                            ),
                             outbound_port,
                             ack_branch,
                         ))
@@ -14814,9 +14997,10 @@ fn handle_b2bua_reinvite(
         let via_value = format!(
             "SIP/2.0/{} {}:{};branch={}",
             transport_str,
-            state.via_host(&transport),
-            // Via port = the target leg's anchored listener (A-leg's arrival socket
-            // when forwarding B→A on a multi-homed host); via_port for the B-leg.
+            // Via host + port = the target leg's anchored listener (A-leg's arrival
+            // socket, family-correct, on a multi-homed / dual-stack host); the
+            // per-transport via_host/via_port for the B-leg (local_addr None).
+            state.a_leg_advertised_host(target_local_addr, &transport),
             a_leg_advertised_port(target_local_addr, state.via_port(&transport)),
             branch,
         );
@@ -14901,8 +15085,10 @@ fn handle_b2bua_reinvite(
         let _ = crate::proxy::core::decrement_max_forwards(&mut forwarded.headers);
 
         // Sanitize SDP: mask other leg's identity in o= and s= lines, and
-        // rewrite the o= address for topology hiding.
-        let sdp_addr = state.via_host(&transport);
+        // rewrite the o= address for topology hiding — family-matched to the
+        // target leg (same arrival socket as the Via above), so a v6 A-leg gets
+        // a v6 o= address to go with its v6 Via.
+        let sdp_addr = state.a_leg_advertised_host(target_local_addr, &transport);
         sanitize_sdp_identity(&mut forwarded.body, &state.sdp_name, Some(&sdp_addr));
 
         // RTPEngine: rewrite re-INVITE SDP through offer to maintain media anchoring.
@@ -15231,9 +15417,10 @@ fn handle_b2bua_update(
         let via_value = format!(
             "SIP/2.0/{} {}:{};branch={}",
             transport_str,
-            state.via_host(&transport),
-            // Via port = the target leg's anchored listener (A-leg's arrival socket
-            // when forwarding B→A on a multi-homed host); via_port for the B-leg.
+            // Via host + port = the target leg's anchored listener (A-leg's arrival
+            // socket, family-correct, on a multi-homed / dual-stack host); the
+            // per-transport via_host/via_port for the B-leg (local_addr None).
+            state.a_leg_advertised_host(target_local_addr, &transport),
             a_leg_advertised_port(target_local_addr, state.via_port(&transport)),
             branch,
         );
@@ -15319,7 +15506,8 @@ fn handle_b2bua_update(
         // Body-aware media handling: empty-body UPDATE (session-timer
         // refresh) bypasses SDP rewrite and rtpengine entirely.
         if !forwarded.body.is_empty() {
-            let sdp_addr = state.via_host(&transport);
+            // Family-matched to the target leg (same arrival socket as the Via).
+            let sdp_addr = state.a_leg_advertised_host(target_local_addr, &transport);
             sanitize_sdp_identity(&mut forwarded.body, &state.sdp_name, Some(&sdp_addr));
 
             if let (Some(ref rtpengine_set), Some(ref media_sessions), Some(ref profiles)) =
@@ -15495,7 +15683,7 @@ fn build_b2bua_in_dialog_request(
     let via = format!(
         "SIP/2.0/{} {}:{};branch={}",
         transport_str,
-        state.via_host(&leg.transport.transport),
+        state.a_leg_advertised_host(leg.transport.local_addr, &leg.transport.transport),
         a_leg_advertised_port(leg.transport.local_addr, state.via_port(&leg.transport.transport)),
         branch,
     );
@@ -16212,7 +16400,10 @@ fn b2bua_complete_terminated_transfer(
             .via(format!(
                 "SIP/2.0/{} {}:{};branch={}",
                 transport_str,
-                state.via_host(&target_leg.transport.transport),
+                state.a_leg_advertised_host(
+                    target_leg.transport.local_addr,
+                    &target_leg.transport.transport,
+                ),
                 a_leg_advertised_port(
                     target_leg.transport.local_addr,
                     state.via_port(&target_leg.transport.transport)
@@ -16585,7 +16776,7 @@ fn b2bua_forward_indialog_request(
     let via_value = format!(
         "SIP/2.0/{} {}:{};branch={}",
         transport_str,
-        state.via_host(&transport),
+        state.a_leg_advertised_host(target_local_addr, &transport),
         a_leg_advertised_port(target_local_addr, state.via_port(&transport)),
         branch,
     );
@@ -17445,6 +17636,110 @@ mod tests {
         // And when the arrival socket happens to equal the default, still correct.
         let same: SocketAddr = "10.0.0.1:5060".parse().unwrap();
         assert_eq!(a_leg_advertised_port(Some(same), 5060), 5060);
+    }
+
+    // -----------------------------------------------------------------------
+    // A-leg advertised host (per-family / dual-stack identity)
+    // -----------------------------------------------------------------------
+
+    fn dualstack_registry() -> crate::transport::ListenerRegistry {
+        crate::transport::ListenerRegistry::from_entries(vec![
+            (Transport::Udp, "192.0.2.10:5060".parse().unwrap(), None::<String>),
+            (Transport::Udp, "[2001:db8::10]:5060".parse().unwrap(), None::<String>),
+        ])
+    }
+
+    #[test]
+    fn resolve_advertised_host_uses_exact_listener_advertise() {
+        // Per-listener advertise is the most specific source, per family.
+        let registry = crate::transport::ListenerRegistry::from_entries(vec![
+            (Transport::Udp, "192.0.2.10:5060".parse().unwrap(), Some("pcscf-v4.example".to_string())),
+            (Transport::Udp, "[2001:db8::10]:5060".parse().unwrap(), Some("pcscf-v6.example".to_string())),
+        ]);
+        let advertised = std::collections::HashMap::new();
+        let v4: SocketAddr = "192.0.2.10:5060".parse().unwrap();
+        let v6: SocketAddr = "[2001:db8::10]:5060".parse().unwrap();
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, v4.ip(), Some(v4), &Transport::Udp),
+            "pcscf-v4.example"
+        );
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, v4.ip(), Some(v6), &Transport::Udp),
+            "pcscf-v6.example"
+        );
+    }
+
+    #[test]
+    fn resolve_advertised_host_uses_concrete_bind_ip_per_family() {
+        // No advertise anywhere: the exact bound IP, bracketed for v6.
+        let registry = dualstack_registry();
+        let advertised = std::collections::HashMap::new();
+        let default_ip: IpAddr = "192.0.2.10".parse().unwrap();
+        let v6: SocketAddr = "[2001:db8::10]:5060".parse().unwrap();
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, default_ip, Some(v6), &Transport::Udp),
+            "[2001:db8::10]"
+        );
+        let v4: SocketAddr = "192.0.2.10:5060".parse().unwrap();
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, default_ip, Some(v4), &Transport::Udp),
+            "192.0.2.10"
+        );
+    }
+
+    #[test]
+    fn resolve_advertised_host_filters_transport_advertised_by_family() {
+        // The gap this closes: a transport-level advertised v4 literal must NOT be
+        // stamped on a v6 UE's identity — it falls through to the v6 bind IP; a
+        // same-family literal IS used.
+        let registry = dualstack_registry();
+        let mut advertised = std::collections::HashMap::new();
+        advertised.insert(Transport::Udp, "198.51.100.1".to_string()); // public v4
+        let default_ip: IpAddr = "192.0.2.10".parse().unwrap();
+        let v6: SocketAddr = "[2001:db8::10]:5060".parse().unwrap();
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, default_ip, Some(v6), &Transport::Udp),
+            "[2001:db8::10]"
+        );
+        let v4: SocketAddr = "192.0.2.10:5060".parse().unwrap();
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, default_ip, Some(v4), &Transport::Udp),
+            "198.51.100.1"
+        );
+    }
+
+    #[test]
+    fn resolve_advertised_host_fqdn_advertised_used_for_any_family() {
+        // An FQDN advertised host resolves to both A and AAAA, so it's accepted
+        // regardless of the UE's family.
+        let registry = dualstack_registry();
+        let mut advertised = std::collections::HashMap::new();
+        advertised.insert(Transport::Udp, "pcscf.ims.example".to_string());
+        let default_ip: IpAddr = "192.0.2.10".parse().unwrap();
+        let v6: SocketAddr = "[2001:db8::10]:5060".parse().unwrap();
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, default_ip, Some(v6), &Transport::Udp),
+            "pcscf.ims.example"
+        );
+    }
+
+    #[test]
+    fn resolve_advertised_host_none_is_legacy_behavior() {
+        // No arrival socket (outbound leg): first per-transport advertised host,
+        // else the resolved default local IP — the pre-dual-stack via_host.
+        let registry = dualstack_registry();
+        let default_ip: IpAddr = "192.0.2.10".parse().unwrap();
+        let mut advertised = std::collections::HashMap::new();
+        advertised.insert(Transport::Udp, "203.0.113.5".to_string());
+        assert_eq!(
+            resolve_advertised_host(&registry, &advertised, default_ip, None, &Transport::Udp),
+            "203.0.113.5"
+        );
+        let empty = std::collections::HashMap::new();
+        assert_eq!(
+            resolve_advertised_host(&registry, &empty, default_ip, None, &Transport::Udp),
+            "192.0.2.10"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -20068,6 +20363,48 @@ a=rtpmap:8 PCMA/8000\r\n";
     }
 
     #[test]
+    fn sanitize_sdp_identity_rewrites_o_line_ipv6_address_and_addrtype() {
+        // A v6 substitute host (bracketed, as via_host() produces) must land on
+        // the o= line unbracketed with the addrtype flipped IP4 -> IP6.
+        let sdp = "v=0\r\no=FreeSWITCH 123 456 IN IP4 10.0.0.1\r\ns=FreeSWITCH\r\nt=0 0\r\nm=audio 8000 RTP/AVP 0\r\n";
+        let mut body = sdp.as_bytes().to_vec();
+        sanitize_sdp_identity(&mut body, "SIPhon", Some("[2001:db8::1]"));
+        let result = std::str::from_utf8(&body).unwrap();
+        assert!(
+            result.contains("o=SIPhon 123 456 IN IP6 2001:db8::1\r\n"),
+            "o= line should carry IN IP6 + an unbracketed v6 address, got: {result}"
+        );
+        assert!(!result.contains("IN IP4 2001"), "addrtype must not stay IP4: {result}");
+        assert!(!result.contains('['), "SDP address must not be bracketed: {result}");
+    }
+
+    #[test]
+    fn sanitize_sdp_identity_masks_address_on_malformed_o_line() {
+        // A non-canonical o= line (doubled space → 7 tokens) must STILL have its
+        // trailing address substituted — a missing rewrite would leak the peer's
+        // real address (topology-hiding regression).
+        let sdp = "v=0\r\no=carol 1 2 IN IP4  198.51.100.9\r\ns=-\r\nt=0 0\r\n";
+        let mut body = sdp.as_bytes().to_vec();
+        sanitize_sdp_identity(&mut body, "SIPhon", Some("203.0.113.7"));
+        let result = std::str::from_utf8(&body).unwrap();
+        assert!(!result.contains("198.51.100.9"), "peer address must be masked: {result}");
+        assert!(result.contains("203.0.113.7"), "substitute address must be present: {result}");
+        assert!(!result.contains("carol"), "username must be replaced: {result}");
+    }
+
+    #[test]
+    fn sdp_origin_address_classifies_and_strips() {
+        assert_eq!(sdp_origin_address("10.0.0.1"), ("10.0.0.1".to_string(), Some("IP4")));
+        assert_eq!(sdp_origin_address("[2001:db8::1]"), ("2001:db8::1".to_string(), Some("IP6")));
+        assert_eq!(sdp_origin_address("2001:db8::1"), ("2001:db8::1".to_string(), Some("IP6")));
+        // FQDN — emitted verbatim, addrtype left to the caller.
+        assert_eq!(sdp_origin_address("pcscf.example"), ("pcscf.example".to_string(), None));
+        // Bracketed but unparseable (zoned link-local): brackets stripped, never
+        // leaked into SDP.
+        assert_eq!(sdp_origin_address("[fe80::1%eth0]"), ("fe80::1%eth0".to_string(), None));
+    }
+
+    #[test]
     fn sanitize_sdp_identity_no_op_on_empty_body() {
         let mut body = Vec::new();
         sanitize_sdp_identity(&mut body, "SIPhon", None);
@@ -20141,6 +20478,21 @@ a=rtpmap:8 PCMA/8000\r\n";
             "got: {result}",
         );
         assert!(!result.contains("198.51.100.9"));
+    }
+
+    #[test]
+    fn stamp_sdp_origin_rewrites_ipv6_address_and_addrtype() {
+        // v6 substitute (bracketed via_host()) -> unbracketed address + IP6.
+        let sdp = "v=0\r\no=carol 5 6 IN IP4 198.51.100.9\r\ns=-\r\nt=0 0\r\n";
+        let mut body = sdp.as_bytes().to_vec();
+        stamp_sdp_origin(&mut body, "SIPhon", 42, 1, Some("[2001:db8::7]"));
+        let result = std::str::from_utf8(&body).unwrap();
+        assert!(
+            result.contains("o=SIPhon 42 1 IN IP6 2001:db8::7\r\n"),
+            "got: {result}",
+        );
+        assert!(!result.contains("IN IP4 2001"), "addrtype must flip to IP6: {result}");
+        assert!(!result.contains('['), "SDP address must be unbracketed: {result}");
     }
 
     /// The whole point of siphon-owned o=: a re-emit toward the same peer keeps

--- a/src/script/api/ipsec.rs
+++ b/src/script/api/ipsec.rs
@@ -1044,9 +1044,13 @@ struct StashEntry {
 pub struct PyIpsec {
     manager: Arc<IpsecManager>,
     config: Arc<IpsecConfig>,
-    /// Local P-CSCF address.  Captured at startup from the listener
-    /// configuration.
-    pcscf_addr: IpAddr,
+    /// Local P-CSCF address per family, captured at startup from the listener
+    /// configuration.  The SA's P-CSCF side MUST match the UE's address family
+    /// — the kernel rejects a mixed-family XFRM selector (3GPP TS 33.203 §7.2),
+    /// so a dual-stack P-CSCF keeps a v4 and a v6 local address and picks the
+    /// one matching the UE that is registering.
+    pcscf_addr_v4: Option<IpAddr>,
+    pcscf_addr_v6: Option<IpAddr>,
     /// Stash for PendingSAs awaiting the auth REGISTER round-trip.
     stash: Arc<DashMap<String, StashEntry>>,
     /// TTL for stashed entries.
@@ -1054,7 +1058,12 @@ pub struct PyIpsec {
 }
 
 impl PyIpsec {
-    pub fn new(manager: Arc<IpsecManager>, config: Arc<IpsecConfig>, pcscf_addr: IpAddr) -> Self {
+    pub fn new(
+        manager: Arc<IpsecManager>,
+        config: Arc<IpsecConfig>,
+        pcscf_addr_v4: Option<IpAddr>,
+        pcscf_addr_v6: Option<IpAddr>,
+    ) -> Self {
         // Wire up the direct Rust-side accessors so `PyRequest`'s
         // `is_ipsec_protected` and `matched_sa` getters can resolve
         // without going through the Python type system.  Idempotent —
@@ -1064,9 +1073,22 @@ impl PyIpsec {
         Self {
             manager,
             config,
-            pcscf_addr,
+            pcscf_addr_v4,
+            pcscf_addr_v6,
             stash: Arc::new(DashMap::new()),
             stash_ttl: DEFAULT_STASH_TTL,
+        }
+    }
+
+    /// The P-CSCF local address matching the UE's address family, or `None`
+    /// when no listener of that family is configured.  The SA's P-CSCF side
+    /// must be the same family as the UE — a mixed-family selector never
+    /// matches in the kernel (3GPP TS 33.203 §7.2).
+    fn pcscf_addr_for(&self, ue_ipv6: bool) -> Option<IpAddr> {
+        if ue_ipv6 {
+            self.pcscf_addr_v6
+        } else {
+            self.pcscf_addr_v4
         }
     }
 }
@@ -1160,7 +1182,18 @@ impl PyIpsec {
             ))
         })?;
         let manager = Arc::clone(&self.manager);
-        let pcscf_addr = self.pcscf_addr;
+        // Pick the P-CSCF local address matching the UE's family.  The four SAs
+        // and policies are keyed on (source, destination) of the same family;
+        // a v4 P-CSCF address against a v6 UE (or vice-versa) programs a
+        // mixed-family selector the kernel silently never matches — so fail
+        // loudly rather than install a dead SA (3GPP TS 33.203 §7.2).
+        let pcscf_addr = self.pcscf_addr_for(ue_addr.is_ipv6()).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "no {family} P-CSCF listener configured for {family} UE {ue_addr}; \
+                 cannot build a same-family IPsec SA selector (3GPP TS 33.203 §7.2)",
+                family = if ue_addr.is_ipv6() { "IPv6" } else { "IPv4" },
+            ))
+        })?;
         let pcscf_port_c = self.config.pcscf_port_c;
         let pcscf_port_s = self.config.pcscf_port_s;
 
@@ -1263,9 +1296,11 @@ impl PyIpsec {
     }
 
     fn __repr__(&self) -> String {
+        let fmt = |addr: Option<IpAddr>| addr.map(|a| a.to_string()).unwrap_or_else(|| "-".to_string());
         format!(
-            "Ipsec(pcscf_addr={}, pcscf_port_c={}, pcscf_port_s={}, active={}, stashed={})",
-            self.pcscf_addr,
+            "Ipsec(pcscf_addr_v4={}, pcscf_addr_v6={}, pcscf_port_c={}, pcscf_port_s={}, active={}, stashed={})",
+            fmt(self.pcscf_addr_v4),
+            fmt(self.pcscf_addr_v6),
             self.config.pcscf_port_c,
             self.config.pcscf_port_s,
             self.manager.active_count(),
@@ -1488,6 +1523,36 @@ mod tests {
     fn parse_hex_param_rejects_wrong_length() {
         assert!(parse_hex_param("abc").is_none());
         assert!(parse_hex_param("\"00\"").is_none());
+    }
+
+    #[test]
+    fn pcscf_addr_for_selects_by_ue_family() {
+        let manager = Arc::new(IpsecManager::with_partition(
+            crate::ipsec::XfrmBackend::Netlink,
+            10000,
+            8192,
+        ));
+        let config = Arc::new(IpsecConfig {
+            pcscf_port_c: 5064,
+            pcscf_port_s: 5066,
+            backend: crate::config::IpsecBackend::Netlink,
+            spi_range_start: None,
+            spi_range_count: 8192,
+            path_host: None,
+        });
+        let v4: IpAddr = "192.0.2.10".parse().unwrap();
+        let v6: IpAddr = "2001:db8::10".parse().unwrap();
+
+        // Dual-stack: each UE family selects its own P-CSCF local address.
+        let dual = PyIpsec::new(Arc::clone(&manager), Arc::clone(&config), Some(v4), Some(v6));
+        assert_eq!(dual.pcscf_addr_for(false), Some(v4));
+        assert_eq!(dual.pcscf_addr_for(true), Some(v6));
+
+        // v4-only P-CSCF: a v6 UE has no same-family local address, so allocate
+        // must fail loudly rather than program a mixed-family selector.
+        let v4_only = PyIpsec::new(Arc::clone(&manager), Arc::clone(&config), Some(v4), None);
+        assert_eq!(v4_only.pcscf_addr_for(false), Some(v4));
+        assert_eq!(v4_only.pcscf_addr_for(true), None);
     }
 
     #[test]

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -2589,6 +2589,16 @@ mod tests {
         assert_eq!(request.via_target_override(), Some("10.0.0.2:5060"));
     }
 
+    #[test]
+    fn force_send_via_preserves_bracketed_ipv6_target() {
+        // A bare bracketed v6 literal (no port) must round-trip verbatim so the
+        // dispatcher's bracket-aware split renders a valid sent-by rather than
+        // the truncated "[2001:db8:" a naive rsplit_once(':') would produce.
+        let mut request = make_request();
+        request.force_send_via("udp", "[2001:db8::1]");
+        assert_eq!(request.via_target_override(), Some("[2001:db8::1]"));
+    }
+
     // --- Utility tests ---
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -753,16 +753,31 @@ impl SiphonServer {
                 "IPsec SA manager initialized (script-driven via siphon.ipsec)"
             );
 
-            // Derive pcscf_addr from the first UDP listen entry without
-            // binding the listener.  Used at SA creation time as the
-            // P-CSCF side of the kernel's xfrm selectors.
-            let pcscf_addr = config
-                .listen
-                .udp
-                .first()
-                .and_then(|entry| entry.address().parse::<std::net::SocketAddr>().ok())
-                .map(|addr| addr.ip())
-                .unwrap_or_else(|| std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+            // Derive the P-CSCF local address per family from the first UDP
+            // listen entry of each family, without binding the listener.  Used
+            // at SA creation time as the P-CSCF side of the kernel's xfrm
+            // selectors — which must match the UE's family (3GPP TS 33.203
+            // §7.2), so a dual-stack P-CSCF needs both.
+            let mut pcscf_addr_v4: Option<std::net::IpAddr> = None;
+            let mut pcscf_addr_v6: Option<std::net::IpAddr> = None;
+            // Prefer a concrete bind address over a wildcard (0.0.0.0 / [::]):
+            // an unspecified address yields a dead XFRM selector, so take the
+            // first concrete listener of each family when one exists, only
+            // falling back to a wildcard entry if that's all that's configured
+            // (preserves the historical single-wildcard-listener behaviour).
+            for entry in &config.listen.udp {
+                if let Ok(addr) = entry.address().parse::<std::net::SocketAddr>() {
+                    let ip = addr.ip();
+                    let slot = if ip.is_ipv6() { &mut pcscf_addr_v6 } else { &mut pcscf_addr_v4 };
+                    match slot {
+                        None => *slot = Some(ip),
+                        Some(existing) if existing.is_unspecified() && !ip.is_unspecified() => {
+                            *slot = Some(ip);
+                        }
+                        _ => {}
+                    }
+                }
+            }
 
             let ipsec_manager_for_singleton = Arc::clone(&manager);
             let ipsec_config_arc = Arc::new(ipsec_config.clone());
@@ -770,14 +785,19 @@ impl SiphonServer {
                 let py_ipsec = crate::script::api::ipsec::PyIpsec::new(
                     ipsec_manager_for_singleton,
                     ipsec_config_arc,
-                    pcscf_addr,
+                    pcscf_addr_v4,
+                    pcscf_addr_v6,
                 );
                 if let Err(error) =
                     crate::script::api::set_ipsec_singleton(python, py_ipsec)
                 {
                     error!("failed to store IPsec singleton: {error}");
                 } else {
-                    info!(pcscf_addr = %pcscf_addr, "ipsec namespace registered for injection");
+                    info!(
+                        pcscf_addr_v4 = ?pcscf_addr_v4,
+                        pcscf_addr_v6 = ?pcscf_addr_v6,
+                        "ipsec namespace registered for injection"
+                    );
                 }
             });
 

--- a/src/sip/uri.rs
+++ b/src/sip/uri.rs
@@ -17,6 +17,44 @@ pub fn strip_ipv6_brackets(host: &str) -> &str {
         .unwrap_or(host)
 }
 
+/// Split a SIP `host[:port]` authority into its host and optional port,
+/// IPv6-bracket aware.  The returned host keeps its brackets for a v6 literal.
+///
+/// Handles `[2001:db8::1]:5060`, `[2001:db8::1]`, `host:5060`, `host`, and a
+/// bare (unbracketed) IPv6 literal such as `2001:db8::1` — the last is returned
+/// whole with no port, because a trailing `:port` cannot be disambiguated from
+/// the address without brackets (RFC 3261 §19.1.2 / §25.1).
+///
+/// Lenient by contract: a malformed port yields `None` rather than an error.
+/// This is the best-effort splitter for send-side overrides (e.g.
+/// `force_send_via`); the strict, error-returning parse lives in
+/// [`crate::sip::headers::via::Via::parse`].
+pub fn split_host_port(authority: &str) -> (&str, Option<u16>) {
+    let authority = authority.trim();
+    if authority.starts_with('[') {
+        // Bracketed IPv6 literal, with an optional `:port` after the `]`.
+        if let Some(bracket_end) = authority.find(']') {
+            let host = &authority[..=bracket_end];
+            let port = authority[bracket_end + 1..]
+                .strip_prefix(':')
+                .and_then(|port_str| port_str.parse::<u16>().ok());
+            return (host, port);
+        }
+        // Unterminated bracket — hand it back untouched rather than mangle it.
+        return (authority, None);
+    }
+    match authority.rsplit_once(':') {
+        // A colon still in the host portion means this is a bare, unbracketed
+        // IPv6 literal (not host:port) — keep it whole.
+        Some((host, _)) if host.contains(':') => (authority, None),
+        Some((host, port_str)) => match port_str.parse::<u16>() {
+            Ok(port) => (host, Some(port)),
+            Err(_) => (authority, None),
+        },
+        None => (authority, None),
+    }
+}
+
 /// SIP URI as defined in RFC 3261
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SipUri {
@@ -167,6 +205,45 @@ mod tests {
     fn strip_ipv6_brackets_partial() {
         assert_eq!(strip_ipv6_brackets("[::1"), "[::1");
         assert_eq!(strip_ipv6_brackets("::1]"), "::1]");
+    }
+
+    #[test]
+    fn split_host_port_ipv4() {
+        assert_eq!(split_host_port("10.0.0.1:5060"), ("10.0.0.1", Some(5060)));
+        assert_eq!(split_host_port("10.0.0.1"), ("10.0.0.1", None));
+    }
+
+    #[test]
+    fn split_host_port_hostname() {
+        assert_eq!(split_host_port("proxy.example.com:5061"), ("proxy.example.com", Some(5061)));
+        assert_eq!(split_host_port("proxy.example.com"), ("proxy.example.com", None));
+    }
+
+    #[test]
+    fn split_host_port_ipv6_bracketed_with_port() {
+        assert_eq!(
+            split_host_port("[2001:db8::1]:5060"),
+            ("[2001:db8::1]", Some(5060))
+        );
+    }
+
+    #[test]
+    fn split_host_port_ipv6_bracketed_no_port() {
+        // Regression: the old rsplit_once(':') truncated this to "[2001:db8:".
+        assert_eq!(split_host_port("[2001:db8::1]"), ("[2001:db8::1]", None));
+        assert_eq!(split_host_port("[::1]"), ("[::1]", None));
+    }
+
+    #[test]
+    fn split_host_port_ipv6_bare_unbracketed() {
+        // No brackets → can't disambiguate a port; whole thing is the host.
+        assert_eq!(split_host_port("2001:db8::1"), ("2001:db8::1", None));
+        assert_eq!(split_host_port("::1"), ("::1", None));
+    }
+
+    #[test]
+    fn split_host_port_bad_port_is_all_host() {
+        assert_eq!(split_host_port("host:notaport"), ("host:notaport", None));
     }
 
     #[test]

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -67,19 +67,59 @@ pub fn detect_routable_local_ip(ipv6: bool) -> Option<IpAddr> {
 /// zombie connections from accumulating (especially behind NAT).
 pub const CONNECTION_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Apply IP_TOS / IPV6_TCLASS on a socket2 reference.
+/// Apply the DSCP mark to a socket, selecting the knob by address family.
 ///
 /// `tos` is the full 8-bit TOS byte (DSCP << 2).  Use [`crate::config::dscp_to_tos`]
 /// to convert from a 6-bit DSCP value.
 ///
-/// socket2 0.6 only exposes `set_tos_v4` (IP_TOS).  For IPv6 sockets we
-/// fall back to a raw `setsockopt(IPV6_TCLASS)` via `set_tos_v4` which on
-/// Linux works on dual-stack sockets.  If the v4 call fails we log and
-/// continue — TOS is best-effort (the kernel may ignore it without
-/// `CAP_NET_ADMIN` depending on DSCP value).
+/// v4 socket → `IP_TOS` (IPPROTO_IP).  v6 socket → `IPV6_TCLASS` (IPPROTO_IPV6)
+/// for native IPv6 packets **and** `IP_TOS` too: a dual-stack `[::]` socket also
+/// emits v4-mapped IPv4 packets whose DSCP rides `IP_TOS`, so setting only
+/// `IPV6_TCLASS` would leave those unmarked.  `IP_TOS` alone (the pre-dual-stack
+/// behaviour) is silently ineffective for native IPv6, which is the gap this
+/// closes.  socket2 0.6 gates `set_tclass_v6` behind its `all` feature (not
+/// enabled), so the v6 path goes straight to `libc::setsockopt` — the same
+/// raw-setsockopt pattern used in [`crate::firewall`].
+///
+/// Best-effort: a marking failure logs and is ignored, never taking the
+/// listener/connection down (DSCP is advisory; the kernel may reject some values
+/// without `CAP_NET_ADMIN`).
 pub fn apply_tos(sock_ref: &SockRef<'_>, tos: u32) {
-    if let Err(error) = sock_ref.set_tos_v4(tos) {
-        warn!(tos, "failed to set IP_TOS/IPV6_TCLASS: {error}");
+    let is_ipv6 = sock_ref
+        .local_addr()
+        .map(|addr| addr.is_ipv6())
+        .unwrap_or(false);
+    if is_ipv6 {
+        set_tclass_v6(sock_ref, tos);
+        // Also mark v4-mapped egress on a dual-stack socket.  Best-effort: on a
+        // pure-v6 socket this may be a no-op / ENOPROTOOPT, which is harmless.
+        let _ = sock_ref.set_tos_v4(tos);
+    } else if let Err(error) = sock_ref.set_tos_v4(tos) {
+        warn!(tos, "failed to set IP_TOS (DSCP): {error}");
+    }
+}
+
+/// Set `IPV6_TCLASS` on a v6 socket via a raw `setsockopt`.  Best-effort.
+fn set_tclass_v6(sock_ref: &SockRef<'_>, tos: u32) {
+    use std::os::fd::AsRawFd;
+    let tclass = tos as libc::c_int;
+    // SAFETY: `sock_ref` owns a valid open socket fd for the duration of the
+    // call, and we pass a correctly-sized `c_int` option value + length.
+    let ret = unsafe {
+        libc::setsockopt(
+            sock_ref.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_TCLASS,
+            &tclass as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        warn!(
+            tos,
+            "failed to set IPV6_TCLASS (DSCP): {}",
+            std::io::Error::last_os_error()
+        );
     }
 }
 
@@ -269,6 +309,38 @@ impl ListenerRegistry {
         self.entries
             .get(&(transport, addr))
             .map(|advertise| SendSocket { transport, addr, advertise: advertise.clone() })
+    }
+
+    /// Resolve the listener of `transport` matching the given address family
+    /// (`ipv6 == true` selects an IPv6 listener), for family-aware local
+    /// identity on a dual-stack host.  When several listeners of that
+    /// transport+family exist (e.g. a P-CSCF's 5060/5064/5066), the lowest
+    /// bound address wins deterministically — the backing HashMap's iteration
+    /// order is otherwise unstable.  Returns `None` when no listener of that
+    /// family is configured for the transport.
+    pub fn resolve_family(&self, transport: Transport, ipv6: bool) -> Option<SendSocket> {
+        self.entries
+            .iter()
+            .filter(|((t, addr), _)| *t == transport && addr.is_ipv6() == ipv6)
+            .min_by_key(|((_, addr), _)| *addr)
+            .map(|((transport, addr), advertise)| SendSocket {
+                transport: *transport,
+                addr: *addr,
+                advertise: advertise.clone(),
+            })
+    }
+
+    /// Whether `destination` points back at one of our own listeners, for loop
+    /// detection across every listener on a multi-homed / dual-stack host (not
+    /// just the first-per-transport `listen_addrs` view).  A destination on a
+    /// listener's port matches when its IP equals that listener's IP or is a
+    /// loopback address (a peer may address us by loopback).
+    pub fn matches_local(&self, destination: &SocketAddr) -> bool {
+        let ip = destination.ip();
+        let port = destination.port();
+        self.entries
+            .keys()
+            .any(|(_, addr)| port == addr.port() && (ip == addr.ip() || ip.is_loopback()))
     }
 
     /// Number of registered listeners (diagnostics / tests).
@@ -540,6 +612,35 @@ mod tests {
         apply_tos(&sock_ref, 184); // EF
         let tos = sock_ref.tos_v4().unwrap();
         assert_eq!(tos, 184, "TOS should be 184 (EF = DSCP 46 << 2)");
+    }
+
+    #[test]
+    fn apply_tos_sets_tclass_on_ipv6_socket() {
+        // A v6 socket must get IPV6_TCLASS (IP_TOS is a no-op for native v6),
+        // otherwise its egress carries no DSCP mark.
+        use std::os::fd::AsRawFd;
+        let socket = socket2::Socket::new(
+            socket2::Domain::IPV6,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )
+        .unwrap();
+        let sock_ref = SockRef::from(&socket);
+        apply_tos(&sock_ref, 96); // CS3
+        let mut tclass: libc::c_int = -1;
+        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+        // SAFETY: valid open v6 socket fd; correctly-sized c_int out-param.
+        let ret = unsafe {
+            libc::getsockopt(
+                sock_ref.as_raw_fd(),
+                libc::IPPROTO_IPV6,
+                libc::IPV6_TCLASS,
+                &mut tclass as *mut libc::c_int as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        assert_eq!(ret, 0, "getsockopt(IPV6_TCLASS) should succeed");
+        assert_eq!(tclass, 96, "IPV6_TCLASS should be 96 (CS3)");
     }
 
     #[tokio::test]
@@ -887,5 +988,39 @@ mod tests {
 
         // An address siphon isn't listening on does not resolve.
         assert!(registry.resolve(Transport::Udp, addr("172.16.0.1:5060")).is_none());
+    }
+
+    #[test]
+    fn listener_registry_resolve_family_picks_matching_family() {
+        let registry = ListenerRegistry::from_entries([
+            (Transport::Udp, addr("192.0.2.10:5066"), Some("v4.example".to_string())),
+            (Transport::Udp, addr("192.0.2.10:5060"), None),
+            (Transport::Udp, addr("[2001:db8::10]:5060"), Some("v6.example".to_string())),
+        ]);
+        // v6 selector → the v6 listener, carrying its advertise.
+        let v6 = registry.resolve_family(Transport::Udp, true).unwrap();
+        assert!(v6.addr.is_ipv6());
+        assert_eq!(v6.advertise.as_deref(), Some("v6.example"));
+        // v4 selector → deterministically the lowest v4 addr (:5060 < :5066).
+        let v4 = registry.resolve_family(Transport::Udp, false).unwrap();
+        assert_eq!(v4.addr, addr("192.0.2.10:5060"));
+        // No listener of that transport+family.
+        assert!(registry.resolve_family(Transport::Tcp, true).is_none());
+    }
+
+    #[test]
+    fn listener_registry_matches_local_covers_all_families_and_loopback() {
+        let registry = ListenerRegistry::from_entries([
+            (Transport::Udp, addr("192.0.2.10:5060"), None),
+            (Transport::Udp, addr("[2001:db8::10]:5060"), None),
+        ]);
+        // Both families' listeners match (dual-stack loop detection).
+        assert!(registry.matches_local(&addr("192.0.2.10:5060")));
+        assert!(registry.matches_local(&addr("[2001:db8::10]:5060")));
+        // Loopback on a listener port is treated as our own.
+        assert!(registry.matches_local(&addr("127.0.0.1:5060")));
+        // A different port is not ours; a foreign IP on a listener port isn't either.
+        assert!(!registry.matches_local(&addr("192.0.2.10:5999")));
+        assert!(!registry.matches_local(&addr("198.51.100.1:5060")));
     }
 }

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -446,8 +446,9 @@ impl ConnectionPool {
         socket.set_reuseaddr(true)?;
         socket.set_reuseport(true)?;
         if let Some(tos) = self.tos {
-            let sock_ref = socket2::SockRef::from(&socket);
-            sock_ref.set_tos_v4(tos)?;
+            // Family-aware, best-effort — a DSCP marking failure must not fail
+            // the outbound connection.
+            super::apply_tos(&socket2::SockRef::from(&socket), tos);
         }
         socket.bind(bind_addr).map_err(|e| {
             warn!(
@@ -707,7 +708,8 @@ impl ConnectionPool {
                     socket.set_reuseaddr(true)?;
                     socket.set_reuseport(true)?;
                     if let Some(tos) = self.tos {
-                        socket2::SockRef::from(&socket).set_tos_v4(tos)?;
+                        // Family-aware, best-effort (see connect_tcp).
+                        super::apply_tos(&socket2::SockRef::from(&socket), tos);
                     }
                     socket.bind(source).map_err(|error| {
                         warn!(bind_addr = %source, destination = %destination, "pool: TLS bind to requested source failed: {error}");

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -118,12 +118,10 @@ pub async fn listen(
         if let Err(error) = socket.set_reuseport(true) {
             error!("failed to set SO_REUSEPORT: {error}"); return;
         }
-        // DSCP / DiffServ marking (RFC 4594).
+        // DSCP / DiffServ marking (RFC 4594) — family-aware (IP_TOS on v4,
+        // IPV6_TCLASS on v6), best-effort so it never fails the listener.
         if let Some(tos) = tos {
-            let sock_ref = socket2::SockRef::from(&socket);
-            if let Err(error) = sock_ref.set_tos_v4(tos) {
-                error!("failed to set IP_TOS on TCP listener: {error}"); return;
-            }
+            super::apply_tos(&socket2::SockRef::from(&socket), tos);
         }
         if let Err(error) = socket.bind(local_addr) {
             error!("failed to bind TCP listener to {local_addr}: {error}"); return;

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -349,11 +349,9 @@ pub async fn listen(
         if let Err(error) = socket.set_reuseport(true) {
             error!("failed to set SO_REUSEPORT on TLS socket: {error}"); return;
         }
+        // DSCP / DiffServ marking (RFC 4594) — family-aware, best-effort.
         if let Some(tos) = tos {
-            let sock_ref = socket2::SockRef::from(&socket);
-            if let Err(error) = sock_ref.set_tos_v4(tos) {
-                error!("failed to set IP_TOS on TLS socket: {error}"); return;
-            }
+            super::apply_tos(&socket2::SockRef::from(&socket), tos);
         }
         if let Err(error) = socket.bind(local_addr) {
             error!("failed to bind TLS listener on {local_addr}: {error}"); return;

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -134,9 +134,10 @@ fn create_reusable_udp_socket(local_addr: SocketAddr, tos: Option<u32>) -> std::
     socket.set_reuse_port(true)?;
     socket.set_nonblocking(true)?;
 
-    // DSCP / DiffServ marking (RFC 4594).
+    // DSCP / DiffServ marking (RFC 4594) — family-aware, best-effort (a marking
+    // failure must not stop the listener coming up).
     if let Some(tos) = tos {
-        socket.set_tos_v4(tos)?;
+        super::apply_tos(&socket2::SockRef::from(&socket), tos);
     }
 
     socket.bind(&SockAddr::from(local_addr))?;

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -208,7 +208,7 @@ fn spawn_outbound_dispatcher(
 fn bind_tcp_listener(
     local_addr: SocketAddr,
     tos: Option<u32>,
-    label: &str,
+    _label: &str,
 ) -> std::io::Result<tokio::net::TcpListener> {
     let socket = if local_addr.is_ipv6() {
         tokio::net::TcpSocket::new_v6()?
@@ -218,11 +218,9 @@ fn bind_tcp_listener(
     socket.set_reuseaddr(true)?;
     #[cfg(unix)]
     socket.set_reuseport(true)?;
+    // DSCP / DiffServ marking (RFC 4594) — family-aware, best-effort.
     if let Some(tos) = tos {
-        let sock_ref = socket2::SockRef::from(&socket);
-        if let Err(error) = sock_ref.set_tos_v4(tos) {
-            tracing::error!("failed to set IP_TOS on {label} socket: {error}");
-        }
+        super::apply_tos(&socket2::SockRef::from(&socket), tos);
     }
     socket.bind(local_addr)?;
     socket.listen(1024)


### PR DESCRIPTION
## What

A P-CSCF that binds both an IPv4 and an IPv6 Gm listener set now stamps the **family-matching** local identity on each UE's signalling, instead of collapsing "my address" to the first configured listener (which handed the wrong family to the other family's UEs). Per GSMA IR.92 a UE registers over one family at a time, so this is dual-stack per process, not per UE.

## Changes

- **Per-family UE-facing host** — new `resolve_advertised_host` free fn + `DispatcherState::a_leg_advertised_host`, a host-side analogue of the existing `a_leg_advertised_port`. Routed into every A-leg-facing Via / Contact / Record-Route / SDP `o=` site that already threads the arrival socket for the port (OPTIONS 2xx, B2BUA A-leg responses, in-dialog requests, re-INVITE/UPDATE, REFER, zombie re-ACK). `is_own_address` loop detection now checks every configured listener across both families via the `ListenerRegistry`.
- **Per-family IPsec P-CSCF address** — `PyIpsec` holds a v4 and a v6 local address; `ipsec.allocate` selects by the UE's family and raises loudly when the UE's family has no listener, rather than installing a dead mixed-family XFRM selector (TS 33.203 §7.2). The script-facing `allocate` signature is unchanged (auto-selects).
- **SDP `o=`** — the topology-hiding rewrite emits the substituted address unbracketed and flips `IN IP4`/`IN IP6` to match the address family (was: verbatim addrtype + illegal brackets for v6). Malformed / non-canonical `o=` lines still have the peer address masked (no topology-hiding regression).
- **IPv6 Via** — the flow-relay and IPsec-auto-source Via paths bracket v6 literals; the `force_send_via` target split is bracket-aware (`split_host_port`), fixing truncation of a bare `[2001:db8::1]`.
- **DSCP** — `apply_tos` is family-aware: v6 sockets get `IPV6_TCLASS` (native v6) **and** `IP_TOS` (v4-mapped on `[::]`), best-effort at every listener/pool site (was IPv4-only, so native-v6 egress went unmarked).
- Example (`examples/ims_pcscf.yaml`) gains a commented dual-stack listener block with per-listener `advertise`; the SDK mock mirrors the ipsec family check.

## Scope

UE-facing (Gm) identity only. Core-side / outbound (Mw) dual-stack — the B-leg/outbound Via and the UAC/registrant `resolve_via_host` path, the resolver's A-before-AAAA default, and the outbound pool bind family — is a tracked follow-up; the core stays IPv4 with Gm as the only dual-stack interface for now.

## Design note

Explicit per-family listeners are recommended over a single `[::]` — siphon does not normalise v4-mapped (`::ffff:`) peers, so an explicit v4 listener keeps addresses canonical in Via / `received=` / registrar keys.

## Tests

- Unit: family host-selection (`resolve_advertised_host`, 5 cases), `ListenerRegistry::resolve_family` / `matches_local`, `split_host_port` (bracketed / bare v6 / bad-port), SDP v6 addrtype + malformed-line masking + `sdp_origin_address` classification, `IPV6_TCLASS` readback, ipsec `pcscf_addr_for`.
- SDK: dual-stack allocate + single-stack family-mismatch error (3 new), `set_pcscf_families` helper.
- Full suite green (`cargo test`, clippy `-D warnings`); SDK pytest green.
- Full 16-row SIPp + mem-leak baseline deferred to pre-release.
