### PR TITLE
fix(b2bua): REFER 202 could be overtaken by its own first NOTIFY on UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,23 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   The server name is client-supplied plaintext and is used only to pick a
   certificate — it is not an identity signal.
 
+### Fixed
+- **REFER `202 Accepted` could be overtaken by its own first NOTIFY on UDP.**
+  On a siphon-terminated transfer the B2BUA answers `202` and immediately sends
+  the `message/sipfrag` `NOTIFY (100 Trying)` that opens the implicit
+  subscription. Both were enqueued in the right order, but the UDP transport
+  does not preserve it: every UDP worker clones the same outbound receiver
+  (flume is MPMC) and owns its own `SO_REUSEPORT` socket, so the two messages
+  are routinely picked up by two workers and race to `send_to`. When the NOTIFY
+  won, a referrer saw a NOTIFY for a subscription it had not been told existed
+  yet — RFC 3515 §2.4.4 has the 202 establish it — and a strict UA is entitled
+  to reject it. The pair is now enqueued as one ordered unit that a single
+  worker writes in sequence, so nothing can interleave between them. Stream
+  transports were never affected (one distributor task per listener) and are
+  unchanged. This was also the cause of the intermittent
+  `sipp-b2bua-refer` CI failure (`while expecting '202' … received 'NOTIFY'`).
+  Regression-guarded by a multi-worker UDP ordering test.
+
 ## [1.5.0] — 2026-07-27
 
 ### Added

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -3481,6 +3481,7 @@ fn relay_request(
     //   - URI-relay: the legacy path through `send_to_target`.
     let connection_id = if let Some(local) = flow_local_addr {
         let outbound_message = OutboundMessage {
+            followups: None,
             connection_id: ConnectionId(flow.map(|f| f.connection_id).unwrap_or(0)),
             transport: outbound_transport,
             destination,
@@ -3832,6 +3833,7 @@ fn relay_fork_branch(
     // normal resolver/pool path.
     let connection_id = if let Some(flow) = flow {
         let outbound_message = OutboundMessage {
+            followups: None,
             connection_id: ConnectionId(flow.connection_id),
             transport: outbound_transport,
             destination,
@@ -5361,6 +5363,7 @@ fn send_to_target(
 
             if let Some(connection_id) = connection_id {
                 let outbound_message = OutboundMessage {
+                    followups: None,
                     connection_id,
                     transport: Transport::Tls,
                     destination,
@@ -5424,6 +5427,7 @@ fn send_to_target(
             match state.stream_connections.reuse(destination, transport) {
                 Some(connection_id) => {
                     let outbound_message = OutboundMessage {
+                        followups: None,
                         connection_id,
                         transport,
                         destination,
@@ -5472,6 +5476,7 @@ fn send_to_target(
             let source_local_addr =
                 crate::script::api::ipsec::outbound_local_addr_for(destination).or(send_source);
             let outbound_message = OutboundMessage {
+                followups: None,
                 connection_id: fallback_connection_id,
                 transport,
                 destination,
@@ -6856,10 +6861,66 @@ fn send_outbound_from(
         data,
         source_local_addr,
         server_name: None,
+        followups: None,
     };
 
     if let Err(error) = state.outbound.send(outbound_message) {
         error!("failed to enqueue outbound message: {error}");
+    }
+}
+
+/// Serialize and enqueue `messages` as ONE outbound unit, so they leave in the
+/// given order with nothing interleaved.
+///
+/// Separate `send_message_from` calls do not order on UDP — the workers share
+/// the outbound channel and each owns its own socket, so two enqueues race (see
+/// [`OutboundMessage::followups`]). Use this wherever the sequence is part of
+/// the protocol rather than an accident of timing.
+fn send_messages_in_order_from(
+    messages: Vec<SipMessage>,
+    transport: Transport,
+    destination: SocketAddr,
+    connection_id: ConnectionId,
+    source_local_addr: Option<SocketAddr>,
+    state: &DispatcherState,
+) {
+    let mut frames = messages.into_iter().map(|message| Bytes::from(message.to_bytes()));
+    let Some(first) = frames.next() else {
+        return;
+    };
+    let followups: Vec<Bytes> = frames.collect();
+
+    // HEP sees each frame individually — they are distinct SIP messages on the
+    // wire, and a capture that merged them would not decode.
+    if let Some(ref hep) = state.hep_sender {
+        let local = source_local_addr
+            .or_else(|| state.listen_addrs.get(&transport).copied())
+            .unwrap_or(state.local_addr);
+        let local = state.hep_local_addr(local, transport);
+        hep.capture_outbound(local, destination, transport, &first);
+        for frame in &followups {
+            hep.capture_outbound(local, destination, transport, frame);
+        }
+    }
+
+    debug!(
+        destination = %destination,
+        frames = 1 + followups.len(),
+        "sending ordered message group"
+    );
+
+    let outbound_message = OutboundMessage {
+        connection_id,
+        transport,
+        destination,
+        data: first,
+        source_local_addr,
+        server_name: None,
+        followups: if followups.is_empty() { None } else { Some(followups) },
+    };
+
+    if let Err(error) = state.outbound.send(outbound_message) {
+        error!("failed to enqueue ordered outbound group: {error}");
     }
 }
 
@@ -10589,6 +10650,7 @@ fn b2bua_send_b_leg_invite(
     // resolver/pool path.
     if let Some(flow) = flow {
         let outbound_message = OutboundMessage {
+            followups: None,
             connection_id: ConnectionId(flow.connection_id),
             transport: outbound_transport,
             destination,
@@ -11030,6 +11092,7 @@ fn handle_registrant_ipsec_challenge(
             return;
         }
         let outbound_message = crate::transport::OutboundMessage {
+            followups: None,
             connection_id: crate::transport::ConnectionId::default(),
             transport,
             destination,
@@ -14692,6 +14755,7 @@ fn arm_reliable_provisional_retransmit(
                         "retransmitting reliable 1xx (RFC 3262)"
                     );
                     let _ = outbound.send(OutboundMessage {
+                        followups: None,
                         connection_id,
                         transport,
                         destination,
@@ -14767,6 +14831,7 @@ fn arm_b2bua_2xx_retransmit(
                         "retransmitting A-leg 2xx (RFC 3261 §13.3.1.4)"
                     );
                     let _ = outbound.send(OutboundMessage {
+                        followups: None,
                         connection_id,
                         transport,
                         destination,
@@ -16151,7 +16216,16 @@ fn b2bua_refer_accept(
                 "B2BUA REFER: accepting (siphon-terminated) — 202 + NOTIFY 100 Trying"
             );
 
-            // 202 Accepted to the referrer, on the flow the REFER arrived on.
+            // 202 Accepted to the referrer, on the flow the REFER arrived on,
+            // followed by the first NOTIFY (sipfrag 100 Trying) opening the
+            // implicit subscription.
+            //
+            // RFC 3515 §2.4.4 orders these: the 202 is what tells the referrer
+            // the subscription exists, so a NOTIFY that overtakes it can be
+            // rejected as being for an unknown subscription. They are enqueued
+            // as one ordered unit because two separate sends do NOT order on
+            // UDP — the workers share the outbound channel and each owns its own
+            // SO_REUSEPORT socket, so the NOTIFY could and did win the race.
             let accepted = build_response(
                 &message,
                 202,
@@ -16159,17 +16233,8 @@ fn b2bua_refer_accept(
                 state.server_header.as_deref(),
                 &[],
             );
-            send_message_from(
-                accepted,
-                inbound.transport,
-                inbound.remote_addr,
-                inbound.connection_id,
-                Some(inbound.local_addr),
-                state,
-            );
+            let mut ordered = vec![accepted];
 
-            // Open the subscription and send the first NOTIFY (sipfrag 100
-            // Trying) toward the referrer on the same flow.
             let notify_cseq = state.call_actors.reserve_leg_cseq(call_id, from_a_leg);
             let origin_leg = state.call_actors.clone_leg(call_id, from_a_leg);
             if let (Some(cseq), Some(leg)) = (notify_cseq, origin_leg) {
@@ -16194,16 +16259,18 @@ fn b2bua_refer_accept(
                         crate::b2bua::transfer::build_sipfrag_body(100, "Trying").into_bytes(),
                     )),
                 ) {
-                    send_message_from(
-                        notify,
-                        inbound.transport,
-                        inbound.remote_addr,
-                        inbound.connection_id,
-                        Some(inbound.local_addr),
-                        state,
-                    );
+                    ordered.push(notify);
                 }
             }
+
+            send_messages_in_order_from(
+                ordered,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
 
             // Dial the transfer target as a new leg, then record the
             // subscription tagged with that leg's Call-ID. The leg's 2xx is

--- a/src/registrant/mod.rs
+++ b/src/registrant/mod.rs
@@ -1332,6 +1332,7 @@ pub async fn registration_loop(
                             None
                         };
                         let outbound_message = OutboundMessage {
+                            followups: None,
                             connection_id: ConnectionId::default(),
                             transport,
                             destination,
@@ -1366,6 +1367,7 @@ pub async fn registration_loop(
                             None
                         };
                         let outbound_message = OutboundMessage {
+                            followups: None,
                             connection_id: ConnectionId::default(),
                             transport,
                             destination,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -377,6 +377,43 @@ pub struct OutboundMessage {
     /// destination IP literal (no SNI). Ignored for non-TLS transports and for
     /// TLS connection *reuse* (no handshake occurs).
     pub server_name: Option<String>,
+    /// Further messages that MUST leave after `data`, to the same destination,
+    /// without anything interleaving between them.
+    ///
+    /// Enqueueing two `OutboundMessage`s back to back does **not** order them on
+    /// UDP: every UDP worker clones the same outbound receiver (flume is MPMC)
+    /// and owns a separate `SO_REUSEPORT` socket, so two messages are routinely
+    /// picked up by two workers and race to `send_to`. Anything that is only
+    /// correct in a specific order — RFC 3515 §2.4.4's `202 Accepted` before the
+    /// first `message/sipfrag` NOTIFY, where the 202 is what tells the referrer
+    /// the implicit subscription exists — must travel as one unit so a single
+    /// worker writes them in sequence.
+    ///
+    /// `None` on effectively every message, and empty then costs no allocation.
+    /// Stream transports preserve order anyway (one distributor task per
+    /// listener), but honour this for free by writing the frames into the same
+    /// per-connection channel in order.
+    pub followups: Option<Vec<Bytes>>,
+}
+
+impl OutboundMessage {
+    /// The frames to write, in the order they must leave: `data`, then any
+    /// [`followups`](Self::followups).
+    pub fn frames(&self) -> impl Iterator<Item = &Bytes> {
+        std::iter::once(&self.data)
+            .chain(self.followups.iter().flat_map(|extra| extra.iter()))
+    }
+
+    /// Owned form of [`frames`](Self::frames), for senders that move each frame
+    /// into a per-connection channel.
+    pub fn into_frames(self) -> Vec<Bytes> {
+        let mut frames = Vec::with_capacity(1 + self.followups.as_ref().map_or(0, |e| e.len()));
+        frames.push(self.data);
+        if let Some(extra) = self.followups {
+            frames.extend(extra);
+        }
+        frames
+    }
 }
 
 /// Routes outbound messages to the correct transport channel.
@@ -755,10 +792,54 @@ mod tests {
             data: Bytes::from_static(b"SIP/2.0 200 OK\r\n\r\n"),
             source_local_addr: None,
             server_name: None,
+            followups: None,
         };
         assert_eq!(message.connection_id, ConnectionId(99));
         assert_eq!(message.transport, Transport::Udp);
         assert_eq!(message.destination.port(), 5060);
+    }
+
+    fn message_with_followups(followups: Option<Vec<Bytes>>) -> OutboundMessage {
+        OutboundMessage {
+            connection_id: ConnectionId(1),
+            transport: Transport::Udp,
+            destination: "10.0.0.1:5060".parse().unwrap(),
+            data: Bytes::from_static(b"202"),
+            source_local_addr: None,
+            server_name: None,
+            followups,
+        }
+    }
+
+    #[test]
+    fn frames_is_just_data_without_followups() {
+        let message = message_with_followups(None);
+        let frames: Vec<_> = message.frames().cloned().collect();
+        assert_eq!(frames, vec![Bytes::from_static(b"202")]);
+        assert_eq!(message.into_frames(), vec![Bytes::from_static(b"202")]);
+    }
+
+    #[test]
+    fn frames_yields_data_then_followups_in_order() {
+        // The order here IS the protocol requirement (RFC 3515 §2.4.4): the
+        // REFER's 202 must precede the NOTIFY that reports on the subscription
+        // it opened.
+        let message = message_with_followups(Some(vec![
+            Bytes::from_static(b"NOTIFY-1"),
+            Bytes::from_static(b"NOTIFY-2"),
+        ]));
+        let frames: Vec<_> = message.frames().cloned().collect();
+        assert_eq!(
+            frames,
+            vec![
+                Bytes::from_static(b"202"),
+                Bytes::from_static(b"NOTIFY-1"),
+                Bytes::from_static(b"NOTIFY-2"),
+            ]
+        );
+        // Owned form must agree with the borrowed one — the stream distributors
+        // use `into_frames`, the UDP workers use `frames`.
+        assert_eq!(message.into_frames(), frames);
     }
 
     fn addr(s: &str) -> SocketAddr {
@@ -942,6 +1023,7 @@ mod tests {
             data: Bytes::from_static(b"PING"),
             source_local_addr: source,
             server_name: None,
+            followups: None,
         };
 
         // Pinned to listener A → lands on A's channel.

--- a/src/transport/sctp.rs
+++ b/src/transport/sctp.rs
@@ -38,13 +38,20 @@ pub async fn listen(
                 // the `connection_map` shard guard — stalling all outbound and
                 // blocking accept's `insert` on the same shard. `try_send` sheds
                 // for a backed-up (stuck) peer instead.
-                match sender.try_send(outbound.data) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        warn!("SCTP outbound dropped: connection {:?} send buffer full (slow/stuck peer)", outbound.connection_id);
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        warn!("SCTP outbound dropped: connection {:?} closed", outbound.connection_id);
+                let connection_id = outbound.connection_id;
+                // Frames of one message keep their relative order — same
+                // per-connection channel, single distributor task.
+                for frame in outbound.into_frames() {
+                    match sender.try_send(frame) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            warn!("SCTP outbound dropped: connection {:?} send buffer full (slow/stuck peer)", connection_id);
+                            break;
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            warn!("SCTP outbound dropped: connection {:?} closed", connection_id);
+                            break;
+                        }
                     }
                 }
             } else {

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -60,30 +60,45 @@ pub async fn listen(
                 // `try_send` keeps the guard for only the synchronous send and
                 // sheds for a backed-up (stuck) peer — it will retransmit or its
                 // connection will close.
-                match sender.try_send(outbound.data) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        warn!("TCP outbound dropped: connection {:?} send buffer full (slow/stuck peer)", outbound.connection_id);
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        warn!("TCP outbound dropped: connection {:?} closed", outbound.connection_id);
+                let connection_id = outbound.connection_id;
+                // Frames of one message keep their relative order: they enter
+                // the same per-connection channel back to back, and this is the
+                // only distributor task feeding it.
+                for frame in outbound.into_frames() {
+                    match sender.try_send(frame) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            warn!("TCP outbound dropped: connection {:?} send buffer full (slow/stuck peer)", connection_id);
+                            break;
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            warn!("TCP outbound dropped: connection {:?} closed", connection_id);
+                            break;
+                        }
                     }
                 }
             } else if let Some(ref pool) = pool {
-                match pool.send_tcp(outbound.destination, outbound.data).await {
-                    Ok(connection_id) => {
-                        debug!(
-                            destination = %outbound.destination,
-                            connection_id = ?connection_id,
-                            "TCP outbound: sent via pool"
-                        );
-                    }
-                    Err(error) => {
-                        warn!(
-                            destination = %outbound.destination,
-                            connection_id = ?outbound.connection_id,
-                            "TCP outbound pool connect failed: {error}"
-                        );
+                let destination = outbound.destination;
+                let requested_connection_id = outbound.connection_id;
+                // Sequential await per frame — the pool coalesces to one
+                // connection per destination, so frames stay in order on it.
+                for frame in outbound.into_frames() {
+                    match pool.send_tcp(destination, frame).await {
+                        Ok(connection_id) => {
+                            debug!(
+                                destination = %destination,
+                                connection_id = ?connection_id,
+                                "TCP outbound: sent via pool"
+                            );
+                        }
+                        Err(error) => {
+                            warn!(
+                                destination = %destination,
+                                connection_id = ?requested_connection_id,
+                                "TCP outbound pool connect failed: {error}"
+                            );
+                            break;
+                        }
                     }
                 }
             } else {

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -494,30 +494,42 @@ pub async fn listen(
                 // park here, stalling outbound for every connection and blocking
                 // accept's `insert` on the same shard — the wedge. `try_send`
                 // sheds for a backed-up (stuck) peer instead.
-                match sender.try_send(outbound.data) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        warn!("TLS outbound dropped: connection {:?} send buffer full (slow/stuck peer)", outbound.connection_id);
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        warn!("TLS outbound dropped: connection {:?} closed", outbound.connection_id);
+                let connection_id = outbound.connection_id;
+                // Frames of one message keep their relative order — same
+                // per-connection channel, single distributor task.
+                for frame in outbound.into_frames() {
+                    match sender.try_send(frame) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            warn!("TLS outbound dropped: connection {:?} send buffer full (slow/stuck peer)", connection_id);
+                            break;
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            warn!("TLS outbound dropped: connection {:?} closed", connection_id);
+                            break;
+                        }
                     }
                 }
             } else if let Some(ref pool) = pool {
                 // No existing connection — create outbound TLS via pool
-                match pool.send_tls(outbound.destination, outbound.server_name.as_deref(), outbound.data).await {
-                    Ok(connection_id) => {
-                        debug!(
-                            destination = %outbound.destination,
-                            connection_id = ?connection_id,
-                            "TLS outbound: sent via pool"
-                        );
-                    }
-                    Err(error) => {
-                        warn!(
-                            destination = %outbound.destination,
-                            "TLS outbound pool connect failed: {error}"
-                        );
+                let destination = outbound.destination;
+                let server_name = outbound.server_name.clone();
+                for frame in outbound.into_frames() {
+                    match pool.send_tls(destination, server_name.as_deref(), frame).await {
+                        Ok(connection_id) => {
+                            debug!(
+                                destination = %destination,
+                                connection_id = ?connection_id,
+                                "TLS outbound: sent via pool"
+                            );
+                        }
+                        Err(error) => {
+                            warn!(
+                                destination = %destination,
+                                "TLS outbound pool connect failed: {error}"
+                            );
+                            break;
+                        }
                     }
                 }
             } else {

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -91,8 +91,19 @@ pub async fn listen(
                                     warn!("[udp-worker-{}] invalid destination: {}", worker_index, outbound.destination);
                                     continue;
                                 };
-                                if let Err(e) = socket.send_to(&outbound.data, &dest_addr).await {
-                                    warn!("[udp-worker-{}] send_to {} failed: {}", worker_index, outbound.destination, e);
+                                // Every frame of this message goes out from THIS
+                                // worker's socket, in order, before the worker
+                                // takes another message off the shared channel.
+                                // That is the only ordering guarantee available
+                                // on UDP here: workers share the receiver
+                                // MPMC-style, so two separately-enqueued
+                                // messages can leave from two sockets in either
+                                // order (see `OutboundMessage::followups`).
+                                for frame in outbound.frames() {
+                                    if let Err(e) = socket.send_to(frame, &dest_addr).await {
+                                        warn!("[udp-worker-{}] send_to {} failed: {}", worker_index, outbound.destination, e);
+                                        break;
+                                    }
                                 }
                             }
                             Err(_) => {
@@ -148,6 +159,7 @@ fn create_reusable_udp_socket(local_addr: SocketAddr, tos: Option<u32>) -> std::
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn udp_connection_id_is_deterministic() {
@@ -172,5 +184,115 @@ mod tests {
         let remote1: SocketAddr = "192.168.1.100:50123".parse().unwrap();
         let remote2: SocketAddr = "192.168.1.100:50124".parse().unwrap();
         assert_ne!(udp_connection_id(local, remote1), udp_connection_id(local, remote2));
+    }
+
+    /// Frames of one `OutboundMessage` must reach the peer in the order they
+    /// were queued, however many workers are draining the shared channel.
+    ///
+    /// This is the regression guard for the REFER `202`/`NOTIFY` inversion:
+    /// every worker clones the same outbound receiver and owns its own
+    /// `SO_REUSEPORT` socket, so two *separately enqueued* messages race and can
+    /// land inverted (RFC 3515 §2.4.4 requires the 202 first). Grouping them
+    /// into one message pins them to a single worker, which sends them in
+    /// sequence.
+    ///
+    /// The guarantee is per-group ordering, NOT adjacency on the wire: another
+    /// worker may be sending a different group concurrently, so groups legitimately
+    /// interleave with each other. Many groups are driven through so a within-group
+    /// inversion has room to show up rather than passing by luck on one attempt.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ordered_frames_are_not_reordered_across_workers() {
+        const GROUPS: usize = 100;
+        const FRAMES: usize = 3;
+
+        // Generous receive buffer + a reader running before anything is sent:
+        // the workers can burst faster than one recv loop drains, and a dropped
+        // datagram here would look like a failure without being one.
+        let peer = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )
+        .unwrap();
+        peer.set_recv_buffer_size(4 * 1024 * 1024).unwrap();
+        peer.set_nonblocking(true).unwrap();
+        peer.bind(&SockAddr::from("127.0.0.1:0".parse::<SocketAddr>().unwrap()))
+            .unwrap();
+        let peer = tokio::net::UdpSocket::from_std(peer.into()).unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+
+        let reader = tokio::spawn(async move {
+            let mut received = Vec::with_capacity(GROUPS * FRAMES);
+            let mut buffer = [0u8; 2048];
+            while received.len() < GROUPS * FRAMES {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    peer.recv_from(&mut buffer),
+                )
+                .await
+                {
+                    Ok(Ok((size, _))) => {
+                        received.push(String::from_utf8_lossy(&buffer[..size]).to_string())
+                    }
+                    Ok(Err(error)) => panic!("recv failed: {error}"),
+                    Err(_) => break,
+                }
+            }
+            received
+        });
+
+        let listen_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let (inbound_tx, _inbound_rx) = flume::unbounded::<InboundMessage>();
+        let (outbound_tx, outbound_rx) = flume::unbounded::<OutboundMessage>();
+
+        listen(
+            listen_addr,
+            inbound_tx,
+            outbound_rx,
+            Arc::new(TransportAcl::new(vec![], vec![])),
+            None,
+        )
+        .await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        for group in 0..GROUPS {
+            outbound_tx
+                .send(OutboundMessage {
+                    connection_id: ConnectionId::default(),
+                    transport: Transport::Udp,
+                    destination: peer_addr,
+                    data: Bytes::from(format!("{group}:0")),
+                    source_local_addr: None,
+                    server_name: None,
+                    followups: Some(vec![
+                        Bytes::from(format!("{group}:1")),
+                        Bytes::from(format!("{group}:2")),
+                    ]),
+                })
+                .unwrap();
+        }
+
+        let received = reader.await.unwrap();
+        assert_eq!(
+            received.len(),
+            GROUPS * FRAMES,
+            "expected every frame to arrive; got {}",
+            received.len()
+        );
+
+        // Within each group, frame N must arrive before frame N+1.
+        let mut next_expected = vec![0usize; GROUPS];
+        for (arrival, payload) in received.iter().enumerate() {
+            let (group, frame) = payload.split_once(':').expect("malformed payload");
+            let group: usize = group.parse().expect("group id");
+            let frame: usize = frame.parse().expect("frame id");
+            assert_eq!(
+                frame, next_expected[group],
+                "group {group} frame {frame} arrived at position {arrival} but \
+                 frame {} was still outstanding — frames of one message were reordered",
+                next_expected[group]
+            );
+            next_expected[group] += 1;
+        }
     }
 }

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -187,13 +187,20 @@ fn spawn_outbound_dispatcher(
                 // the `connection_map` shard guard — stalling all outbound and
                 // blocking accept's `insert` on the same shard. `try_send` sheds
                 // for a backed-up (stuck) peer instead.
-                match sender.try_send(outbound.data) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        warn!("{} outbound dropped: connection {:?} send buffer full (slow/stuck peer)", label, outbound.connection_id);
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        warn!("{} outbound dropped: connection {:?} closed", label, outbound.connection_id);
+                let connection_id = outbound.connection_id;
+                // Frames of one message keep their relative order — same
+                // per-connection channel, single distributor task.
+                for frame in outbound.into_frames() {
+                    match sender.try_send(frame) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            warn!("{} outbound dropped: connection {:?} send buffer full (slow/stuck peer)", label, connection_id);
+                            break;
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            warn!("{} outbound dropped: connection {:?} closed", label, connection_id);
+                            break;
+                        }
                     }
                 }
             } else {

--- a/src/uac/mod.rs
+++ b/src/uac/mod.rs
@@ -377,6 +377,7 @@ impl UacSender {
         }
 
         let outbound_message = OutboundMessage {
+            followups: None,
             connection_id,
             transport,
             destination,
@@ -480,6 +481,7 @@ impl UacSender {
         }
 
         let outbound_message = OutboundMessage {
+            followups: None,
             connection_id: ConnectionId::default(),
             transport,
             destination,
@@ -529,6 +531,7 @@ impl UacSender {
         }
 
         let outbound_message = OutboundMessage {
+            followups: None,
             connection_id: ConnectionId::default(),
             transport,
             destination,

--- a/tests/integration/transport_tests.rs
+++ b/tests/integration/transport_tests.rs
@@ -94,6 +94,7 @@ async fn udp_roundtrip() {
     // Send response back through outbound channel
     outbound_tx
         .send_async(OutboundMessage {
+            followups: None,
             connection_id: inbound.connection_id,
             transport: inbound.transport,
             destination: inbound.remote_addr,
@@ -150,6 +151,7 @@ async fn tcp_roundtrip() {
     // Send response back through outbound channel (routed via connection_map)
     outbound_tx
         .send_async(OutboundMessage {
+            followups: None,
             connection_id: inbound.connection_id,
             transport: inbound.transport,
             destination: inbound.remote_addr,
@@ -300,6 +302,7 @@ async fn tcp_outbound_fallback_to_pool_when_no_connection() {
         \r\n");
     outbound_tx
         .send_async(OutboundMessage {
+            followups: None,
             connection_id: ConnectionId::default(),
             transport: Transport::Tcp,
             destination: target_addr,
@@ -448,6 +451,7 @@ async fn tls_roundtrip() {
     // Send response back
     outbound_tx
         .send_async(OutboundMessage {
+            followups: None,
             connection_id: inbound.connection_id,
             transport: inbound.transport,
             destination: inbound.remote_addr,
@@ -508,6 +512,7 @@ async fn ws_roundtrip() {
     // Send response back through outbound channel
     outbound_tx
         .send_async(OutboundMessage {
+            followups: None,
             connection_id: inbound.connection_id,
             transport: inbound.transport,
             destination: inbound.remote_addr,
@@ -581,6 +586,7 @@ async fn wss_roundtrip() {
     // Send response back
     outbound_tx
         .send_async(OutboundMessage {
+            followups: None,
             connection_id: inbound.connection_id,
             transport: inbound.transport,
             destination: inbound.remote_addr,


### PR DESCRIPTION
On a siphon-terminated transfer the B2BUA answers the REFER with `202 Accepted`
and immediately sends the `message/sipfrag` `NOTIFY (100 Trying)` that opens the
implicit subscription. The referrer could receive them inverted.

## Root cause

Not in the REFER logic — the dispatcher enqueues the two in the right order. The
UDP transport does not preserve it.

`udp::listen` spawns `num_cpus::get()` workers, and every worker **clones the
same `outbound_rx`**. flume is MPMC, so two messages enqueued back to back are
routinely handed to two different workers, each holding its own `SO_REUSEPORT`
socket, which then race to `send_to`. Whichever task the runtime schedules first
reaches the wire first.

When the NOTIFY won, the referrer saw a NOTIFY for a subscription it had not yet
been told existed — RFC 3515 §2.4.4 has the 202 establish it — and a strict UA
is entitled to reject that. SIPp does exactly that, which is what the
intermittent `sipp-b2bua-refer` job had been reporting:

```
Aborting call on unexpected message for Call-Id '1-1@…':
while expecting '202' (index 7), received 'NOTIFY sip:alice@… SIP/2.0'
```

Stream transports were never affected: TCP/TLS/WS/SCTP each have a single
outbound distributor task per listener, so enqueue order is write order.

## Fix

`OutboundMessage` grows `followups: Option<Vec<Bytes>>` — further frames that
must leave after `data`, to the same destination, with nothing interleaved. A
UDP worker sends every frame of a message from its own socket, in order, before
taking another message off the shared channel. That is the only ordering
guarantee available given the MPMC fan-out, and it is exactly the one the
protocol needs.

The REFER path now builds the 202 and the first NOTIFY and hands them to a new
`send_messages_in_order_from` as one unit.

`None` on effectively every other message, so the common path is one extra
`is_none()` branch and no allocation. Stream distributors honour the field for
free by writing frames into the same per-connection channel in order.

## Scope

This fixes the ordering hazard where a caller declares the sequence. It does
**not** make UDP globally ordered: two separately-enqueued messages to the same
peer can still race, because that is inherent to the multi-worker fan-out that
the throughput baseline depends on. Anywhere else the order is load-bearing
should use `send_messages_in_order_from` rather than two sends.

## Tests

- `ordered_frames_are_not_reordered_across_workers` — drives 100 three-frame
  groups through a real multi-worker UDP listener on a 4-thread runtime and
  asserts that within each group frame N arrives before frame N+1. Note the
  guarantee is per-group ordering, not adjacency: another worker may be sending
  a different group concurrently, so groups legitimately interleave with each
  other.
- `frames_yields_data_then_followups_in_order` /
  `frames_is_just_data_without_followups` — accessor units, including that the
  borrowed (`frames`, used by UDP) and owned (`into_frames`, used by the stream
  distributors) forms agree.

`cargo clippy --all-targets --all-features -- -D warnings` clean; full suite
3519 passed / 0 failed.

Perf note: not baseline-tested. The change adds one `is_none()` branch per
outbound message and no allocation when unused; it does not alter the worker
fan-out or the channel topology.
