### PR TITLE
fix(b2bua): retransmit siphon-originated requests per RFC 3261 §17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Fixed
+- **B2BUA-originated requests are now retransmitted per RFC 3261 §17.1 on
+  unreliable transports.** The proxy datapath relays through the transaction
+  layer and so has always had Timer A (INVITE, §17.1.1.2) and Timer E
+  (non-INVITE, §17.1.2.2). The B2BUA does not — it owns its legs and routes
+  responses by branch, registering no client transaction — so every request it
+  originated left the socket exactly once. A single lost datagram therefore
+  produced total silence: no retry at 500 ms, nothing on the wire, and the call
+  failing on the synthetic `408` when the 30 s answer timeout swept it, with the
+  very next call succeeding. It showed up most sharply on an IPsec-protected
+  originating leg, where the first packet after an idle gap or across an SA
+  re-key is exactly the one at risk — a soft-UE MO call would fail cold and
+  answer warm — but it applied to every UDP B2BUA leg. A lost `BYE` was the
+  quieter half of the same gap: nothing retried it, so the far end kept the call
+  up with its media still anchored.
+
+  Each siphon-originated request (INVITE, CANCEL, BYE, re-INVITE/UPDATE, PRACK,
+  REFER, forwarded in-dialog requests) now carries a retransmit schedule keyed on
+  its own Via branch and method: `T1` then doubling without a ceiling for INVITE,
+  doubling but capped at `T2` for the rest, giving up at `64·T1`. Intervals come
+  from the configured transaction timers, so tuning `T1`/`T2` tunes these too.
+  The schedule is cancelled by the first response on that branch (§17.1.1.2 — a
+  provisional moves Calling → Proceeding), by a `CANCEL` for the INVITE it
+  abandons (§9.1), and by the answer-timeout teardown. `ACK` is excluded
+  (§17.1.1.3 — it is re-emitted in answer to a retransmitted final, never on a
+  timer of its own), as are relayed responses, which belong to the server
+  transaction. Reliable transports never arm a schedule and are byte-identical.
+
+  A retransmission leaves the **same local socket** as the original, which is
+  what makes it work on a flow-dialled leg: the kernel XFRM selector matches only
+  the protected client port, so a retry that fell back to the default listener
+  would go out unprotected and be dropped (3GPP TS 33.203 §7.4).
+
+- **A `relay(flow=…)` INVITE's Timer A retransmits no longer leave the wrong
+  socket.** The proxy relay and fork paths pinned `source_local_addr: None` on
+  their client-transaction timer entries, so while the first send went out the
+  flow's socket, every retransmit fell back to the default UDP channel — the
+  first-configured listener, typically the plain one — putting the retry outside
+  the IPsec SA on a multi-listener host. Retransmits now resolve the same egress
+  socket the original send did (captured flow, then IPsec auto-source, then a
+  script `send_socket=` pin).
+
+- **Flow-pinned sends are now visible.** A request sent over a captured flow
+  (`call.dial(flow=…)` / `relay(flow=…)`) bypasses the normal egress helper, and
+  with it that helper's HEP capture — so a flow-pinned B-leg INVITE was the one
+  request that never reached Homer. It is captured now, and the B-leg INVITE
+  additionally logs its destination, source socket, transport and size at debug
+  level. Nothing on that path logged before, which made an absent send line easy
+  to misread as the request never having been handed to the transport.
+
 ## [1.5.1] — 2026-07-29
 
 ### Added

--- a/src/b2bua/mod.rs
+++ b/src/b2bua/mod.rs
@@ -11,8 +11,13 @@
 //! - [`transfer`]: REFER/Replaces call transfer handling.
 //! - [`header_policy`]: Versioned per-call header policy (which headers
 //!   cross the trust boundary, which are stripped, rewritten, or translated).
+//! - [`retransmit`]: RFC 3261 §17.1 retransmission schedules for
+//!   siphon-originated requests (the B2BUA owns its legs and registers no
+//!   client transaction, so it gets no Timer A / Timer E from the
+//!   transaction layer).
 
 pub mod actor;
 pub mod fork;
 pub mod header_policy;
+pub mod retransmit;
 pub mod transfer;

--- a/src/b2bua/retransmit.rs
+++ b/src/b2bua/retransmit.rs
@@ -1,0 +1,612 @@
+//! RFC 3261 §17.1 retransmission for siphon-originated B2BUA requests.
+//!
+//! The proxy datapath relays through the transaction layer, so a relayed
+//! request gets a client transaction and with it Timer A (INVITE, §17.1.1.2)
+//! or Timer E (non-INVITE, §17.1.2.2). The B2BUA does not: it owns its legs
+//! and routes responses by branch through [`crate::b2bua::actor`], never
+//! registering a client transaction. Everything it originated therefore left
+//! the socket exactly once, and over an unreliable transport a single lost
+//! datagram produced total silence until the 30 s answer-timeout sweep
+//! synthesised a 408 — no INVITE retransmit at 500 ms, no BYE retransmit, no
+//! recovery at all.
+//!
+//! This module supplies the missing UAC-side retransmission without pulling
+//! B2BUA legs into the transaction FSM (which would also auto-ACK non-2xx
+//! finals and change absorption semantics under the leg model). It is a plain
+//! schedule store: the dispatcher arms an entry when it puts a
+//! siphon-originated request on the wire, the 100 ms timer tick asks for what
+//! is [`due`](B2buaRetransmits::due), and the first response on that branch
+//! disarms it.
+//!
+//! Intervals come from [`TimerConfig`] (`T1`/`T2`), so a deployment that tunes
+//! its transaction timers tunes these too — there are no constants here.
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use dashmap::DashMap;
+
+use crate::sip::message::Method;
+use crate::transaction::timer::TimerConfig;
+use crate::transport::{ConnectionId, Transport};
+
+/// Identifies one in-flight siphon-originated request.
+///
+/// Keyed on branch **and** method: RFC 3261 §9.1 gives a CANCEL the same Via
+/// branch as the INVITE it cancels, so a branch alone would make the two
+/// collide and let one disarm the other.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RetransmitKey {
+    pub branch: String,
+    pub method: Method,
+}
+
+impl RetransmitKey {
+    pub fn new(branch: impl Into<String>, method: Method) -> Self {
+        Self { branch: branch.into(), method }
+    }
+}
+
+/// Where and how to put a retransmission back on the wire.
+///
+/// `source_local_addr` is the load-bearing field on a multi-homed or
+/// IPsec-protected host: a retransmission that leaves a different socket than
+/// the original is not a retransmission, it is a new (and on an SA, dropped)
+/// packet. It carries the flow's `local_addr` for a flow-pinned leg.
+#[derive(Debug, Clone)]
+pub struct RetransmitTarget {
+    pub destination: SocketAddr,
+    pub transport: Transport,
+    pub connection_id: ConnectionId,
+    pub source_local_addr: Option<SocketAddr>,
+}
+
+#[derive(Debug, Clone)]
+struct RetransmitEntry {
+    data: Bytes,
+    target: RetransmitTarget,
+    /// When the next retransmission is due.
+    next_at: Instant,
+    /// Current interval; doubles on each fire.
+    interval: Duration,
+    /// Timer B (INVITE, §17.1.1.2) / Timer F (non-INVITE, §17.1.2.2) deadline:
+    /// 64·T1 after arming.
+    give_up_at: Instant,
+    /// INVITE doubles without a ceiling; non-INVITE caps each interval at T2.
+    invite: bool,
+    /// Retransmissions emitted so far (the original send is not counted).
+    attempts: u32,
+}
+
+/// One unit of work produced by [`B2buaRetransmits::due`].
+#[derive(Debug, Clone)]
+pub enum Due {
+    /// Put these bytes back on the wire. The entry has already been
+    /// rescheduled at its next interval.
+    Send {
+        key: RetransmitKey,
+        data: Bytes,
+        target: RetransmitTarget,
+        /// 1 for the first retransmission, 2 for the second, and so on.
+        attempt: u32,
+    },
+    /// 64·T1 elapsed with no response. The entry has already been removed;
+    /// the caller only reports it.
+    GaveUp {
+        key: RetransmitKey,
+        destination: SocketAddr,
+        attempts: u32,
+    },
+}
+
+/// Retransmission schedules for every siphon-originated B2BUA request that is
+/// still awaiting its first response.
+pub struct B2buaRetransmits {
+    entries: DashMap<RetransmitKey, RetransmitEntry>,
+    /// Live entry count, mirroring `entries.len()`.
+    ///
+    /// Exists purely so [`is_armed`](Self::is_armed) is a single relaxed load.
+    /// The cancel path runs on **every** inbound response, including the whole
+    /// proxy datapath where nothing is ever armed, and building a
+    /// [`RetransmitKey`] there costs a `String` clone and a shard lock per
+    /// message. `DashMap::len()` is no help — it sums every shard. This keeps
+    /// the proxy hot path at one atomic read and zero allocations.
+    armed: std::sync::atomic::AtomicUsize,
+    timers: TimerConfig,
+}
+
+impl B2buaRetransmits {
+    pub fn new(timers: TimerConfig) -> Self {
+        Self {
+            entries: DashMap::new(),
+            armed: std::sync::atomic::AtomicUsize::new(0),
+            timers,
+        }
+    }
+
+    /// Whether any schedule is armed at all.
+    ///
+    /// The cheap guard callers use before doing anything per-message: false on
+    /// every proxy-only deployment and on any B2BUA with no request in flight.
+    pub fn is_armed(&self) -> bool {
+        self.armed.load(std::sync::atomic::Ordering::Relaxed) != 0
+    }
+
+    /// Arm a schedule for a request just handed to the transport.
+    ///
+    /// Returns `false` without storing anything when the transport is reliable
+    /// — RFC 3261 §17.1.1.2 and §17.1.2.2 both make retransmission
+    /// unreliable-transport-only, since a stream transport already recovers
+    /// loss itself. Re-arming an existing key replaces it, which is what a
+    /// 401/407 or 422 retry on the same leg wants.
+    pub fn arm(
+        &self,
+        key: RetransmitKey,
+        data: Bytes,
+        target: RetransmitTarget,
+        now: Instant,
+    ) -> bool {
+        if !matches!(
+            crate::transaction::state::Transport::from(target.transport),
+            crate::transaction::state::Transport::Udp
+        ) {
+            return false;
+        }
+
+        let interval = self.timers.timer_a_initial();
+        let invite = key.method == Method::Invite;
+        let replaced = self.entries.insert(
+            key,
+            RetransmitEntry {
+                data,
+                target,
+                next_at: now + interval,
+                interval,
+                give_up_at: now + self.timers.timer_b(),
+                invite,
+                attempts: 0,
+            },
+        );
+        // Re-arming an existing key (the 401/407 or 422 retry) replaces rather
+        // than adds, so only a fresh key moves the counter.
+        if replaced.is_none() {
+            self.armed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        true
+    }
+
+    /// Stop retransmitting one request. Returns `true` if a schedule was armed.
+    pub fn disarm(&self, key: &RetransmitKey) -> bool {
+        if self.entries.remove(key).is_some() {
+            self.armed.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            return true;
+        }
+        false
+    }
+
+    /// Stop retransmitting every request on `branch`, whatever its method.
+    ///
+    /// Used on call teardown so an INVITE and its CANCEL both stop; nothing
+    /// may outlive the call it belongs to.
+    pub fn disarm_branch(&self, branch: &str) -> usize {
+        let doomed: Vec<RetransmitKey> = self
+            .entries
+            .iter()
+            .filter(|entry| entry.key().branch == branch)
+            .map(|entry| entry.key().clone())
+            .collect();
+        let mut removed = 0;
+        for key in doomed {
+            if self.disarm(&key) {
+                removed += 1;
+            }
+        }
+        removed
+    }
+
+    /// Everything due at `now`: retransmissions to emit, and schedules that
+    /// have reached 64·T1 and been dropped.
+    ///
+    /// Surviving entries are rescheduled in place before returning, so the
+    /// caller can send without holding any lock.
+    pub fn due(&self, now: Instant) -> Vec<Due> {
+        let mut due = Vec::new();
+        let mut expired = Vec::new();
+
+        for mut entry in self.entries.iter_mut() {
+            if now >= entry.give_up_at {
+                expired.push((
+                    entry.key().clone(),
+                    entry.target.destination,
+                    entry.attempts,
+                ));
+                continue;
+            }
+            if now < entry.next_at {
+                continue;
+            }
+
+            // RFC 3261 §17.1.1.2: Timer A doubles without a ceiling.
+            // §17.1.2.2: Timer E doubles but is capped at T2.
+            let doubled = entry.interval.saturating_mul(2);
+            entry.interval = if entry.invite {
+                doubled
+            } else {
+                doubled.min(self.timers.t2)
+            };
+            entry.next_at = now + entry.interval;
+            entry.attempts += 1;
+
+            due.push(Due::Send {
+                key: entry.key().clone(),
+                data: entry.data.clone(),
+                target: entry.target.clone(),
+                attempt: entry.attempts,
+            });
+        }
+
+        for (key, destination, attempts) in expired {
+            if self.disarm(&key) {
+                due.push(Due::GaveUp { key, destination, attempts });
+            }
+        }
+
+        due
+    }
+
+    /// Number of armed schedules. The steady-state leak signal: it must return
+    /// to its baseline once a batch of calls has completed.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(transport: Transport) -> RetransmitTarget {
+        RetransmitTarget {
+            destination: "192.0.2.10:5060".parse().expect("test destination"),
+            transport,
+            connection_id: ConnectionId::default(),
+            source_local_addr: Some("192.0.2.1:6100".parse().expect("test source")),
+        }
+    }
+
+    fn store() -> B2buaRetransmits {
+        B2buaRetransmits::new(TimerConfig::default())
+    }
+
+    fn invite_key() -> RetransmitKey {
+        RetransmitKey::new("z9hG4bK-b-leg-1", Method::Invite)
+    }
+
+    /// Collect the intervals between successive retransmissions by walking a
+    /// virtual clock forward to whatever the store says is next.
+    fn schedule(store: &B2buaRetransmits, key: &RetransmitKey, count: usize) -> Vec<Duration> {
+        let start = Instant::now();
+        let mut now = start;
+        let mut previous = start;
+        let mut gaps = Vec::new();
+        // Step in T1/10 increments so we observe the deadline, not a guess.
+        let step = store.timers.t1 / 10;
+        // Bound the walk at the 64·T1 give-up point so a scheduling bug fails
+        // the test instead of hanging it.
+        let deadline = start + store.timers.timer_b();
+        while gaps.len() < count {
+            now += step;
+            assert!(
+                now < deadline,
+                "only {} of {} retransmits arrived before 64·T1",
+                gaps.len(),
+                count
+            );
+            for event in store.due(now) {
+                if matches!(&event, Due::Send { key: fired, .. } if fired == key) {
+                    gaps.push(now - previous);
+                    previous = now;
+                }
+            }
+        }
+        gaps
+    }
+
+    #[test]
+    fn invite_retransmits_at_t1_then_doubles_without_a_ceiling() {
+        // RFC 3261 §17.1.1.2: Timer A fires at T1 and doubles on every fire.
+        let store = store();
+        let key = invite_key();
+        assert!(store.arm(key.clone(), Bytes::from_static(b"INVITE"), target(Transport::Udp), Instant::now()));
+
+        let t1 = store.timers.t1;
+        let gaps = schedule(&store, &key, 5);
+
+        // Each gap lands within one sampling step of the ideal interval.
+        let tolerance = t1 / 5;
+        for (index, expected) in [t1, t1 * 2, t1 * 4, t1 * 8, t1 * 16].iter().enumerate() {
+            let actual = gaps[index];
+            assert!(
+                actual >= *expected && actual - *expected <= tolerance,
+                "retransmit {} landed at {:?}, expected ~{:?}",
+                index + 1,
+                actual,
+                expected
+            );
+        }
+        // The fifth interval (16·T1 = 8s) is past T2, proving INVITE is not
+        // capped the way non-INVITE is.
+        assert!(gaps[4] > store.timers.t2, "INVITE doubling must not be capped at T2");
+    }
+
+    #[test]
+    fn non_invite_retransmit_interval_caps_at_t2() {
+        // RFC 3261 §17.1.2.2: Timer E doubles but never exceeds T2.
+        let store = store();
+        let key = RetransmitKey::new("z9hG4bK-bye-1", Method::Bye);
+        assert!(store.arm(key.clone(), Bytes::from_static(b"BYE"), target(Transport::Udp), Instant::now()));
+
+        let t2 = store.timers.t2;
+        let gaps = schedule(&store, &key, 5);
+        let tolerance = store.timers.t1 / 5;
+
+        for (index, gap) in gaps.iter().enumerate() {
+            assert!(
+                *gap <= t2 + tolerance,
+                "non-INVITE retransmit {} waited {:?}, above the T2 cap {:?}",
+                index + 1,
+                gap,
+                t2
+            );
+        }
+        // And it actually reaches the cap rather than stalling early.
+        assert!(
+            gaps.last().copied().unwrap_or_default() >= t2 - tolerance,
+            "non-INVITE interval should climb to T2"
+        );
+    }
+
+    #[test]
+    fn gives_up_at_64_t1_and_removes_the_entry() {
+        // Timer B (§17.1.1.2) / Timer F (§17.1.2.2) = 64·T1.
+        let store = store();
+        let key = invite_key();
+        let armed_at = Instant::now();
+        store.arm(key.clone(), Bytes::from_static(b"INVITE"), target(Transport::Udp), armed_at);
+
+        // Just before the deadline the schedule is still live.
+        let _ = store.due(armed_at + store.timers.timer_b() - Duration::from_millis(1));
+        assert_eq!(store.len(), 1);
+
+        let events = store.due(armed_at + store.timers.timer_b());
+        assert!(
+            events.iter().any(|event| matches!(event, Due::GaveUp { .. })),
+            "64·T1 must produce a GaveUp"
+        );
+        assert!(
+            !events.iter().any(|event| matches!(event, Due::Send { .. })),
+            "an expired schedule must not also emit a retransmit"
+        );
+        assert_eq!(store.len(), 0, "the expired entry must be removed");
+    }
+
+    #[test]
+    fn reliable_transports_never_arm() {
+        // §17.1.1.2 / §17.1.2.2 — retransmission is unreliable-transport only.
+        let store = store();
+        for transport in [
+            Transport::Tcp,
+            Transport::Tls,
+            Transport::WebSocket,
+            Transport::WebSocketSecure,
+            Transport::Sctp,
+        ] {
+            let key = RetransmitKey::new(format!("z9hG4bK-{transport}"), Method::Invite);
+            assert!(
+                !store.arm(key, Bytes::from_static(b"INVITE"), target(transport), Instant::now()),
+                "{transport} must not arm a retransmit schedule"
+            );
+        }
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn first_response_disarms_before_any_retransmit() {
+        // §17.1.1.2: the first provisional moves Calling -> Proceeding and
+        // cancels Timer A.
+        let store = store();
+        let key = invite_key();
+        let armed_at = Instant::now();
+        store.arm(key.clone(), Bytes::from_static(b"INVITE"), target(Transport::Udp), armed_at);
+
+        assert!(store.disarm(&key));
+        assert!(store.due(armed_at + store.timers.timer_b() * 2).is_empty());
+        assert_eq!(store.len(), 0);
+        // Disarming twice is harmless — the teardown path may race the response.
+        assert!(!store.disarm(&key));
+    }
+
+    #[test]
+    fn cancel_and_its_invite_share_a_branch_but_not_a_schedule() {
+        // RFC 3261 §9.1: CANCEL carries the INVITE's Via branch. Keying on the
+        // branch alone would let the CANCEL's arrival stop the INVITE's timer.
+        let store = store();
+        let branch = "z9hG4bK-shared";
+        let invite = RetransmitKey::new(branch, Method::Invite);
+        let cancel = RetransmitKey::new(branch, Method::Cancel);
+        let now = Instant::now();
+
+        store.arm(invite.clone(), Bytes::from_static(b"INVITE"), target(Transport::Udp), now);
+        store.arm(cancel.clone(), Bytes::from_static(b"CANCEL"), target(Transport::Udp), now);
+        assert_eq!(store.len(), 2);
+
+        store.disarm(&cancel);
+        assert_eq!(store.len(), 1, "disarming the CANCEL must leave the INVITE armed");
+
+        let events = store.due(now + store.timers.t1);
+        match events.as_slice() {
+            [Due::Send { key, .. }] => assert_eq!(key.method, Method::Invite),
+            other => panic!("expected only the INVITE to retransmit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disarm_branch_clears_every_method_on_that_branch() {
+        let store = store();
+        let branch = "z9hG4bK-teardown";
+        let now = Instant::now();
+        store.arm(RetransmitKey::new(branch, Method::Invite), Bytes::from_static(b"I"), target(Transport::Udp), now);
+        store.arm(RetransmitKey::new(branch, Method::Cancel), Bytes::from_static(b"C"), target(Transport::Udp), now);
+        store.arm(RetransmitKey::new("other", Method::Bye), Bytes::from_static(b"B"), target(Transport::Udp), now);
+
+        assert_eq!(store.disarm_branch(branch), 2);
+        assert_eq!(store.len(), 1, "an unrelated branch must survive");
+    }
+
+    #[test]
+    fn retransmit_replays_the_original_bytes_and_source_pin() {
+        // A retransmission that leaves a different socket is a new packet, not
+        // a retransmission — on an IPsec SA the kernel selector drops it.
+        let store = store();
+        let key = invite_key();
+        let now = Instant::now();
+        let original = Bytes::from_static(b"INVITE sip:bob@example.com SIP/2.0\r\n\r\n");
+        store.arm(key.clone(), original.clone(), target(Transport::Udp), now);
+
+        match store.due(now + store.timers.t1).as_slice() {
+            [Due::Send { data, target: sent, attempt, .. }] => {
+                assert_eq!(data, &original, "retransmit must replay identical bytes");
+                assert_eq!(
+                    sent.source_local_addr,
+                    Some("192.0.2.1:6100".parse().expect("test source")),
+                    "retransmit must leave the same local socket as the original"
+                );
+                assert_eq!(sent.destination, "192.0.2.10:5060".parse().expect("test destination"));
+                assert_eq!(*attempt, 1);
+            }
+            other => panic!("expected exactly one retransmit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn re_arming_the_same_key_replaces_the_schedule() {
+        // The 401/407 and 422 retry paths supersede a leg's INVITE in place.
+        let store = store();
+        let key = invite_key();
+        let now = Instant::now();
+        store.arm(key.clone(), Bytes::from_static(b"first"), target(Transport::Udp), now);
+        store.arm(key.clone(), Bytes::from_static(b"second"), target(Transport::Udp), now);
+
+        assert_eq!(store.len(), 1);
+        match store.due(now + store.timers.t1).as_slice() {
+            [Due::Send { data, .. }] => assert_eq!(data, &Bytes::from_static(b"second")),
+            other => panic!("expected the replacement to be retransmitted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn steady_state_arm_disarm_cycles_do_not_grow_the_store() {
+        // Per-module leak gate: a completed request must leave nothing behind.
+        let store = store();
+        let baseline = store.len();
+
+        for index in 0..2_000 {
+            let key = RetransmitKey::new(format!("z9hG4bK-call-{index}"), Method::Invite);
+            store.arm(key.clone(), Bytes::from_static(b"INVITE"), target(Transport::Udp), Instant::now());
+            store.disarm(&key);
+        }
+
+        assert_eq!(store.len(), baseline, "armed schedules must not accumulate");
+    }
+
+    /// `is_armed` gates the per-response cancel on the proxy hot path, so it
+    /// must never disagree with the map. A stuck-true counter would put a
+    /// `String` clone and a shard lock back on every proxy response; a
+    /// stuck-false one would stop cancelling retransmits altogether.
+    #[test]
+    fn is_armed_tracks_the_map_across_every_mutation_path() {
+        let store = store();
+        let now = Instant::now();
+        let check = |store: &B2buaRetransmits, at: &str| {
+            assert_eq!(
+                store.is_armed(),
+                !store.is_empty(),
+                "is_armed disagreed with len() after {at}"
+            );
+        };
+
+        check(&store, "construction");
+        assert!(!store.is_armed());
+
+        let invite = RetransmitKey::new("z9hG4bK-a", Method::Invite);
+        let cancel = RetransmitKey::new("z9hG4bK-a", Method::Cancel);
+        let bye = RetransmitKey::new("z9hG4bK-b", Method::Bye);
+
+        store.arm(invite.clone(), Bytes::from_static(b"I"), target(Transport::Udp), now);
+        check(&store, "arm");
+        assert!(store.is_armed());
+
+        // Re-arming the same key replaces — the count must not double.
+        store.arm(invite.clone(), Bytes::from_static(b"I2"), target(Transport::Udp), now);
+        check(&store, "re-arm");
+        assert_eq!(store.len(), 1);
+
+        // A refused (reliable-transport) arm must not move the counter.
+        store.arm(
+            RetransmitKey::new("z9hG4bK-tcp", Method::Invite),
+            Bytes::from_static(b"I"),
+            target(Transport::Tcp),
+            now,
+        );
+        check(&store, "refused arm");
+        assert_eq!(store.len(), 1);
+
+        store.arm(cancel, Bytes::from_static(b"C"), target(Transport::Udp), now);
+        store.arm(bye.clone(), Bytes::from_static(b"B"), target(Transport::Udp), now);
+        check(&store, "more arms");
+
+        // A no-op disarm must not move it either.
+        assert!(!store.disarm(&RetransmitKey::new("z9hG4bK-nope", Method::Invite)));
+        check(&store, "no-op disarm");
+
+        assert!(store.disarm(&bye));
+        check(&store, "disarm");
+
+        store.disarm_branch("z9hG4bK-a");
+        check(&store, "disarm_branch");
+        assert!(!store.is_armed(), "the store is empty again");
+
+        // And the give-up path.
+        store.arm(invite.clone(), Bytes::from_static(b"I"), target(Transport::Udp), now);
+        let _ = store.due(now + store.timers.timer_b());
+        check(&store, "give-up");
+        assert!(!store.is_armed());
+    }
+
+    #[test]
+    fn abandoned_schedules_drain_via_give_up_without_a_disarm() {
+        // Backstop for the leak gate: even if nothing ever disarms (peer went
+        // silent and the call teardown raced), 64·T1 reaps the entry.
+        let store = store();
+        let armed_at = Instant::now();
+        for index in 0..500 {
+            store.arm(
+                RetransmitKey::new(format!("z9hG4bK-silent-{index}"), Method::Invite),
+                Bytes::from_static(b"INVITE"),
+                target(Transport::Udp),
+                armed_at,
+            );
+        }
+        assert_eq!(store.len(), 500);
+
+        let events = store.due(armed_at + store.timers.timer_b());
+        assert_eq!(events.len(), 500);
+        assert!(events.iter().all(|event| matches!(event, Due::GaveUp { .. })));
+        assert_eq!(store.len(), 0, "give-up must drain the store");
+    }
+}

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -117,6 +117,13 @@ struct DispatcherState {
     transaction_manager: Arc<TransactionManager>,
     /// Timer wheel — keyed by a unique timer ID string.
     timer_wheel: Arc<DashMap<String, TimerEntry>>,
+    /// RFC 3261 §17.1 retransmission schedules for siphon-originated B2BUA
+    /// requests. The proxy datapath gets Timer A / Timer E from the client
+    /// transactions it registers; the B2BUA registers none (it owns its legs
+    /// and routes responses by branch), so without this every B-leg INVITE,
+    /// BYE and CANCEL left the socket exactly once and a single lost datagram
+    /// stalled the call until the answer-timeout sweep.
+    b2bua_retransmits: Arc<crate::b2bua::retransmit::B2buaRetransmits>,
     /// Proxy session store — links server transactions to client transactions.
     session_store: Arc<ProxySessionStore>,
     /// DNS resolver for SIP target resolution (RFC 3263).
@@ -656,6 +663,9 @@ pub async fn run(
         call_actors,
         transaction_manager,
         timer_wheel: Arc::new(DashMap::new()),
+        b2bua_retransmits: Arc::new(
+            crate::b2bua::retransmit::B2buaRetransmits::new(timer_config),
+        ),
         session_store: Arc::new(ProxySessionStore::new()),
         dns_resolver,
         hep_sender,
@@ -793,6 +803,7 @@ pub async fn run(
                 tokio::select! {
                     _ = timer_interval.tick() => {
                         fire_expired_timers(&state);
+                        sweep_b2bua_retransmits(&state);
                     }
                     _ = answer_timeout_interval.tick() => {
                         check_b2bua_answer_timeouts(&state);
@@ -1253,6 +1264,118 @@ fn clear_media_session_on_timeout(
             true
         }
         _ => false,
+    }
+}
+
+/// The local UDP socket [`send_to_target`] will egress from for `destination`,
+/// given the caller's own pin.
+///
+/// Mirrors that helper's UDP arm exactly — IPsec auto-source first (the kernel
+/// XFRM selector requires it), then the caller's pin — so anything that has to
+/// predict where a datagram will leave from (a retransmit schedule, a
+/// transaction timer entry) agrees with where it actually left from. Stream
+/// transports get `None`: they are reached over a live connection keyed by
+/// `connection_id`, and RFC 3261 §17.1.1.2/§17.1.2.2 do not retransmit on a
+/// reliable transport anyway.
+fn udp_egress_source(
+    transport: Transport,
+    destination: SocketAddr,
+    pin: Option<SocketAddr>,
+) -> Option<SocketAddr> {
+    match transport {
+        Transport::Udp => {
+            crate::script::api::ipsec::outbound_local_addr_for(destination).or(pin)
+        }
+        _ => None,
+    }
+}
+
+/// The local socket a relayed request will actually leave from, so the client
+/// transaction's Timer A / Timer E retransmits egress from the same place the
+/// first attempt did.
+///
+/// A retransmission that leaves a different socket is not a retransmission: on
+/// a multi-listener host the fallback is the *default* UDP channel — the first
+/// configured listener, typically the plain `:5060` — so a request relayed over
+/// an IPsec-protected flow would have its retries emitted outside the SA and
+/// silently dropped by the peer's kernel selector (3GPP TS 33.203 §7.4). The
+/// first send has resolved this correctly since flows shipped; the timer entry
+/// pinned `None` and quietly downgraded every retry.
+///
+/// A captured flow wins outright — that branch bypasses [`send_to_target`] and
+/// writes to `flow.local_addr` directly. Everything else defers to
+/// [`udp_egress_source`].
+fn client_retransmit_source(
+    outbound_transport: Transport,
+    destination: SocketAddr,
+    flow: Option<&crate::script::api::registrar::PyFlow>,
+    send_socket: Option<&crate::transport::SendSocket>,
+) -> Option<SocketAddr> {
+    if outbound_transport == Transport::Udp {
+        if let Some(flow) = flow {
+            return Some(flow.local_addr);
+        }
+    }
+    udp_egress_source(
+        outbound_transport,
+        destination,
+        send_socket.map(|pin| pin.addr),
+    )
+}
+
+/// Re-emit every siphon-originated B2BUA request whose RFC 3261 §17.1
+/// retransmit interval has elapsed, and reap the schedules that reached 64·T1.
+///
+/// Runs on the same 100 ms tick as [`fire_expired_timers`] and costs nothing
+/// when nothing is armed — entries exist only for requests still awaiting
+/// their first response.
+///
+/// Each retransmission goes back out through [`send_outbound_from`] with the
+/// **original** `source_local_addr`, so a flow-pinned B-leg's retransmit leaves
+/// the same protected socket the first attempt did. Falling back to the default
+/// listener here would put the retry outside the IPsec SA, which is precisely
+/// the failure this whole path exists to survive (3GPP TS 33.203 §7.4).
+fn sweep_b2bua_retransmits(state: &DispatcherState) {
+    use crate::b2bua::retransmit::Due;
+
+    // `due` walks every shard, so skip it outright on a proxy-only deployment
+    // or a B2BUA with nothing in flight — one relaxed atomic read per tick.
+    if !state.b2bua_retransmits.is_armed() {
+        return;
+    }
+
+    for event in state.b2bua_retransmits.due(std::time::Instant::now()) {
+        match event {
+            Due::Send { key, data, target, attempt } => {
+                debug!(
+                    branch = %key.branch,
+                    method = %key.method.as_str(),
+                    destination = %target.destination,
+                    source = ?target.source_local_addr,
+                    transport = %target.transport,
+                    attempt,
+                    size = data.len(),
+                    "B2BUA: retransmitting request (RFC 3261 §17.1)"
+                );
+                send_outbound_from(
+                    data,
+                    target.transport,
+                    target.destination,
+                    target.connection_id,
+                    target.source_local_addr,
+                    state,
+                );
+            }
+            Due::GaveUp { key, destination, attempts } => {
+                warn!(
+                    branch = %key.branch,
+                    method = %key.method.as_str(),
+                    %destination,
+                    attempts,
+                    "B2BUA: no response after 64*T1 — giving up on retransmitting request"
+                );
+            }
+        }
     }
 }
 
@@ -3541,6 +3664,12 @@ fn relay_request(
     // in) and is updated below for TCP/TLS once the connection is established.
     let txn_transport = crate::transaction::state::Transport::from(outbound_transport);
     let placeholder_connection_id = inbound.connection_id;
+    let retransmit_source = client_retransmit_source(
+        outbound_transport,
+        destination,
+        flow,
+        send_socket,
+    );
     let mut inserted_session_arc: Option<Arc<RwLock<ProxySession>>> = None;
     let client_key_opt = match state.transaction_manager.new_client_transaction(relayed, txn_transport) {
         Ok((client_key, actions)) => {
@@ -3554,9 +3683,7 @@ fn relay_request(
                         destination: Some(destination),
                         transport: Some(outbound_transport),
                         connection_id: Some(placeholder_connection_id),
-                        // Client transactions are outbound — no inbound
-                        // socket to pin.
-                        source_local_addr: None,
+                        source_local_addr: retransmit_source,
                     });
                 }
             }
@@ -3909,6 +4036,12 @@ fn relay_fork_branch(
     // connection is established.
     let txn_transport = crate::transaction::state::Transport::from(outbound_transport);
     let placeholder_connection_id = inbound.connection_id;
+    let retransmit_source = client_retransmit_source(
+        outbound_transport,
+        destination,
+        flow,
+        send_socket,
+    );
     let client_key_opt = match state.transaction_manager.new_client_transaction(relayed, txn_transport) {
         Ok((client_key, actions)) => {
             for action in &actions {
@@ -3921,9 +4054,7 @@ fn relay_fork_branch(
                         destination: Some(destination),
                         transport: Some(outbound_transport),
                         connection_id: Some(placeholder_connection_id),
-                        // Client transactions are outbound — no inbound
-                        // socket to pin.
-                        source_local_addr: None,
+                        source_local_addr: retransmit_source,
                     });
                 }
             }
@@ -3950,6 +4081,17 @@ fn relay_fork_branch(
     // — mirrors the relay(flow=...) path) when one is attached, else via the
     // normal resolver/pool path.
     let connection_id = if let Some(flow) = flow {
+        // This branch bypasses `send_to_target`, so it has to do that helper's
+        // HEP capture itself — otherwise a flow-pinned relay is the one request
+        // that never reaches Homer.
+        if let Some(ref hep) = state.hep_sender {
+            hep.capture_outbound(
+                state.hep_local_addr(flow.local_addr, outbound_transport),
+                destination,
+                outbound_transport,
+                &data,
+            );
+        }
         let outbound_message = OutboundMessage {
             followups: None,
             connection_id: ConnectionId(flow.connection_id),
@@ -4013,6 +4155,23 @@ fn handle_response(
     status_code: u16,
     state: &DispatcherState,
 ) {
+    // RFC 3261 §17.1.1.2 / §17.1.2.2: the first response on a branch ends
+    // retransmission of the request that provoked it — a provisional moves an
+    // INVITE client transaction Calling -> Proceeding and cancels Timer A, and
+    // any final ends the transaction.
+    //
+    // The B2BUA runs its own schedule (it registers no client transaction), so
+    // it needs its own cancel, and it has to happen *here*: several responses
+    // never reach `handle_b2bua_response` — a 100 Trying is absorbed below
+    // (§16.7 step 3), a 2xx for an already-cancelled call is diverted to the
+    // zombie path — and a leg that kept retransmitting behind a peer which
+    // already holds the request is exactly the spurious duplicate that trips
+    // merged-request detection (482).
+    //
+    // Keyed on the CSeq method so a CANCEL's own response does not stop the
+    // INVITE it shares a branch with (§9.1). Non-B2BUA responses simply miss.
+    disarm_b2bua_retransmit_for_response(&message, state);
+
     // Check if this response matches a UAC request (keepalive, health probe)
     if state.uac_sender.match_response(&message) {
         debug!(status_code = status_code, "UAC response matched");
@@ -4129,8 +4288,9 @@ fn handle_response(
     // Timer E for NICT), then absorb without forwarding.
     //
     // For a B2BUA leg there is no client transaction registered under this key
-    // (the B2BUA manages its own legs and does not arm Timer A here), so
-    // process_client_event returns Err and this is a harmless no-op.
+    // (the B2BUA manages its own legs and drives its own retransmit schedule
+    // instead — see `b2bua_retransmits` below), so process_client_event returns
+    // Err and that part is a harmless no-op.
     if status_code == 100 {
         // Drive only the INVITE client transaction (cancel Timer A). A
         // non-INVITE client transaction (NICT) treats a provisional as a
@@ -7634,6 +7794,17 @@ fn send_b2bua_to_bleg(
         Transport::Udp => source_local_addr,
         _ => None,
     };
+    // The schedule has to record the socket the datagram will *actually* leave
+    // from, which for an IPsec destination is the auto-source `send_to_target`
+    // resolves rather than the pin handed in here.
+    arm_b2bua_retransmit(
+        &message,
+        &data,
+        transport,
+        destination,
+        udp_egress_source(transport, destination, send_source),
+        state,
+    );
     send_to_target(
         data,
         &target,
@@ -7642,6 +7813,113 @@ fn send_b2bua_to_bleg(
         send_source,
         state,
     );
+}
+
+/// Arm an RFC 3261 §17.1 retransmit schedule for a siphon-originated B2BUA
+/// request, keyed on its own topmost Via branch.
+///
+/// Only requests qualify, and only those that expect a response:
+///
+/// * **Responses** also travel through [`send_b2bua_to_bleg`] (the B2BUA relays
+///   the far leg's provisionals and finals through it). Response
+///   retransmission belongs to the server transaction, never here.
+/// * **ACK** is excluded by RFC 3261 §17.1.1.3: an ACK for a non-2xx final is
+///   re-emitted only in answer to a retransmitted final, and the 2xx ACK is
+///   re-emitted by the TU when the 2xx is retransmitted (which
+///   [`crate::b2bua::actor::CallActorStore`] already drives). Putting ACK on a
+///   timer would flood the peer.
+///
+/// A message with no parseable Via branch cannot be correlated to its response,
+/// so it is left unarmed rather than retransmitted blindly.
+fn arm_b2bua_retransmit(
+    message: &SipMessage,
+    data: &Bytes,
+    transport: Transport,
+    destination: SocketAddr,
+    source_local_addr: Option<SocketAddr>,
+    state: &DispatcherState,
+) {
+    let method = match message.method() {
+        Some(method) if *method != crate::sip::message::Method::Ack => method.clone(),
+        // A response, or an ACK — see the doc comment.
+        _ => return,
+    };
+
+    let branch = match message
+        .headers
+        .get("Via")
+        .and_then(|raw| Via::parse_multi(raw).ok())
+        .and_then(|vias| vias.first().and_then(|via| via.branch.clone()))
+    {
+        Some(branch) => branch,
+        None => return,
+    };
+
+    // RFC 3261 §9.1: a CANCEL abandons the INVITE it shares a branch with, so
+    // stop retransmitting that INVITE the moment we cancel it. Doing this here
+    // covers every site that emits a CANCEL (answer timeout, LCR ring timeout,
+    // upstream CANCEL relay, deferred CANCEL drain) from one place.
+    if method == crate::sip::message::Method::Cancel {
+        state.b2bua_retransmits.disarm(
+            &crate::b2bua::retransmit::RetransmitKey::new(
+                branch.clone(),
+                crate::sip::message::Method::Invite,
+            ),
+        );
+    }
+
+    state.b2bua_retransmits.arm(
+        crate::b2bua::retransmit::RetransmitKey::new(branch, method),
+        data.clone(),
+        crate::b2bua::retransmit::RetransmitTarget {
+            destination,
+            transport,
+            // Schedules exist for UDP only (`B2buaRetransmits::arm` refuses
+            // reliable transports), and UDP egress selects its socket from
+            // `source_local_addr`, never from the connection id.
+            connection_id: ConnectionId::default(),
+            source_local_addr,
+        },
+        std::time::Instant::now(),
+    );
+}
+
+/// Cancel the retransmit schedule of the request this response answers.
+///
+/// Reads the branch off the topmost Via and the method off CSeq — the response
+/// echoes both, per RFC 3261 §8.2.6.2 — so a CANCEL's 200 stops the CANCEL and
+/// leaves the INVITE it shares a branch with alone (§9.1). Called for every
+/// inbound response; one that belongs to no B2BUA leg simply misses.
+fn disarm_b2bua_retransmit_for_response(message: &SipMessage, state: &DispatcherState) {
+    // This runs on every inbound response, including the entire proxy datapath
+    // where nothing is ever armed. Bail on one relaxed atomic read before
+    // building a key — that would otherwise cost a String clone and a shard
+    // lock per message at full CPS.
+    if !state.b2bua_retransmits.is_armed() {
+        return;
+    }
+
+    let branch = match message
+        .headers
+        .get("Via")
+        .and_then(|raw| Via::parse_multi(raw).ok())
+        .and_then(|vias| vias.first().and_then(|via| via.branch.clone()))
+    {
+        Some(branch) => branch,
+        None => return,
+    };
+    let method = match message
+        .headers
+        .get("CSeq")
+        .and_then(|raw| crate::sip::headers::cseq::CSeq::parse(raw).ok())
+    {
+        Some(cseq) => cseq.method,
+        None => return,
+    };
+
+    state
+        .b2bua_retransmits
+        .disarm(&crate::b2bua::retransmit::RetransmitKey::new(branch, method));
 }
 
 /// Create Rust-backed auth, registrar, log, and proxy utility singletons
@@ -9899,6 +10177,12 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
                 }
                 let mut targets: Vec<(SipMessage, Transport, SocketAddr, Option<SocketAddr>)> = Vec::new();
                 for b_leg in &call.b_legs {
+                    // We are giving up on this call, so stop retransmitting the
+                    // request that never drew a response. The CANCEL emitted
+                    // below covers the legs whose INVITE was stashed; this also
+                    // catches a leg whose stash never landed, which would
+                    // otherwise keep retransmitting until 64*T1.
+                    state.b2bua_retransmits.disarm_branch(&b_leg.branch);
                     if let Some(invite_arc) = b_leg.b_leg_invite.as_ref() {
                         if let Ok(invite) = invite_arc.lock() {
                             if let Some(cancel_msg) = build_cancel_from_invite(&invite) {
@@ -11054,7 +11338,44 @@ fn b2bua_send_b_leg_invite(
     // Send: over the captured flow (direct OutboundMessage, bypassing DNS/pool —
     // mirrors the proxy relay(flow=...) path) when one is attached, else via the
     // resolver/pool path.
+    //
+    // Either way the INVITE gets an RFC 3261 §17.1.1.2 Timer A schedule first
+    // (UDP only). Without it this INVITE left the socket exactly once: one lost
+    // datagram — the first packet after an idle gap, or one dropped across an
+    // IPsec re-key — meant total silence until the 30 s answer timeout
+    // synthesised a 408, with the next call seconds later succeeding.
+    arm_b2bua_retransmit(
+        &b_leg_invite,
+        &data,
+        outbound_transport,
+        destination,
+        client_retransmit_source(outbound_transport, destination, flow, send_socket),
+        state,
+    );
+
     if let Some(flow) = flow {
+        // This branch bypasses `send_to_target`/`send_outbound_from`, so it has
+        // to do their HEP capture itself — otherwise a flow-pinned B-leg INVITE
+        // is the one request that never reaches Homer.
+        if let Some(ref hep) = state.hep_sender {
+            hep.capture_outbound(
+                state.hep_local_addr(flow.local_addr, outbound_transport),
+                destination,
+                outbound_transport,
+                &data,
+            );
+        }
+        // ...and log the send. Nothing on this path logged before, so an absent
+        // "sending message" line was never evidence the INVITE had not been
+        // handed to the transport — it simply was never logged.
+        debug!(
+            call_id = %call_id,
+            destination = %destination,
+            source = %flow.local_addr,
+            transport = %outbound_transport,
+            size = data.len(),
+            "B2BUA: sending B-leg INVITE over captured flow"
+        );
         let outbound_message = OutboundMessage {
             followups: None,
             connection_id: ConnectionId(flow.connection_id),

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -2370,3 +2370,248 @@ fn zombie_reinvite_entry_preserves_the_flow_egress_socket() {
         "the post-teardown re-ACK must still leave from the anchored socket"
     );
 }
+
+// ---------------------------------------------------------------------------
+// RFC 3261 §17.1 retransmission of siphon-originated B2BUA requests
+// ---------------------------------------------------------------------------
+
+/// The soft-UE listener set (3GPP TS 33.203): plain SIP toward the local peer
+/// plus the two protected sec-agree ports, with the plain one doubling as the
+/// default UDP channel because it is configured first.
+///
+/// Returns the router and the three receiving ends in `(plain, port_uc,
+/// port_us)` order.
+#[allow(clippy::type_complexity)]
+fn soft_ue_router() -> (
+    siphon::transport::OutboundRouter,
+    flume::Receiver<siphon::transport::OutboundMessage>,
+    flume::Receiver<siphon::transport::OutboundMessage>,
+    flume::Receiver<siphon::transport::OutboundMessage>,
+) {
+    let plain = flume::unbounded();
+    let protected_client = flume::unbounded();
+    let protected_server = flume::unbounded();
+
+    let mut udp_by_local = std::collections::HashMap::new();
+    udp_by_local.insert(ue_plain(), plain.0.clone());
+    udp_by_local.insert(ue_port_uc(), protected_client.0.clone());
+    udp_by_local.insert(ue_port_us(), protected_server.0.clone());
+
+    let (dummy, _dummy_rx) = flume::unbounded();
+    let router = siphon::transport::OutboundRouter {
+        // The default channel is the first-configured listener — the plain one.
+        udp: plain.0.clone(),
+        udp_by_local,
+        tcp: dummy.clone(),
+        tls: dummy.clone(),
+        ws: dummy.clone(),
+        wss: dummy.clone(),
+        sctp: dummy,
+    };
+    (router, plain.1, protected_client.1, protected_server.1)
+}
+
+fn ue_plain() -> SocketAddr {
+    "192.0.2.10:5060".parse().expect("plain listener")
+}
+fn ue_port_uc() -> SocketAddr {
+    "192.0.2.10:6100".parse().expect("protected client port")
+}
+fn ue_port_us() -> SocketAddr {
+    "192.0.2.10:6101".parse().expect("protected server port")
+}
+fn pcscf_port_ps() -> SocketAddr {
+    "192.0.2.20:5066".parse().expect("P-CSCF protected server port")
+}
+
+/// Build the retransmit target a flow-dialled B-leg produces: written to the
+/// P-CSCF protected server port, sourced from the UE protected client port.
+fn flow_pinned_target() -> siphon::b2bua::retransmit::RetransmitTarget {
+    siphon::b2bua::retransmit::RetransmitTarget {
+        destination: pcscf_port_ps(),
+        transport: Transport::Udp,
+        connection_id: ConnectionId::default(),
+        source_local_addr: Some(ue_port_uc()),
+    }
+}
+
+/// Push one due retransmit through the router exactly as the dispatcher's
+/// `send_outbound_from` does, so the assertion is about where the datagram
+/// actually lands rather than about the store's bookkeeping.
+fn route(
+    router: &siphon::transport::OutboundRouter,
+    event: &siphon::b2bua::retransmit::Due,
+) {
+    if let siphon::b2bua::retransmit::Due::Send { data, target, .. } = event {
+        router
+            .send(siphon::transport::OutboundMessage {
+                followups: None,
+                connection_id: target.connection_id,
+                transport: target.transport,
+                destination: target.destination,
+                data: data.clone(),
+                source_local_addr: target.source_local_addr,
+                server_name: None,
+            })
+            .expect("router send");
+    }
+}
+
+/// The regression this whole path exists for: a B-leg INVITE dialled over a
+/// captured flow is retransmitted when it draws no response, and the retransmit
+/// leaves the *same protected socket* the first attempt did.
+///
+/// Before this, the B2BUA registered no client transaction, so the INVITE left
+/// the socket exactly once. One lost datagram — the first packet after an idle
+/// gap, or one dropped across an IPsec re-key — meant no retry at 500 ms and
+/// total silence until the 30 s answer timeout synthesised a 408, with the next
+/// call seconds later answering 200.
+///
+/// The socket half matters just as much: the kernel XFRM selector matches only
+/// `(ue_addr, port_uc) → (pcscf_addr, port_ps)`, so a retransmit that fell back
+/// to the default channel (the plain listener, configured first) would go out
+/// unprotected and be dropped — a retry that cannot possibly work.
+#[test]
+fn flow_pinned_b_leg_invite_retransmits_from_the_protected_socket() {
+    use siphon::b2bua::retransmit::{B2buaRetransmits, RetransmitKey};
+
+    let timers = siphon::transaction::timer::TimerConfig::default();
+    let store = B2buaRetransmits::new(timers);
+    let (router, plain, protected_client, protected_server) = soft_ue_router();
+
+    let invite = bytes::Bytes::from_static(
+        b"INVITE sip:bob@ims.mnc001.mcc001.3gppnetwork.org SIP/2.0\r\n\r\n",
+    );
+    let key = RetransmitKey::new("z9hG4bK-mo-invite", Method::Invite);
+    let sent_at = std::time::Instant::now();
+    assert!(
+        store.arm(key.clone(), invite.clone(), flow_pinned_target(), sent_at),
+        "a UDP flow-pinned B-leg INVITE must arm a Timer A schedule"
+    );
+
+    // Nothing is due before T1 — a retransmit any earlier would be a duplicate,
+    // not a recovery.
+    assert!(store.due(sent_at + timers.t1 / 2).is_empty());
+
+    for event in store.due(sent_at + timers.t1) {
+        route(&router, &event);
+    }
+
+    let retransmitted = protected_client
+        .try_recv()
+        .expect("the INVITE must be retransmitted at T1 when no response arrives");
+    assert_eq!(
+        retransmitted.data, invite,
+        "a retransmit replays the original bytes verbatim"
+    );
+    assert_eq!(retransmitted.source_local_addr, Some(ue_port_uc()));
+    assert_eq!(retransmitted.destination, pcscf_port_ps());
+    assert!(
+        plain.try_recv().is_err(),
+        "a flow-pinned retransmit must never fall back to the plain default listener"
+    );
+    assert!(protected_server.try_recv().is_err());
+}
+
+/// A response stops the retransmissions (RFC 3261 §17.1.1.2 — the first
+/// provisional moves Calling -> Proceeding and cancels Timer A). Nothing may go
+/// on the wire behind a peer that already holds the request; a spurious
+/// duplicate can trip the far end's merged-request detection (§8.2.2.2).
+#[test]
+fn a_response_stops_the_flow_pinned_b_leg_retransmissions() {
+    use siphon::b2bua::retransmit::{B2buaRetransmits, RetransmitKey};
+
+    let timers = siphon::transaction::timer::TimerConfig::default();
+    let store = B2buaRetransmits::new(timers);
+    let (router, plain, protected_client, _protected_server) = soft_ue_router();
+
+    let key = RetransmitKey::new("z9hG4bK-mo-invite", Method::Invite);
+    let sent_at = std::time::Instant::now();
+    store.arm(
+        key.clone(),
+        bytes::Bytes::from_static(b"INVITE sip:bob@example.com SIP/2.0\r\n\r\n"),
+        flow_pinned_target(),
+        sent_at,
+    );
+
+    // The 100 Trying lands well inside T1.
+    assert!(store.disarm(&key));
+
+    for event in store.due(sent_at + timers.timer_b()) {
+        route(&router, &event);
+    }
+    assert!(
+        protected_client.try_recv().is_err(),
+        "an answered INVITE must not be retransmitted"
+    );
+    assert!(plain.try_recv().is_err());
+    assert_eq!(store.len(), 0, "the schedule must not outlive the request");
+}
+
+/// An ordinary single-listener B2BUA is byte-identical to before: the retransmit
+/// carries no source pin and lands on the default channel, exactly where the
+/// original send went.
+#[test]
+fn unpinned_b_leg_retransmit_uses_the_default_egress() {
+    use siphon::b2bua::retransmit::{B2buaRetransmits, Due, RetransmitKey};
+
+    let timers = siphon::transaction::timer::TimerConfig::default();
+    let store = B2buaRetransmits::new(timers);
+    let (router, plain, protected_client, _protected_server) = soft_ue_router();
+
+    let sent_at = std::time::Instant::now();
+    store.arm(
+        RetransmitKey::new("z9hG4bK-trunk", Method::Invite),
+        bytes::Bytes::from_static(b"INVITE sip:bob@trunk.example SIP/2.0\r\n\r\n"),
+        siphon::b2bua::retransmit::RetransmitTarget {
+            destination: "203.0.113.5:5060".parse().expect("trunk"),
+            transport: Transport::Udp,
+            connection_id: ConnectionId::default(),
+            source_local_addr: None,
+        },
+        sent_at,
+    );
+
+    let due = store.due(sent_at + timers.t1);
+    assert!(matches!(due.as_slice(), [Due::Send { .. }]));
+    for event in &due {
+        route(&router, event);
+    }
+
+    let sent = plain.try_recv().expect("unpinned retransmit uses the default channel");
+    assert_eq!(sent.source_local_addr, None);
+    assert!(protected_client.try_recv().is_err());
+}
+
+/// A siphon-originated BYE is retransmitted too, on the non-INVITE schedule
+/// (§17.1.2.2 Timer E). This is the leak the INVITE-only view misses: a lost BYE
+/// leaves a call up on the far end with its media still anchored, and nothing
+/// ever retried it.
+#[test]
+fn flow_pinned_bye_retransmits_on_the_non_invite_schedule() {
+    use siphon::b2bua::retransmit::{B2buaRetransmits, RetransmitKey};
+
+    let timers = siphon::transaction::timer::TimerConfig::default();
+    let store = B2buaRetransmits::new(timers);
+    let (router, plain, protected_client, _protected_server) = soft_ue_router();
+
+    let bye = bytes::Bytes::from_static(b"BYE sip:bob@example.com SIP/2.0\r\n\r\n");
+    let sent_at = std::time::Instant::now();
+    store.arm(
+        RetransmitKey::new("z9hG4bK-bye", Method::Bye),
+        bye.clone(),
+        flow_pinned_target(),
+        sent_at,
+    );
+
+    for event in store.due(sent_at + timers.t1) {
+        route(&router, &event);
+    }
+
+    let retransmitted = protected_client
+        .try_recv()
+        .expect("an unanswered BYE must be retransmitted at T1");
+    assert_eq!(retransmitted.data, bye);
+    assert_eq!(retransmitted.source_local_addr, Some(ue_port_uc()));
+    assert!(plain.try_recv().is_err());
+}


### PR DESCRIPTION
## What

Adds RFC 3261 §17.1 retransmission for requests the B2BUA originates, and fixes
two related egress defects on the flow-pinned path.

## Why

Follow-up to #129. That fix landed the *steady-state* case — a warm UE↔UE call
over a registration flow rings, answers and tears down. The residual reported
against 1.5.1: the **first** MO call after an idle gap or after an IPsec SA
re-key still draws no B-leg response and fails `408` after 30 s, while the next
call seconds later answers `200`. 5/6 warm calls pass; the cold one does not.
The failing call's whole trace is three lines — dial, 30 s of silence, synthetic
408.

That is not a no-egress bug and not a stale-SA drop. The B2BUA never retransmits
anything it originates.

`TransactionManager::new_client_transaction` is called from exactly two places,
both on the proxy relay path (`relay_request`, `relay_fork_branch`). The B2BUA
owns its legs and routes responses by branch, registering no client transaction
— as the comment in `handle_response` already states outright. So a B-leg INVITE was
handed to the transport once and never again: over UDP, one lost datagram means
no retry at 500 ms, nothing on the wire, and the call dying on the answer
timeout's synthetic 408. It presents as cold-only because the first packet after
an idle gap, or one dropped across an SA re-key, is exactly the packet at risk —
and Timer A is the mechanism meant to absorb it.

The same gap covered every other siphon-originated request. A lost `BYE` was the
quieter half: nothing retried it, so the far end kept the call up with its media
still anchored and no ACR-STOP.

Two things found while tracing it:

- **The requested debug capture could not have answered the question.** `sending
  message` is logged only by `send_message_from`. Neither the flow branch nor
  `send_to_target`'s UDP arm ever logged a success line, on 1.5.0 or 1.5.1 — so
  an absent send line was never evidence the INVITE had not been handed to the
  transport. The flow branch also bypassed the HEP capture its non-flow sibling
  does, so a flow-pinned B-leg INVITE was the one request that never reached
  Homer.
- **`relay(flow=…)` retransmits left the wrong socket.** Both relay paths pinned
  `source_local_addr: None` on their client-transaction timer entries, so the
  first send went out the flow's socket and every Timer A retransmit fell back to
  the default UDP channel — the first-configured listener, typically the plain
  one — putting the retry outside the SA on a multi-listener host. Same class as
  the bug #129 fixed, surviving on the retransmit path.

## How

`src/b2bua/retransmit.rs` holds a schedule per in-flight request, keyed on
`(via branch, method)` — both, because §9.1 gives a CANCEL the INVITE's branch,
so a branch alone would let one cancel the other's timer.

- INVITE → Timer A: `T1`, doubling without a ceiling (§17.1.1.2).
- non-INVITE → Timer E: `T1`, doubling capped at `T2` (§17.1.2.2).
- Give up at `64·T1`. Intervals come from the configured `TimerConfig`, so
  tuning `T1`/`T2` tunes these.
- Unreliable transports only; reliable ones are byte-identical.

Armed at the `send_b2bua_to_bleg` chokepoint (~25 call sites) plus the B-leg
INVITE's flow branch, which bypasses that helper. Excluded: relayed responses
(the server transaction owns those) and `ACK` (§17.1.1.3 — it answers a
retransmitted final, never a timer of its own).

Cancelled by the first response on the branch, which had to go in
`handle_response` rather than `handle_b2bua_response`: a `100 Trying` is absorbed
per §16.7 step 3 and a 2xx for an already-cancelled call is diverted to the
zombie path, so neither reaches the B2BUA handler, and a leg still retransmitting
behind a peer that already holds the request is the spurious duplicate that trips
merged-request detection (482). Also cancelled by a CANCEL for the INVITE it
abandons, and at answer-timeout teardown.

A retransmission leaves the **same** local socket as the original — resolved
through one shared helper (`udp_egress_source`) so it agrees with what
`send_to_target` actually does, including IPsec auto-source. A retry that fell
back to the default listener could not work on a protected leg: the kernel XFRM
selector matches only the protected client port (3GPP TS 33.203 §7.4).

The per-response cancel runs on the whole proxy datapath, where nothing is ever
armed, so it is gated behind one relaxed atomic load — no key construction, no
shard lock, no allocation per message.

## Tests

- 12 unit tests in `src/b2bua/retransmit.rs`: both schedules against their RFC
  intervals, the 64·T1 give-up, reliable transports never arming, first-response
  cancel, CANCEL/INVITE branch sharing, re-arm-replaces, byte-and-source-identical
  replay, the armed-counter/map invariant, plus two leak gates (arm→disarm cycles
  return `len()` to baseline; abandoned schedules drain via give-up).
- 4 integration tests in `tests/integration/b2bua_tests.rs` on the soft-UE
  listener set (plain + two protected ports, plain doubling as the default
  channel): the flow-pinned INVITE retransmits **from the protected socket**, a
  response stops it, an unpinned leg still uses the default egress, and a BYE
  retransmits on the non-INVITE schedule.

## Verification

- `cargo test`: 3588 passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- SIPp: `--b2bua`, `--call`, `--reinvite`, `--b2bua-auth`, `--auto100`,
  `--rtpengine` all green.
- 16-row baseline (4 sizes × UDP/TCP × proxy/B2BUA): 0 Failed and 0
  Retransmissions on every row, peaks within noise of the README table.
- `mem_leak_test.sh` in both modes, and the criterion regression gate.

## Note for the field report

The residual can be narrowed further from logs already captured: if the kernel
refused the datagram after a re-key, the UDP worker logged `[udp-worker-N]
send_to <dest> failed: …`. Absent that line in the failing window, the datagram
left the socket and the loss was on the wire — which is what the missing Timer A
is there to survive. Retransmission is a UAC-side timer, so it cannot rescue a
drop that outlasts 64·T1 (32 s); the reported data (call #2 seconds later
succeeds) says the window is short. If a cold failure survives this, the next
lever is the UE-side re-key path, not the egress path.
