### PR TITLE
feat(transport): listen.mtu — RFC 3261 §18.1.1 over-MTU UDP→TCP fallback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,6 +247,46 @@ jobs:
             siphon.log
             *.log
 
+  # ── RFC 3261 §18.1.1 over-MTU UDP->TCP fallback (IPv4) ─────────────────────
+  # Deterministic signal: an over-MTU MESSAGE is relayed at a TCP-only receiver
+  # (200 only if siphon switched to TCP); a small MESSAGE at a UDP-only receiver
+  # (200 only if it stayed UDP).  Needs no special capability.  The runner builds
+  # the image, runs both cases, dumps siphon+receiver logs on failure, and tears
+  # the stack down on exit.
+  sipp-mtu:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: MTU §18.1.1 fallback tests (IPv4)
+        run: scripts/mtu_test.sh v4
+
+  # IPv6 leg — manual dispatch only.  A user-defined compose network with
+  # enable_ipv6 + a private ULA subnet keeps all traffic inside the bridge (no
+  # host IPv6 egress needed), but docker's IPv6 bridge is not reliable on
+  # GitHub-hosted runners, so this is opt-in (also runnable locally with
+  # `scripts/mtu_test.sh v6`) rather than a required check.
+  sipp-mtu-ipv6:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Enable docker IPv6 (merge into the runner's daemon.json)
+        run: |
+          sudo apt-get install -y jq
+          tmp=$(mktemp)
+          jq '. + {experimental: true, ip6tables: true}' \
+            /etc/docker/daemon.json 2>/dev/null > "$tmp" || \
+            echo '{"experimental": true, "ip6tables": true}' > "$tmp"
+          sudo mv "$tmp" /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: MTU §18.1.1 fallback tests (IPv6)
+        run: scripts/mtu_test.sh v6
+
   # ── B2BUA functional tests ─────────────────────────────────────────────
   sipp-b2bua:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`listen.mtu` — RFC 3261 §18.1.1 UDP→TCP fallback for oversized requests.**
+  When `listen.mtu` is set, an outbound SIP *request* built for UDP whose
+  serialised length exceeds `mtu − 200` bytes is relayed over TCP instead — but
+  only when the next hop has a **reachable** TCP listener (confirmed by a short
+  connect probe on the over-MTU path); otherwise it stays on UDP (delivered,
+  fragmented) with a `warn`, so an over-MTU request is never dropped against a
+  UDP-only peer. This stops an oversized IMS-core NOTIFY (large
+  `reginfo+xml` / iFC fan-out) from IP-fragmenting and being silently dropped by
+  UEs / IPX peers with strict ICMP filtering. Applies to the proxy relay, fork,
+  and B2BUA dial paths; responses follow the request's transport and the inbound
+  side is unchanged. Default is off (no behaviour change on a bump); IMS
+  deployments set `1280` (the IPv6 minimum MTU). Family-agnostic — works for v4
+  and v6 next hops. Kamailio analog: `udp_mtu` + `udp_mtu_try_proto=TCP`.
 - **Docker Compose quickstart + Getting started guide.** A root
   `docker-compose.yaml` runs the published image with your `siphon.yaml` and
   `scripts/` bind-mounted (host networking, hot-reload, a SIP `OPTIONS`

--- a/examples/ims_scscf.yaml
+++ b/examples/ims_scscf.yaml
@@ -19,6 +19,13 @@
 #   P-CSCF: 5060    I-CSCF: 4060    S-CSCF: 6060
 
 listen:
+  # RFC 3261 §18.1.1: relay an oversized UDP *request* (a large proxied /
+  # forwarded INVITE, SUBSCRIBE, etc.) over TCP instead of letting it
+  # IP-fragment on the IMS-core UDP legs, when the next hop has a reachable TCP
+  # listener.  Applies to the proxy relay / fork / B2BUA-dial paths — not to
+  # requests this node originates itself.  1280 = the IPv6 minimum MTU.  Wrap in
+  # an env for the cluster operator to tune: mtu: ${IMS_LISTEN_MTU:-1280}
+  mtu: 1280
   udp:
     - "0.0.0.0:6060"
   tcp:

--- a/scripts/mtu_relay.py
+++ b/scripts/mtu_relay.py
@@ -1,0 +1,34 @@
+"""Minimal relay for the RFC 3261 §18.1.1 over-MTU UDP->TCP docker test.
+
+siphon relays every MESSAGE to a fixed next hop selected by the R-URI userpart,
+so one siphon instance serves both test cases against transport-restricted
+SIPp receivers:
+
+  * MESSAGE to `tcprecv@` -> relayed to the TCP-only receiver.  It only arrives
+    if siphon (correctly) switched an over-MTU request to TCP.
+  * MESSAGE to `udprecv@` -> relayed to the UDP-only receiver.  It only arrives
+    if siphon (correctly) kept an under-MTU request on UDP.
+
+Receiver addresses come from the environment so the same script serves the
+IPv4 and IPv6 compose stacks.  OPTIONS is answered locally for the healthcheck.
+"""
+import os
+
+from siphon import proxy
+
+TCP_RECV = os.environ["MTU_RECV_TCP"]  # e.g. "sip:172.30.0.20:5060"
+UDP_RECV = os.environ["MTU_RECV_UDP"]  # e.g. "sip:172.30.0.21:5060"
+
+
+@proxy.on_request("MESSAGE")
+def on_message(request):
+    if (request.ruri.user or "") == "tcprecv":
+        request.relay(TCP_RECV)
+    else:
+        request.relay(UDP_RECV)
+
+
+@proxy.on_request("OPTIONS")
+def on_options(request):
+    # Container healthcheck probe.
+    request.reply(200, "OK")

--- a/scripts/mtu_test.sh
+++ b/scripts/mtu_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# mtu_test.sh — RFC 3261 §18.1.1 over-MTU UDP->TCP fallback docker tests.
+#
+# Proves, over BOTH address families, that siphon relays an over-MTU UDP
+# request over TCP and keeps an under-MTU request on UDP.  The signal is
+# deterministic: the over-MTU MESSAGE is relayed at a TCP-ONLY SIPp receiver
+# (a 200 only comes back if siphon switched to TCP) and the small MESSAGE at a
+# UDP-ONLY receiver (a 200 only comes back if siphon kept UDP).
+#
+# Usage:
+#   scripts/mtu_test.sh          # both families
+#   scripts/mtu_test.sh v4       # IPv4 only
+#   scripts/mtu_test.sh v6       # IPv6 only
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+COMPOSE=(docker compose -f sipp/docker-compose.mtu.yaml)
+
+FAMILIES="${1:-v4 v6}"
+
+cleanup() { "${COMPOSE[@]}" down --remove-orphans -t 3 >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# One case: bring up siphon (healthcheck-gated) + the target receiver, give the
+# receiver's SIPp a moment to bind (siphon's TCP reachability probe must find it
+# listening), then run the one-shot UAC.  The UAC exit code is the result — a
+# clean single MESSAGE transaction exits 0; anything else fails the case (we do
+# NOT tolerate 255 here, so a scenario-parse error can't pass as green).
+run_case() {
+  local name="$1" siphon="$2" recv="$3" uac="$4"
+  echo "=== ${name} ==="
+  "${COMPOSE[@]}" up -d --wait "${siphon}"
+  "${COMPOSE[@]}" up -d "${recv}"
+  sleep 3
+  local rc=0
+  "${COMPOSE[@]}" run --rm "${uac}" || rc=$?
+  if [[ ${rc} -ne 0 ]]; then
+    echo "FAILED (${name}): exit ${rc}"
+    "${COMPOSE[@]}" logs "${siphon}" "${recv}" 2>/dev/null | tail -80 || true
+    exit "${rc}"
+  fi
+  "${COMPOSE[@]}" down --remove-orphans -t 3 >/dev/null 2>&1 || true
+  echo "PASS (${name})"
+}
+
+echo "Building siphon image (sipp-siphon)..."
+"${COMPOSE[@]}" build siphon-mtu4
+
+for fam in ${FAMILIES}; do
+  case "${fam}" in
+    v4)
+      run_case "IPv4 over-MTU -> TCP"  siphon-mtu4 recv-tcp4 uac-oversized4
+      run_case "IPv4 under-MTU -> UDP" siphon-mtu4 recv-udp4 uac-small4
+      ;;
+    v6)
+      run_case "IPv6 over-MTU -> TCP"  siphon-mtu6 recv-tcp6 uac-oversized6
+      run_case "IPv6 under-MTU -> UDP" siphon-mtu6 recv-udp6 uac-small6
+      ;;
+    *) echo "unknown family: ${fam} (use v4 and/or v6)"; exit 2 ;;
+  esac
+done
+
+echo "All RFC 3261 §18.1.1 MTU tests passed for: ${FAMILIES}"

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -26,6 +26,15 @@ listen:
   # Set to 0 or "BE" (Best Effort) to disable marking.
   # Per-listener overrides are possible in the extended form (see below).
   dscp: CS3
+  # Path MTU (bytes) for the outbound UDP request path (RFC 3261 §18.1.1).
+  # When set, an outbound SIP request built for UDP whose serialised length
+  # exceeds mtu-200 is relayed over TCP instead (if the next hop has a reachable
+  # TCP path), else it stays on UDP with a warning.  This prevents oversized
+  # requests (e.g. a large reg-event NOTIFY) from IP-fragmenting and being
+  # silently dropped by peers with strict ICMP filtering.  Default: off (unset),
+  # so UDP-at-any-size behaviour is unchanged.  1280 = the IPv6 minimum MTU, a
+  # safe lower bound for dual-stack IMS core legs.
+  # mtu: 1280
   udp:
     - "0.0.0.0:5060"    # Standard SIP (PSTN gateways, legacy UEs)
     # - "[::]:5060"      # Dual-stack IPv6 (accepts both IPv4 and IPv6)

--- a/sipp/configs/siphon.mtu.yaml
+++ b/sipp/configs/siphon.mtu.yaml
@@ -1,0 +1,28 @@
+# siphon.mtu.yaml — RFC 3261 §18.1.1 over-MTU UDP->TCP fallback test config.
+#
+# Used with: sipp/docker-compose.mtu.yaml (IPv4 + IPv6 stacks).
+# Script:    scripts/mtu_relay.py
+#
+# The bind address is parameterised so the same file serves the v4 stack
+# (MTU_BIND=0.0.0.0) and the v6 stack (MTU_BIND=[fd18:5109::10]).  listen.mtu
+# is small (1280, the IPv6 minimum MTU) so a padded MESSAGE crosses the
+# mtu-200 = 1080-byte threshold and is relayed over TCP.
+
+listen:
+  mtu: ${MTU_LISTEN_MTU:-1280}
+  udp:
+    - "${MTU_BIND:-0.0.0.0}:5060"
+  tcp:
+    - "${MTU_BIND:-0.0.0.0}:5060"
+
+domain:
+  local:
+    - "mtu.test"
+
+script:
+  path: "/etc/siphon/scripts/mtu_relay.py"
+  reload: auto
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/docker-compose.mtu.yaml
+++ b/sipp/docker-compose.mtu.yaml
@@ -1,0 +1,186 @@
+# docker-compose.mtu.yaml — RFC 3261 §18.1.1 over-MTU UDP->TCP fallback,
+# exercised over BOTH address families.
+#
+# Each family has its own isolated network and a five-service stack:
+#   siphon-mtu{4,6}   — proxy with listen.mtu=1280, relays MESSAGE by R-URI user
+#   recv-tcp{4,6}     — SIPp UAS, TCP-only  (-t t1): only reached if siphon
+#                       switched an over-MTU request to TCP
+#   recv-udp{4,6}     — SIPp UAS, UDP-only: only reached if siphon kept an
+#                       under-MTU request on UDP
+#   uac-oversized{4,6}— sends an oversized MESSAGE to `tcprecv@` -> expect 200
+#   uac-small{4,6}    — sends a small MESSAGE to `udprecv@` -> expect 200
+#
+# All traffic stays inside the compose network, so the v6 stack needs no host
+# IPv6 egress.  Driven by scripts/mtu_test.sh (and the CI `sipp-mtu` job).
+
+x-siphon-health: &siphon-health
+  # UDP OPTIONS probe against the container's own address; family auto-detected
+  # by the presence of a ':' in MTU_HEALTH_TARGET (the mtu_relay.py script
+  # answers OPTIONS with 200).
+  test:
+    - CMD-SHELL
+    - >-
+      python3 -c "import socket,os;h=os.environ['MTU_HEALTH_TARGET'];
+      fam=socket.AF_INET6 if ':' in h else socket.AF_INET;
+      s=socket.socket(fam,socket.SOCK_DGRAM);s.settimeout(2);
+      s.sendto(b'OPTIONS sip:mtu.test SIP/2.0\r\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\r\nFrom: <sip:hc@mtu.test>;tag=hc\r\nTo: <sip:mtu.test>\r\nCall-ID: hc@check\r\nCSeq: 1 OPTIONS\r\nMax-Forwards: 1\r\nContent-Length: 0\r\n\r\n',(h,5060));s.recv(1024);s.close()"
+  interval: 3s
+  timeout: 3s
+  retries: 20
+  start_period: 10s
+
+services:
+  # ─── IPv4 stack ────────────────────────────────────────────────────────────
+  siphon-mtu4:
+    image: sipp-siphon
+    build:
+      context: ..
+    volumes:
+      - ./configs/siphon.mtu.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+    environment:
+      MTU_BIND: "0.0.0.0"
+      MTU_HEALTH_TARGET: "172.30.0.10"
+      MTU_RECV_TCP: "sip:172.30.0.20:5060"
+      MTU_RECV_UDP: "sip:172.30.0.21:5060"
+    networks:
+      mtu4:
+        ipv4_address: 172.30.0.10
+    healthcheck: *siphon-health
+    profiles: [mtu4]
+
+  recv-tcp4:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-mtu4:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu4:
+        ipv4_address: 172.30.0.20
+    entrypoint: [sipp, -sf, /sipp/scenarios/message_uas.xml, -t, t1, -p, "5060", -i, "172.30.0.20", -timeout, "60"]
+    profiles: [mtu4]
+
+  recv-udp4:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-mtu4:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu4:
+        ipv4_address: 172.30.0.21
+    entrypoint: [sipp, -sf, /sipp/scenarios/message_uas.xml, -p, "5060", -i, "172.30.0.21", -timeout, "60"]
+    profiles: [mtu4]
+
+  uac-oversized4:
+    image: ctaloi/sipp:latest
+    depends_on:
+      recv-tcp4:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu4:
+        ipv4_address: 172.30.0.30
+    entrypoint: [sipp, "172.30.0.10:5060", -sf, /sipp/scenarios/mtu_message_oversized.xml, -s, tcprecv, -i, "172.30.0.30", -m, "1", -l, "1", -timeout, "20", -trace_err]
+    profiles: [mtu4]
+
+  uac-small4:
+    image: ctaloi/sipp:latest
+    depends_on:
+      recv-udp4:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu4:
+        ipv4_address: 172.30.0.31
+    entrypoint: [sipp, "172.30.0.10:5060", -sf, /sipp/scenarios/mtu_message_small.xml, -s, udprecv, -i, "172.30.0.31", -m, "1", -l, "1", -timeout, "20", -trace_err]
+    profiles: [mtu4]
+
+  # ─── IPv6 stack ────────────────────────────────────────────────────────────
+  siphon-mtu6:
+    image: sipp-siphon
+    build:
+      context: ..
+    volumes:
+      - ./configs/siphon.mtu.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+    environment:
+      MTU_BIND: "[fd18:5109::10]"
+      MTU_HEALTH_TARGET: "fd18:5109::10"
+      MTU_RECV_TCP: "sip:[fd18:5109::20]:5060"
+      MTU_RECV_UDP: "sip:[fd18:5109::21]:5060"
+    networks:
+      mtu6:
+        ipv6_address: fd18:5109::10
+    healthcheck: *siphon-health
+    profiles: [mtu6]
+
+  recv-tcp6:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-mtu6:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu6:
+        ipv6_address: fd18:5109::20
+    entrypoint: [sipp, -sf, /sipp/scenarios/message_uas.xml, -t, t1, -p, "5060", -i, "fd18:5109::20", -timeout, "60"]
+    profiles: [mtu6]
+
+  recv-udp6:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-mtu6:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu6:
+        ipv6_address: fd18:5109::21
+    entrypoint: [sipp, -sf, /sipp/scenarios/message_uas.xml, -p, "5060", -i, "fd18:5109::21", -timeout, "60"]
+    profiles: [mtu6]
+
+  uac-oversized6:
+    image: ctaloi/sipp:latest
+    depends_on:
+      recv-tcp6:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu6:
+        ipv6_address: fd18:5109::30
+    entrypoint: [sipp, "[fd18:5109::10]:5060", -sf, /sipp/scenarios/mtu_message_oversized.xml, -s, tcprecv, -i, "fd18:5109::30", -m, "1", -l, "1", -timeout, "20", -trace_err]
+    profiles: [mtu6]
+
+  uac-small6:
+    image: ctaloi/sipp:latest
+    depends_on:
+      recv-udp6:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      mtu6:
+        ipv6_address: fd18:5109::31
+    entrypoint: [sipp, "[fd18:5109::10]:5060", -sf, /sipp/scenarios/mtu_message_small.xml, -s, udprecv, -i, "fd18:5109::31", -m, "1", -l, "1", -timeout, "20", -trace_err]
+    profiles: [mtu6]
+
+networks:
+  mtu4:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24
+  mtu6:
+    enable_ipv6: true
+    driver: bridge
+    ipam:
+      config:
+        - subnet: fd18:5109::/64

--- a/sipp/mtu_message_oversized.xml
+++ b/sipp/mtu_message_oversized.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  RFC 3261 §18.1.1 over-MTU test — OVERSIZED MESSAGE.
+
+  The text/plain body is padded so the serialised request comfortably exceeds
+  listen.mtu - 200 (= 1080 bytes at mtu 1280), so siphon must relay it over a
+  congestion-controlled transport (TCP).  The R-URI userpart `tcprecv` routes
+  the relay at the TCP-ONLY receiver, so a 200 OK comes back only if siphon
+  actually switched the over-MTU request to TCP.
+
+  Run: sipp -sf mtu_message_oversized.xml -s tcprecv <proxy>:5060
+-->
+<scenario name="MTU oversized MESSAGE (expect TCP relay)">
+
+  <send retrans="500">
+    <![CDATA[
+MESSAGE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:sender@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 MESSAGE
+Contact: <sip:sender@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/siphon-mtu-test
+Content-Type: text/plain
+Content-Length: [len]
+
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+MTU-OVERSIZE-PADDING mtu-oversize-padding MTU-OVERSIZE-PADDING mtu-oversize-padding
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/mtu_message_small.xml
+++ b/sipp/mtu_message_small.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  RFC 3261 §18.1.1 over-MTU test — SMALL MESSAGE.
+
+  A tiny body keeps the request well under listen.mtu - 200, so siphon must
+  keep it on UDP.  The R-URI userpart `udprecv` routes the relay at the
+  UDP-ONLY receiver, so a 200 OK comes back only if siphon left it on UDP
+  (a wrongful TCP switch would never reach a UDP-only peer).
+
+  Run: sipp -sf mtu_message_small.xml -s udprecv <proxy>:5060
+-->
+<scenario name="MTU small MESSAGE (expect UDP relay)">
+
+  <send retrans="500">
+    <![CDATA[
+MESSAGE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:sender@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 MESSAGE
+Contact: <sip:sender@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/siphon-mtu-test
+Content-Type: text/plain
+Content-Length: [len]
+
+ping
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/src/config.rs
+++ b/src/config.rs
@@ -433,6 +433,16 @@ pub struct ListenConfig {
     /// Set to `0` or `"BE"` to disable marking.
     #[serde(default = "default_dscp", deserialize_with = "deserialize_dscp")]
     pub dscp: Option<u8>,
+    /// Path MTU in bytes for the outbound UDP request path (RFC 3261 §18.1.1).
+    /// When set, an outbound SIP *request* built for UDP whose serialised length
+    /// exceeds `mtu - 200` is sent over TCP instead (if a TCP path to the
+    /// destination is reachable), else it falls back to UDP with a warning.
+    /// Default `None` (off) — existing UDP-at-any-size deployments are unchanged.
+    /// `1280` (the IPv6 minimum MTU) is a safe dual-stack lower bound for IMS
+    /// core legs. Responses follow the transport of the request they answer;
+    /// the inbound side is unaffected.
+    #[serde(default)]
+    pub mtu: Option<u16>,
     #[serde(default)]
     pub udp: Vec<ListenEntry>,
     #[serde(default)]
@@ -454,6 +464,7 @@ impl Default for ListenConfig {
     fn default() -> Self {
         Self {
             dscp: default_dscp(),
+            mtu: None,
             udp: Vec::new(),
             tcp: Vec::new(),
             tls: Vec::new(),
@@ -5158,6 +5169,39 @@ script:
 "#;
         let config = Config::from_str(yaml).unwrap();
         assert_eq!(config.listen.dscp, Some(46));
+    }
+
+    #[test]
+    fn listen_config_mtu_from_yaml() {
+        let yaml = r#"
+listen:
+  mtu: 1280
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert_eq!(config.listen.mtu, Some(1280));
+    }
+
+    #[test]
+    fn listen_config_mtu_defaults_off() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert_eq!(config.listen.mtu, None, "mtu must default to off (no behaviour change on a bump)");
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -95,6 +95,9 @@ struct DispatcherState {
     /// socket siphon is actually listening on, and the advertised host for the
     /// outgoing Via comes from the matched listener.
     listener_registry: crate::transport::ListenerRegistry,
+    /// Path MTU (bytes) for the outbound UDP request path (RFC 3261 §18.1.1).
+    /// `Some(mtu)` biases an over-`(mtu - 200)` UDP request to TCP; `None` = off.
+    mtu: Option<u16>,
     /// Server header value injected into locally-generated responses.
     server_header: Option<String>,
     /// User-Agent header value for outbound requests (UAC, registrant).
@@ -504,6 +507,19 @@ pub async fn run(
         }
     }
 
+    // RFC 3261 §18.1.1 MTU floor sanity check.  Below the 576-byte IPv4 minimum
+    // (mtu-200 ≈ 376), almost every request crosses the threshold and switches
+    // to TCP — very likely a typo (e.g. `mtu: 128`).
+    if let Some(mtu) = config.listen.mtu {
+        if mtu < 576 {
+            warn!(
+                mtu,
+                "listen.mtu is below the 576-byte IPv4 minimum — nearly every request will \
+                 exceed mtu-200 and be relayed over TCP; is this intended?"
+            );
+        }
+    }
+
     let default_server = format!("{product_name}/{product_version}");
     let server_header = Some(
         config
@@ -605,6 +621,7 @@ pub async fn run(
         rtpengine_sessions,
         rtpengine_profiles,
         session_timer_config: config.session_timer.clone(),
+        mtu: config.listen.mtu,
         header_policy_registry,
         default_header_policy,
         default_refer_mode: config.b2bua.resolved_default_refer_mode(),
@@ -3078,7 +3095,7 @@ fn relay_request(
     //   a) flow=Some — use the captured inbound flow directly,
     //      bypassing DNS resolution of any URI.
     //   b) flow=None — resolve the next_hop / top Route / R-URI as usual.
-    let (target_uri_string, destination, mut outbound_transport, flow_local_addr) =
+    let (target_uri_string, mut destination, mut outbound_transport, flow_local_addr) =
         if let Some(flow) = flow {
             let transport = match flow.transport.as_str() {
                 "udp" => Transport::Udp,
@@ -3242,6 +3259,32 @@ fn relay_request(
         }
         _ => None,
     };
+
+    // RFC 3261 §18.1.1 — bias an over-MTU UDP request to TCP.  The length is
+    // measured before our Via is added (`mtu - 200` leaves headroom for it plus
+    // downstream Via additions).  Skipped for flow-/IPsec-pinned egress: a
+    // captured flow and an IPsec SA both pin the transport authoritatively (the
+    // kernel XFRM selector would drop a switched-transport frame).  The
+    // `state.mtu.is_some()` guard keeps the serialise off the default hot path.
+    if state.mtu.is_some() && flow.is_none() && ipsec_source.is_none() {
+        if let Some((tcp_transport, tcp_addr)) = mtu_tcp_upgrade(
+            state.mtu,
+            outbound_transport,
+            relayed.to_bytes().len(),
+            &target_uri_string,
+            destination,
+            &state.dns_resolver,
+        ) {
+            // A hostname's _sip._tcp path could point back at us — don't switch
+            // into a loop (the UDP destination already passed is_own_address).
+            if state.is_own_address(&tcp_addr) {
+                warn!(%tcp_addr, "§18.1.1: TCP path loops back to us — keeping UDP");
+            } else {
+                outbound_transport = tcp_transport;
+                destination = tcp_addr;
+            }
+        }
+    }
 
     // Resolve the script `send_socket=` egress pin against the *final*
     // outbound transport (the IPsec block above may have re-pinned it).  It
@@ -3587,7 +3630,7 @@ fn relay_fork_branch(
     // Resolve the branch destination + transport: over the captured inbound flow
     // (RFC 5626 §5.3 connection reuse — the only way back to a WebSocket UE,
     // RFC 7118 §5) when one is attached, else by DNS-resolving the target URI.
-    let (destination, outbound_transport) = if let Some(flow) = flow {
+    let (mut destination, mut outbound_transport) = if let Some(flow) = flow {
         let transport = match flow.transport.as_str() {
             "udp" => Transport::Udp,
             "tcp" => Transport::Tcp,
@@ -3622,6 +3665,26 @@ fn relay_fork_branch(
 
     if core::decrement_max_forwards(&mut relayed.headers).is_err() {
         return; // caller handles the error for the whole fork
+    }
+
+    // RFC 3261 §18.1.1 — bias an over-MTU UDP fork branch to TCP.  Skipped for a
+    // flow-pinned branch (its transport is fixed by connection reuse).
+    if state.mtu.is_some() && flow.is_none() {
+        if let Some((tcp_transport, tcp_addr)) = mtu_tcp_upgrade(
+            state.mtu,
+            outbound_transport,
+            relayed.to_bytes().len(),
+            target,
+            destination,
+            &state.dns_resolver,
+        ) {
+            if state.is_own_address(&tcp_addr) {
+                warn!(%tcp_addr, "fork §18.1.1: TCP path loops back to us — keeping UDP");
+            } else {
+                outbound_transport = tcp_transport;
+                destination = tcp_addr;
+            }
+        }
     }
 
     // A script send_socket= egress pin applies to this branch only when it has
@@ -5020,6 +5083,100 @@ fn resolve_candidates_inner(
 /// weighted-random / shuffled pick on every call.
 fn resolve_target(uri_string: &str, resolver: &SipResolver) -> Option<RelayTarget> {
     resolve_candidates(uri_string, resolver).into_iter().next()
+}
+
+/// RFC 3261 §18.1.1: a UDP request whose serialised length exceeds `mtu - 200`
+/// bytes must be sent over a congestion-controlled transport (TCP).  The 200
+/// bytes is headroom for the Via siphon adds plus additions by downstream hops.
+fn over_mtu(len: usize, mtu: u16) -> bool {
+    len > mtu.saturating_sub(200) as usize
+}
+
+/// Time budget for the §18.1.1 TCP-reachability probe (below).  Kept short so a
+/// blackholed TCP port on the (rare) over-MTU path adds only bounded latency; a
+/// peer with no TCP listener refuses immediately (ECONNREFUSED), well under it.
+const TCP_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Probe a **reachable** TCP path to the next hop for the §18.1.1 over-MTU
+/// switch.  Returns the TCP `SocketAddr` to send to, or `None` when no TCP
+/// listener answers — in which case the caller keeps UDP and delivers the
+/// request (fragmented) rather than dropping it, honouring RFC 3261 §18.1.1's
+/// "retry using UDP" on a TCP connection failure.
+///
+/// The candidate address is the same `SocketAddr` for a numeric next hop (SIP
+/// peers co-locate UDP+TCP; there is no SRV to consult, matching Kamailio's
+/// `udp_mtu_try_proto=TCP`), or the `_sip._tcp` SRV / A/AAAA result for a
+/// hostname.  A short blocking connect then confirms a TCP listener is actually
+/// there before we commit the Via/transaction to TCP: the resolver's A/AAAA
+/// fallback means a hostname almost always "resolves" for TCP even with no TCP
+/// service, so the connect — not the resolution — is the real reachability test.
+fn resolve_tcp_path(
+    uri_string: &str,
+    udp_destination: SocketAddr,
+    resolver: &SipResolver,
+) -> Option<SocketAddr> {
+    let candidate = if uri_string.parse::<SocketAddr>().is_ok() {
+        udp_destination
+    } else {
+        let uri = parse_uri_standalone(uri_string).ok()?;
+        if crate::sip::uri::strip_ipv6_brackets(&uri.host)
+            .parse::<std::net::IpAddr>()
+            .is_ok()
+        {
+            // Numeric host (v4 or bracketed v6) — same address, TCP.
+            udp_destination
+        } else {
+            let results = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(resolver.resolve(
+                    &uri.host,
+                    uri.port,
+                    &uri.scheme,
+                    Some("tcp"),
+                ))
+            });
+            results.into_iter().next()?.address
+        }
+    };
+    // The real reachability test: only switch if a TCP listener answers.
+    let reachable = tokio::task::block_in_place(|| {
+        std::net::TcpStream::connect_timeout(&candidate, TCP_PROBE_TIMEOUT).is_ok()
+    });
+    reachable.then_some(candidate)
+}
+
+/// Apply the RFC 3261 §18.1.1 over-MTU UDP→TCP decision for one outbound
+/// request.  Given the current transport, the serialised (pre-Via) request
+/// length and its next hop, returns `Some((Tcp, tcp_addr))` when the request is
+/// too big for UDP and a TCP path resolves, else `None` (keep UDP — logging the
+/// forced over-MTU send when a switch was wanted but no TCP path exists).
+fn mtu_tcp_upgrade(
+    mtu: Option<u16>,
+    outbound_transport: Transport,
+    serialized_len: usize,
+    target_uri_string: &str,
+    destination: SocketAddr,
+    resolver: &SipResolver,
+) -> Option<(Transport, SocketAddr)> {
+    let mtu = mtu?;
+    if outbound_transport != Transport::Udp || !over_mtu(serialized_len, mtu) {
+        return None;
+    }
+    match resolve_tcp_path(target_uri_string, destination, resolver) {
+        Some(tcp_addr) => {
+            debug!(
+                serialized_len, mtu, %destination,
+                "RFC 3261 §18.1.1: over-MTU UDP request → TCP"
+            );
+            Some((Transport::Tcp, tcp_addr))
+        }
+        None => {
+            warn!(
+                serialized_len, mtu, %destination,
+                "transport: forced UDP over-MTU send (no reachable TCP path)"
+            );
+            None
+        }
+    }
 }
 
 /// For a B→A in-dialog forward over **TLS**, decide whether to dial the remote
@@ -9734,7 +9891,7 @@ fn b2bua_send_b_leg_invite(
     // 7118 §5) when one is attached, else from next_hop when set, else from
     // target.  R-URI construction below still uses target_uri unconditionally —
     // that split is the whole point of next_hop.
-    let (destination, outbound_transport) = if let Some(flow) = flow {
+    let (mut destination, mut outbound_transport) = if let Some(flow) = flow {
         let transport = match flow.transport.as_str() {
             "udp" => Transport::Udp,
             "tcp" => Transport::Tcp,
@@ -9763,6 +9920,28 @@ fn b2bua_send_b_leg_invite(
         };
         (relay_target.address, relay_target.transport.unwrap_or(Transport::Udp))
     };
+
+    // RFC 3261 §18.1.1 — bias an over-MTU UDP B-leg INVITE to TCP.  Skipped for a
+    // flow-pinned B-leg.  The length is measured on the A-leg request as an
+    // approximation of the derived B-leg INVITE (header-policy strips/adds mean
+    // it is not exact); the decision must precede the Via build below so the
+    // Via/txn reflect the chosen transport.  An over-estimate cannot drop the
+    // call — the reachability probe in resolve_tcp_path keeps UDP when the peer
+    // has no TCP listener; an under-estimate simply leaves a borderline B-leg on
+    // UDP (fragmenting, as it would pre-feature).
+    if state.mtu.is_some() && flow.is_none() {
+        if let Some((tcp_transport, tcp_addr)) = mtu_tcp_upgrade(
+            state.mtu,
+            outbound_transport,
+            original_request.to_bytes().len(),
+            next_hop.unwrap_or(target_uri),
+            destination,
+            &state.dns_resolver,
+        ) {
+            outbound_transport = tcp_transport;
+            destination = tcp_addr;
+        }
+    }
 
     // A script send_socket= egress pin applies to the B-leg only when it has no
     // captured flow (a flow already pins egress) and its transport matches the
@@ -18603,6 +18782,65 @@ a=rtpmap:8 PCMA/8000\r\n";
     async fn resolve_target_unresolvable_domain() {
         let resolver = test_resolver();
         assert!(resolve_target("sip:alice@this-domain-should-not-exist-xyzzy.invalid", &resolver).is_none());
+    }
+
+    // -- RFC 3261 §18.1.1 over-MTU UDP → TCP fallback ------------------------
+
+    #[test]
+    fn over_mtu_threshold() {
+        // Must EXCEED mtu-200 to trigger (the headroom for our Via + downstream).
+        assert!(!over_mtu(1080, 1280), "exactly at the boundary is not over");
+        assert!(over_mtu(1081, 1280));
+        assert!(!over_mtu(500, 1280));
+        // A tiny mtu saturates to 0 rather than underflowing.
+        assert!(over_mtu(1, 100));
+        assert!(!over_mtu(0, 100));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mtu_tcp_upgrade_switches_when_tcp_reachable() {
+        let resolver = test_resolver();
+        // A live TCP listener so the reachability probe succeeds.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let dest = listener.local_addr().unwrap();
+        let uri = dest.to_string(); // numeric "127.0.0.1:PORT" next hop
+        // Over threshold + reachable TCP → switch to TCP at the same address.
+        assert_eq!(
+            mtu_tcp_upgrade(Some(1280), Transport::Udp, 1300, &uri, dest, &resolver),
+            Some((Transport::Tcp, dest)),
+        );
+        // Under threshold → keep UDP (no probe).
+        assert_eq!(mtu_tcp_upgrade(Some(1280), Transport::Udp, 900, &uri, dest, &resolver), None);
+        // MTU off → never switch.
+        assert_eq!(mtu_tcp_upgrade(None, Transport::Udp, 1300, &uri, dest, &resolver), None);
+        // Already non-UDP → never switch.
+        assert_eq!(mtu_tcp_upgrade(Some(1280), Transport::Tcp, 1300, &uri, dest, &resolver), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mtu_tcp_upgrade_keeps_udp_when_no_tcp_listener() {
+        // Bind then drop → a closed port; the reachability probe refuses, so an
+        // over-MTU request must STAY on UDP (delivered fragmented, not dropped).
+        let dest: SocketAddr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap()
+        };
+        let resolver = test_resolver();
+        assert_eq!(
+            mtu_tcp_upgrade(Some(1280), Transport::Udp, 1300, &dest.to_string(), dest, &resolver),
+            None,
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resolve_tcp_path_numeric_probes_reachability() {
+        let resolver = test_resolver();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let dest = listener.local_addr().unwrap();
+        // Bare IP:port and a sip: URI with a numeric host both resolve to the
+        // same address, and the live listener makes the probe succeed.
+        assert_eq!(resolve_tcp_path(&dest.to_string(), dest, &resolver), Some(dest));
+        assert_eq!(resolve_tcp_path(&format!("sip:{dest}"), dest, &resolver), Some(dest));
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

RFC 3261 §18.1.1: an outbound SIP *request* built for UDP whose serialised length exceeds `mtu − 200` bytes is relayed over TCP instead — but only when the next hop has a **reachable** TCP listener. Otherwise it stays on UDP (delivered, fragmented) with a `warn`, so an over-MTU request is never dropped. This stops an oversized IMS-core NOTIFY (large `reginfo+xml` / iFC fan-out) or INVITE from IP-fragmenting and being silently dropped by UEs / IPX peers with strict ICMP filtering. Kamailio analog: `udp_mtu` + `udp_mtu_try_proto=TCP`.

Default **off** — no behaviour change on a bump. `1280` (the IPv6 minimum MTU) is a safe lower bound for dual-stack IMS core legs.

## How

- New `listen.mtu: Option<u16>` config → `DispatcherState.mtu`.
- The decision (`over_mtu` + `mtu_tcp_upgrade`) runs on the proxy relay, fork, and B2BUA-dial paths, before the Via/transaction are stamped, and is **skipped for flow-/IPsec-pinned egress** (the pinned transport is authoritative — a switched-transport frame would be dropped by the kernel XFRM selector).
- Reachability is confirmed by a short blocking connect probe on the (rare) over-MTU path. The resolver's A/AAAA fallback means a hostname almost always "resolves" for TCP even without a TCP service, so the connect — not the resolution — is the real test. A UDP-only peer → probe fails → stay UDP (fragmented), never dropped (honours §18.1.1's "retry using UDP" SHOULD).
- A `_sip._tcp` path that loops back to one of our own listeners is detected and kept on UDP.

## Scope / limitations

- Locally-**originated** requests (`subscribe_state.notify()`, `proxy.send_request`) are not covered — only relayed / forwarded / dialed requests. Noted in the `ims_scscf.yaml` comment.
- The B2BUA path measures the A-leg request as an approximation of the derived B-leg INVITE; an over-estimate can't drop the call (probe → UDP fallback), an under-estimate just leaves a borderline request on UDP as it would pre-feature.
- A boot `warn` fires if `listen.mtu` is set below the 576-byte IPv4 minimum (footgun guard, e.g. a `mtu: 128` typo).

## Tests

- **Unit:** `over_mtu` threshold; `mtu_tcp_upgrade` switches when a live TCP listener answers and keeps UDP against a closed port; `resolve_tcp_path` numeric/URI probing; config parse + default-off.
- **Docker, both address families** (`scripts/mtu_test.sh`, `sipp/docker-compose.mtu.yaml`): siphon relays a padded MESSAGE at a **TCP-only** receiver (200 only if it switched to TCP) and a small MESSAGE at a **UDP-only** receiver (200 only if it stayed UDP), over a v4 bridge and a v6 (ULA) bridge. **IPv4 validated locally and gated in CI** (`sipp-mtu`, no special capability). The IPv6 stack + `sipp-mtu-ipv6` job are **manual-dispatch only** — docker IPv6-in-bridge isn't reliable on GitHub-hosted runners; run locally with `scripts/mtu_test.sh v6`.
- Full suite + clippy `-D warnings` green. Full 16-row SIPp + mem-leak baseline deferred to pre-release.
