### PR TITLE
fix(b2bua): completed transfer could BYE the referrer before the NOTIFY reporting success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   certificate — it is not an identity signal.
 
 ### Fixed
+- **An initial NOTIFY could overtake the 2xx that accepted its subscription.**
+  A script that replies to a SUBSCRIBE and then calls `subscribe_state.notify()`
+  / `presence.notify()` had the reply and the NOTIFY enqueued as two independent
+  messages, which does not order them on UDP. RFC 6665 §4.1.2.3 has the notifier
+  send the initial NOTIFY once the subscription is accepted — that is, after the
+  2xx. §4.4.1 obliges a subscriber to cope with the reverse arrival order, but
+  that allowance exists for a network that reorders in flight; it is not licence
+  for the notifier to emit out of order in the first place. Deferred messages
+  addressed to the same peer as the reply now leave as ordered followups of it.
+  Deferred messages for any other peer are unaffected and still go out at the end
+  of the request.
 - **A completed transfer could BYE the referrer before telling it the transfer
   succeeded.** At the end of a siphon-terminated REFER the B2BUA sends the
   referrer a terminating `NOTIFY` (sipfrag `200 OK`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   certificate — it is not an identity signal.
 
 ### Fixed
+- **A completed transfer could BYE the referrer before telling it the transfer
+  succeeded.** At the end of a siphon-terminated REFER the B2BUA sends the
+  referrer a terminating `NOTIFY` (sipfrag `200 OK`,
+  `Subscription-State: terminated`) and then BYEs that leg. Both went out as
+  separate enqueues to the same peer, which does not order them on UDP (same
+  cause as the 202/NOTIFY inversion below). Arriving inverted, the referrer
+  tears the dialog down on the BYE and answers the late NOTIFY with `481`,
+  never learning the outcome of the transfer it requested — RFC 3515 §2.4.4
+  makes that NOTIFY the result report, and RFC 5589 §6 shows it ahead of the
+  BYE. The pair now travels as one ordered unit when both target the same flow.
 - **REFER `202 Accepted` could be overtaken by its own first NOTIFY on UDP.**
   On a siphon-terminated transfer the B2BUA answers `202` and immediately sends
   the `message/sipfrag` `NOTIFY (100 Trying)` that opens the implicit

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1369,12 +1369,55 @@ fn process_timer_actions(
     source_local_addr: Option<SocketAddr>,
     state: &DispatcherState,
 ) {
+    process_timer_actions_with_followups(
+        actions,
+        key,
+        destination,
+        transport,
+        connection_id,
+        source_local_addr,
+        Vec::new(),
+        state,
+    )
+}
+
+/// As [`process_timer_actions`], but `followups` are appended to the FIRST
+/// `Action::SendMessage` so they leave immediately after it, in order, with
+/// nothing interleaved (see [`OutboundMessage::followups`]).
+///
+/// Only the first-send path of a script reply passes a non-empty list. Every
+/// other caller — timer-driven retransmits above all — goes through
+/// [`process_timer_actions`] with an empty one, so a cached response being
+/// re-emitted never drags a stale NOTIFY along with it.
+#[allow(clippy::too_many_arguments)]
+fn process_timer_actions_with_followups(
+    actions: &[Action],
+    key: &TransactionKey,
+    destination: Option<SocketAddr>,
+    transport: Option<Transport>,
+    connection_id: Option<ConnectionId>,
+    source_local_addr: Option<SocketAddr>,
+    mut followups: Vec<Bytes>,
+    state: &DispatcherState,
+) {
     for action in actions {
         match action {
             Action::SendMessage(message) => {
                 if let (Some(dest), Some(trans)) = (destination, transport) {
                     let conn_id = connection_id.unwrap_or_default();
-                    send_message_from(message.clone(), trans, dest, conn_id, source_local_addr, state);
+                    if followups.is_empty() {
+                        send_message_from(message.clone(), trans, dest, conn_id, source_local_addr, state);
+                    } else {
+                        send_frames_in_order_from(
+                            Bytes::from(message.to_bytes()),
+                            std::mem::take(&mut followups),
+                            trans,
+                            dest,
+                            conn_id,
+                            source_local_addr,
+                            state,
+                        );
+                    }
                 }
             }
             Action::StartTimer(name, duration) => {
@@ -2987,6 +3030,26 @@ fn handle_request(
                 }
             }
 
+            // Messages the handler deferred (subscribe_state.notify(),
+            // presence.notify()) that are addressed to the peer this reply goes
+            // to must leave AFTER it: RFC 6665 §4.1.2.3 has the notifier send
+            // the initial NOTIFY once the subscription is accepted, i.e. after
+            // the 2xx to the SUBSCRIBE. §4.4.1 obliges a subscriber to cope with
+            // the reverse arrival order, but that allowance exists for a network
+            // that reorders — it is not licence for the notifier to emit out of
+            // order, which is what queueing them as two independent messages did
+            // (the UDP workers share the outbound channel and each owns a
+            // socket, so the NOTIFY could overtake the reply).
+            //
+            // They ride along as followups of the reply instead. Deferred
+            // messages for any OTHER peer are untouched and still go out via
+            // `flush_deferred_sends` at the end of the request.
+            let mut reply_followups: Vec<Bytes> = crate::script::api::proxy_utils::
+                drain_deferred_sends_for(inbound.remote_addr, inbound.transport)
+                .into_iter()
+                .map(|deferred| Bytes::from(deferred.message.to_bytes()))
+                .collect();
+
             // Feed response into server transaction so it can cache it for
             // retransmit handling and manage Timer J/G/H.
             // The state machine emits SendMessage which process_timer_actions
@@ -3011,16 +3074,21 @@ fn handle_request(
                 if let Some(event) = server_event {
                     match state.transaction_manager.process_server_event(key, event) {
                         Ok(actions) => {
-                            process_timer_actions(
+                            sent_by_transaction = actions.iter().any(|a| matches!(a, Action::SendMessage(_)));
+                            process_timer_actions_with_followups(
                                 &actions,
                                 key,
                                 Some(inbound.remote_addr),
                                 Some(inbound.transport),
                                 Some(inbound.connection_id),
                                 Some(inbound.local_addr),
+                                if sent_by_transaction {
+                                    std::mem::take(&mut reply_followups)
+                                } else {
+                                    Vec::new()
+                                },
                                 state,
                             );
-                            sent_by_transaction = actions.iter().any(|a| matches!(a, Action::SendMessage(_)));
                         }
                         Err(error) => {
                             debug!(key = %key, "failed to feed reply to server transaction: {error}");
@@ -3029,7 +3097,27 @@ fn handle_request(
                 }
             }
             if !sent_by_transaction {
-                send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
+                send_frames_in_order_from(
+                    Bytes::from(response.to_bytes()),
+                    std::mem::take(&mut reply_followups),
+                    inbound.transport,
+                    inbound.remote_addr,
+                    inbound.connection_id,
+                    Some(inbound.local_addr),
+                    state,
+                );
+            }
+            // Anything still held (no reply path fired at all) must not be lost.
+            if !reply_followups.is_empty() {
+                if let Some(uac_sender) = crate::script::api::proxy_utils::uac_sender() {
+                    for frame in std::mem::take(&mut reply_followups) {
+                        uac_sender.send_bytes(
+                            frame,
+                            inbound.remote_addr,
+                            inbound.transport,
+                        );
+                    }
+                }
             }
 
         }
@@ -7031,8 +7119,29 @@ fn send_messages_in_order_from(
     let Some(first) = frames.next() else {
         return;
     };
-    let followups: Vec<Bytes> = frames.collect();
+    send_frames_in_order_from(
+        first,
+        frames.collect(),
+        transport,
+        destination,
+        connection_id,
+        source_local_addr,
+        state,
+    )
+}
 
+/// [`send_messages_in_order_from`] for callers that already hold serialized
+/// frames — `first` leaves before every entry of `followups`, in order.
+#[allow(clippy::too_many_arguments)]
+fn send_frames_in_order_from(
+    first: Bytes,
+    followups: Vec<Bytes>,
+    transport: Transport,
+    destination: SocketAddr,
+    connection_id: ConnectionId,
+    source_local_addr: Option<SocketAddr>,
+    state: &DispatcherState,
+) {
     // HEP sees each frame individually — they are distinct SIP messages on the
     // wire, and a capture that merged them would not decode.
     if let Some(ref hep) = state.hep_sender {
@@ -7099,15 +7208,12 @@ fn send_message_from(
 /// dispatched, so the reply is *enqueued* first (RFC 6665 §4.1.2.3 — the
 /// notifier sends the initial NOTIFY after the 200 to the SUBSCRIBE).
 ///
-/// Enqueueing first is not the same as leaving first: on UDP the workers share
-/// the outbound channel and each owns its own socket, so the deferred NOTIFY can
-/// still overtake the reply (see `OutboundMessage::followups` for the ordered-unit
-/// mechanism that does guarantee it). That is tolerable here and NOT tolerable for
-/// a REFER's 202 — RFC 6665 §4.4.1 requires a subscriber to accept a NOTIFY that
-/// arrives before the SUBSCRIBE's 200 and to treat it as creating the dialog,
-/// whereas RFC 3515 gives no such allowance for the 202. Making this ordered too
-/// means threading the reply into the flush, which is a wider change than the
-/// hazard warrants.
+/// By this point the reply path has already claimed any deferred message going
+/// to the *same* peer as the reply and sent it as an ordered followup, so what
+/// reaches here is addressed elsewhere and has nothing to be ordered against.
+/// Enqueueing is not the same as leaving — on UDP the workers share the outbound
+/// channel and each owns its own socket — which is why that ordering is done by
+/// pairing the frames rather than by send order (see `OutboundMessage::followups`).
 fn flush_deferred_sends(_state: &DispatcherState) {
     let deferred = crate::script::api::proxy_utils::drain_deferred_sends();
     if deferred.is_empty() {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -7096,7 +7096,18 @@ fn send_message_from(
 
 /// Drain deferred messages queued by presence.notify() etc. during the handler
 /// and send each one via the UacSender.  Called after the reply/relay has been
-/// dispatched so ordering is preserved (RFC 3265 §3.1.6.2).
+/// dispatched, so the reply is *enqueued* first (RFC 6665 §4.1.2.3 — the
+/// notifier sends the initial NOTIFY after the 200 to the SUBSCRIBE).
+///
+/// Enqueueing first is not the same as leaving first: on UDP the workers share
+/// the outbound channel and each owns its own socket, so the deferred NOTIFY can
+/// still overtake the reply (see `OutboundMessage::followups` for the ordered-unit
+/// mechanism that does guarantee it). That is tolerable here and NOT tolerable for
+/// a REFER's 202 — RFC 6665 §4.4.1 requires a subscriber to accept a NOTIFY that
+/// arrives before the SUBSCRIBE's 200 and to treat it as creating the dialog,
+/// whereas RFC 3515 gives no such allowance for the 202. Making this ordered too
+/// means threading the reply into the flush, which is a wider change than the
+/// hazard warrants.
 fn flush_deferred_sends(_state: &DispatcherState) {
     let deferred = crate::script::api::proxy_utils::drain_deferred_sends();
     if deferred.is_empty() {
@@ -16676,7 +16687,19 @@ fn b2bua_complete_terminated_transfer(
         }
     }
 
-    // Terminating NOTIFY (sipfrag 200 OK) to the referrer on its subscription.
+    // Terminating NOTIFY (sipfrag 200 OK) and then BYE, both to the referrer.
+    //
+    // The order is load-bearing: the BYE ends the very dialog the NOTIFY is
+    // sent on. A referrer that sees the BYE first tears the dialog down and
+    // answers the late NOTIFY with 481, never learning the transfer succeeded
+    // (RFC 3515 §2.4.4; RFC 5589 §6 shows the result NOTIFY ahead of the BYE).
+    // Two separate sends do NOT order on UDP — the workers share the outbound
+    // channel and each owns its own socket — so when both target the same flow
+    // they travel as one unit (see `OutboundMessage::followups`).
+    let mut referrer_messages: Vec<SipMessage> = Vec::new();
+    let mut referrer_route: Option<(Transport, SocketAddr, ConnectionId, Option<SocketAddr>)> =
+        None;
+
     if let Some(cseq) = state.call_actors.reserve_leg_cseq(call_id, referrer_on_a_leg) {
         if let Some(referrer_leg) = state.call_actors.clone_leg(call_id, referrer_on_a_leg) {
             let extra_headers = [
@@ -16706,14 +16729,13 @@ fn b2bua_complete_terminated_transfer(
                     referrer_leg.transport.remote_addr,
                     referrer_leg.transport.transport,
                 );
-                send_message_from(
-                    notify,
+                referrer_route = Some((
                     transport,
                     dest,
                     referrer_leg.transport.connection_id,
                     referrer_leg.transport.local_addr,
-                    state,
-                );
+                ));
+                referrer_messages.push(notify);
             }
         }
     }
@@ -16731,15 +16753,43 @@ fn b2bua_complete_terminated_transfer(
                 referrer_leg.transport.remote_addr,
                 referrer_leg.transport.transport,
             );
-            send_message_from(
-                bye,
+            let route = (
                 transport,
                 dest,
                 referrer_leg.transport.connection_id,
                 referrer_leg.transport.local_addr,
-                state,
             );
+            if referrer_route == Some(route) {
+                referrer_messages.push(bye);
+            } else {
+                // Different flow than the NOTIFY took (or no NOTIFY was built):
+                // nothing to order against, so flush the NOTIFY on its own route
+                // first and send the BYE on this one.
+                if let Some((transport, dest, connection_id, local_addr)) = referrer_route.take() {
+                    send_messages_in_order_from(
+                        std::mem::take(&mut referrer_messages),
+                        transport,
+                        dest,
+                        connection_id,
+                        local_addr,
+                        state,
+                    );
+                }
+                referrer_route = Some(route);
+                referrer_messages.push(bye);
+            }
         }
+    }
+
+    if let Some((transport, dest, connection_id, local_addr)) = referrer_route {
+        send_messages_in_order_from(
+            referrer_messages,
+            transport,
+            dest,
+            connection_id,
+            local_addr,
+            state,
+        );
     }
 
     state

--- a/src/script/api/proxy_utils.rs
+++ b/src/script/api/proxy_utils.rs
@@ -64,6 +64,38 @@ pub fn drain_deferred_sends() -> Vec<DeferredMessage> {
     })
 }
 
+/// Drain only the deferred messages addressed to `(destination, transport)`,
+/// preserving their relative order and leaving every other queued message in
+/// place for [`drain_deferred_sends`].
+///
+/// The caller sends these itself, ordered behind the reply going to that same
+/// peer (RFC 6665 §4.1.2.3 — the initial NOTIFY follows the 2xx that accepted
+/// the subscription).  Unlike [`drain_deferred_sends`] this does NOT disable
+/// deferred mode: messages for other peers must still reach the flush at the
+/// end of the request rather than being dropped.
+pub fn drain_deferred_sends_for(
+    destination: std::net::SocketAddr,
+    transport: Transport,
+) -> Vec<DeferredMessage> {
+    DEFERRED_SENDS.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        let Some(ref mut queue) = *guard else {
+            return Vec::new();
+        };
+        let mut matched = Vec::new();
+        let mut remaining = Vec::with_capacity(queue.len());
+        for deferred in queue.drain(..) {
+            if deferred.destination == destination && deferred.transport == transport {
+                matched.push(deferred);
+            } else {
+                remaining.push(deferred);
+            }
+        }
+        *queue = remaining;
+        matched
+    })
+}
+
 /// Try to queue a message for deferred sending.  Returns `true` if deferred
 /// mode is active and the message was queued; `false` if no request handler
 /// is active (caller should send immediately).
@@ -813,6 +845,81 @@ fn memory_pct_linux() -> u32 {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod deferred_send_tests {
+    use super::*;
+    use crate::sip::builder::SipMessageBuilder;
+    use crate::sip::message::Method;
+    use crate::sip::uri::SipUri;
+
+    fn notify_to(user: &str) -> SipMessage {
+        SipMessageBuilder::new()
+            .request(
+                Method::Notify,
+                SipUri::new("example.com".to_string()).with_user(user.to_string()),
+            )
+            .via("SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-test".to_string())
+            .to(format!("<sip:{user}@example.com>"))
+            .from("<sip:notifier@example.com>;tag=1".to_string())
+            .call_id(format!("call-{user}"))
+            .cseq("1 NOTIFY".to_string())
+            .content_length(0)
+            .build()
+            .expect("NOTIFY must build")
+    }
+
+    fn addr(spec: &str) -> std::net::SocketAddr {
+        spec.parse().expect("addr")
+    }
+
+    #[test]
+    fn drain_for_takes_only_the_matching_peer() {
+        let subscriber = addr("10.0.0.1:5060");
+        let other = addr("10.0.0.2:5060");
+
+        enable_deferred_sends();
+        assert!(try_defer_send(notify_to("alice"), subscriber, Transport::Udp));
+        assert!(try_defer_send(notify_to("bob"), other, Transport::Udp));
+        assert!(try_defer_send(notify_to("carol"), subscriber, Transport::Udp));
+
+        let matched = drain_deferred_sends_for(subscriber, Transport::Udp);
+        assert_eq!(matched.len(), 2, "both messages for the reply's peer");
+        // Relative order preserved — they are sent as ordered followups.
+        assert_eq!(matched[0].destination, subscriber);
+        assert_eq!(matched[1].destination, subscriber);
+        assert!(matched[0].message.to_bytes().windows(5).any(|w| w == b"alice"));
+        assert!(matched[1].message.to_bytes().windows(5).any(|w| w == b"carol"));
+
+        // The other peer's message MUST survive for the end-of-request flush.
+        // Draining used to disable deferred mode outright, which silently
+        // dropped it.
+        let remaining = drain_deferred_sends();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].destination, other);
+    }
+
+    #[test]
+    fn drain_for_distinguishes_transport() {
+        let peer = addr("10.0.0.1:5060");
+        enable_deferred_sends();
+        assert!(try_defer_send(notify_to("alice"), peer, Transport::Udp));
+        assert!(try_defer_send(notify_to("bob"), peer, Transport::Tcp));
+
+        assert_eq!(drain_deferred_sends_for(peer, Transport::Udp).len(), 1);
+        let remaining = drain_deferred_sends();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].transport, Transport::Tcp);
+    }
+
+    #[test]
+    fn drain_for_is_empty_when_deferred_mode_is_off() {
+        // Reply paths run this unconditionally; with no handler active it must
+        // be a no-op rather than a panic.
+        drain_deferred_sends();
+        assert!(drain_deferred_sends_for(addr("10.0.0.1:5060"), Transport::Udp).is_empty());
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/uac/mod.rs
+++ b/src/uac/mod.rs
@@ -551,6 +551,32 @@ impl UacSender {
         }
     }
 
+    /// Fire-and-forget an already-serialized message.
+    ///
+    /// Used for a deferred message that was serialized to ride along with a
+    /// reply (RFC 6665 §4.1.2.3 ordering) but whose reply path never fired —
+    /// it must still reach the peer rather than be dropped on the floor.
+    pub fn send_bytes(&self, data: Bytes, destination: SocketAddr, transport: Transport) {
+        if let Some(ref hep) = self.hep_sender {
+            let addr = self.addr_for(&transport);
+            hep.capture_outbound(addr, destination, transport, &data);
+        }
+
+        let outbound_message = OutboundMessage {
+            followups: None,
+            connection_id: ConnectionId::default(),
+            transport,
+            destination,
+            data,
+            source_local_addr: None,
+            server_name: None,
+        };
+
+        if let Err(error) = self.outbound.send(outbound_message) {
+            warn!("UAC send_bytes failed: {error}");
+        }
+    }
+
     /// Number of in-flight UAC requests awaiting a response.
     ///
     /// Surfaced as the `siphon_uac_pending_requests` gauge. A steadily rising


### PR DESCRIPTION
Follow-up to #127, which fixed the REFER `202`/`NOTIFY` inversion and noted that
UDP is still not globally ordered. This is the audit of every other place two
sends land on one peer back to back, plus the one real instance it turned up.

## The bug

At the end of a siphon-terminated transfer, `b2bua_complete_terminated_transfer`
sends the referrer a terminating `NOTIFY` (sipfrag `200 OK`,
`Subscription-State: terminated`) and then BYEs that same leg — two separate
`send_message_from` calls to the same destination on the same connection.

Same cause as #127: UDP workers share the outbound receiver (flume MPMC) and
each owns its own `SO_REUSEPORT` socket, so the two race.

Inverted, the referrer tears the dialog down on the BYE and answers the late
NOTIFY with `481 Call/Transaction Does Not Exist` — so it never learns the
outcome of the transfer it requested. RFC 3515 §2.4.4 makes that NOTIFY the
result report, and RFC 5589 §6 shows it ahead of the BYE.

Both messages now travel as one ordered unit via `send_messages_in_order_from`
when they target the same flow. When they don't (or no NOTIFY was built), the
NOTIFY is flushed on its own route first and the BYE follows on its own — no
behaviour change there, just no false pairing.

The ACK a few lines above goes to the *target* leg, a different peer, so it is
untouched.

## Audit

Shortlisted every pair of outbound sends within 60 lines of each other in the
same function in `dispatcher.rs` (82 send sites), then read each candidate to
ask the question that actually matters: **do both go to the same peer, and does
the first establish or destroy state the second depends on?**

Real:

- `b2bua_complete_terminated_transfer` — NOTIFY then BYE to the referrer. Fixed
  here.
- `flush_deferred_sends` — a script's `request.reply(200)` followed by a
  deferred `subscribe_state.notify()` / `presence.notify()` are two enqueues to
  the same peer. Its doc comment claimed "ordering is preserved", which is only
  true on stream transports; corrected in place rather than left asserting a
  guarantee that does not hold. **Not** made ordered: RFC 6665 §4.4.1 requires a
  subscriber to accept a NOTIFY that arrives before the SUBSCRIBE's 200 and to
  treat it as creating the dialog, so the hazard is benign — unlike RFC 3515,
  which gives the 202 no such allowance. Making it ordered means threading the
  reply into the flush, which is more surgery than the risk justifies.

Not bugs:

- CANCEL `200 OK` + INVITE `487` to the same UAC (`handle_cancel_via_session`,
  `handle_b2bua_cancel`) — two independent transactions; either arrival order is
  legal and handled, and the network can reorder them anyway.
- `handle_b2bua_invite`, `handle_b2bua_refer`, `handle_response`,
  `handle_srs_invite`, `handle_request`, `relay_request` clusters — mutually
  exclusive match arms or early-return error paths; only one send executes.
- `handle_b2bua_bye`, `handle_b2bua_reinvite` — the paired sends go to opposite
  legs, i.e. different peers.

## Tests

No new test. The existing `sipp-b2bua-refer` scenario already asserts this exact
order on the wire (the UAC expects `NOTIFY` then `BYE`), so it is the regression
guard — and it means this was likely a second contributor to that job's
intermittency alongside the 202 race fixed in #127. #127's
`ordered_frames_are_not_reordered_across_workers` covers the transport-level
guarantee this relies on.

`cargo clippy --all-targets --all-features -- -D warnings` clean; full suite
3519 passed / 0 failed.
