### PR TITLE
feat(media): address_family on a media profile — IPv4/IPv6 interworking on rtpengine + siphon-rtp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`address_family` on a media profile — IPv4/IPv6 interworking on the media
+  plane.** A `media.profiles.<name>.offer` / `.answer` block can now pin the
+  address family the media engine allocates its relay endpoints in for that side
+  of the call (`IP4` / `IP6`, the SDP `addrtype` spelling; `ipv4` / `ipv6` are
+  accepted and normalised). Unset — the default — keeps today's behaviour: the
+  engine follows the offered SDP, so the relay is single-family. Setting it is
+  what lets a v6-only access leg (VoNR / IPv6 VoLTE) bridge to a v4 core: the
+  profile used toward the core sets `IP4`, the one back toward the UE `IP6`.
+  Wired on both modern backends — **rtpengine** receives it as the dedicated
+  `"address family"` NG dict key (it is a first-class key there, *not* a token in
+  the `flags` list, where the engine would ignore it), **siphon-rtp** as the
+  `address_family` control field. The classic `rtpproxy` backend has no
+  equivalent — its `6` modifier states the family of the address the command
+  carries, it does not select one — so siphon logs a warning at boot naming any
+  profile that asks for it there. An unrecognised value fails the config load
+  rather than being passed to an engine that would drop it silently.
 - **`listen.mtu` — RFC 3261 §18.1.1 UDP→TCP fallback for oversized requests.**
   When `listen.mtu` is set, an outbound SIP *request* built for UDP whose
   serialised length exceeds `mtu − 200` bytes is relayed over TCP instead — but

--- a/docs/cookbook/media-rtp.md
+++ b/docs/cookbook/media-rtp.md
@@ -86,8 +86,12 @@ still apply, but only the flags rtpproxy understands: a profile's
 `direction: ["internal","external"]` becomes bridge mode (`ie`/`ei`) and an
 `asymmetric` flag maps through; IPv6 is detected per stream. SRTP/DTLS/ICE flags are
 ignored — rtpproxy is a plain RTP relay (use `rtpengine` or `siphon-rtp` for SRTP↔RTP,
-WebRTC, or transcoding). It has the same weighted round-robin + per-call-id affinity
-and per-instance `V` health probes as the other backends.
+WebRTC, or transcoding). A profile's
+[`address_family`](#ipv4-and-ipv6-interworking) is unsupported here too — rtpproxy's
+`6` modifier reports the family of the address the command carries, it cannot select
+one for the relay — and siphon warns at boot naming any profile that sets it. It has
+the same weighted round-robin + per-call-id affinity and per-instance `V` health
+probes as the other backends.
 
 !!! note "rtpproxy is anchor-only"
     The extra `rtpengine` verbs — announcements / tones (`play_media`, `play_dtmf`),
@@ -176,6 +180,37 @@ media:
 ```python
 await rtpengine.offer(request, profile="srtp_to_srtp")
 ```
+
+### IPv4 and IPv6 interworking
+
+`address_family` pins the family the engine allocates its **own** relay endpoints
+in for that side of the call. Leave it unset (the default) and the engine follows
+the offered SDP, which gives you a single-family relay — fine until one side is
+v6-only. Set it per direction to bridge, e.g. a v6 VoLTE access leg reaching a v4
+core:
+
+```yaml
+media:
+  profiles:
+    v6_access_to_v4_core:
+      offer:                     # toward the core: hand it a v4 endpoint
+        replace: ["origin"]
+        address_family: "IP4"
+      answer:                    # back toward the v6 UE
+        replace: ["origin"]
+        address_family: "IP6"
+```
+
+The value is the SDP `addrtype` spelling, `IP4` or `IP6` (`ipv4` / `ipv6` are
+accepted and normalised; anything else fails the config load, because a media
+engine ignores an unknown family silently and you would get a relay in the wrong
+family with no error). The engine needs an interface configured in the target
+family — rtpengine's `interface=` must list both, otherwise it has nothing to
+allocate from.
+
+Works on **rtpengine** (sent as the dedicated `address family` NG key) and
+**siphon-rtp** (the `address_family` control field). The classic **rtpproxy**
+backend has no equivalent and logs a warning at boot if a profile sets it.
 
 ## Shape the SDP yourself
 

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -147,6 +147,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Built-in profile: WSS↔RTP | Implemented | `wss_to_rtp` | DTLS-SRTP/AVPF + ICE ↔ RTP |
 | Built-in profile: RTP passthrough | Implemented | `rtp_passthrough` | IMS-internal |
 | Custom media profiles | Implemented | `media.profiles` | User-defined NG flags |
+| Media-plane IPv4↔IPv6 interworking | Implemented | `media.profiles.<name>.{offer,answer}.address_family` | Pins the family (`IP4`/`IP6`) the engine allocates its relay endpoints in per direction, so a v6-only access leg can bridge to a v4 core; unset (default) = follow the offered SDP, unchanged single-family behaviour. rtpengine (dedicated `address family` NG key, not a `flags` token) + siphon-rtp (`address_family` control field); the classic rtpproxy backend cannot express it and is warned about at boot. Unknown values fail the config load. Wire-level tests on both backends (`offer_carries_address_family_on_the_wire`). Not yet validated against a live dual-stack engine. |
 | SDP manipulation (`sdp` namespace) | Implemented | None | Parse/modify/apply SDP from Python scripts |
 | SDP attribute get/set/remove | Implemented | None | Session and media-level `a=` attributes |
 | SDP codec filtering | Implemented | None | `filter_codecs()` / `remove_codecs()` |
@@ -350,7 +351,7 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Authentication | 6 (HTTP/HA1, digest 401/407, anti-spoof, Diameter Cx, IMS AKA) | 3 (static, local Milenage AKA, SHA-256) | 9 |
 | Security | 5 (rate limit, scanner, trusted CIDR, fail ban, APIBan) | 1 (IP ACLs) | 6 |
 | NAT | 5 (rport, fix contact, fix register, script fixup, stale eviction) | 3 (keepalive, CRLF keepalive, flow tokens) | 8 |
-| Media | 1 (RTPEngine NG) | 6 (LB, 4 profiles, custom profiles) | 7 |
+| Media | 1 (RTPEngine NG) | 7 (LB, 4 profiles, custom profiles, v4↔v6 interworking) | 8 |
 | Gateway routing | 3 (groups, round-robin, probes) | 4 (weighted, hash, failover, dynamic) | 7 |
 | CDR | 0 | 5 (file, syslog, HTTP, register events, extra fields) | 5 |
 | Tracing | 3 (HEP v3 UDP, agent ID, error suppression) | 2 (TCP, TLS) | 5 |
@@ -358,4 +359,4 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Scripting | 14 (proxy, B2BUA, registrar, auth, gateway, cache, presence, logging, metrics, async, ...) | 3 (LI, timer, SDK) | 17 |
 | 3GPP/IMS | 10 (Cx, Sh, Rx, peer mgmt, IMS AKA HSS-backed, IPsec, iFC, P/I/S-CSCF, Npcf) | 4 (Ro, Rf, local Milenage AKA, Nchf) | 14 |
 | LI/Recording | 0 | 5 (X1, X2, X3, SIPREC, audit) | 5 |
-| **Totals** | **~66** | **~42** | **~109** |
+| **Totals** | **~66** | **~43** | **~110** |

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -555,6 +555,8 @@ auth:
 #   # `profiles:` and `health_check_interval_secs:` apply here too. A profile's
 #   # NAT `direction` (["internal","external"]) and `asymmetric` flag map to
 #   # rtpproxy bridge/symmetry modifiers; IPv6 is auto-detected per stream.
+#   # A profile's `address_family:` is NOT supported here (rtpengine/siphon-rtp
+#   # only) — siphon warns at boot if one sets it on this backend.
 #   # The `media.events:` listener is unused — rtpproxy pushes no async events.
 #
 # Custom media profiles (extend or override built-ins):
@@ -581,6 +583,34 @@ auth:
 #         ice: "remove"
 #         replace: ["origin"]
 #         direction: ["internal", "external"]
+#
+# Per-profile keys:
+#   transport_protocol  RTP/AVP, RTP/SAVP, RTP/AVPF, RTP/SAVPF
+#   ice                 remove | force | force-relay
+#   dtls                passive | active | off
+#   replace             SDP fields the engine rewrites, e.g. ["origin"]
+#   address_family      IP4 | IP6 — the family the engine allocates its relay
+#                       endpoints in for this side of the call. Unset (default)
+#                       means "follow the offered SDP", i.e. a single-family
+#                       relay. Set it to bridge families: a v6 VoLTE access side
+#                       reaching a v4 core sets IP4 on the profile used toward
+#                       the core. rtpengine + siphon-rtp only; the rtpproxy
+#                       backend cannot honour it (warned at boot).
+#   flags               trust-address, symmetric, asymmetric, port latching, …
+#   direction           NAT leg pair, e.g. ["external", "internal"]
+#   record_call         true to have the engine record this leg
+#   record_path         recording output directory
+#
+# IPv4/IPv6 interworking — v6 access leg, v4 core:
+# media:
+#   profiles:
+#     v6_access_to_v4_core:
+#       offer:                          # toward the core: allocate v4
+#         replace: ["origin"]
+#         address_family: "IP4"
+#       answer:                         # back toward the v6 access side
+#         replace: ["origin"]
+#         address_family: "IP6"
 #
 # Python usage:
 #   rtpengine.offer(request, profile="srtp_to_srtp")

--- a/src/config.rs
+++ b/src/config.rs
@@ -1969,6 +1969,36 @@ fn default_siphon_rtp_play_timeout_ms() -> u64 {
     300_000
 }
 
+/// Serde deserializer for a media profile's `address_family`, canonicalising to
+/// the `IP4`/`IP6` spelling every media engine expects (it is the SDP `addrtype`
+/// token — rtpengine's `"address family"` NG key, siphon-rtp's `address_family`
+/// JSON field).
+///
+/// Case-insensitive, and `ipv4`/`ipv6` are accepted as aliases.  Any other value
+/// is a config error: the engines ignore an unknown family silently, so a typo
+/// would otherwise land as a relay quietly allocated in the wrong family.
+fn deserialize_address_family<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    let value: Option<String> = Option::deserialize(deserializer)?;
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "ip4" | "ipv4" => Ok(Some("IP4".to_string())),
+        "ip6" | "ipv6" => Ok(Some("IP6".to_string())),
+        other => Err(de::Error::custom(format!(
+            "media profile address_family must be \"IP4\" or \"IP6\" (aliases \
+             \"ipv4\"/\"ipv6\"), got {other:?}"
+        ))),
+    }
+}
+
 /// A user-defined RTPEngine media profile with separate offer/answer NG flags.
 #[derive(Debug, Deserialize, Clone)]
 pub struct MediaProfileConfig {
@@ -1988,6 +2018,17 @@ pub struct NgFlagsConfig {
     /// SDP fields to replace: "origin".
     #[serde(default)]
     pub replace: Vec<String>,
+    /// Address family the engine should allocate its relay endpoints in for this
+    /// side of the call: `"IP4"` or `"IP6"`.  Unset (the default) leaves the
+    /// engine following the offered SDP's own family — a single-family relay.
+    ///
+    /// Setting it is how an IPv4↔IPv6 interworking leg is expressed: a v6 VoLTE
+    /// access side bridged to a v4 core sets `address_family: "IP4"` on the
+    /// profile used toward the core.  Accepted case-insensitively, and `ipv4`/
+    /// `ipv6` are taken as aliases; anything else is a hard config error rather
+    /// than a value the media engine would silently ignore.
+    #[serde(default, deserialize_with = "deserialize_address_family")]
+    pub address_family: Option<String>,
     /// Additional flags: "trust-address", "symmetric", "asymmetric".
     #[serde(default)]
     pub flags: Vec<String>,
@@ -4450,6 +4491,72 @@ media:
         assert!(profile.offer.dtls.is_none());
         assert_eq!(profile.offer.direction, vec!["external", "internal"]);
         assert_eq!(profile.answer.direction, vec!["internal", "external"]);
+        // Unset unless the profile asks for a family.
+        assert!(profile.offer.address_family.is_none());
+        assert!(profile.answer.address_family.is_none());
+    }
+
+    /// A v6 VoLTE access side bridged to a v4 core: the profile used toward the
+    /// core pins `IP4`.  Accepted case-insensitively with `ipv4`/`ipv6` aliases,
+    /// always canonicalised to the SDP `addrtype` spelling the engines want.
+    #[test]
+    fn parses_media_profile_address_family() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+media:
+  rtpengine:
+    address: "127.0.0.1:22222"
+  profiles:
+    v6_access_to_v4_core:
+      offer:
+        replace: ["origin"]
+        address_family: "IP4"
+      answer:
+        replace: ["origin"]
+        address_family: "ipv6"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        let media = config.media.unwrap();
+        let profile = media.profiles.get("v6_access_to_v4_core").unwrap();
+        assert_eq!(profile.offer.address_family.as_deref(), Some("IP4"));
+        assert_eq!(profile.answer.address_family.as_deref(), Some("IP6"));
+    }
+
+    /// The engines drop an unknown family silently, so a typo has to fail the
+    /// config load — otherwise it lands as a relay in the wrong family.
+    #[test]
+    fn rejects_media_profile_bad_address_family() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+media:
+  rtpengine:
+    address: "127.0.0.1:22222"
+  profiles:
+    broken:
+      offer:
+        address_family: "IP5"
+      answer: {}
+"#;
+        let error = Config::from_str(yaml).expect_err("IP5 must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("address_family"),
+            "error should name the field: {message}"
+        );
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -5529,6 +5529,33 @@ pub fn init_rtpengine(
         &media_config.profiles,
     ));
 
+    // `address_family` has no equivalent in the classic rtpproxy control
+    // protocol: its `6` modifier states the family of the address the command
+    // carries (derived from the offered c= line), it does not select a family for
+    // the relay.  Say so at boot rather than let the knob look wired.
+    if matches!(
+        media_config.backend,
+        crate::config::MediaBackendKind::Rtpproxy
+    ) {
+        let mut with_family: Vec<&str> = media_config
+            .profiles
+            .iter()
+            .filter(|(_, profile)| {
+                profile.offer.address_family.is_some() || profile.answer.address_family.is_some()
+            })
+            .map(|(name, _)| name.as_str())
+            .collect();
+        if !with_family.is_empty() {
+            with_family.sort_unstable();
+            warn!(
+                profiles = %with_family.join(", "),
+                "media profile sets address_family, which the rtpproxy backend \
+                 cannot honour (rtpengine / siphon-rtp only) — IPv4/IPv6 \
+                 interworking will not happen on these profiles"
+            );
+        }
+    }
+
     // Create the Python-side singleton (shares the same Arcs).
     let py_rtpengine = crate::script::api::rtpengine::PyRtpEngine::new(
         Arc::clone(&backend),

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -82,6 +82,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
                 record_call: false,
@@ -92,6 +93,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
                 record_call: false,
@@ -107,6 +109,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
                 record_call: false,
@@ -117,6 +120,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
                 record_call: false,
@@ -132,6 +136,7 @@ impl ProfileRegistry {
                 ice: Some("force".into()),
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
                 record_call: false,
@@ -142,6 +147,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
                 record_call: false,
@@ -157,6 +163,7 @@ impl ProfileRegistry {
                 ice: Some("force".into()),
                 dtls: Some("passive".into()),
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
                 record_call: false,
@@ -167,6 +174,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
                 record_call: false,
@@ -186,6 +194,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![
                     "media handover".into(),
                     "port latching".into(),
@@ -199,6 +208,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![
                     "media handover".into(),
                     "port latching".into(),
@@ -223,6 +233,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec![],
                 direction: vec![],
                 record_call: false,
@@ -239,6 +250,7 @@ impl ProfileRegistry {
                 ice: None,
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec!["trust-address".into()],
                 direction: vec![],
                 record_call: false,
@@ -249,6 +261,7 @@ impl ProfileRegistry {
                 ice: None,
                 dtls: None,
                 replace: vec!["origin".into()],
+                address_family: None,
                 flags: vec!["trust-address".into()],
                 direction: vec![],
                 record_call: false,
@@ -275,6 +288,15 @@ pub struct NgFlags {
     pub dtls: Option<String>,
     /// SDP fields to replace: "origin".
     pub replace: Vec<String>,
+    /// Address family for the engine's relay endpoints on this side of the call:
+    /// `"IP4"` or `"IP6"` (the SDP `addrtype` spelling).  `None` leaves the
+    /// engine following the offered SDP's own family — a single-family relay.
+    ///
+    /// Carried on the wire as rtpengine's dedicated `"address family"` NG dict
+    /// key (**not** a `flags` token — rtpengine would ignore it there) and as
+    /// siphon-rtp's `address_family` JSON field.  The classic `rtpproxy` backend
+    /// has no equivalent and cannot honour it.
+    pub address_family: Option<String>,
     /// Additional flags: "trust-address", "symmetric", "asymmetric".
     pub flags: Vec<String>,
     /// Direction pair for NAT traversal: ["external", "internal"].
@@ -293,6 +315,7 @@ impl NgFlags {
             ice: config.ice.clone(),
             dtls: config.dtls.clone(),
             replace: config.replace.clone(),
+            address_family: config.address_family.clone(),
             flags: config.flags.clone(),
             direction: config.direction.clone(),
             record_call: config.record_call,
@@ -321,6 +344,12 @@ impl NgFlags {
         if !self.replace.is_empty() {
             let items: Vec<&str> = self.replace.iter().map(|s| s.as_str()).collect();
             pairs.push(("replace", BencodeValue::string_list(&items)));
+        }
+        // rtpengine reads the address family from a dedicated dict key
+        // (`"address family": "IP4"`), NOT as a token in the `flags` list — a
+        // family smuggled into `flags` is silently dropped by the engine.
+        if let Some(address_family) = &self.address_family {
+            pairs.push(("address family", BencodeValue::string(address_family)));
         }
         if !self.flags.is_empty() {
             let items: Vec<&str> = self.flags.iter().map(|s| s.as_str()).collect();
@@ -392,6 +421,7 @@ mod tests {
                     ice: Some("force".into()),
                     dtls: Some("passive".into()),
                     replace: vec!["origin".into()],
+                    address_family: None,
                     flags: vec![],
                     direction: vec!["external".into(), "internal".into()],
                     record_call: false,
@@ -402,6 +432,7 @@ mod tests {
                     ice: Some("remove".into()),
                     dtls: Some("off".into()),
                     replace: vec!["origin".into()],
+                    address_family: None,
                     flags: vec![],
                     direction: vec!["internal".into(), "external".into()],
                     record_call: false,
@@ -430,6 +461,7 @@ mod tests {
                     ice: None,
                     dtls: None,
                     replace: vec![],
+                    address_family: None,
                     flags: vec![],
                     direction: vec![],
                     record_call: false,
@@ -440,6 +472,7 @@ mod tests {
                     ice: None,
                     dtls: None,
                     replace: vec![],
+                    address_family: None,
                     flags: vec![],
                     direction: vec![],
                     record_call: false,
@@ -566,6 +599,99 @@ mod tests {
         let keys: Vec<&str> = pairs.iter().map(|(k, _)| *k).collect();
         assert!(keys.contains(&"record call"), "missing 'record call' key");
         assert!(keys.contains(&"recording-dir"), "missing 'recording-dir' key");
+    }
+
+    /// `address family` must ride its own NG dict key with the SDP `addrtype`
+    /// spelling.  rtpengine reads the family from that key only — a family put in
+    /// the free-form `flags` list is silently ignored by the engine, which is the
+    /// exact bug this key exists to avoid.
+    #[test]
+    fn ng_flags_emits_address_family_as_its_own_key() {
+        let flags = NgFlags {
+            address_family: Some("IP4".into()),
+            ..NgFlags::default()
+        };
+        let pairs = flags.to_bencode_pairs();
+        let (key, value) = pairs
+            .iter()
+            .find(|(key, _)| *key == "address family")
+            .expect("missing 'address family' key");
+        assert_eq!(*key, "address family");
+        assert_eq!(*value, super::super::bencode::BencodeValue::string("IP4"));
+        // Never smuggled into the flags list.
+        assert!(!pairs.iter().any(|(key, _)| *key == "flags"));
+    }
+
+    #[test]
+    fn ng_flags_omits_address_family_when_unset() {
+        let flags = NgFlags::default();
+        assert!(!flags
+            .to_bencode_pairs()
+            .iter()
+            .any(|(key, _)| *key == "address family"));
+    }
+
+    /// A profile's `address_family` must survive the YAML → `NgFlags` hop; it
+    /// previously had no `NgFlagsConfig` source at all.
+    #[test]
+    fn address_family_flows_from_config_to_flags() {
+        let mut custom = HashMap::new();
+        custom.insert(
+            "v6_access_to_v4_core".to_string(),
+            MediaProfileConfig {
+                offer: NgFlagsConfig {
+                    transport_protocol: None,
+                    ice: None,
+                    dtls: None,
+                    replace: vec!["origin".into()],
+                    address_family: Some("IP4".into()),
+                    flags: vec![],
+                    direction: vec![],
+                    record_call: false,
+                    record_path: None,
+                },
+                answer: NgFlagsConfig {
+                    transport_protocol: None,
+                    ice: None,
+                    dtls: None,
+                    replace: vec!["origin".into()],
+                    address_family: Some("IP6".into()),
+                    flags: vec![],
+                    direction: vec![],
+                    record_call: false,
+                    record_path: None,
+                },
+            },
+        );
+        let registry = ProfileRegistry::from_config(&custom);
+        let entry = registry.get("v6_access_to_v4_core").unwrap();
+        assert_eq!(entry.offer.address_family.as_deref(), Some("IP4"));
+        assert_eq!(entry.answer.address_family.as_deref(), Some("IP6"));
+        let keys: Vec<&str> = entry
+            .offer
+            .to_bencode_pairs()
+            .iter()
+            .map(|(key, _)| *key)
+            .collect();
+        assert!(keys.contains(&"address family"));
+    }
+
+    /// Built-ins must stay family-agnostic — anchoring a plain call must not
+    /// suddenly pin a relay family (that would be a silent wire change).
+    #[test]
+    fn builtin_profiles_leave_address_family_unset() {
+        let registry = ProfileRegistry::new();
+        for name in registry.profile_names() {
+            let entry = registry.get(name).unwrap();
+            assert!(
+                entry.offer.address_family.is_none(),
+                "{name} offer pins an address family"
+            );
+            assert!(
+                entry.answer.address_family.is_none(),
+                "{name} answer pins an address family"
+            );
+        }
     }
 
     #[test]

--- a/src/rtpengine/rtpproxy.rs
+++ b/src/rtpengine/rtpproxy.rs
@@ -599,6 +599,13 @@ fn unsupported(operation: &str) -> RtpEngineError {
 ///   get the `ie`/`ei` pairing rtpproxy bridging expects).
 /// - a `flags` entry of `"asymmetric"` → `a` (rtpproxy defaults to symmetric).
 /// - an IPv6 stream → `6`.
+///
+/// A profile's `address_family` is deliberately **not** mapped here: rtpproxy's
+/// `6` states the family of the address this very command carries (taken from the
+/// offered `c=` line), so it is an observation, not a policy knob — forcing it
+/// against the address would just make rtpproxy reject the command.  Selecting a
+/// relay family per leg (IPv4↔IPv6 interworking) is an rtpengine / siphon-rtp
+/// capability; `init_rtpengine` warns at boot if a profile asks for it here.
 fn command_modifiers(flags: &NgFlags, is_ipv6: bool) -> String {
     let mut modifiers = String::new();
     for direction in &flags.direction {

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -63,12 +63,13 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         ice: flags.ice.clone(),
         dtls: flags.dtls.clone(),
         replace: flags.replace.clone(),
+        address_family: flags.address_family.clone(),
         flags: flags.flags.clone(),
         direction: flags.direction.clone(),
         record_call: flags.record_call,
         record_path: flags.record_path.clone(),
-        // Proto fields siphon's NgFlags has no source for (address_family,
-        // ws_uri, received_from, rtcp_mux). Default them: each carries
+        // Proto fields siphon's NgFlags has no source for (ws_uri,
+        // received_from, rtcp_mux). Default them: each carries
         // skip_serializing_if, so the emitted wire form is unchanged.
         ..ProfileFlags::default()
     }
@@ -1502,6 +1503,7 @@ mod tests {
             ice: Some("force".into()),
             dtls: Some("passive".into()),
             replace: vec!["origin".into()],
+            address_family: Some("IP4".into()),
             flags: vec!["trust-address".into(), "symmetric".into()],
             direction: vec!["external".into(), "internal".into()],
             record_call: true,
@@ -1512,6 +1514,7 @@ mod tests {
         assert_eq!(proto.ice.as_deref(), Some("force"));
         assert_eq!(proto.dtls.as_deref(), Some("passive"));
         assert_eq!(proto.replace, vec!["origin".to_string()]);
+        assert_eq!(proto.address_family.as_deref(), Some("IP4"));
         assert_eq!(proto.flags, vec!["trust-address".to_string(), "symmetric".to_string()]);
         assert_eq!(proto.direction, vec!["external".to_string(), "internal".to_string()]);
         assert!(proto.record_call);
@@ -1685,6 +1688,96 @@ mod tests {
         assert_eq!(client.active_sessions(), 1);
         assert_eq!(client.instance_count(), 1);
         assert_eq!(client.instance_addresses(), vec![address]);
+    }
+
+    /// The engine-facing twin of the rtpengine `"address family"` NG key: on this
+    /// backend the family rides the offer's `profile.address_family` JSON field.
+    /// Asserted on the raw frame so a rename or a drop in the mapping shows up as
+    /// a wire change, not just a struct-field change.
+    #[tokio::test]
+    async fn offer_carries_address_family_on_the_wire() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (frame_tx, frame_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = Vec::new();
+            // Decode as raw JSON rather than `Request` so the assertion is on the
+            // wire shape the engine actually parses.
+            let raw: serde_json::Value = read_frame(&mut stream, &mut buffer).await;
+            let _ = frame_tx.send(raw);
+            write_frame(
+                &mut stream,
+                &Response {
+                    id: 1,
+                    result: CmdResult::Ok {
+                        sdp: Some("v=0\r\nc=IN IP4 203.0.113.1\r\n".into()),
+                        duration_ms: None,
+                        to_tag: None,
+                        stats: None,
+                        play_id: None,
+                    },
+                },
+            )
+            .await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
+        let flags = NgFlags {
+            address_family: Some("IP6".into()),
+            ..NgFlags::default()
+        };
+        client
+            .offer("call-af", "tag-a", b"v=0\r\n", &flags)
+            .await
+            .unwrap();
+
+        let raw = frame_rx.await.unwrap();
+        assert_eq!(raw["command"], "offer");
+        assert_eq!(raw["profile"]["address_family"], "IP6");
+    }
+
+    /// Absent by default — anchoring a plain call must not pin a relay family.
+    #[tokio::test]
+    async fn offer_omits_address_family_when_unset() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (frame_tx, frame_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = Vec::new();
+            let raw: serde_json::Value = read_frame(&mut stream, &mut buffer).await;
+            let _ = frame_tx.send(raw);
+            write_frame(
+                &mut stream,
+                &Response {
+                    id: 1,
+                    result: CmdResult::Ok {
+                        sdp: Some("v=0\r\n".into()),
+                        duration_ms: None,
+                        to_tag: None,
+                        stats: None,
+                        play_id: None,
+                    },
+                },
+            )
+            .await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
+        client
+            .offer("call-af", "tag-a", b"v=0\r\n", &NgFlags::default())
+            .await
+            .unwrap();
+
+        let raw = frame_rx.await.unwrap();
+        assert!(raw["profile"]["address_family"].is_null());
     }
 
     /// Fake engine that accepts one `PlayMedia` with `play_id`, then optionally

--- a/tests/integration/rtpengine_tests.rs
+++ b/tests/integration/rtpengine_tests.rs
@@ -310,6 +310,77 @@ async fn profile_flags_produce_valid_bencode() {
     }
 }
 
+/// End-to-end proof that a profile's `address_family` reaches the engine as the
+/// dedicated `"address family"` NG key — rtpengine reads the family from that key
+/// only, so a value stuck in the free-form `flags` list would be silently ignored
+/// and the relay would come back in the offerer's family.
+#[tokio::test]
+async fn offer_carries_address_family_on_the_wire() {
+    let (command_sender, mut command_receiver) = tokio::sync::mpsc::channel(4);
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let address = socket.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let mut buffer = BytesMut::zeroed(65535);
+        while let Ok((size, source)) = socket.recv_from(&mut buffer).await {
+            let data = &buffer[..size];
+            let space = data.iter().position(|&byte| byte == b' ').unwrap();
+            let cookie = data[..space].to_vec();
+            let command = bencode::decode_full_dict(&data[space + 1..]).unwrap();
+            let family = command
+                .dict_get_str("address family")
+                .map(|value| value.to_string());
+            let flags_has_family = match command.dict_get("flags") {
+                Some(BencodeValue::List(items)) => items.iter().any(|item| match item {
+                    BencodeValue::String(bytes) => {
+                        let text = String::from_utf8_lossy(bytes).to_ascii_uppercase();
+                        text.contains("IP4") || text.contains("IP6")
+                    }
+                    _ => false,
+                }),
+                _ => false,
+            };
+            let _ = command_sender.send((family, flags_has_family)).await;
+
+            let response = BencodeValue::dict(vec![
+                ("result", BencodeValue::string("ok")),
+                (
+                    "sdp",
+                    BencodeValue::string(concat!(
+                        "v=0\r\n",
+                        "o=- 0 0 IN IP4 203.0.113.1\r\n",
+                        "s=-\r\n",
+                        "c=IN IP4 203.0.113.1\r\n",
+                        "t=0 0\r\n",
+                        "m=audio 30000 RTP/AVP 0\r\n",
+                    )),
+                ),
+            ]);
+            let mut reply = cookie;
+            reply.push(b' ');
+            reply.extend_from_slice(&bencode::encode(&response));
+            let _ = socket.send_to(&reply, source).await;
+        }
+    });
+
+    let client = RtpEngineClient::new(address, 1000).await.unwrap();
+    let flags = NgFlags {
+        address_family: Some("IP4".into()),
+        ..NgFlags::default()
+    };
+    client
+        .offer("call-af", "tag-a", b"v=0\r\n", &flags)
+        .await
+        .unwrap();
+
+    let (family, flags_has_family) = command_receiver.recv().await.unwrap();
+    assert_eq!(family.as_deref(), Some("IP4"));
+    assert!(
+        !flags_has_family,
+        "the family must ride its own key, never the flags list"
+    );
+}
+
 #[tokio::test]
 async fn config_media_section_backward_compatible() {
     use siphon::config::Config;


### PR DESCRIPTION
A media profile can now pin the **address family the media engine allocates its
own relay endpoints in**, per direction:

```yaml
media:
  profiles:
    v6_access_to_v4_core:
      offer:                     # toward the core: hand it a v4 endpoint
        replace: ["origin"]
        address_family: "IP4"
      answer:                    # back toward the v6 UE
        replace: ["origin"]
        address_family: "IP6"
```

Unset — the default — is exactly today's behaviour: the engine follows the
offered SDP, so the relay is single-family. Setting it is what lets a v6-only
access leg (VoNR / IPv6 VoLTE) bridge to a v4 core.

### Why it needed a dedicated field

rtpengine reads the family from its own NG dict key (`"address family": "IP4"`),
**not** from a token in the free-form `flags` list — a family put in `flags` is
silently ignored by the engine. `NgFlags` had no field for it and
`to_bencode_pairs` emitted only transport-protocol / ICE / DTLS / replace /
flags / direction / record, so there was no way to send it at all.

### What's wired

- **`NgFlagsConfig` / `NgFlags`** grow `address_family`, threaded through
  `from_config`.
- **rtpengine backend** — emitted from `to_bencode_pairs` as the `address family`
  key, so it rides `offer`, `answer` and the SIPREC `subscribe request`/`answer`
  paths that already merge profile pairs.
- **siphon-rtp backend** — mapped into the proto's `ProfileFlags.address_family`
  (the field already existed on the wire contract; `profile_flags_from_ng` was
  defaulting it away). No pin bump needed, `siphon-rtp-proto` 0.1.4 has it.
- **rtpproxy backend** — cannot express it. Its `6` modifier states the family of
  the address the command carries (taken from the offered `c=`), it does not
  select one for the relay, so forcing it would just get the command rejected.
  Rather than let the knob look wired, `init_rtpengine` warns at boot naming
  every profile that sets it on this backend, and both `siphon.yaml` and the
  cookbook say so.
- **Bad values fail the config load.** `IP4`/`IP6` (the SDP `addrtype` spelling),
  case-insensitive, `ipv4`/`ipv6` accepted as aliases and normalised; anything
  else is a hard error. An engine drops an unknown family silently, so a typo
  would otherwise surface as a relay in the wrong family with nothing logged.

### Tests

- Wire-level on **both** backends, not just struct-level: the rtpengine test
  decodes the bencode the client actually sent and asserts the `address family`
  key is present *and* that no family leaked into `flags`; the siphon-rtp test
  decodes the control frame as raw JSON and asserts
  `profile.address_family == "IP6"` (plus the omitted-when-unset twin).
- Config parse + canonicalisation (`ipv6` → `IP6`) and the reject-`IP5` case.
- YAML → `NgFlags` → bencode flow, and a guard that every built-in profile
  leaves the family unset (so anchoring a plain call can never start pinning a
  family).
- `profile_flags_from_ng_maps_every_field` extended — it is the field-exactness
  guard that should have caught this gap.

Full suite green (3507 tests, 0 failed), clippy clean with `-D warnings`.

Docs: `siphon.yaml` reference (per-profile key list + an interworking example),
cookbook `media-rtp.md` (new section + the rtpproxy caveat), feature matrix,
CHANGELOG.

Not yet validated against a live dual-stack engine — that's the next step on the
P-CSCF side.
