### PR TITLE
feat(examples): WhatsApp Business Calling gateway (SIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   explicit per-family listeners, each with an optional per-listener `advertise`
   (see `examples/ims_pcscf.yaml`). Core-side (Mw / outbound) dual-stack is a
   separate follow-up.
+- **WhatsApp Business Calling gateway example.** WhatsApp's Business Calling API
+  is SIP-over-TLS to `wa.meta.vc`, so SIPhon bridges WhatsApp voice to an internal
+  SIP/IMS network as a B2BUA in both directions with no new protocol code — a TLS
+  trunk plus a routing script. New `examples/whatsapp_calling.{py,yaml}` (server-
+  auth TLS with no client cert, outbound digest via `call.set_credentials()`,
+  direction detection via `call.from_gateway()` on Meta's source ranges
+  (`gateway.groups[].source_networks`, handshake-verified on TLS), OPUS passthrough,
+  SDES via the built-in `srtp_to_rtp`/`rtp_to_srtp` profiles and DTLS-SRTP via new
+  `whatsapp_dtls_in`/`whatsapp_dtls_out` profiles, and no session timer since Meta
+  rejects re-INVITEs) plus a `docs/cookbook/whatsapp-calling.md` recipe. The
+  messaging side (Cloud API) is a separate HTTP example in the siphon-http addon.
+  SDK fix along the way: the `Call` mock's `set_from_user()` / `set_ruri_user()`
+  now mutate the parsed URI (they previously did string ops on a `SipUri` and
+  raised), matching `set_to_user()`.
 - **Docker Compose quickstart + Getting started guide.** A root
   `docker-compose.yaml` runs the published image with your `siphon.yaml` and
   `scripts/` bind-mounted (host networking, hot-reload, a SIP `OPTIONS`

--- a/docs/cookbook/whatsapp-calling.md
+++ b/docs/cookbook/whatsapp-calling.md
@@ -1,0 +1,120 @@
+# WhatsApp calling (Business Calling API)
+
+The [WhatsApp Business Calling API](https://developers.facebook.com/documentation/business-messaging/whatsapp/calling)
+is SIP-native: Meta terminates and originates voice calls as ordinary SIP over
+TLS to `wa.meta.vc`, with OPUS media over SRTP. That makes SIPhon a natural
+gateway between WhatsApp and your own SIP/IMS network, in both directions, with
+no new protocol code — it is a specialised TLS trunk plus a B2BUA routing script.
+
+```
+WhatsApp  <-- SIP/TLS + SRTP -->  SIPhon  <-- SIP + RTP -->  internal PBX / trunk
+```
+
+The runnable example is [`examples/whatsapp_calling.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/whatsapp_calling.py)
+and [`examples/whatsapp_calling.yaml`](https://github.com/siphon-project/siphon-sip/blob/main/examples/whatsapp_calling.yaml).
+
+!!! note "Messaging is a separate integration"
+    WhatsApp also has a Cloud API for **text / media / template messages**. That
+    is plain HTTP (Graph API + webhooks), not SIP, so it lives with the HTTP
+    addon: see the **WhatsApp Cloud API** recipe in the
+    [siphon-http cookbook](https://http.siphon-sip.org/cookbook/whatsapp-cloud-api/).
+
+## What Meta requires
+
+A few WhatsApp constraints shape the config; get them wrong and calls fail:
+
+- **TLS is mandatory and server-auth only.** Meta presents a server certificate
+  for `wa.meta.vc` and does **not** do mutual TLS — it neither sends nor requests
+  a client certificate. So, unlike a Microsoft Teams trunk, there is **no
+  `tls.client_certificate`**. Meta connects to the public FQDN you register as
+  the number's SIP server, so that FQDN must be your `advertised_address` and the
+  SAN on your server cert.
+- **OPUS only.** WhatsApp offers/accepts OPUS (48 kHz) plus `telephone-event`
+  (RFC 4733 DTMF). This gateway anchors and relays media; it does not transcode,
+  so the internal leg must also speak OPUS. Bridging to a G.711/AMR-only endpoint
+  needs rtpengine transcoding, which is out of scope here.
+- **No re-INVITE toward Meta.** A re-INVITE fails the call, so the example ships
+  **without** a `session_timer:` block (a `refresher=uac` session timer would
+  send Meta a refresh re-INVITE). Do not enable session timers, hold, or a
+  transfer-driven media re-anchor toward the WhatsApp leg.
+- **No PSTN breakout.** Meta's terms forbid bridging WhatsApp calls to the PSTN;
+  keep the internal leg on-net VoIP/SIP.
+- **Trust via TLS + digest.** Outbound calls authenticate to Meta with SIP
+  digest, and you can challenge inbound ones. Meta does **not** do mutual TLS, so
+  do not trust an application-layer header (like `X-FB-External-Domain`) as an
+  auth signal — any peer reaching the TLS port could forge it. The source IP, by
+  contrast, is handshake-verified on TLS; Meta sources from a wide published set
+  of ranges, so the `whatsapp` gateway group lists them under `source_networks`
+  and the script keys direction on `call.from_gateway("whatsapp")`.
+
+## SRTP keying: SDES or DTLS
+
+WhatsApp keys SRTP per phone number, one of two ways:
+
+- **SDES** — the crypto key travels in the SDP over the (secure) TLS signalling.
+  This is a plain SRTP trunk, so SIPhon's built-in `srtp_to_rtp` /`rtp_to_srtp`
+  profiles already do the job. Simplest to bring up; the example defaults to it.
+- **DTLS-SRTP** — a DTLS handshake keys the media (WebRTC-style, with ICE). The
+  example ships `whatsapp_dtls_in` / `whatsapp_dtls_out` profiles for this, based
+  on the built-in `wss_to_rtp` WebRTC profile. rtpengine terminates DTLS on the
+  WhatsApp side and bridges to the internal RTP leg — there is no opaque DTLS
+  pass-through when anchoring. **Validate the DTLS role / ICE against your own
+  number before production**; the correct role can depend on Meta's offer.
+
+Select the mode with `WHATSAPP_MEDIA_MODE=sdes` (default) or `=dtls`.
+
+## The routing script
+
+Direction is keyed on `call.from_gateway("whatsapp")` — the source IP, which on
+the inbound TLS connection is handshake-verified (unlike the spoofable
+`X-FB-External-Domain` header, since Meta does not do mutual TLS). The `whatsapp`
+group's `source_networks` carries Meta's published ranges so the match is stable
+regardless of DNS. Inbound calls bridge to the internal gateway; outbound calls
+authenticate to Meta and dial `wa.meta.vc` over TLS.
+
+```python
+from siphon import b2bua, gateway, rtpengine, log
+
+@b2bua.on_invite
+async def route(call):
+    if call.from_gateway("whatsapp"):
+        # WhatsApp -> internal: a WhatsApp user is calling the business number.
+        destination = gateway.select("internal")
+        await rtpengine.offer(call, profile="srtp_to_rtp")
+        call.dial(destination.uri)
+    else:
+        # internal -> WhatsApp: dial an E.164 over the TLS trunk. From is the
+        # business number, which is also the digest username Meta cross-checks;
+        # SIPhon answers Meta's 407 with Proxy-Authorization automatically.
+        e164 = call.ruri.user
+        call.set_from_user(BUSINESS_NUMBER)
+        call.set_credentials(BUSINESS_NUMBER, SIP_PASSWORD)
+        await rtpengine.offer(call, profile="rtp_to_srtp")
+        call.dial(f"sip:{e164}@wa.meta.vc:5061;transport=tls")
+```
+
+`call.set_credentials()` is all that outbound digest needs — Meta answers the
+first INVITE with `407 Proxy Authentication Required` and SIPhon resends with the
+`Proxy-Authorization` header. The per-number password comes from Meta: GET the
+phone number's settings with `include_sip_credentials=true`.
+
+For inbound calls you can additionally challenge Meta with digest (recommended by
+Meta for defence in depth); on a media-anchored B2BUA, trust is already
+established by the TLS connection.
+
+## Provisioning checklist (Meta side)
+
+1. Configure a SIP server for the business phone number pointing at your gateway
+   FQDN on port 5061 over TLS.
+2. Retrieve the number's SIP digest password (`include_sip_credentials=true`) and
+   pass it to the script as `$WHATSAPP_SIP_PASSWORD`, with the E.164 business
+   number as `$WHATSAPP_BUSINESS_NUMBER`.
+3. Choose the SRTP keying mode (SDES or DTLS) to match `WHATSAPP_MEDIA_MODE`.
+4. Point a publicly-trusted TLS certificate (SAN = your gateway FQDN) at the
+   `tls:` block, and put that FQDN in `advertised_address`.
+
+Run it:
+
+```bash
+siphon -c examples/whatsapp_calling.yaml
+```

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -165,6 +165,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Dynamic group management | Implemented | Python `gateway.add_group()` / `gateway.remove_group()` | |
 | Destination up/down marking | Implemented | Python `gateway.mark_up()` / `gateway.mark_down()` | |
 | Source-membership predicate | Implemented | Python `request.from_gateway()` / `call.from_gateway()` | `ds_is_from_list()` / `ds_is_in_list()` equivalent; IP-only match against all resolved group addresses, cached + refreshed on probe cycle. Trust signal on TCP/TLS/WS/WSS, direction hint on UDP |
+| WhatsApp Business Calling (voice) | Implemented | `examples/whatsapp_calling.{py,yaml}` | SIP-over-TLS trunk to `wa.meta.vc` (server-auth TLS, no mTLS), B2BUA both directions, outbound digest via `call.set_credentials()`, OPUS passthrough, SDES (built-in profiles) / DTLS-SRTP (`whatsapp_dtls_*`). Composed from existing features; live WABA validation pending |
 
 ## Call Detail Records
 

--- a/examples/whatsapp_calling.py
+++ b/examples/whatsapp_calling.py
@@ -1,0 +1,136 @@
+"""
+SIPhon gateway for the WhatsApp Business Calling API (voice).
+
+Bridges WhatsApp voice calls (SIP over TLS to Meta's `wa.meta.vc`) to an
+internal SIP network (PBX / on-net trunk) as a B2BUA, both directions:
+
+    WhatsApp  <-- SIP/TLS + SRTP -->  SIPhon  <-- SIP + RTP -->  internal
+
+Direction is detected with ``call.from_gateway("whatsapp")`` — the A-leg source
+IP, which on the inbound TLS connection is handshake-verified and therefore a
+trustworthy signal. The ``X-FB-External-Domain: wa.meta.vc`` header Meta stamps
+is only a corroborating hint: Meta does not do mutual TLS, so any peer that
+reaches the TLS port could forge that header, whereas it cannot forge its source
+IP on an established TLS connection. Meta sources calls from a wide published set
+of ranges, so the ``whatsapp`` gateway group lists them under ``source_networks``
+(see whatsapp_calling.yaml) — that makes ``from_gateway`` membership stable
+regardless of what ``wa.meta.vc`` currently resolves to.
+
+Outbound (internal -> WhatsApp) calls authenticate to Meta with SIP digest:
+Meta answers the first INVITE with 407 and SIPhon resends with
+``Proxy-Authorization`` automatically once ``call.set_credentials()`` is set.
+The digest username is the normalised business phone number (also placed on the
+From header); the password is Meta's per-number SIP password (GET the phone
+number settings with ``include_sip_credentials=true``).
+
+Environment:
+    WHATSAPP_BUSINESS_NUMBER   E.164 of your WhatsApp business number (From user
+                               + digest username on outbound calls), e.g. +15551234567
+    WHATSAPP_SIP_PASSWORD      Meta-generated per-number SIP digest password
+    WHATSAPP_MEDIA_MODE        "sdes" (default) or "dtls" — SRTP keying to match
+                               how the number is provisioned on Meta's side
+
+WhatsApp also has a messaging API (text / media / templates over HTTP). For that
+see the siphon-http "WhatsApp Cloud API" cookbook — it is a separate, HTTP-only
+integration.
+
+Run: ``siphon -c examples/whatsapp_calling.yaml``
+"""
+import os
+
+from siphon import b2bua, proxy, gateway, rtpengine, log
+
+BUSINESS_NUMBER = os.environ.get("WHATSAPP_BUSINESS_NUMBER", "")
+SIP_PASSWORD = os.environ.get("WHATSAPP_SIP_PASSWORD", "")
+
+# SDES keying (the default) is a plain SRTP trunk, so the built-in srtp_to_rtp /
+# rtp_to_srtp profiles apply. DTLS-SRTP (Meta's default keying) uses the custom
+# whatsapp_dtls_* profiles in whatsapp_calling.yaml — validate those against your
+# own number first.
+if os.environ.get("WHATSAPP_MEDIA_MODE", "sdes").lower() == "dtls":
+    PROFILE_FROM_WHATSAPP = "whatsapp_dtls_in"    # Meta is the offering A-leg
+    PROFILE_TO_WHATSAPP = "whatsapp_dtls_out"     # internal is the offering A-leg
+else:
+    PROFILE_FROM_WHATSAPP = "srtp_to_rtp"
+    PROFILE_TO_WHATSAPP = "rtp_to_srtp"
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    # Answer OPTIONS keepalives from the internal side (Meta does not send them).
+    request.reply(200, "OK")
+
+
+@b2bua.on_invite
+async def route(call):
+    # Source-IP membership (handshake-verified on TLS) is the trust signal for
+    # "this came from WhatsApp"; see the module docstring on why not the header.
+    if call.from_gateway("whatsapp"):
+        await _from_whatsapp(call)
+    else:
+        await _to_whatsapp(call)
+
+
+async def _from_whatsapp(call):
+    """WhatsApp -> internal: a WhatsApp user is calling the business number."""
+    wacid = call.get_header("x-wa-meta-wacid")
+    destination = gateway.select("internal")
+    if not destination:
+        log.error(f"[{call.id}] no healthy internal gateway (wacid={wacid})")
+        call.reject(503, "Service Unavailable")
+        return
+    log.info(f"[{call.id}] WhatsApp -> internal: {destination.uri} (wacid={wacid})")
+    # Meta offers SRTP (SDES) or DTLS-SRTP + OPUS; anchor and present RTP inward.
+    await rtpengine.offer(call, profile=PROFILE_FROM_WHATSAPP)
+    call.dial(destination.uri)
+
+
+async def _to_whatsapp(call):
+    """internal -> WhatsApp: dial a WhatsApp user (E.164) over the TLS trunk."""
+    ruri = call.ruri
+    e164 = ruri.user if ruri else None
+    if not e164:
+        log.error(f"[{call.id}] no destination number in R-URI")
+        call.reject(404, "Not Found")
+        return
+    if not BUSINESS_NUMBER or not SIP_PASSWORD:
+        log.error(f"[{call.id}] WHATSAPP_BUSINESS_NUMBER / WHATSAPP_SIP_PASSWORD unset")
+        call.reject(503, "Service Unavailable")
+        return
+    log.info(f"[{call.id}] internal -> WhatsApp: {e164}")
+    # Business-initiated call: From is the business number, and the same value is
+    # the digest username. SIPhon answers Meta's 407 with Proxy-Authorization.
+    call.set_from_user(BUSINESS_NUMBER)
+    call.set_credentials(BUSINESS_NUMBER, SIP_PASSWORD)
+    await rtpengine.offer(call, profile=PROFILE_TO_WHATSAPP)
+    # transport=tls routes over TLS; Contact/Via carry advertised_address (the
+    # FQDN Meta knows). No re-INVITE is ever sent toward Meta (no session timer).
+    call.dial(f"sip:{e164}@wa.meta.vc:5061;transport=tls")
+
+
+@b2bua.on_answer
+async def answered(call, reply):
+    # Reuse the offer profile (keyed by A-leg Call-ID) so SRTP/DTLS direction and
+    # crypto stay consistent on the 200 OK.
+    await rtpengine.answer(reply, call=call)
+    log.info(f"[{call.id}] answered ({reply.status_code})")
+
+
+@b2bua.on_failure
+async def failed(call, code, reason):
+    log.warn(f"[{call.id}] B-leg failed: {code} {reason}")
+    await rtpengine.delete(call)
+    call.reject(code, reason)
+
+
+@b2bua.on_bye
+async def ended(call, initiator):
+    log.info(f"[{call.id}] BYE (initiator: {initiator.side})")
+    await rtpengine.delete(call)
+
+
+@b2bua.on_cancel
+async def cancelled(call):
+    # Caller abandoned an unanswered call — release the anchored media.
+    log.info(f"[{call.id}] CANCEL (unanswered)")
+    await rtpengine.delete(call)

--- a/examples/whatsapp_calling.yaml
+++ b/examples/whatsapp_calling.yaml
@@ -1,0 +1,183 @@
+# ---------------------------------------------------------------------------
+# SIPhon gateway for the WhatsApp Business Calling API (voice)
+#
+# Bridges WhatsApp voice calls (SIP over TLS to Meta) to an internal SIP
+# network (PBX / carrier trunk) as a B2BUA, both directions:
+#
+#     WhatsApp  <-- SIP/TLS + SRTP -->  SIPhon  <-- SIP + RTP -->  internal
+#
+# See examples/whatsapp_calling.py for the routing logic.
+#
+# Meta side (provisioned in WhatsApp Business, not here):
+#   * Configure a SIP server for your business phone number pointing at this
+#     gateway's public FQDN:5061 over TLS (Meta connects to `advertised_address`
+#     below). Meta's own SIP domain is `wa.meta.vc`.
+#   * Fetch the per-number SIP digest password (GET the phone-number settings
+#     with `include_sip_credentials=true`) and pass it to this script via
+#     $WHATSAPP_SIP_PASSWORD (see examples/whatsapp_calling.py).
+#   * Pick an SRTP keying mode for the number: SDES (simplest, the default this
+#     example ships) or DTLS-SRTP (Meta's default; the `whatsapp_dtls_*`
+#     profiles below — validate against your number before production).
+#
+# Constraints baked into this config (Meta requirements):
+#   * TLS is mandatory; Meta presents a server cert for `wa.meta.vc` and does
+#     NOT do mutual TLS, so there is NO client_certificate here (unlike Teams).
+#   * OPUS is the only WhatsApp audio codec — the internal leg must also speak
+#     OPUS (this gateway anchors/relays, it does not transcode). telephone-event
+#     (RFC 4733 DTMF) rides through.
+#   * No re-INVITE may be sent toward Meta — so there is deliberately NO
+#     `session_timer:` block (a UAC session-timer refresh would re-INVITE Meta
+#     and fail the call). Do not enable it for the WhatsApp leg.
+#   * Meta forbids bridging WhatsApp calls to the PSTN — the "internal" leg must
+#     stay on-net VoIP/SIP, not a PSTN breakout.
+# ---------------------------------------------------------------------------
+
+listen:
+  udp:
+    - "0.0.0.0:5060"          # internal-facing
+  tcp:
+    - "0.0.0.0:5060"          # internal-facing
+  tls:
+    - "0.0.0.0:5061"          # WhatsApp-facing (Meta -> SIPhon, TLS)
+
+# Contact / Via / Record-Route host. This MUST be the public FQDN you gave Meta
+# as the SIP server for the number (Meta connects here), and the SAN on the TLS
+# cert below.
+advertised_address: "whatsapp-gw.example.com"
+
+domain:
+  local:
+    - "whatsapp-gw.example.com"
+
+tls:
+  # Server identity presented to Meta (Meta -> SIPhon). Any publicly-trusted CA
+  # (the SAN must be the FQDN above). There is intentionally no client
+  # certificate: the WhatsApp Business Calling API is server-auth TLS only —
+  # Meta neither sends nor requests a client cert.
+  certificate: "/etc/siphon/tls/whatsapp-gw.example.com/fullchain.pem"
+  private_key: "/etc/siphon/tls/whatsapp-gw.example.com/privkey.pem"
+  method: "TLSv1_2"
+
+script:
+  path: "examples/whatsapp_calling.py"
+  reload: auto
+
+# ---------------------------------------------------------------------------
+# Security. This gateway is internet-facing (Meta connects over the internet)
+# and will be scanned within minutes of going live.
+#
+# NOTE: Meta sources calls from 1000+ IP ranges, so a `trusted_cidrs` allowlist
+# for the WhatsApp side is impractical — trust is established by TLS plus the
+# per-call SIP digest (this script can challenge inbound INVITEs, and
+# authenticates outbound ones with call.set_credentials()). Rate-limit and
+# scanner-block still protect the listeners from generic abuse.
+# ---------------------------------------------------------------------------
+security:
+  rate_limit:
+    window_secs: 10
+    max_requests: 30           # per source IP per window
+    ban_duration_secs: 3600
+
+  scanner_block:
+    user_agents:
+      - "sipvicious"
+      - "friendly-scanner"
+      - "VaxSip"
+      - "sipcli"
+
+  failed_auth_ban:
+    threshold: 10
+    window_secs: 600
+    ban_duration_secs: 3600
+    strong_signal_weight: 3
+
+b2bua:
+  # Strip P-*/X-* (including the x-wa-meta-* / X-FB-External-Domain identifiers
+  # Meta adds) between the WhatsApp side and the internal network — the script
+  # reads them off the A-leg before they are stripped from the B-leg.
+  default_header_policy: "sip-trunk-edge@2026"
+
+gateway:
+  groups:
+    # WhatsApp / Meta side. One static next-hop over TLS; the request URI user
+    # part (the E.164 to reach) is set per-call in the script. Health-probe is
+    # DISABLED: Meta's edge does not answer SIP OPTIONS keepalives, so probing
+    # would flap the destination down.
+    #
+    # source_networks lists Meta's published WhatsApp Calling source ranges so
+    # call.from_gateway("whatsapp") recognises inbound calls by source IP
+    # (handshake-verified on TLS) regardless of what wa.meta.vc resolves to. Meta
+    # publishes a large set that changes over time — populate this from their
+    # current list and automate updates. The placeholder below matches nothing.
+    - name: "whatsapp"
+      algorithm: weighted
+      probe:
+        enabled: false
+      source_networks:
+        - "192.0.2.0/24"          # PLACEHOLDER — replace with Meta's published ranges
+      destinations:
+        - uri: "sip:wa.meta.vc:5061;transport=tls"
+
+    # Internal SIP network (PBX / on-net trunk). Plain SIP over UDP here; must be
+    # OPUS-capable (no transcoding) and on-net (no PSTN breakout, per Meta ToS).
+    - name: "internal"
+      algorithm: weighted
+      probe:
+        enabled: true
+        interval_secs: 30
+        failure_threshold: 3
+        from_domain: "whatsapp-gw.example.com"
+      destinations:
+        - uri: "sip:pbx.internal.example.net:5060"
+
+media:
+  rtpengine:
+    address: "127.0.0.1:22222"
+    timeout_ms: 1000
+    sdp_name: "SIPhon WhatsApp GW"
+  health_check_interval_secs: 30
+
+  # SDES mode (the default this example uses) needs NO custom profiles: WhatsApp
+  # with SDES keying is a standard SRTP trunk, so the built-in `srtp_to_rtp`
+  # (WhatsApp -> internal) and `rtp_to_srtp` (internal -> WhatsApp) profiles
+  # already do the right thing. The script selects them by default.
+  #
+  # The profiles below are the DTLS-SRTP alternative (Meta's default keying),
+  # modelled on the built-in `wss_to_rtp` WebRTC profile. rtpengine terminates
+  # DTLS on the WhatsApp side and bridges to the internal RTP leg (there is no
+  # opaque DTLS pass-through when anchoring). Switch the script's MODE to "dtls"
+  # to use them, and VALIDATE the DTLS role / ICE against your own WhatsApp
+  # number before production — the correct role can depend on Meta's offer.
+  profiles:
+    # WhatsApp -> internal (Meta is the offering A-leg: DTLS-SRTP + ICE + OPUS).
+    whatsapp_dtls_in:
+      offer:
+        transport_protocol: "RTP/AVP"    # present plain RTP to the internal leg
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        direction: ["external", "internal"]
+      answer:
+        transport_protocol: "RTP/SAVPF"  # DTLS-SRTP back to WhatsApp
+        ice: "force"
+        dtls: "passive"
+        replace: ["origin"]
+        direction: ["internal", "external"]
+    # internal -> WhatsApp (internal is the offering A-leg: plain RTP).
+    whatsapp_dtls_out:
+      offer:
+        transport_protocol: "RTP/SAVPF"  # DTLS-SRTP toward WhatsApp
+        ice: "force"
+        dtls: "passive"
+        replace: ["origin"]
+        direction: ["internal", "external"]
+      answer:
+        transport_protocol: "RTP/AVP"    # plain RTP back to the internal leg
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        direction: ["external", "internal"]
+
+log:
+  level: info
+  format: pretty

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Load balancer: cookbook/load-balancer.md
       - Least-Cost Routing: cookbook/least-cost-routing.md
       - SBC (B2BUA): cookbook/sbc.md
+      - WhatsApp calling: cookbook/whatsapp-calling.md
       - Call transfer (REFER): cookbook/call-transfer.md
       - Number normalization: cookbook/number-normalization.md
       - Number routing (LNP / redirect): cookbook/number-routing.md

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -882,7 +882,8 @@ class Call:
                 call.set_ruri_user("+33123456789")
                 call.dial("sip:gw@carrier.example.com")
         """
-        self._ruri = f"sip:{value}@{self._ruri.split('@', 1)[-1]}" if '@' in self._ruri else self._ruri
+        if self._ruri is not None:
+            self._ruri.user = value
 
     def set_from_user(self, value: str) -> None:
         """Set the user part of the From header URI.
@@ -899,10 +900,8 @@ class Call:
                 call.set_from_user("+33123456789")
                 call.dial("sip:gw@carrier.example.com")
         """
-        # In the mock, just update the from_uri string
-        old = self._from_uri
-        if '@' in old:
-            self._from_uri = f"{value}@{old.split('@', 1)[-1]}"
+        if self._from_uri is not None:
+            self._from_uri.user = value
 
     def set_to_user(self, value: str) -> None:
         """Set the user part of the To header URI.

--- a/sdk/tests/test_whatsapp_calling.py
+++ b/sdk/tests/test_whatsapp_calling.py
@@ -1,0 +1,136 @@
+"""Tests for the WhatsApp Business Calling gateway example
+(examples/whatsapp_calling.py), driven through the SDK mocks.
+
+Covers both directions and the WhatsApp-specific invariants:
+  * inbound (Meta -> internal) is detected by source-IP membership of the
+    "whatsapp" gateway group (call.from_gateway), anchored with the SDES inbound
+    profile, and bridged to the internal gateway;
+  * outbound (internal -> Meta) rewrites From to the business number, sets the
+    digest credentials SIPhon uses to answer Meta's 407, anchors with the SDES
+    outbound profile, and dials wa.meta.vc over TLS;
+  * missing credentials / destination number are rejected, not dialled;
+  * MODE=dtls selects the DTLS-SRTP media profiles.
+"""
+import asyncio
+import importlib.util
+import os
+import pathlib
+
+import pytest
+
+from siphon_sdk import mock_module
+
+mock_module.install()
+
+from siphon import gateway  # noqa: E402  (must come after install)
+from siphon_sdk.call import Call  # noqa: E402
+
+EXAMPLE_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent.parent
+    / "examples"
+    / "whatsapp_calling.py"
+)
+INTERNAL_URI = "sip:pbx.internal.example.net:5060"
+# RFC 5737 TEST-NET-3 addresses standing in for Meta's WhatsApp source range
+# and an internal caller.
+WHATSAPP_IP = "203.0.113.50"
+INTERNAL_IP = "203.0.113.20"
+
+
+def _load_example(business="+15551234567", password="s3cret", mode="sdes"):
+    """Import a fresh copy of the example with the given environment.
+
+    The example reads its config from the environment at import time, so each
+    scenario re-imports it.
+    """
+    os.environ["WHATSAPP_BUSINESS_NUMBER"] = business
+    os.environ["WHATSAPP_SIP_PASSWORD"] = password
+    os.environ["WHATSAPP_MEDIA_MODE"] = mode
+    spec = importlib.util.spec_from_file_location("whatsapp_calling_example", EXAMPLE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _fresh_mocks():
+    mock_module.reset()
+    gateway.add_group("internal", [{"uri": INTERNAL_URI, "address": f"{INTERNAL_IP}:5060"}])
+    # In production source_networks carries Meta's published ranges; the mock
+    # matches source IP against the group's destination addresses, so a single
+    # representative address stands in for the range here.
+    gateway.add_group(
+        "whatsapp",
+        [{"uri": "sip:wa.meta.vc:5061;transport=tls", "address": f"{WHATSAPP_IP}:5061"}],
+    )
+    yield
+    mock_module.reset()
+
+
+def _rtpengine_profiles():
+    return [profile for op, profile in mock_module.get_rtpengine().operations if op == "offer"]
+
+
+def _actions(call, kind):
+    return [action for action in call._actions if action.kind == kind]
+
+
+def test_inbound_from_whatsapp_bridges_to_internal():
+    module = _load_example()
+    call = Call(
+        ruri="sip:+15551234567@whatsapp-gw.example.com",
+        source_ip=WHATSAPP_IP,
+        headers={"x-wa-meta-wacid": "wacid-abc"},
+    )
+    asyncio.run(module.route(call))
+
+    assert "srtp_to_rtp" in _rtpengine_profiles()
+    dials = _actions(call, "dial")
+    assert [d.targets for d in dials] == [[INTERNAL_URI]]
+    assert not _actions(call, "reject")
+
+
+def test_outbound_to_whatsapp_sets_from_creds_and_dials_meta():
+    module = _load_example(business="+15559876543", password="metapass")
+    call = Call(ruri="sip:+31612345678@whatsapp-gw.example.com", source_ip=INTERNAL_IP)
+    asyncio.run(module.route(call))
+
+    # From user rewritten to the business number — Meta cross-checks it against
+    # the digest username.
+    assert call.from_uri.user == "+15559876543"
+    creds = _actions(call, "set_credentials")
+    assert creds and creds[0].extras["username"] == "+15559876543"
+    assert creds[0].extras["password"] == "metapass"
+
+    assert "rtp_to_srtp" in _rtpengine_profiles()
+    dials = _actions(call, "dial")
+    assert [d.targets for d in dials] == [["sip:+31612345678@wa.meta.vc:5061;transport=tls"]]
+
+
+def test_outbound_without_credentials_is_rejected_not_dialled():
+    module = _load_example(business="", password="")
+    call = Call(ruri="sip:+31612345678@whatsapp-gw.example.com", source_ip=INTERNAL_IP)
+    asyncio.run(module.route(call))
+
+    rejects = _actions(call, "reject")
+    assert rejects and rejects[0].status_code == 503
+    assert not _actions(call, "dial")
+
+
+def test_outbound_without_destination_number_is_rejected_404():
+    module = _load_example()
+    call = Call(ruri="sip:whatsapp-gw.example.com", source_ip=INTERNAL_IP)  # no user part
+    asyncio.run(module.route(call))
+
+    rejects = _actions(call, "reject")
+    assert rejects and rejects[0].status_code == 404
+    assert not _actions(call, "dial")
+
+
+def test_dtls_mode_selects_dtls_profiles():
+    module = _load_example(mode="dtls")
+    call = Call(ruri="sip:+15551234567@whatsapp-gw.example.com", source_ip=WHATSAPP_IP)
+    asyncio.run(module.route(call))
+
+    assert "whatsapp_dtls_in" in _rtpengine_profiles()
+    assert "srtp_to_rtp" not in _rtpengine_profiles()

--- a/src/config.rs
+++ b/src/config.rs
@@ -3843,6 +3843,52 @@ registrant:
         assert!(ims.features.iter().any(|f| f == "mmtel"));
     }
 
+    /// The shipped WhatsApp Business Calling gateway example must parse, and its
+    /// WhatsApp-specific invariants must hold: no mutual-TLS client cert (Meta is
+    /// server-auth only), no session timer (a re-INVITE would fail the WhatsApp
+    /// leg), the whatsapp + internal gateway groups (WhatsApp probe disabled —
+    /// Meta does not answer OPTIONS), and the DTLS-SRTP media profiles. Guards
+    /// against the example silently rotting.
+    #[test]
+    fn example_whatsapp_calling_yaml_parses() {
+        let yaml = include_str!("../examples/whatsapp_calling.yaml");
+        let config = Config::from_str(yaml).expect("example yaml must parse");
+
+        // Server-auth TLS only — no outbound client certificate toward Meta.
+        let tls = config.tls.expect("tls block");
+        assert!(tls.client_certificate.is_none());
+        assert!(tls.client_private_key.is_none());
+
+        // SIPhon must never originate a re-INVITE toward the WhatsApp leg.
+        assert!(config.session_timer.is_none());
+
+        let gateway = config.gateway.expect("gateway block");
+        let whatsapp = gateway
+            .groups
+            .iter()
+            .find(|g| g.name == "whatsapp")
+            .expect("whatsapp gateway group");
+        assert!(!whatsapp.probe.enabled);
+        // Meta's source ranges drive call.from_gateway("whatsapp") direction
+        // detection — the group must carry source_networks.
+        assert!(!whatsapp.source_networks.is_empty());
+        assert!(gateway.groups.iter().any(|g| g.name == "internal"));
+
+        // DTLS-SRTP profiles for the Meta leg (the SDES default reuses built-ins).
+        let media = config.media.expect("media block");
+        let dtls_in = media
+            .profiles
+            .get("whatsapp_dtls_in")
+            .expect("whatsapp_dtls_in profile");
+        assert_eq!(dtls_in.answer.transport_protocol.as_deref(), Some("RTP/SAVPF"));
+        assert_eq!(dtls_in.answer.dtls.as_deref(), Some("passive"));
+        let dtls_out = media
+            .profiles
+            .get("whatsapp_dtls_out")
+            .expect("whatsapp_dtls_out profile");
+        assert_eq!(dtls_out.offer.dtls.as_deref(), Some("passive"));
+    }
+
     #[test]
     fn parses_security_config() {
         let yaml = r#"


### PR DESCRIPTION
WhatsApp's Business Calling API is SIP-over-TLS to `wa.meta.vc`, so siphon can bridge WhatsApp voice to an internal SIP/IMS network as a B2BUA with no new protocol code. This is a specialised TLS trunk plus a routing script.

## Adds

- **`examples/whatsapp_calling.{py,yaml}`** — B2BUA both directions. Server-auth TLS (no client certificate; Meta does not do mutual TLS), outbound digest via `call.set_credentials()` (siphon answers Meta's 407 with `Proxy-Authorization` automatically), OPUS passthrough, and no `session_timer` (Meta rejects re-INVITEs toward its leg). Direction is keyed on `call.from_gateway("whatsapp")`, the source IP that is handshake-verified on TLS, with Meta's ranges listed in the group's `source_networks`, rather than the forgeable `X-FB-External-Domain` header. SDES keying reuses the built-in `srtp_to_rtp`/`rtp_to_srtp` profiles; DTLS-SRTP uses new `whatsapp_dtls_{in,out}` profiles (marked as needing validation against a live number).
- **Docs**: `docs/cookbook/whatsapp-calling.md` + nav, a feature-readiness-matrix row, and a `## [Unreleased]` CHANGELOG entry. The cookbook cross-links the siphon-http WhatsApp Cloud API (messaging) recipe.
- **Tests**: a `src/config.rs` parse guard for the example config (asserts no client cert, no session timer, the gateway groups, and the DTLS profiles), plus `sdk/tests/test_whatsapp_calling.py` driving both directions through the SDK mocks.

Also fixes a latent SDK-mock bug: `Call.set_from_user` / `set_ruri_user` did string operations on a parsed `SipUri` and would have raised; they now mutate `.user`, matching `set_to_user`.

## Verification

`cargo test` (config parse), the SDK suite (`483 + 5` pass), and `cargo clippy --all-targets --all-features -- -D warnings` are green. Live validation against a WhatsApp Business number (the per-number SIP password from `include_sip_credentials`, SDES first) is the remaining acceptance step.
