### PR TITLE
feat(media): carry the siphon-rtp websocket bridge and DSP profile fields through to the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **Media profiles can drive the `siphon-rtp` WebSocket audio bridge and its DSP
+  chain.** The engine has supported handing a leg's audio to an external
+  WebSocket media server (decode → L16 uplink, L16 downlink → encode, the WS
+  server acting as that leg's far side) for as long as siphon has pinned
+  `siphon-rtp-proto` 0.1.4, but siphon never populated the control fields: the
+  `NgFlags` → `ProfileFlags` conversion copied the nine fields it knew about and
+  swallowed the rest under a `..ProfileFlags::default()` tail, so the bridge was
+  unreachable from signalling and no configuration could turn it on. `NgFlags`
+  and the `media.profiles` YAML schema now carry `ws_uri`, `ws_vad`,
+  `ws_barge_in`, `ws_vad_threshold`, `ws_vad_hangover_ms`, `noise_suppression`
+  and `echo_cancellation`, and the conversion is exhaustive — a proto field
+  siphon does not carry is now a compile error rather than a silent default.
+- **`ws_uri=` on `rtpengine.offer()` / `answer()` / `answer_local()`,** for an
+  endpoint the script computes per call (session token, tenant lookup). It wins
+  over the profile's own value and is recorded on the media session, so a later
+  `answer` reuses the same bridge without repeating it — the same precedence
+  `profile=` already had. Both forms expand `{call_id}`, `{from_tag}`,
+  `{from_user}` and `{to_user}`; an unrecognised placeholder raises instead of
+  passing through as a literal, so a typo cannot reach the engine as a URI path
+  segment.
+- **Built-in `voice_ai` media profile** — plain RTP toward the caller with noise
+  suppression, echo cancellation, VAD and local barge-in on. `ws_uri` is left
+  unset (there is no sensible default endpoint) and comes from YAML or per call.
+- **`received_from` media-profile flag (opt-in)** — carries the real post-NAT
+  source IP siphon saw the request arrive from, gating that leg's media ingress
+  to it. For a NATed UA advertising an unroutable private `c=` address this is a
+  tighter RTPBleed source gate than the signalled address allows. Off by default,
+  so an existing profile emits a byte-identical command; wrong for deployments
+  whose media legitimately arrives from a different address than its signalling.
+- **`rtcp_mux` media-profile flag** — the RFC 5761 directive list (`offer`,
+  `require`, `demux`, `accept`, `reject`, `remove`) overriding the mux decision
+  the engine derives from the offered SDP.
+
+### Changed
+- **siphon refuses to start when a `media.profiles` entry sets a field its
+  `media.backend` cannot honour,** naming the profile, the direction and the
+  field. The WebSocket and DSP flags are `siphon-rtp` only; `received_from` and
+  `rtcp_mux` are also real rtpengine NG keys but have no `rtpproxy` equivalent.
+  This is a hard failure rather than the boot warning that covers
+  `address_family` on `rtpproxy`, because the failure modes differ in kind: an
+  ignored `address_family` costs IPv4/IPv6 interworking on a call that still
+  works, while an ignored `ws_uri` answers the call and bridges it nowhere —
+  silence for the call's whole duration, with nothing logged. A script naming a
+  built-in profile the backend cannot honour (built-ins are registered whatever
+  the backend, so config validation cannot see them) raises a `ValueError`
+  naming the field.
+- Invalid `ws_uri` schemes and `rtcp_mux` tokens fail the config load, matching
+  the existing `address_family` treatment — the engines ignore an unknown value
+  silently, which otherwise lands as a call quietly negotiated the wrong way.
+
 ### Fixed
 - **B2BUA-originated requests are now retransmitted per RFC 3261 §17.1 on
   unreliable transports.** The proxy datapath relays through the transaction
@@ -55,6 +106,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   additionally logs its destination, source socket, transport and size at debug
   level. Nothing on that path logged before, which made an absent send line easy
   to misread as the request never having been handed to the transport.
+
+- **`docs/media-engines.md` claimed SIPREC/MPTY subscriptions were unimplemented
+  on `siphon-rtp` and would surface an engine error.** They have been wired on
+  all three backends since the native backend shipped; the page was steering
+  people away from a working path. The same page's "media profiles are identical
+  across backends" statement is now qualified with the per-engine capability
+  table.
 
 ## [1.5.1] — 2026-07-29
 

--- a/docs/cookbook/media-rtp.md
+++ b/docs/cookbook/media-rtp.md
@@ -151,8 +151,12 @@ A-leg Call-ID that matched the offer (see [the SBC recipe](sbc.md)).
 |---|---|
 | `rtp_passthrough` | Plain RTP both sides — anchoring only (the default) |
 | `srtp_to_rtp` | SRTP UE ↔ RTP core (VoLTE/secure access ↔ trunk) |
+| `rtp_to_srtp` | The reverse pairing — RTP access ↔ SRTP core |
 | `ws_to_rtp` | WebSocket UE (RTP/AVPF + ICE) ↔ RTP core |
 | `wss_to_rtp` | Secure WebSocket (DTLS-SRTP/AVPF + ICE) ↔ RTP core |
+| `srs_recording` | Recording sink — plain RTP, media handover + port latching |
+| `siprec_src` | SIPREC SRC subscription leg toward the recorder |
+| `voice_ai` | Plain RTP toward the caller, audio bridged to a WebSocket AI backend |
 
 `ws_to_rtp` / `wss_to_rtp` are what make a **WebRTC** gateway work — terminate the
 browser's DTLS-SRTP + ICE on one side, plain RTP toward your core on the other.
@@ -211,6 +215,100 @@ allocate from.
 Works on **rtpengine** (sent as the dedicated `address family` NG key) and
 **siphon-rtp** (the `address_family` control field). The classic **rtpproxy**
 backend has no equivalent and logs a warning at boot if a profile sets it.
+
+### Bridge a leg's audio to a WebSocket server
+
+`ws_uri` hands a leg's audio to an external WebSocket media server instead of a
+far SIP leg: the engine dials the URI and relays the leg's RTP to it as L16
+(decode → uplink, downlink → encode). The WS server *is* that leg's far side, so
+this is the shape a call answered by a speech backend takes — pair it with
+[`rtpengine.answer_local`](#the-offer--answer--delete-lifecycle), which
+synthesises the 2xx answer with the engine as the far side.
+
+```yaml
+media:
+  backend: siphon-rtp          # required — see the capability table below
+  siphon_rtp:
+    address: "127.0.0.1:9000"
+  profiles:
+    voice_ai:                  # overrides the built-in of the same name
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        ws_uri: "wss://ai.example.com/stream/{call_id}"
+        ws_vad: true           # emit speech_started / speech_stopped edges
+        ws_barge_in: true      # cut playout locally on the caller's speech
+        ws_vad_threshold: 2000000
+        ws_vad_hangover_ms: 300
+        noise_suppression: true
+        echo_cancellation: true
+      answer: *voice_ai_flags
+```
+
+The URI supports `{call_id}`, `{from_tag}`, `{from_user}` and `{to_user}`,
+expanded per call. An unrecognised placeholder fails rather than passing through
+as a literal, so a typo cannot reach the engine as part of the URI path.
+
+When the endpoint depends on something only the script knows — a session token,
+a tenant lookup — pass it per call instead. It wins over the profile's own value,
+and is recorded on the media session so a later `answer` reuses the same bridge
+without repeating it:
+
+```python
+@b2bua.on_invite
+async def on_invite(call):
+    sdp = await rtpengine.answer_local(
+        call,
+        profile="voice_ai",
+        ws_uri=f"wss://ai.example.com/stream?token={await mint_token(call.call_id)}",
+    )
+    if sdp is not None:
+        call.answer(200, "OK", body=sdp, content_type="application/sdp")
+```
+
+The built-in `voice_ai` profile sets the DSP and VAD flags but deliberately
+leaves `ws_uri` unset — there is no sensible default endpoint, so supply it in
+YAML or per call as above.
+
+`ws_uri`, the `ws_*` knobs, `noise_suppression` and `echo_cancellation` are
+**`siphon-rtp` only**. siphon refuses to start if a `media.profiles` entry sets
+one on another backend, and a script naming such a profile gets a `ValueError`
+naming the field — see [media engines](../media-engines.md) for the full
+capability table.
+
+### Gate media ingress to the signalling source
+
+`received_from: true` carries the real post-NAT source IP siphon saw the request
+arrive from, and the engine gates that leg's ingress to it. For a NATed UA whose
+`c=` line advertises an unroutable private address, that is a **tighter**
+RTPBleed source gate than the signalled address could give. Only the IP is
+carried — media and signalling ports differ, so the port is never gated.
+
+```yaml
+media:
+  profiles:
+    nated_access:
+      offer:
+        replace: ["origin"]
+        received_from: true
+      answer:
+        replace: ["origin"]
+        received_from: true
+```
+
+Off by default, because it is wrong for a deployment whose media legitimately
+arrives from a different address than its signalling (a separate media gateway,
+or a carrier that splits the two). Honoured by **rtpengine** (the `received from`
+NG key) and **siphon-rtp**; **rtpproxy** has no equivalent and fails the config
+load.
+
+`rtcp_mux` takes the same RFC 5761 directives rtpengine does — `offer`,
+`require`, `demux`, `accept`, `reject`, `remove` — to override the mux decision
+the engine would derive from the offered SDP. Empty (the default) mirrors the
+offer. An unknown token fails the config load rather than being silently dropped
+by the engine.
 
 ## Shape the SDP yourself
 

--- a/docs/media-engines.md
+++ b/docs/media-engines.md
@@ -17,16 +17,33 @@ anchors and transforms RTP. You pick one of two engines with `media.backend`:
 !!! warning "siphon-rtp is experimental — use rtpengine in production"
     The siphon-rtp engine is pre-release. Run it for evaluation and lab work;
     keep `rtpengine` (the default) for production until siphon-rtp stabilises.
-    SIPREC/MPTY subscriptions are not implemented on siphon-rtp yet and surface a
-    clear engine error if a script calls them.
 
 **What is the same either way.** The `rtpengine` scripting namespace
 (`offer` / `answer` / `delete`, `play_media`, `play_dtmf`, `silence_media`,
 `@rtpengine.on_dtmf`, …), the [media profiles](cookbook/media-rtp.md#built-in-profiles),
-and the [`MediaSessionStore`](cookbook/media-rtp.md) are **identical**. Only the
+and the [`MediaSessionStore`](cookbook/media-rtp.md) are the same on both. Only the
 engine you run and the `media:` block that points at it change — a script written
-for one backend runs unmodified on the other. The differences are entirely
+for one backend runs unmodified on the other, unless it uses one of the
+engine-specific profile fields below. The rest of the differences are
 operational, and that is what the rest of this page covers.
+
+**What is not.** A few media-profile fields exist only on the engine that can
+perform them. siphon **refuses to start** if a `media.profiles` entry asks for
+something its `media.backend` cannot honour, naming the profile and the field —
+a `ws_uri` the engine never receives would otherwise answer the call and bridge
+it nowhere, with nothing logged and silence on the line.
+
+| Profile field | `siphon-rtp` | `rtpengine` | `rtpproxy` |
+|---|---|---|---|
+| `ws_uri`, `ws_vad`, `ws_barge_in`, `ws_vad_threshold`, `ws_vad_hangover_ms` | yes | — | — |
+| `noise_suppression`, `echo_cancellation` | yes | — | — |
+| `received_from`, `rtcp_mux` | yes | yes | — |
+| `address_family` | yes | yes | — [^af] |
+
+[^af]:
+    `address_family` on `rtpproxy` warns at boot rather than failing the load:
+    rtpproxy's `6` modifier states the family of the address the command already
+    carries, so the call still works and only IPv4/IPv6 interworking is lost.
 
 ---
 

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+import re
 import sys
 import uuid
 from types import ModuleType
@@ -1913,6 +1914,13 @@ class MockRtpEngine:
         """List of ``(operation, profile_or_detail)`` tuples recorded."""
         self.media_calls: list[dict[str, Any]] = []
         """Full parameter dicts for each media-injection call."""
+        self.ws_uris: list[tuple[str, Optional[str]]] = []
+        """``(operation, resolved_ws_uri)`` per offer/answer/answer_local.
+
+        The URI is post-templating, so a test asserts the value the media engine
+        would actually be handed. ``None`` means no WebSocket bridge was
+        requested for that call.
+        """
         self._healthy = True
         self._play_media_duration_ms: Optional[int] = None
         self._answer_local_sdp: str = "v=0\r\nm=audio 40000 RTP/AVP 8 101\r\n"
@@ -1934,8 +1942,59 @@ class MockRtpEngine:
         """Number of configured RTPEngine instances (mock: always 1)."""
         return 1
 
+    _WS_URI_PLACEHOLDERS = ("call_id", "from_tag", "from_user", "to_user")
+
+    def _expand_ws_uri(self, template: str, target: Any) -> str:
+        """Expand ``{call_id}`` / ``{from_tag}`` / ``{from_user}`` /
+        ``{to_user}`` in a ``ws_uri``, mirroring the real implementation.
+
+        An unknown placeholder raises ``ValueError`` rather than passing through
+        as a literal — a typo'd ``{callid}`` would otherwise reach the media
+        engine as part of the URI path.
+        """
+        if "{" not in template:
+            return template
+
+        values = {
+            "call_id": getattr(target, "call_id", None),
+            "from_tag": getattr(target, "from_tag", None),
+        }
+        for name, attribute in (("from_user", "from_uri"), ("to_user", "to_uri")):
+            uri = getattr(target, attribute, None)
+            values[name] = getattr(uri, "user", None) if uri is not None else None
+
+        expanded = template
+        for name in re.findall(r"\{([^}]*)\}", template):
+            if name not in self._WS_URI_PLACEHOLDERS:
+                raise ValueError(
+                    f"ws_uri has unknown placeholder {{{name}}}; supported: "
+                    + ", ".join(f"{{{p}}}" for p in self._WS_URI_PLACEHOLDERS)
+                )
+            if values.get(name) is None:
+                raise ValueError(
+                    f"ws_uri placeholder {{{name}}} has no value on this call"
+                )
+            expanded = expanded.replace("{" + name + "}", str(values[name]))
+        return expanded
+
+    def _resolve_ws_uri(self, ws_uri: Optional[str], target: Any) -> Optional[str]:
+        """Resolve the bridge URI for a call: explicit argument, else the one
+        recorded by the matching ``offer``.
+
+        The real implementation has a third step — the resolved profile's own
+        ``ws_uri`` from ``media.profiles`` — which this mock cannot see, since it
+        holds no profile registry. Pass ``ws_uri=`` explicitly in tests.
+        """
+        if ws_uri is None:
+            for op, recorded in reversed(self.ws_uris):
+                if op == "offer":
+                    return recorded
+            return None
+        return self._expand_ws_uri(ws_uri, target)
+
     async def offer(self, request: Any,
-                    profile: Optional[str] = None) -> bool:
+                    profile: Optional[str] = None,
+                    ws_uri: Optional[str] = None) -> bool:
         """Send ``offer`` command to RTPEngine.
 
         Extracts SDP from message body, sends to engine, replaces body
@@ -1944,16 +2003,35 @@ class MockRtpEngine:
         Args:
             request: Request or Call object with SDP body.
             profile: RTP profile name. Defaults to ``"rtp_passthrough"``.
+            ws_uri: Bridge this leg's audio to an external WebSocket media
+                    server (``siphon-rtp`` backend only), overriding the
+                    profile's own ``ws_uri`` for this call. Supports
+                    ``{call_id}``, ``{from_tag}``, ``{from_user}`` and
+                    ``{to_user}`` placeholders. The resolved URI is recorded on
+                    the media session, so a later ``answer`` reuses it
+                    automatically.
 
         Returns:
             ``True`` on success.
+
+        Example::
+
+            @b2bua.on_invite
+            async def on_invite(call):
+                sdp = await rtpengine.answer_local(
+                    call,
+                    profile="voice_ai",
+                    ws_uri=f"wss://ai.example.com/stream/{call.call_id}",
+                )
         """
         self.operations.append(("offer", profile or "rtp_passthrough"))
+        self.ws_uris.append(("offer", self._resolve_ws_uri(ws_uri, request)))
         return True
 
     async def answer(self, reply: Any,
                      profile: Optional[str] = None,
-                     call: Any = None) -> bool:
+                     call: Any = None,
+                     ws_uri: Optional[str] = None) -> bool:
         """Send ``answer`` command to RTPEngine.
 
         Profile precedence (matches the real implementation):
@@ -1973,6 +2051,10 @@ class MockRtpEngine:
                   From-tag are taken from this object (matching the earlier
                   ``offer``), while To-tag and SDP body still come from
                   ``reply``.
+            ws_uri: WebSocket bridge URI override for this call (``siphon-rtp``
+                    backend only). When omitted, the URI recorded by the
+                    matching ``offer`` is reused — the same precedence as
+                    ``profile``.
 
         Returns:
             ``True`` on success.
@@ -1986,6 +2068,7 @@ class MockRtpEngine:
             else:
                 profile = "rtp_passthrough"
         self.operations.append(("answer", profile))
+        self.ws_uris.append(("answer", self._resolve_ws_uri(ws_uri, call or reply)))
         return True
 
     async def answer_local(
@@ -1993,6 +2076,7 @@ class MockRtpEngine:
         call: Any,
         profile: Optional[str] = None,
         auto_reject: bool = True,
+        ws_uri: Optional[str] = None,
     ) -> Optional[str]:
         """Single-leg UAS answer — synthesise an RFC 3264 answer for the
         caller's **own** offer, with the media engine as the far side (IVR /
@@ -2027,6 +2111,11 @@ class MockRtpEngine:
                          no-encodable-codec result records a deferred 488 and
                          returns ``None``. When ``False`` it raises
                          ``ValueError``.
+            ws_uri: Bridge this leg's audio to an external WebSocket media
+                    server instead of a far SIP leg — the shape a voice-AI
+                    answer takes, since the WS server *is* the far side.
+                    Overrides the profile's own ``ws_uri``; supports the same
+                    placeholders as :meth:`offer`.
 
         Returns:
             The answer SDP as ``str`` on success, or ``None`` when the offer had
@@ -2050,6 +2139,10 @@ class MockRtpEngine:
             else:
                 profile = "rtp_passthrough"
 
+        # Resolved before the no-codec branch so a bad template raises
+        # regardless of whether the engine could answer, as it does for real.
+        resolved_ws_uri = self._resolve_ws_uri(ws_uri, call)
+
         if self._answer_local_no_codec:
             can_reject = auto_reject and hasattr(call, "reject")
             if can_reject:
@@ -2060,16 +2153,19 @@ class MockRtpEngine:
                     "profile": profile,
                     "auto_reject": auto_reject,
                     "answered": False,
+                    "ws_uri": resolved_ws_uri,
                 })
                 return None
             raise ValueError("no encodable codec in offer")
 
         self.operations.append(("answer_local", profile))
+        self.ws_uris.append(("answer_local", resolved_ws_uri))
         self.media_calls.append({
             "op": "answer_local",
             "profile": profile,
             "auto_reject": auto_reject,
             "answered": True,
+            "ws_uri": resolved_ws_uri,
         })
         return self._answer_local_sdp
 

--- a/sdk/tests/test_rtpengine_media.py
+++ b/sdk/tests/test_rtpengine_media.py
@@ -367,3 +367,109 @@ class TestMediaTargetForms:
         assert call["op"] == "play_dtmf"
         assert call["call_id"] == "call-7"
         assert call["from_tag"] == "ftag-7"
+
+
+class TestWebSocketBridge:
+    """``ws_uri`` on offer / answer / answer_local — the voice-AI media bridge.
+
+    The engine dials the URI and bridges the leg's RTP to it, so the URI is the
+    whole feature: a script that cannot set it answers the call and bridges it
+    nowhere.
+    """
+
+    def test_answer_local_records_ws_uri(self, harness):
+        call = Call()
+        asyncio.run(
+            harness.rtpengine.answer_local(
+                call, profile="voice_ai", ws_uri="wss://ai.example.com/stream"
+            )
+        )
+        assert ("answer_local", "wss://ai.example.com/stream") in harness.rtpengine.ws_uris
+        assert harness.rtpengine.media_calls[-1]["ws_uri"] == "wss://ai.example.com/stream"
+
+    def test_no_bridge_requested_records_none(self, harness):
+        asyncio.run(harness.rtpengine.answer_local(Call(), profile="voice_ai"))
+        assert ("answer_local", None) in harness.rtpengine.ws_uris
+
+    def test_call_id_placeholder_expands(self, harness):
+        call = Call(call_id="abc123@example.invalid")
+        asyncio.run(
+            harness.rtpengine.offer(
+                call, profile="voice_ai", ws_uri="wss://ai.example.com/{call_id}"
+            )
+        )
+        assert harness.rtpengine.ws_uris[-1] == (
+            "offer",
+            "wss://ai.example.com/abc123@example.invalid",
+        )
+
+    def test_user_placeholders_expand_from_uris(self, harness):
+        call = Call(
+            call_id="c1",
+            from_uri="sip:1001@example.com",
+            to_uri="sip:2002@example.com",
+        )
+        asyncio.run(
+            harness.rtpengine.offer(
+                call,
+                profile="voice_ai",
+                ws_uri="wss://ai.example.com/s?from={from_user}&to={to_user}",
+            )
+        )
+        assert harness.rtpengine.ws_uris[-1] == (
+            "offer",
+            "wss://ai.example.com/s?from=1001&to=2002",
+        )
+
+    def test_unknown_placeholder_raises(self, harness):
+        with pytest.raises(ValueError, match="unknown placeholder"):
+            asyncio.run(
+                harness.rtpengine.offer(Call(call_id="c1"), ws_uri="wss://ai/{callid}")
+            )
+
+    def test_uri_without_placeholder_is_untouched(self, harness):
+        asyncio.run(
+            harness.rtpengine.offer(Call(call_id="c1"), ws_uri="wss://ai.example.com/stream")
+        )
+        assert harness.rtpengine.ws_uris[-1] == ("offer", "wss://ai.example.com/stream")
+
+    def test_answer_reuses_the_uri_recorded_at_offer(self, harness):
+        call = Call(call_id="c1")
+        asyncio.run(
+            harness.rtpengine.offer(call, profile="voice_ai", ws_uri="wss://ai/recorded")
+        )
+        asyncio.run(harness.rtpengine.answer_local(call))
+        assert harness.rtpengine.ws_uris[-1] == ("answer_local", "wss://ai/recorded")
+
+    def test_explicit_uri_overrides_the_recorded_one(self, harness):
+        call = Call(call_id="c1")
+        asyncio.run(
+            harness.rtpengine.offer(call, profile="voice_ai", ws_uri="wss://ai/recorded")
+        )
+        asyncio.run(harness.rtpengine.answer_local(call, ws_uri="wss://ai/explicit"))
+        assert harness.rtpengine.ws_uris[-1] == ("answer_local", "wss://ai/explicit")
+
+    def test_driven_from_on_invite_handler(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    sdp = await rtpengine.answer_local(
+        call,
+        profile="voice_ai",
+        ws_uri=f"wss://ai.example.com/stream/{call.call_id}",
+    )
+    if sdp is not None:
+        call.answer(200, "OK", body=sdp, content_type="application/sdp")
+"""
+        )
+        result = harness.send_invite(
+            ruri="sip:ai@example.com", from_uri="sip:alice@example.com"
+        )
+        assert result.action == "answer"
+        assert result.call.state == "answered"
+        operation, uri = harness.rtpengine.ws_uris[-1]
+        assert operation == "answer_local"
+        assert uri.startswith("wss://ai.example.com/stream/")

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -576,7 +576,9 @@ auth:
 #   # NAT `direction` (["internal","external"]) and `asymmetric` flag map to
 #   # rtpproxy bridge/symmetry modifiers; IPv6 is auto-detected per stream.
 #   # A profile's `address_family:` is NOT supported here (rtpengine/siphon-rtp
-#   # only) — siphon warns at boot if one sets it on this backend.
+#   # only) — siphon warns at boot if one sets it on this backend. A profile's
+#   # `received_from:` / `rtcp_mux:` are not supported either, and those FAIL the
+#   # config load rather than warning.
 #   # The `media.events:` listener is unused — rtpproxy pushes no async events.
 #
 # Custom media profiles (extend or override built-ins):
@@ -584,8 +586,15 @@ auth:
 # Built-in profiles (always available):
 #   rtp_passthrough — Plain RTP both sides, media anchoring only (default)
 #   srtp_to_rtp     — SRTP UE ↔ RTP core
+#   rtp_to_srtp     — RTP access ↔ SRTP core (the reverse pairing)
 #   ws_to_rtp       — WebSocket UE (RTP/AVPF + ICE) ↔ RTP core
 #   wss_to_rtp      — Secure WebSocket UE (DTLS-SRTP/AVPF + ICE) ↔ RTP core
+#   srs_recording   — Recording sink: plain RTP, media handover + port latching
+#   siprec_src      — SIPREC SRC subscription leg toward the recorder
+#   voice_ai        — Plain RTP toward the caller, audio bridged to a WebSocket
+#                     media server. NS + AEC + VAD + barge-in on; ws_uri is left
+#                     unset (no sensible default endpoint) — set it here or pass
+#                     ws_uri= per call. siphon-rtp backend only.
 #
 # Define custom profiles under media.profiles:
 # media:
@@ -620,6 +629,79 @@ auth:
 #   direction           NAT leg pair, e.g. ["external", "internal"]
 #   record_call         true to have the engine record this leg
 #   record_path         recording output directory
+#   received_from       true to carry the real post-NAT source IP siphon saw the
+#                       request arrive from, gating this leg's media ingress to
+#                       it. For a NATed UA advertising an unroutable private c=
+#                       address this is a TIGHTER RTPBleed source gate than the
+#                       signalled address gives. Only the IP is carried (media
+#                       and signalling ports differ). Off by default — wrong for
+#                       a deployment whose media legitimately arrives from a
+#                       different address than its signalling (separate media
+#                       gateway, carrier that splits the two). rtpengine +
+#                       siphon-rtp only; rtpproxy fails the config load.
+#   rtcp_mux            RFC 5761 directives overriding the mux decision the
+#                       engine derives from the offered SDP: offer | require |
+#                       demux | accept | reject | remove. Empty (default) mirrors
+#                       the offer. rtpengine + siphon-rtp only.
+#
+# siphon-rtp-only keys (siphon REFUSES TO START if a profile sets one of these on
+# the rtpengine or rtpproxy backend — an ignored ws_uri answers the call and
+# bridges it nowhere, i.e. silence for its whole duration with nothing logged):
+#   ws_uri              Bridge this leg's audio to an external WebSocket media
+#                       server: the engine dials the URI and relays the leg's RTP
+#                       to it as L16 (decode → uplink, downlink → encode). The WS
+#                       server IS that leg's far side, so the A↔B relay path is
+#                       not wired in this mode — pair it with
+#                       rtpengine.answer_local() to answer the call with the
+#                       engine as the far side. ws:// and wss:// only (anything
+#                       else fails the config load). Expands {call_id},
+#                       {from_tag}, {from_user}, {to_user} per call; an unknown
+#                       placeholder is an error, not a literal. A script can
+#                       override it per call with rtpengine.offer(...,
+#                       ws_uri=...) / answer(...) / answer_local(...), which also
+#                       records it so a later answer reuses the same bridge.
+#   ws_vad              Run a local energy-VAD on the WebSocket uplink and emit
+#                       speech_started / speech_stopped on the caller's speech
+#                       edges, so the inference server gets turn boundaries (and
+#                       the turn endpoint) without running its own VAD. Inert
+#                       without ws_uri.
+#   ws_barge_in         Flush queued downlink playout in the same tick the caller
+#                       starts speaking, with no server round-trip. Implies
+#                       ws_vad; inert without ws_uri.
+#   ws_vad_threshold    Mean-square energy threshold for the uplink VAD. Unset
+#                       uses the engine's 8/16 kHz L16 default (~1_000_000);
+#                       higher is less sensitive.
+#   ws_vad_hangover_ms  How long speech is held after energy drops before the
+#                       turn endpoint fires. Unset uses the engine's ~200 ms.
+#   noise_suppression   Single-channel noise suppression on this leg's decoded
+#                       ingress audio. Engaged only on a userspace-transcoded leg
+#                       whose ingress codec runs at 8 or 16 kHz, and forces the
+#                       call off the in-kernel fast path (as record_call does).
+#   echo_cancellation   Echo cancellation on this leg's send path, referenced
+#                       against the audio played toward that party. On a
+#                       WebSocket bridge this cancels the phone uplink toward the
+#                       AI using the AI downlink as the reference.
+#
+# Voice-AI bridge — plain RTP toward the caller, audio to a WebSocket backend:
+# media:
+#   backend: siphon-rtp
+#   siphon_rtp:
+#     address: "127.0.0.1:9000"
+#   profiles:
+#     voice_ai:                         # overrides the built-in of the same name
+#       offer: &voice_ai_flags
+#         transport_protocol: "RTP/AVP"
+#         ice: "remove"
+#         dtls: "off"
+#         replace: ["origin"]
+#         ws_uri: "wss://ai.example.com/stream/{call_id}"
+#         ws_vad: true
+#         ws_barge_in: true
+#         ws_vad_threshold: 2000000
+#         ws_vad_hangover_ms: 300
+#         noise_suppression: true
+#         echo_cancellation: true
+#       answer: *voice_ai_flags
 #
 # IPv4/IPv6 interworking — v6 access leg, v4 core:
 # media:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1793,6 +1793,68 @@ pub enum MediaBackendKind {
     Rtpproxy,
 }
 
+impl MediaBackendKind {
+    /// The engine's name as it appears in `media.backend`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rtpengine => "rtpengine",
+            Self::SiphonRtp => "siphon-rtp",
+            Self::Rtpproxy => "rtpproxy",
+        }
+    }
+
+    /// Which of `flags`' set fields this backend has no way to express.
+    ///
+    /// The WebSocket bridge and the DSP knobs are native `siphon-rtp`
+    /// extensions; `received_from` and `rtcp_mux` are also real rtpengine NG
+    /// keys but have no `rtpproxy` equivalent.
+    ///
+    /// A field the engine cannot honour is not a degraded call, it is a dead
+    /// one — a `ws_uri` the engine never sees means the leg is answered and
+    /// bridged nowhere, and the caller hears silence for its whole duration.
+    /// So this drives a hard config error rather than the boot warning that
+    /// covers `address_family` on `rtpproxy` (which merely loses IPv4/IPv6
+    /// interworking on an otherwise working call).
+    pub fn unsupported_profile_fields(self, flags: &NgFlagsConfig) -> Vec<&'static str> {
+        let mut unsupported = Vec::new();
+
+        if !matches!(self, Self::SiphonRtp) {
+            if flags.ws_uri.is_some() {
+                unsupported.push("ws_uri");
+            }
+            if flags.ws_vad {
+                unsupported.push("ws_vad");
+            }
+            if flags.ws_barge_in {
+                unsupported.push("ws_barge_in");
+            }
+            if flags.ws_vad_threshold.is_some() {
+                unsupported.push("ws_vad_threshold");
+            }
+            if flags.ws_vad_hangover_ms.is_some() {
+                unsupported.push("ws_vad_hangover_ms");
+            }
+            if flags.noise_suppression {
+                unsupported.push("noise_suppression");
+            }
+            if flags.echo_cancellation {
+                unsupported.push("echo_cancellation");
+            }
+        }
+
+        if matches!(self, Self::Rtpproxy) {
+            if flags.received_from {
+                unsupported.push("received_from");
+            }
+            if !flags.rtcp_mux.is_empty() {
+                unsupported.push("rtcp_mux");
+            }
+        }
+
+        unsupported
+    }
+}
+
 /// Media proxy configuration.
 #[derive(Debug, Deserialize, Clone)]
 pub struct MediaConfig {
@@ -2032,6 +2094,62 @@ where
     }
 }
 
+/// Serde deserializer for a media profile's `rtcp_mux` directive list.
+///
+/// The engines accept a fixed vocabulary (RFC 5761 mux handling); an unknown
+/// token is silently ignored, which would land as a call quietly negotiating the
+/// opposite mux decision from the one the operator wrote.  Same reasoning as
+/// [`deserialize_address_family`].
+fn deserialize_rtcp_mux<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    const VALID: [&str; 6] = ["offer", "require", "demux", "accept", "reject", "remove"];
+
+    let values: Vec<String> = Vec::deserialize(deserializer)?;
+    values
+        .into_iter()
+        .map(|value| {
+            let normalised = value.trim().to_ascii_lowercase();
+            if VALID.contains(&normalised.as_str()) {
+                Ok(normalised)
+            } else {
+                Err(de::Error::custom(format!(
+                    "media profile rtcp_mux entries must be one of {}, got {value:?}",
+                    VALID.join(", ")
+                )))
+            }
+        })
+        .collect()
+}
+
+/// Serde deserializer for a media profile's `ws_uri`.
+///
+/// The engine dials this as a WebSocket client, so anything that is not
+/// `ws://` / `wss://` can never connect.  Caught here rather than as a
+/// connect failure per call.
+fn deserialize_ws_uri<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    let value: Option<String> = Option::deserialize(deserializer)?;
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    let scheme = trimmed.split("://").next().unwrap_or_default();
+    match scheme.to_ascii_lowercase().as_str() {
+        "ws" | "wss" if trimmed.contains("://") => Ok(Some(trimmed.to_string())),
+        _ => Err(de::Error::custom(format!(
+            "media profile ws_uri must be a ws:// or wss:// URI, got {value:?}"
+        ))),
+    }
+}
+
 /// A user-defined RTPEngine media profile with separate offer/answer NG flags.
 #[derive(Debug, Deserialize, Clone)]
 pub struct MediaProfileConfig {
@@ -2040,7 +2158,7 @@ pub struct MediaProfileConfig {
 }
 
 /// NG protocol flags for one direction (offer or answer).
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
 pub struct NgFlagsConfig {
     /// Transport protocol override (e.g. "RTP/AVP", "RTP/SAVPF").
     pub transport_protocol: Option<String>,
@@ -2073,6 +2191,55 @@ pub struct NgFlagsConfig {
     pub record_call: bool,
     /// Directory path for RTPEngine to write recording files.
     pub record_path: Option<String>,
+    /// Single-channel noise suppression on this leg's decoded ingress audio.
+    /// `siphon-rtp` backend only.
+    #[serde(default)]
+    pub noise_suppression: bool,
+    /// Acoustic/line echo cancellation on this leg's send path, referenced
+    /// against the audio played toward that party.  `siphon-rtp` backend only.
+    #[serde(default)]
+    pub echo_cancellation: bool,
+    /// Bridge this leg's audio to an external WebSocket media server: the engine
+    /// dials this URI and relays the leg's RTP to it as L16.  `siphon-rtp`
+    /// backend only.
+    ///
+    /// Supports `{call_id}`, `{from_tag}`, `{from_user}` and `{to_user}`
+    /// placeholders, expanded per call.  A script can override the whole URI for
+    /// one call with `rtpengine.offer(..., ws_uri=...)`.
+    #[serde(default, deserialize_with = "deserialize_ws_uri")]
+    pub ws_uri: Option<String>,
+    /// Run a local energy-VAD on the WebSocket uplink and emit
+    /// `speech_started`/`speech_stopped` on the caller's speech edges.  Inert
+    /// without `ws_uri`.  `siphon-rtp` backend only.
+    #[serde(default)]
+    pub ws_vad: bool,
+    /// Flush queued downlink playout locally when the caller starts speaking,
+    /// without a server round-trip.  Implies `ws_vad`; inert without `ws_uri`.
+    /// `siphon-rtp` backend only.
+    #[serde(default)]
+    pub ws_barge_in: bool,
+    /// Mean-square energy threshold for the WebSocket uplink VAD.  Unset uses
+    /// the engine default; higher is less sensitive.
+    #[serde(default)]
+    pub ws_vad_threshold: Option<i64>,
+    /// Trailing hangover for the WebSocket uplink VAD in milliseconds — how long
+    /// speech is held after energy drops before the turn endpoint fires.  Unset
+    /// uses the engine default.
+    #[serde(default)]
+    pub ws_vad_hangover_ms: Option<u32>,
+    /// Carry the real post-NAT source IP the proxy saw the request arrive from
+    /// (rtpengine's `received from`), gating the leg's media ingress to it.
+    ///
+    /// A tighter source gate than a NATed UA's unusable private `c=` address.
+    /// Opt-in, and off by default: a profile that leaves it unset emits exactly
+    /// the command it did before this knob existed.  Not honoured by `rtpproxy`.
+    #[serde(default)]
+    pub received_from: bool,
+    /// `rtcp-mux` directives (`offer`, `require`, `demux`, `accept`, `reject`,
+    /// `remove`), overriding the mux decision derived from the offered SDP
+    /// (RFC 5761).  Empty mirrors the offer.  Not honoured by `rtpproxy`.
+    #[serde(default, deserialize_with = "deserialize_rtcp_mux")]
+    pub rtcp_mux: Vec<String>,
 }
 
 /// One or more RTPEngine instances.
@@ -3079,8 +3246,60 @@ impl Config {
 
     /// Parse YAML without env-var expansion (used after expansion is already done).
     fn from_str_raw(yaml: &str) -> Result<Self> {
-        serde_yaml_ng::from_str(yaml)
-            .map_err(|e| SiphonError::Config(format!("invalid siphon.yaml: {e}")))
+        let config: Self = serde_yaml_ng::from_str(yaml)
+            .map_err(|e| SiphonError::Config(format!("invalid siphon.yaml: {e}")))?;
+        config.validate_media_profiles()?;
+        Ok(config)
+    }
+
+    /// Reject a media profile asking for something `media.backend` cannot do.
+    ///
+    /// Runs on every load path (`from_file` and `from_str` both route through
+    /// `from_str_raw`), so a misconfigured box fails to start instead of coming
+    /// up healthy and answering calls into a media path that was never wired.
+    ///
+    /// Only covers operator-declared `media.profiles` — a built-in profile is
+    /// registered regardless of backend, so a script naming one the backend
+    /// cannot honour is caught at the call instead (see the `rtpengine` script
+    /// API's profile resolution).
+    fn validate_media_profiles(&self) -> Result<()> {
+        let Some(media) = &self.media else {
+            return Ok(());
+        };
+
+        // Sorted so the error text is deterministic across runs (HashMap order).
+        let mut names: Vec<&String> = media.profiles.keys().collect();
+        names.sort_unstable();
+
+        for name in names {
+            let Some(profile) = media.profiles.get(name) else {
+                continue;
+            };
+            for (direction, flags) in [("offer", &profile.offer), ("answer", &profile.answer)] {
+                let unsupported = media.backend.unsupported_profile_fields(flags);
+                if !unsupported.is_empty() {
+                    return Err(SiphonError::Config(format!(
+                        "media profile {name:?} sets {} on its {direction} flags, which the \
+                         {} backend cannot honour — remove {} or set media.backend to a \
+                         backend that supports {}",
+                        unsupported.join(", "),
+                        media.backend.as_str(),
+                        if unsupported.len() == 1 {
+                            "the field"
+                        } else {
+                            "those fields"
+                        },
+                        if unsupported.len() == 1 {
+                            "it"
+                        } else {
+                            "them"
+                        },
+                    )));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Returns true if the given host/IP is one of our configured local domains.
@@ -4636,6 +4855,240 @@ media:
             message.contains("address_family"),
             "error should name the field: {message}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Media profiles: WebSocket bridge / DSP / received_from / rtcp_mux
+    // -----------------------------------------------------------------------
+
+    /// Base config for the WS-profile cases, parameterised on backend + profile
+    /// body so each test states only what it is about.
+    fn ws_profile_yaml(backend_block: &str, profile_body: &str) -> String {
+        format!(
+            "listen:\n  udp:\n    - \"0.0.0.0:5060\"\ndomain:\n  local:\n    \
+             - \"example.com\"\nscript:\n  path: \"scripts/proxy_default.py\"\n\
+             media:\n{backend_block}  profiles:\n    voice_ai_custom:\n{profile_body}"
+        )
+    }
+
+    const SIPHON_RTP_BACKEND: &str =
+        "  backend: siphon-rtp\n  siphon_rtp:\n    address: \"127.0.0.1:9000\"\n";
+    const RTPENGINE_BACKEND: &str = "  rtpengine:\n    address: \"127.0.0.1:22222\"\n";
+    const RTPPROXY_BACKEND: &str =
+        "  backend: rtpproxy\n  rtpproxy:\n    address: \"127.0.0.1:22222\"\n";
+
+    #[test]
+    fn parses_media_profile_websocket_and_dsp_fields() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        replace: [\"origin\"]\n        \
+             ws_uri: \"wss://ai.example.com/stream/{call_id}\"\n        \
+             ws_vad: true\n        ws_barge_in: true\n        \
+             ws_vad_threshold: 2000000\n        ws_vad_hangover_ms: 300\n        \
+             noise_suppression: true\n        echo_cancellation: true\n        \
+             received_from: true\n        rtcp_mux: [\"require\"]\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let media = config.media.unwrap();
+        let offer = &media.profiles.get("voice_ai_custom").unwrap().offer;
+        assert_eq!(
+            offer.ws_uri.as_deref(),
+            Some("wss://ai.example.com/stream/{call_id}")
+        );
+        assert!(offer.ws_vad);
+        assert!(offer.ws_barge_in);
+        assert_eq!(offer.ws_vad_threshold, Some(2_000_000));
+        assert_eq!(offer.ws_vad_hangover_ms, Some(300));
+        assert!(offer.noise_suppression);
+        assert!(offer.echo_cancellation);
+        assert!(offer.received_from);
+        assert_eq!(offer.rtcp_mux, vec!["require"]);
+    }
+
+    /// Defaults must stay off, so an existing profile emits exactly the command
+    /// it did before these knobs existed.
+    #[test]
+    fn media_profile_websocket_fields_default_off() {
+        let yaml = ws_profile_yaml(
+            RTPENGINE_BACKEND,
+            "      offer:\n        replace: [\"origin\"]\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let media = config.media.unwrap();
+        let offer = &media.profiles.get("voice_ai_custom").unwrap().offer;
+        assert!(offer.ws_uri.is_none());
+        assert!(!offer.ws_vad);
+        assert!(!offer.ws_barge_in);
+        assert!(offer.ws_vad_threshold.is_none());
+        assert!(offer.ws_vad_hangover_ms.is_none());
+        assert!(!offer.noise_suppression);
+        assert!(!offer.echo_cancellation);
+        assert!(!offer.received_from);
+        assert!(offer.rtcp_mux.is_empty());
+    }
+
+    #[test]
+    fn rejects_media_profile_non_websocket_ws_uri_scheme() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_uri: \"https://ai.example.com/stream\"\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("https:// must be rejected");
+        assert!(
+            error.to_string().contains("ws_uri"),
+            "error should name the field: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_media_profile_bad_rtcp_mux_token() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        rtcp_mux: [\"mux-please\"]\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("unknown token must be rejected");
+        assert!(
+            error.to_string().contains("rtcp_mux"),
+            "error should name the field: {error}"
+        );
+    }
+
+    #[test]
+    fn accepts_media_profile_rtcp_mux_case_insensitively() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        rtcp_mux: [\"OFFER\", \" Require \"]\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let media = config.media.unwrap();
+        assert_eq!(
+            media.profiles.get("voice_ai_custom").unwrap().offer.rtcp_mux,
+            vec!["offer", "require"]
+        );
+    }
+
+    /// A `ws_uri` the engine never receives means the leg is answered and bridged
+    /// nowhere — silence for the call's whole duration.  So it fails the load
+    /// rather than warning, unlike `address_family` on rtpproxy (which only
+    /// loses IPv4/IPv6 interworking on an otherwise working call).
+    #[test]
+    fn rejects_websocket_profile_on_rtpengine_backend() {
+        let yaml = ws_profile_yaml(
+            RTPENGINE_BACKEND,
+            "      offer:\n        ws_uri: \"wss://ai.example.com/stream\"\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("ws_uri on rtpengine must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("ws_uri") && message.contains("rtpengine"),
+            "error should name the field and the backend: {message}"
+        );
+        assert!(
+            message.contains("voice_ai_custom"),
+            "error should name the profile: {message}"
+        );
+    }
+
+    #[test]
+    fn rejects_dsp_profile_on_rtpproxy_backend() {
+        let yaml = ws_profile_yaml(
+            RTPPROXY_BACKEND,
+            "      offer:\n        noise_suppression: true\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("noise_suppression must be rejected");
+        assert!(
+            error.to_string().contains("noise_suppression"),
+            "error should name the field: {error}"
+        );
+    }
+
+    /// The answer direction is checked too — a profile is only half-validated if
+    /// only its offer flags are.
+    #[test]
+    fn rejects_websocket_profile_set_on_answer_direction_only() {
+        let yaml = ws_profile_yaml(
+            RTPENGINE_BACKEND,
+            "      offer: {}\n      answer:\n        ws_barge_in: true\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("answer-side ws_barge_in must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("ws_barge_in") && message.contains("answer"),
+            "error should name the field and direction: {message}"
+        );
+    }
+
+    /// `received_from` and `rtcp_mux` are real rtpengine NG keys, so only
+    /// rtpproxy rejects them.
+    #[test]
+    fn accepts_received_from_and_rtcp_mux_on_rtpengine_backend() {
+        let yaml = ws_profile_yaml(
+            RTPENGINE_BACKEND,
+            "      offer:\n        received_from: true\n        \
+             rtcp_mux: [\"require\"]\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).expect("rtpengine honours both");
+        let media = config.media.unwrap();
+        assert!(media.profiles.get("voice_ai_custom").unwrap().offer.received_from);
+    }
+
+    #[test]
+    fn rejects_received_from_on_rtpproxy_backend() {
+        let yaml = ws_profile_yaml(
+            RTPPROXY_BACKEND,
+            "      offer:\n        received_from: true\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("rtpproxy cannot gate on received_from");
+        assert!(
+            error.to_string().contains("received_from"),
+            "error should name the field: {error}"
+        );
+    }
+
+    #[test]
+    fn accepts_websocket_profile_on_siphon_rtp_backend() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_uri: \"wss://ai.example.com/stream\"\n        \
+             noise_suppression: true\n      answer: {}\n",
+        );
+        Config::from_str(&yaml).expect("siphon-rtp honours the WS bridge");
+    }
+
+    /// The check must not fire on a config with no `media` block at all.
+    #[test]
+    fn media_profile_validation_skips_config_without_media() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert!(config.media.is_none());
+    }
+
+    #[test]
+    fn unsupported_profile_fields_is_empty_for_plain_profile() {
+        let plain = NgFlagsConfig {
+            replace: vec!["origin".into()],
+            ..NgFlagsConfig::default()
+        };
+        for backend in [
+            MediaBackendKind::Rtpengine,
+            MediaBackendKind::SiphonRtp,
+            MediaBackendKind::Rtpproxy,
+        ] {
+            assert!(
+                backend.unsupported_profile_fields(&plain).is_empty(),
+                "{} rejected a plain profile",
+                backend.as_str()
+            );
+        }
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17503,6 +17503,13 @@ fn b2bua_complete_terminated_transfer(
                         from_tag: tgt_tag.clone(),
                         to_tag: Some(surv_tag.clone()),
                         profile: old_session.profile.clone(),
+                        // Deliberately not carried over from `old_session`: this
+                        // is a fresh engine call-id for the survivor↔target
+                        // pair, and any WebSocket bridge the pre-transfer anchor
+                        // held died with the old call-id.  Copying the URI here
+                        // would make a later `answer` on this Call-ID resolve a
+                        // bridge that was never established for it.
+                        ws_uri: None,
                         created_at: std::time::Instant::now(),
                     });
                     store.remove(old_key);
@@ -21961,6 +21968,7 @@ a=rtpmap:8 PCMA/8000\r\n";
             from_tag: "a-tag".to_string(),
             to_tag: None,
             profile: "srtp_to_rtp".to_string(),
+            ws_uri: None,
             created_at: std::time::Instant::now(),
         }
     }

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -40,6 +40,62 @@ pub enum MediaBackend {
 }
 
 impl MediaBackend {
+    /// Which engine this is, as the `media.backend` config spells it.
+    pub fn kind(&self) -> crate::config::MediaBackendKind {
+        use crate::config::MediaBackendKind;
+        match self {
+            Self::RtpEngine(_) => MediaBackendKind::Rtpengine,
+            Self::SiphonRtp(_) => MediaBackendKind::SiphonRtp,
+            Self::RtpProxy(_) => MediaBackendKind::Rtpproxy,
+        }
+    }
+
+    /// Which of `flags`' set fields this engine has no way to express.
+    ///
+    /// The same capability table [`crate::config::Config`] enforces at load
+    /// time, applied to the *resolved* [`NgFlags`] of a call.  Config validation
+    /// only sees operator-declared `media.profiles`; a built-in profile is
+    /// registered whatever the backend, so a script naming one this engine
+    /// cannot honour has to be caught here instead.
+    pub fn unsupported_flags(&self, flags: &NgFlags) -> Vec<&'static str> {
+        let mut unsupported = Vec::new();
+
+        if !matches!(self, Self::SiphonRtp(_)) {
+            if flags.ws_uri.is_some() {
+                unsupported.push("ws_uri");
+            }
+            if flags.ws_vad {
+                unsupported.push("ws_vad");
+            }
+            if flags.ws_barge_in {
+                unsupported.push("ws_barge_in");
+            }
+            if flags.ws_vad_threshold.is_some() {
+                unsupported.push("ws_vad_threshold");
+            }
+            if flags.ws_vad_hangover_ms.is_some() {
+                unsupported.push("ws_vad_hangover_ms");
+            }
+            if flags.noise_suppression {
+                unsupported.push("noise_suppression");
+            }
+            if flags.echo_cancellation {
+                unsupported.push("echo_cancellation");
+            }
+        }
+
+        if matches!(self, Self::RtpProxy(_)) {
+            if flags.carry_received_from || flags.received_from.is_some() {
+                unsupported.push("received_from");
+            }
+            if !flags.rtcp_mux.is_empty() {
+                unsupported.push("rtcp_mux");
+            }
+        }
+
+        unsupported
+    }
+
     /// Send an `offer`, returning the rewritten SDP.
     pub async fn offer(
         &self,
@@ -477,5 +533,116 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, RtpEngineError::Protocol(_)));
         assert!(error.to_string().contains("siphon-rtp"));
+    }
+
+    // -- backend capability reporting -----------------------------------------
+
+    async fn rtpengine_backend() -> MediaBackend {
+        let set = RtpEngineSet::new(vec![(dead_address(), 200, 1)]).await.unwrap();
+        MediaBackend::RtpEngine(Arc::new(set))
+    }
+
+    async fn rtpproxy_backend() -> MediaBackend {
+        let set = RtpProxyClientSet::new(vec![(dead_address(), 200, 1)], 0).await.unwrap();
+        MediaBackend::RtpProxy(set)
+    }
+
+    fn siphon_rtp_backend() -> MediaBackend {
+        let (event_tx, _event_rx) = mpsc::channel::<RtpEngineEvent>(16);
+        let set =
+            SiphonRtpClientSet::new(vec![(dead_address(), 200, 1)], None, 5_000, event_tx).unwrap();
+        MediaBackend::SiphonRtp(set)
+    }
+
+    fn ws_and_dsp_flags() -> NgFlags {
+        NgFlags {
+            ws_uri: Some("wss://ai.invalid/stream".into()),
+            ws_vad: true,
+            ws_barge_in: true,
+            ws_vad_threshold: Some(2_000_000),
+            ws_vad_hangover_ms: Some(300),
+            noise_suppression: true,
+            echo_cancellation: true,
+            ..NgFlags::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn kind_reports_the_configured_backend() {
+        use crate::config::MediaBackendKind;
+        assert_eq!(rtpengine_backend().await.kind(), MediaBackendKind::Rtpengine);
+        assert_eq!(rtpproxy_backend().await.kind(), MediaBackendKind::Rtpproxy);
+        assert_eq!(siphon_rtp_backend().kind(), MediaBackendKind::SiphonRtp);
+    }
+
+    /// A plain profile must be honourable everywhere, or every existing
+    /// deployment would start failing calls.
+    #[tokio::test]
+    async fn plain_flags_are_supported_on_every_backend() {
+        let plain = NgFlags {
+            replace: vec!["origin".into()],
+            flags: vec!["trust-address".into()],
+            ..NgFlags::default()
+        };
+        assert!(rtpengine_backend().await.unsupported_flags(&plain).is_empty());
+        assert!(rtpproxy_backend().await.unsupported_flags(&plain).is_empty());
+        assert!(siphon_rtp_backend().unsupported_flags(&plain).is_empty());
+    }
+
+    // `SiphonRtpClient::new` spawns its connection manager, so these need a
+    // runtime even though the capability check itself does no I/O.
+    #[tokio::test]
+    async fn siphon_rtp_supports_every_websocket_and_dsp_flag() {
+        assert!(siphon_rtp_backend()
+            .unsupported_flags(&ws_and_dsp_flags())
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn rtpengine_reports_every_websocket_and_dsp_flag_unsupported() {
+        let unsupported = rtpengine_backend().await.unsupported_flags(&ws_and_dsp_flags());
+        assert_eq!(
+            unsupported,
+            vec![
+                "ws_uri",
+                "ws_vad",
+                "ws_barge_in",
+                "ws_vad_threshold",
+                "ws_vad_hangover_ms",
+                "noise_suppression",
+                "echo_cancellation",
+            ]
+        );
+    }
+
+    /// `received_from` / `rtcp_mux` are real NG keys, so rtpengine honours them
+    /// and only rtpproxy does not.
+    #[tokio::test]
+    async fn received_from_and_rtcp_mux_split_rtpengine_from_rtpproxy() {
+        let flags = NgFlags {
+            carry_received_from: true,
+            rtcp_mux: vec!["require".into()],
+            ..NgFlags::default()
+        };
+        assert!(rtpengine_backend().await.unsupported_flags(&flags).is_empty());
+        assert!(siphon_rtp_backend().unsupported_flags(&flags).is_empty());
+        assert_eq!(
+            rtpproxy_backend().await.unsupported_flags(&flags),
+            vec!["received_from", "rtcp_mux"]
+        );
+    }
+
+    /// An injected address counts as asking for the gate even if the policy bit
+    /// was cleared along the way.
+    #[tokio::test]
+    async fn rtpproxy_reports_injected_received_from_unsupported() {
+        let flags = NgFlags {
+            received_from: Some("198.51.100.7".parse().unwrap()),
+            ..NgFlags::default()
+        };
+        assert_eq!(
+            rtpproxy_backend().await.unsupported_flags(&flags),
+            vec!["received_from"]
+        );
     }
 }

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -4,11 +4,18 @@
 //! UE side, plain RTP on the core side).  The profile determines which NG flags
 //! are sent in `offer` and `answer` commands.
 //!
-//! Four built-in profiles are always available:
-//!   srtp_to_rtp, ws_to_rtp, wss_to_rtp, rtp_passthrough
+//! Eight built-in profiles are always available:
+//!   srtp_to_rtp, rtp_to_srtp, ws_to_rtp, wss_to_rtp, rtp_passthrough,
+//!   srs_recording, siprec_src, voice_ai
 //!
 //! Operators can define additional profiles (or override built-ins) in the YAML
 //! config under `media.profiles`.
+//!
+//! Not every flag is honourable by every media backend — the WebSocket bridge
+//! and DSP knobs are native `siphon-rtp` extensions, and `rtpproxy` has no
+//! equivalent for `address_family`, `received_from` or `rtcp_mux`.  A profile
+//! asking for something its configured backend cannot do is rejected at config
+//! load; see `MediaBackendKind::unsupported_profile_fields`.
 
 use std::collections::HashMap;
 
@@ -42,6 +49,7 @@ impl ProfileRegistry {
         profiles.insert("rtp_passthrough".into(), Self::builtin_rtp_passthrough());
         profiles.insert("srs_recording".into(), Self::builtin_srs_recording());
         profiles.insert("siprec_src".into(), Self::builtin_siprec_src());
+        profiles.insert("voice_ai".into(), Self::builtin_voice_ai());
         Self { profiles }
     }
 
@@ -80,24 +88,16 @@ impl ProfileRegistry {
             offer: NgFlags {
                 transport_protocol: Some("RTP/SAVP".into()),
                 ice: Some("remove".into()),
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
             answer: NgFlags {
                 transport_protocol: Some("RTP/AVP".into()),
                 ice: Some("remove".into()),
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
         }
     }
@@ -107,24 +107,16 @@ impl ProfileRegistry {
             offer: NgFlags {
                 transport_protocol: Some("RTP/SAVP".into()),
                 ice: Some("remove".into()),
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
             answer: NgFlags {
                 transport_protocol: Some("RTP/AVP".into()),
                 ice: Some("remove".into()),
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
         }
     }
@@ -134,24 +126,16 @@ impl ProfileRegistry {
             offer: NgFlags {
                 transport_protocol: Some("RTP/AVPF".into()),
                 ice: Some("force".into()),
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
             answer: NgFlags {
                 transport_protocol: Some("RTP/AVP".into()),
                 ice: Some("remove".into()),
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
         }
     }
@@ -163,22 +147,57 @@ impl ProfileRegistry {
                 ice: Some("force".into()),
                 dtls: Some("passive".into()),
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["external".into(), "internal".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
             answer: NgFlags {
                 transport_protocol: Some("RTP/AVP".into()),
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
                 direction: vec!["internal".into(), "external".into()],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
+            },
+        }
+    }
+
+    fn builtin_voice_ai() -> ProfileEntry {
+        // Voice-AI bridge profile: plain RTP toward the caller, with the leg's
+        // audio bridged to an external WebSocket media server by the engine.
+        //
+        // `ws_uri` is deliberately unset — there is no sensible default endpoint,
+        // so the operator supplies it on a `media.profiles` override or the
+        // script passes `ws_uri=` per call.  Everything this profile *does* set
+        // is live on its own: noise suppression and echo cancellation clean the
+        // uplink toward the inference server (the AI downlink is the echo
+        // reference), and VAD + barge-in give the server turn boundaries and
+        // let the bridge cut playout locally on the caller's speech edge without
+        // a server round-trip.
+        //
+        // `siphon-rtp` backend only; the rtpengine and rtpproxy backends have no
+        // equivalent for any of these and reject the profile at config load.
+        ProfileEntry {
+            offer: NgFlags {
+                transport_protocol: Some("RTP/AVP".into()),
+                ice: Some("remove".into()),
+                dtls: Some("off".into()),
+                replace: vec!["origin".into()],
+                noise_suppression: true,
+                echo_cancellation: true,
+                ws_vad: true,
+                ws_barge_in: true,
+                ..NgFlags::default()
+            },
+            answer: NgFlags {
+                transport_protocol: Some("RTP/AVP".into()),
+                ice: Some("remove".into()),
+                dtls: Some("off".into()),
+                replace: vec!["origin".into()],
+                noise_suppression: true,
+                echo_cancellation: true,
+                ws_vad: true,
+                ws_barge_in: true,
+                ..NgFlags::default()
             },
         }
     }
@@ -194,28 +213,18 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![
-                    "media handover".into(),
-                    "port latching".into(),
-                ],
-                direction: vec![],
+                flags: vec!["media handover".into(), "port latching".into()],
                 record_call: true,
-                record_path: None,
+                ..NgFlags::default()
             },
             answer: NgFlags {
                 transport_protocol: Some("RTP/AVP".into()),
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![
-                    "media handover".into(),
-                    "port latching".into(),
-                ],
-                direction: vec![],
+                flags: vec!["media handover".into(), "port latching".into()],
                 record_call: true,
-                record_path: None,
+                ..NgFlags::default()
             },
         }
     }
@@ -233,11 +242,7 @@ impl ProfileRegistry {
                 ice: Some("remove".into()),
                 dtls: Some("off".into()),
                 replace: vec!["origin".into()],
-                address_family: None,
-                flags: vec![],
-                direction: vec![],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
             answer: NgFlags::default(),
         }
@@ -246,26 +251,14 @@ impl ProfileRegistry {
     fn builtin_rtp_passthrough() -> ProfileEntry {
         ProfileEntry {
             offer: NgFlags {
-                transport_protocol: None,
-                ice: None,
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
                 flags: vec!["trust-address".into()],
-                direction: vec![],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
             answer: NgFlags {
-                transport_protocol: None,
-                ice: None,
-                dtls: None,
                 replace: vec!["origin".into()],
-                address_family: None,
                 flags: vec!["trust-address".into()],
-                direction: vec![],
-                record_call: false,
-                record_path: None,
+                ..NgFlags::default()
             },
         }
     }
@@ -305,10 +298,87 @@ pub struct NgFlags {
     pub record_call: bool,
     /// Directory path for RTPEngine to write recording files.
     pub record_path: Option<String>,
+    /// Single-channel noise suppression on this leg's decoded ingress audio,
+    /// before it is relayed/transcoded toward the peer.  Engaged only on a
+    /// userspace-transcoded leg whose ingress codec runs at 8 or 16 kHz, and
+    /// setting it forces the call off the in-kernel fast path exactly as
+    /// `record_call` does.
+    ///
+    /// A native `siphon-rtp` extension: the NG/bencode and rtpproxy backends
+    /// have no equivalent and cannot honour it.
+    pub noise_suppression: bool,
+    /// Acoustic/line echo cancellation on this leg's **send** path, using the
+    /// audio played toward that party as the far-end reference.  On a WebSocket
+    /// voice-AI bridge it cancels the phone uplink toward the AI using the AI
+    /// downlink as the reference.  Like [`NgFlags::noise_suppression`] it
+    /// promotes a same-codec call onto the userspace media pipeline.
+    ///
+    /// A native `siphon-rtp` extension: the NG/bencode and rtpproxy backends
+    /// have no equivalent and cannot honour it.
+    pub echo_cancellation: bool,
+    /// Bridge this call's offerer (leg A) audio to an external WebSocket media
+    /// server — the voice-AI integration.  The engine dials this URI as a
+    /// WebSocket client and bridges leg A's RTP to it (decode → L16 uplink, L16
+    /// downlink → encode); the WS server *is* leg A's far side, so the A↔B
+    /// relay path is not wired in this mode.  Both `ws://` and `wss://` are
+    /// dialled.
+    ///
+    /// A native `siphon-rtp` extension: the NG/bencode and rtpproxy backends
+    /// have no equivalent and cannot honour it.
+    pub ws_uri: Option<String>,
+    /// Run a local energy-VAD on the WS uplink so the bridge emits
+    /// `speech_started` / `speech_stopped` control frames on the caller's speech
+    /// edges — the inference server gets turn boundaries (and the turn
+    /// endpoint) without running its own VAD.  Inert without
+    /// [`NgFlags::ws_uri`].
+    pub ws_vad: bool,
+    /// Local barge-in on the WS leg: when the caller starts speaking the bridge
+    /// flushes the queued downlink playout in the same tick (no server
+    /// round-trip) and notifies the server via `speech_started`.  Implies
+    /// [`NgFlags::ws_vad`].  Inert without [`NgFlags::ws_uri`].
+    pub ws_barge_in: bool,
+    /// Mean-square energy threshold for the WS uplink VAD.  `None` uses the
+    /// engine's 8/16 kHz L16 default (~1_000_000); higher is less sensitive.
+    /// Only meaningful with [`NgFlags::ws_vad`] / [`NgFlags::ws_barge_in`].
+    pub ws_vad_threshold: Option<i64>,
+    /// Trailing hangover for the WS uplink VAD in milliseconds — how long speech
+    /// is held after energy drops before `speech_stopped` (the turn endpoint)
+    /// fires.  `None` uses the engine's ~200 ms default.  Only meaningful with
+    /// [`NgFlags::ws_vad`] / [`NgFlags::ws_barge_in`].
+    pub ws_vad_hangover_ms: Option<u32>,
+    /// Profile **policy**: carry the real post-NAT source IP the proxy saw this
+    /// request arrive from (rtpengine's `received from`) on offer/answer.
+    ///
+    /// Separate from [`NgFlags::received_from`] because the policy comes from
+    /// YAML at startup while the address is per-call data that only exists once
+    /// a message is in hand.  Opt-in, so a profile that does not set it emits a
+    /// byte-identical command to before this field existed.
+    pub carry_received_from: bool,
+    /// The per-call value behind [`NgFlags::carry_received_from`], injected by
+    /// the script API from the message's source address just before the command
+    /// is sent.  Never populated from YAML.
+    ///
+    /// When a NATed UA advertises a private `c=` address its media actually
+    /// originates from its NAT's public IP; gating ingress to that is a
+    /// *tighter* RTPBleed source gate than the unusable signalled address.  Only
+    /// the IP is carried — the media port differs from the signalling port, so
+    /// the port is never gated.
+    pub received_from: Option<std::net::IpAddr>,
+    /// `rtcp-mux` directive list (`offer` | `require` | `demux` | `accept` |
+    /// `reject` | `remove`), overriding the mux decision the engine would derive
+    /// from the offered SDP (RFC 5761).  Empty mirrors the offer (the default).
+    ///
+    /// Honoured by rtpengine and `siphon-rtp`; the classic `rtpproxy` backend
+    /// has no equivalent.
+    pub rtcp_mux: Vec<String>,
 }
 
 impl NgFlags {
     /// Build from the YAML config representation.
+    ///
+    /// [`NgFlags::received_from`] is deliberately left `None`: the config only
+    /// carries the *policy* (`carry_received_from`); the address itself is
+    /// per-call and is injected by the script API.
     pub fn from_config(config: &NgFlagsConfig) -> Self {
         Self {
             transport_protocol: config.transport_protocol.clone(),
@@ -320,6 +390,16 @@ impl NgFlags {
             direction: config.direction.clone(),
             record_call: config.record_call,
             record_path: config.record_path.clone(),
+            noise_suppression: config.noise_suppression,
+            echo_cancellation: config.echo_cancellation,
+            ws_uri: config.ws_uri.clone(),
+            ws_vad: config.ws_vad,
+            ws_barge_in: config.ws_barge_in,
+            ws_vad_threshold: config.ws_vad_threshold,
+            ws_vad_hangover_ms: config.ws_vad_hangover_ms,
+            carry_received_from: config.received_from,
+            received_from: None,
+            rtcp_mux: config.rtcp_mux.clone(),
         }
     }
 
@@ -365,6 +445,31 @@ impl NgFlags {
         if let Some(record_path) = &self.record_path {
             pairs.push(("recording-dir", BencodeValue::string(record_path)));
         }
+        // rtpengine takes the source gate as a two-element `[family, address]`
+        // list under `"received from"`, the same shape it uses for `"media
+        // address"`.  Only emitted once the script API has injected the address
+        // (`carry_received_from` alone changes nothing on the wire).
+        if let Some(received_from) = &self.received_from {
+            let family = if received_from.is_ipv6() { "IP6" } else { "IP4" };
+            let address = received_from.to_string();
+            pairs.push((
+                "received from",
+                BencodeValue::List(vec![
+                    BencodeValue::string(family),
+                    BencodeValue::string(&address),
+                ]),
+            ));
+        }
+        if !self.rtcp_mux.is_empty() {
+            let items: Vec<&str> = self.rtcp_mux.iter().map(|s| s.as_str()).collect();
+            pairs.push(("rtcp-mux", BencodeValue::string_list(&items)));
+        }
+        // The WS bridge and DSP knobs (ws_uri, ws_vad, ws_barge_in,
+        // ws_vad_threshold, ws_vad_hangover_ms, noise_suppression,
+        // echo_cancellation) are native siphon-rtp extensions with no NG
+        // equivalent, so they are deliberately not emitted here.  A profile that
+        // sets them on this backend is rejected at config load rather than
+        // silently degraded — see `MediaBackendKind::unsupported_profile_fields`.
 
         pairs
     }
@@ -388,6 +493,7 @@ mod tests {
         assert!(registry.get("rtp_passthrough").is_some());
         assert!(registry.get("srs_recording").is_some());
         assert!(registry.get("siprec_src").is_some());
+        assert!(registry.get("voice_ai").is_some());
     }
 
     #[test]
@@ -401,13 +507,19 @@ mod tests {
     fn profile_names_sorted() {
         let registry = ProfileRegistry::new();
         let names = registry.profile_names();
-        assert_eq!(names.len(), 7);
-        // Sorted alphabetically
-        assert_eq!(names[0], "rtp_passthrough");
-        assert_eq!(names[1], "rtp_to_srtp");
-        assert_eq!(names[2], "siprec_src");
-        assert_eq!(names[3], "srs_recording");
-        assert_eq!(names[6], "wss_to_rtp");
+        assert_eq!(
+            names,
+            vec![
+                "rtp_passthrough",
+                "rtp_to_srtp",
+                "siprec_src",
+                "srs_recording",
+                "srtp_to_rtp",
+                "voice_ai",
+                "ws_to_rtp",
+                "wss_to_rtp",
+            ]
+        );
     }
 
     #[test]
@@ -421,22 +533,16 @@ mod tests {
                     ice: Some("force".into()),
                     dtls: Some("passive".into()),
                     replace: vec!["origin".into()],
-                    address_family: None,
-                    flags: vec![],
                     direction: vec!["external".into(), "internal".into()],
-                    record_call: false,
-                    record_path: None,
+                    ..NgFlagsConfig::default()
                 },
                 answer: NgFlagsConfig {
                     transport_protocol: Some("RTP/AVP".into()),
                     ice: Some("remove".into()),
                     dtls: Some("off".into()),
                     replace: vec!["origin".into()],
-                    address_family: None,
-                    flags: vec![],
                     direction: vec!["internal".into(), "external".into()],
-                    record_call: false,
-                    record_path: None,
+                    ..NgFlagsConfig::default()
                 },
             },
         );
@@ -447,7 +553,7 @@ mod tests {
         assert_eq!(entry.answer.dtls.as_deref(), Some("off"));
         // Built-ins still exist
         assert!(registry.get("srtp_to_rtp").is_some());
-        assert_eq!(registry.profile_names().len(), 8);
+        assert_eq!(registry.profile_names().len(), 9);
     }
 
     #[test]
@@ -458,25 +564,11 @@ mod tests {
             MediaProfileConfig {
                 offer: NgFlagsConfig {
                     transport_protocol: Some("CUSTOM/OFFER".into()),
-                    ice: None,
-                    dtls: None,
-                    replace: vec![],
-                    address_family: None,
-                    flags: vec![],
-                    direction: vec![],
-                    record_call: false,
-                    record_path: None,
+                    ..NgFlagsConfig::default()
                 },
                 answer: NgFlagsConfig {
                     transport_protocol: Some("CUSTOM/ANSWER".into()),
-                    ice: None,
-                    dtls: None,
-                    replace: vec![],
-                    address_family: None,
-                    flags: vec![],
-                    direction: vec![],
-                    record_call: false,
-                    record_path: None,
+                    ..NgFlagsConfig::default()
                 },
             },
         );
@@ -631,6 +723,145 @@ mod tests {
             .any(|(key, _)| *key == "address family"));
     }
 
+    // -- received_from / rtcp_mux on the NG (bencode) wire --------------------
+
+    /// rtpengine wants the source gate as a `[family, address]` pair, the same
+    /// shape it uses for `"media address"`.
+    #[test]
+    fn ng_flags_emits_received_from_as_family_address_pair() {
+        use super::super::bencode::BencodeValue;
+
+        let flags = NgFlags {
+            received_from: Some("198.51.100.7".parse().unwrap()),
+            ..NgFlags::default()
+        };
+        let pairs = flags.to_bencode_pairs();
+        let (_, value) = pairs
+            .iter()
+            .find(|(key, _)| *key == "received from")
+            .expect("missing 'received from' key");
+        assert_eq!(
+            *value,
+            BencodeValue::List(vec![
+                BencodeValue::string("IP4"),
+                BencodeValue::string("198.51.100.7"),
+            ])
+        );
+    }
+
+    #[test]
+    fn ng_flags_emits_received_from_with_ip6_family() {
+        use super::super::bencode::BencodeValue;
+
+        let flags = NgFlags {
+            received_from: Some("2001:db8::7".parse().unwrap()),
+            ..NgFlags::default()
+        };
+        let pairs = flags.to_bencode_pairs();
+        let (_, value) = pairs
+            .iter()
+            .find(|(key, _)| *key == "received from")
+            .expect("missing 'received from' key");
+        assert_eq!(
+            *value,
+            BencodeValue::List(vec![
+                BencodeValue::string("IP6"),
+                BencodeValue::string("2001:db8::7"),
+            ])
+        );
+    }
+
+    /// The policy bit alone must not reach the wire — only the injected address
+    /// does, so an opted-in profile on a call with no usable source address
+    /// emits exactly what it did before.
+    #[test]
+    fn ng_flags_omits_received_from_without_injected_address() {
+        let flags = NgFlags {
+            carry_received_from: true,
+            ..NgFlags::default()
+        };
+        assert!(!flags
+            .to_bencode_pairs()
+            .iter()
+            .any(|(key, _)| *key == "received from"));
+    }
+
+    #[test]
+    fn ng_flags_emits_rtcp_mux_directives() {
+        use super::super::bencode::BencodeValue;
+
+        let flags = NgFlags {
+            rtcp_mux: vec!["offer".into(), "require".into()],
+            ..NgFlags::default()
+        };
+        let pairs = flags.to_bencode_pairs();
+        let (_, value) = pairs
+            .iter()
+            .find(|(key, _)| *key == "rtcp-mux")
+            .expect("missing 'rtcp-mux' key");
+        assert_eq!(*value, BencodeValue::string_list(&["offer", "require"]));
+    }
+
+    /// The WS bridge and DSP knobs have no NG equivalent.  They must not leak
+    /// onto the bencode wire under any spelling — an engine that does not know
+    /// the key would ignore it, and the call would look configured and be silent.
+    #[test]
+    fn ng_flags_never_emits_websocket_or_dsp_fields() {
+        let flags = NgFlags {
+            ws_uri: Some("wss://ai.invalid/stream".into()),
+            ws_vad: true,
+            ws_barge_in: true,
+            ws_vad_threshold: Some(2_000_000),
+            ws_vad_hangover_ms: Some(300),
+            noise_suppression: true,
+            echo_cancellation: true,
+            ..NgFlags::default()
+        };
+        let pairs = flags.to_bencode_pairs();
+        assert!(
+            pairs.is_empty(),
+            "WS/DSP-only flags must produce no NG pairs, got: {:?}",
+            pairs.iter().map(|(key, _)| *key).collect::<Vec<_>>()
+        );
+    }
+
+    /// The no-wire-drift guard for the NG backend: default flags emit nothing.
+    #[test]
+    fn ng_flags_default_emits_no_pairs() {
+        assert!(NgFlags::default().to_bencode_pairs().is_empty());
+    }
+
+    // -- config → flags for the new fields ------------------------------------
+
+    #[test]
+    fn websocket_and_dsp_fields_flow_from_config_to_flags() {
+        let config = NgFlagsConfig {
+            ws_uri: Some("wss://ai.example.com/stream".into()),
+            ws_vad: true,
+            ws_barge_in: true,
+            ws_vad_threshold: Some(2_000_000),
+            ws_vad_hangover_ms: Some(300),
+            noise_suppression: true,
+            echo_cancellation: true,
+            received_from: true,
+            rtcp_mux: vec!["require".into()],
+            ..NgFlagsConfig::default()
+        };
+        let flags = NgFlags::from_config(&config);
+        assert_eq!(flags.ws_uri.as_deref(), Some("wss://ai.example.com/stream"));
+        assert!(flags.ws_vad);
+        assert!(flags.ws_barge_in);
+        assert_eq!(flags.ws_vad_threshold, Some(2_000_000));
+        assert_eq!(flags.ws_vad_hangover_ms, Some(300));
+        assert!(flags.noise_suppression);
+        assert!(flags.echo_cancellation);
+        assert_eq!(flags.rtcp_mux, vec!["require"]);
+        // The YAML carries the policy; the address is per-call and stays unset
+        // until the script API injects it.
+        assert!(flags.carry_received_from);
+        assert!(flags.received_from.is_none());
+    }
+
     /// A profile's `address_family` must survive the YAML → `NgFlags` hop; it
     /// previously had no `NgFlagsConfig` source at all.
     #[test]
@@ -640,26 +871,14 @@ mod tests {
             "v6_access_to_v4_core".to_string(),
             MediaProfileConfig {
                 offer: NgFlagsConfig {
-                    transport_protocol: None,
-                    ice: None,
-                    dtls: None,
                     replace: vec!["origin".into()],
                     address_family: Some("IP4".into()),
-                    flags: vec![],
-                    direction: vec![],
-                    record_call: false,
-                    record_path: None,
+                    ..NgFlagsConfig::default()
                 },
                 answer: NgFlagsConfig {
-                    transport_protocol: None,
-                    ice: None,
-                    dtls: None,
                     replace: vec!["origin".into()],
                     address_family: Some("IP6".into()),
-                    flags: vec![],
-                    direction: vec![],
-                    record_call: false,
-                    record_path: None,
+                    ..NgFlagsConfig::default()
                 },
             },
         );

--- a/src/rtpengine/session.rs
+++ b/src/rtpengine/session.rs
@@ -23,6 +23,13 @@ pub struct MediaSession {
     pub to_tag: Option<String>,
     /// The media profile name used for this session.
     pub profile: String,
+    /// The fully-expanded WebSocket bridge URI this session's media is attached
+    /// to, when one was requested (`siphon-rtp` voice-AI bridge).
+    ///
+    /// Recorded at `offer` so a later `answer` on the same Call-ID reuses the
+    /// same bridge without the script re-passing `ws_uri=` — the same reason
+    /// [`MediaSession::profile`] is recorded.
+    pub ws_uri: Option<String>,
     /// When this session was created.
     pub created_at: Instant,
 }
@@ -115,6 +122,7 @@ mod tests {
             from_tag: "tag-a".to_string(),
             to_tag: None,
             profile: "srtp_to_rtp".to_string(),
+            ws_uri: None,
             created_at: Instant::now(),
         }
     }

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -57,6 +57,12 @@ const READ_CHUNK: usize = 8192;
 /// semantics; only the wire encoding (JSON vs bencode) differs.  A free
 /// function rather than a `From` impl because both `From` and `ProfileFlags`
 /// are foreign to this crate (orphan rule).
+///
+/// Deliberately exhaustive — **no `..ProfileFlags::default()` tail**.  The tail
+/// is what let the WebSocket-bridge fields sit unreachable from signalling while
+/// the engine supported them: a struct-update fallback turns "siphon forgot to
+/// carry this" into a silent default instead of a compile error.  Adding a proto
+/// field must break this function.
 pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
     ProfileFlags {
         transport_protocol: flags.transport_protocol.clone(),
@@ -68,10 +74,18 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         direction: flags.direction.clone(),
         record_call: flags.record_call,
         record_path: flags.record_path.clone(),
-        // Proto fields siphon's NgFlags has no source for (ws_uri,
-        // received_from, rtcp_mux). Default them: each carries
-        // skip_serializing_if, so the emitted wire form is unchanged.
-        ..ProfileFlags::default()
+        noise_suppression: flags.noise_suppression,
+        echo_cancellation: flags.echo_cancellation,
+        ws_uri: flags.ws_uri.clone(),
+        ws_vad: flags.ws_vad,
+        ws_barge_in: flags.ws_barge_in,
+        ws_vad_threshold: flags.ws_vad_threshold,
+        ws_vad_hangover_ms: flags.ws_vad_hangover_ms,
+        // The per-call address, not the `carry_received_from` policy bit — the
+        // script API injects the former only when the latter is set, so an
+        // opted-out profile leaves this `None` and serialises away.
+        received_from: flags.received_from,
+        rtcp_mux: flags.rtcp_mux.clone(),
     }
 }
 
@@ -1496,6 +1510,178 @@ mod tests {
         mpsc::channel(16)
     }
 
+    /// A fake engine that answers like [`spawn_offer_server`] but also hands back
+    /// the **raw JSON body** of every frame it received.
+    ///
+    /// Decoding to `Request` and asserting on the struct would not catch the bug
+    /// this work fixes: a field siphon never populates round-trips as `None`
+    /// through a `Request` just as happily as one it does populate. Asserting on
+    /// the bytes actually written is what proves the field reached the wire.
+    async fn spawn_capturing_server() -> (SocketAddr, mpsc::UnboundedReceiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (capture_tx, capture_rx) = mpsc::unbounded_channel::<String>();
+        tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                let capture_tx = capture_tx.clone();
+                tokio::spawn(async move {
+                    let mut buffer = Vec::new();
+                    loop {
+                        // Decode a frame to learn its length, but publish the
+                        // raw body bytes rather than the decoded value.
+                        let decoded = loop {
+                            match frame::decode::<Request>(&buffer) {
+                                Ok(Some((request, consumed))) => break Some((request, consumed)),
+                                Ok(None) => {
+                                    let mut chunk = vec![0u8; READ_CHUNK];
+                                    match stream.read(&mut chunk).await {
+                                        Ok(0) | Err(_) => break None,
+                                        Ok(read) => buffer.extend_from_slice(&chunk[..read]),
+                                    }
+                                }
+                                Err(_) => break None,
+                            }
+                        };
+                        let Some((request, consumed)) = decoded else {
+                            return;
+                        };
+                        let body =
+                            String::from_utf8_lossy(&buffer[frame::HEADER_LEN..consumed]).into_owned();
+                        buffer.drain(..consumed);
+                        let _ = capture_tx.send(body);
+
+                        let result = match request.command {
+                            Command::Ping => CmdResult::Pong,
+                            Command::Offer { .. }
+                            | Command::Answer { .. }
+                            | Command::AnswerLocal { .. } => CmdResult::Ok {
+                                sdp: Some("v=0\r\nc=IN IP4 203.0.113.1\r\n".to_string()),
+                                duration_ms: None,
+                                to_tag: None,
+                                stats: None,
+                                play_id: None,
+                            },
+                            _ => CmdResult::Ok {
+                                sdp: None,
+                                duration_ms: None,
+                                to_tag: None,
+                                stats: None,
+                                play_id: None,
+                            },
+                        };
+                        write_frame(&mut stream, &Response { id: request.id, result }).await;
+                    }
+                });
+            }
+        });
+        (address, capture_rx)
+    }
+
+    /// The emitted offer frame for `flags`, as the raw JSON the engine receives.
+    async fn captured_offer_json(flags: &NgFlags) -> String {
+        let (address, mut capture_rx) = spawn_capturing_server().await;
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2_000, 5_000, event_tx);
+        client
+            .offer("call-1", "tag-a", b"v=0\r\n", flags)
+            .await
+            .expect("offer");
+        capture_rx.recv().await.expect("captured frame")
+    }
+
+    /// The acceptance criterion for the WebSocket bridge: a profile carrying
+    /// `ws_uri` must put it on the wire.  This is the assertion that would have
+    /// failed for as long as `profile_flags_from_ng` defaulted the field.
+    #[tokio::test]
+    async fn offer_frame_carries_ws_uri_and_dsp_fields() {
+        let json = captured_offer_json(&NgFlags {
+            transport_protocol: Some("RTP/AVP".into()),
+            replace: vec!["origin".into()],
+            ws_uri: Some("wss://ai.example.com/stream/call-1".into()),
+            ws_vad: true,
+            ws_barge_in: true,
+            ws_vad_threshold: Some(2_000_000),
+            ws_vad_hangover_ms: Some(300),
+            noise_suppression: true,
+            echo_cancellation: true,
+            rtcp_mux: vec!["require".into()],
+            received_from: Some("198.51.100.7".parse().unwrap()),
+            ..NgFlags::default()
+        })
+        .await;
+
+        for expected in [
+            r#""ws_uri":"wss://ai.example.com/stream/call-1""#,
+            r#""ws_vad":true"#,
+            r#""ws_barge_in":true"#,
+            r#""ws_vad_threshold":2000000"#,
+            r#""ws_vad_hangover_ms":300"#,
+            r#""noise_suppression":true"#,
+            r#""echo_cancellation":true"#,
+            r#""rtcp_mux":["require"]"#,
+            r#""received_from":"198.51.100.7""#,
+        ] {
+            assert!(
+                json.contains(expected),
+                "offer frame missing {expected}\nframe was: {json}"
+            );
+        }
+    }
+
+    /// The no-wire-drift guard.  A profile that sets none of the new fields must
+    /// serialise to exactly the bytes it did before they existed, so no existing
+    /// deployment sees its offer change.  Asserted as the whole frame, not a
+    /// substring — a spurious `"ws_vad":false` would slip past a `contains`.
+    #[tokio::test]
+    async fn offer_frame_without_new_fields_is_byte_identical() {
+        let json = captured_offer_json(&NgFlags {
+            transport_protocol: Some("RTP/AVP".into()),
+            ice: Some("remove".into()),
+            replace: vec!["origin".into()],
+            flags: vec!["trust-address".into()],
+            direction: vec!["external".into(), "internal".into()],
+            ..NgFlags::default()
+        })
+        .await;
+
+        assert_eq!(
+            json,
+            concat!(
+                r#"{"id":1,"command":"offer","call_id":"call-1","from_tag":"tag-a","#,
+                r#""sdp":"v=0\r\n","profile":{"transport_protocol":"RTP/AVP","ice":"remove","#,
+                r#""replace":["origin"],"flags":["trust-address"],"#,
+                r#""direction":["external","internal"]}}"#,
+            )
+        );
+    }
+
+    /// `carry_received_from` is siphon-side policy.  Setting it without an
+    /// injected address must not add a field to the frame.
+    #[tokio::test]
+    async fn offer_frame_omits_received_from_when_only_policy_is_set() {
+        let json = captured_offer_json(&NgFlags {
+            carry_received_from: true,
+            ..NgFlags::default()
+        })
+        .await;
+        assert!(
+            !json.contains("received_from"),
+            "policy bit leaked onto the wire: {json}"
+        );
+    }
+
+    /// Every field, not just the ones that happened to be wired.
+    ///
+    /// The earlier version of this test asserted only the nine fields
+    /// `profile_flags_from_ng` copied, so it stayed green for as long as the
+    /// WebSocket-bridge fields were dropped by a `..ProfileFlags::default()`
+    /// tail.  Asserting the whole struct is what makes "every field" mean it —
+    /// compare against a fully-populated expected value so a newly-added proto
+    /// field cannot pass by being defaulted on both sides.
     #[test]
     fn profile_flags_from_ng_maps_every_field() {
         let ng = NgFlags {
@@ -1508,17 +1694,62 @@ mod tests {
             direction: vec!["external".into(), "internal".into()],
             record_call: true,
             record_path: Some("/var/spool".into()),
+            noise_suppression: true,
+            echo_cancellation: true,
+            ws_uri: Some("wss://ai.invalid/stream".into()),
+            ws_vad: true,
+            ws_barge_in: true,
+            ws_vad_threshold: Some(2_000_000),
+            ws_vad_hangover_ms: Some(300),
+            carry_received_from: true,
+            received_from: Some("198.51.100.7".parse().unwrap()),
+            rtcp_mux: vec!["require".into()],
         };
-        let proto = profile_flags_from_ng(&ng);
-        assert_eq!(proto.transport_protocol.as_deref(), Some("RTP/SAVPF"));
-        assert_eq!(proto.ice.as_deref(), Some("force"));
-        assert_eq!(proto.dtls.as_deref(), Some("passive"));
-        assert_eq!(proto.replace, vec!["origin".to_string()]);
-        assert_eq!(proto.address_family.as_deref(), Some("IP4"));
-        assert_eq!(proto.flags, vec!["trust-address".to_string(), "symmetric".to_string()]);
-        assert_eq!(proto.direction, vec!["external".to_string(), "internal".to_string()]);
-        assert!(proto.record_call);
-        assert_eq!(proto.record_path.as_deref(), Some("/var/spool"));
+
+        let expected = ProfileFlags {
+            transport_protocol: Some("RTP/SAVPF".into()),
+            ice: Some("force".into()),
+            dtls: Some("passive".into()),
+            replace: vec!["origin".into()],
+            address_family: Some("IP4".into()),
+            flags: vec!["trust-address".into(), "symmetric".into()],
+            direction: vec!["external".into(), "internal".into()],
+            record_call: true,
+            record_path: Some("/var/spool".into()),
+            noise_suppression: true,
+            echo_cancellation: true,
+            ws_uri: Some("wss://ai.invalid/stream".into()),
+            ws_vad: true,
+            ws_barge_in: true,
+            ws_vad_threshold: Some(2_000_000),
+            ws_vad_hangover_ms: Some(300),
+            received_from: Some("198.51.100.7".parse().unwrap()),
+            rtcp_mux: vec!["require".into()],
+        };
+
+        assert_eq!(profile_flags_from_ng(&ng), expected);
+    }
+
+    /// `carry_received_from` is siphon-side policy, not a wire field: on its own
+    /// it must change nothing.  Only the injected address is emitted.
+    #[test]
+    fn profile_flags_from_ng_ignores_received_from_policy_without_address() {
+        let ng = NgFlags {
+            carry_received_from: true,
+            ..NgFlags::default()
+        };
+        assert_eq!(profile_flags_from_ng(&ng), ProfileFlags::default());
+    }
+
+    /// The no-wire-drift guard: a profile setting none of the new fields must
+    /// convert to exactly the default `ProfileFlags`, so every existing
+    /// deployment's emitted JSON is unchanged.
+    #[test]
+    fn profile_flags_from_ng_default_is_wire_identical() {
+        assert_eq!(
+            profile_flags_from_ng(&NgFlags::default()),
+            ProfileFlags::default()
+        );
     }
 
     #[test]

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -16,7 +16,7 @@ use pyo3::types::PyDict;
 use tracing::{debug, warn};
 
 use crate::rtpengine::client::PlayMediaSource;
-use crate::rtpengine::profile::ProfileRegistry;
+use crate::rtpengine::profile::{NgFlags, ProfileRegistry};
 use crate::rtpengine::MediaBackend;
 use crate::rtpengine::RtpEngineError;
 use crate::rtpengine::session::{MediaSession, MediaSessionStore};
@@ -108,6 +108,175 @@ fn resolve_play_media_source(
 
 /// Default profile name when none is specified.
 const DEFAULT_PROFILE: &str = "rtp_passthrough";
+
+/// The per-call values a `ws_uri` template can interpolate.
+struct WsUriContext<'a> {
+    call_id: &'a str,
+    from_tag: &'a str,
+    from_user: Option<&'a str>,
+    to_user: Option<&'a str>,
+}
+
+/// The From/To user parts of a message, for `ws_uri` templating.
+///
+/// Reuses [`NameAddr::parse`] rather than re-parsing name-addrs by hand, so a
+/// display-name-with-comma or an angle-bracketed URI is handled the same way the
+/// `request.from_uri` / `request.to_uri` getters handle it.
+fn ws_uri_user_parts(message: &Arc<Mutex<SipMessage>>) -> (Option<String>, Option<String>) {
+    let Ok(message) = message.lock() else {
+        return (None, None);
+    };
+    let user_of = |raw: Option<&String>| -> Option<String> {
+        raw.and_then(|value| crate::sip::headers::nameaddr::NameAddr::parse(value).ok())
+            .and_then(|nameaddr| nameaddr.uri.user)
+    };
+    (
+        user_of(message.headers.from()),
+        user_of(message.headers.to()),
+    )
+}
+
+/// The source IP of the message a media verb was handed, for `received_from`.
+///
+/// `SipMessage` does not carry the peer address — it is held by the Python
+/// wrapper the dispatcher built (`PyRequest` / `PyCall`), so it has to be read
+/// off the object while it is still borrowed, before any async block.
+/// A `PyReply` has no source of its own (the address that matters is the
+/// offerer's), so it yields `None` and the gate is simply not set.
+fn extract_source_ip(object: &Bound<'_, PyAny>) -> Option<String> {
+    if let Ok(request) = object.cast::<PyRequest>() {
+        return Some(request.borrow().source_ip_str().to_string());
+    }
+    if let Ok(call) = object.cast::<PyCall>() {
+        return Some(call.borrow().cdr_source_ip());
+    }
+    None
+}
+
+/// Expand `{call_id}` / `{from_tag}` / `{from_user}` / `{to_user}` in a `ws_uri`.
+///
+/// An unrecognised placeholder is an **error**, not a literal: a typo'd
+/// `{callid}` passed through verbatim would reach the engine as part of the URI
+/// path and the inference server would answer a route nobody meant to call. A
+/// placeholder with no value for this call (no From user part, say) is the same
+/// error — silently emitting an empty path segment is the same class of bug.
+///
+/// A URI with no `{` is returned untouched, so the common non-templated case
+/// costs one scan and no allocation decisions.
+fn expand_ws_uri(template: &str, context: &WsUriContext<'_>) -> PyResult<String> {
+    if !template.contains('{') {
+        return Ok(template.to_string());
+    }
+
+    let mut expanded = String::with_capacity(template.len());
+    let mut rest = template;
+
+    while let Some(open) = rest.find('{') {
+        expanded.push_str(&rest[..open]);
+        let after_open = &rest[open + 1..];
+        let Some(close) = after_open.find('}') else {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "ws_uri has an unclosed '{{' placeholder: {template:?}"
+            )));
+        };
+        let name = &after_open[..close];
+        let value = match name {
+            "call_id" => Some(context.call_id),
+            "from_tag" => Some(context.from_tag),
+            "from_user" => context.from_user,
+            "to_user" => context.to_user,
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "ws_uri has unknown placeholder {{{other}}}; supported: \
+                     {{call_id}}, {{from_tag}}, {{from_user}}, {{to_user}}"
+                )))
+            }
+        };
+        let Some(value) = value else {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "ws_uri placeholder {{{name}}} has no value on this call"
+            )));
+        };
+        expanded.push_str(value);
+        rest = &after_open[close + 1..];
+    }
+    expanded.push_str(rest);
+
+    Ok(expanded)
+}
+
+/// Resolve which WebSocket bridge URI a call should use, before templating.
+///
+/// Precedence mirrors [`resolve_answer_profile`], for the same reason: an
+/// `answer` following an `offer` should keep the bridge the offer set up without
+/// the script having to repeat itself.
+///   1. Explicit `ws_uri=` argument from the script (override).
+///   2. URI recorded by the matching `offer` (looked up by Call-ID).
+///   3. The resolved profile's `ws_uri`.
+fn resolve_ws_uri(
+    ws_uri: Option<&str>,
+    sessions: &MediaSessionStore,
+    call_id: &str,
+    profile_ws_uri: Option<&str>,
+) -> Option<String> {
+    if let Some(uri) = ws_uri {
+        return Some(uri.to_string());
+    }
+    if let Some(recorded) = sessions.get(call_id).and_then(|session| session.ws_uri) {
+        return Some(recorded);
+    }
+    profile_ws_uri.map(|uri| uri.to_string())
+}
+
+/// Apply the per-call WebSocket URI and `received_from` address to a profile's
+/// resolved flags, and reject flags the configured backend cannot honour.
+///
+/// This is the single place a call's [`NgFlags`] become final, so it is also the
+/// only place the backend-capability check has to live. Built-in profiles are
+/// registered regardless of backend (config validation only covers
+/// operator-declared `media.profiles`), so without this a script naming
+/// `voice_ai` on an rtpengine backend would answer the call and bridge it
+/// nowhere — silence for the call's whole duration, with nothing logged.
+fn finalise_flags(
+    mut flags: NgFlags,
+    backend: &MediaBackend,
+    ws_uri: Option<String>,
+    source_ip: Option<&str>,
+    profile_name: &str,
+) -> PyResult<NgFlags> {
+    if let Some(uri) = ws_uri {
+        flags.ws_uri = Some(uri);
+    }
+    if flags.carry_received_from {
+        match source_ip.and_then(|ip| ip.parse::<std::net::IpAddr>().ok()) {
+            Some(address) => flags.received_from = Some(address),
+            None => {
+                // Opted in but we have no address to carry. Leaving the gate
+                // unset is the safe direction (the engine falls back to the
+                // signalled address), but it is silently weaker than asked for,
+                // so say it.
+                warn!(
+                    profile = %profile_name,
+                    "media profile sets received_from but no usable source \
+                     address is available for this call — media ingress will \
+                     not be gated to it"
+                );
+            }
+        }
+    }
+
+    let unsupported = backend.unsupported_flags(&flags);
+    if !unsupported.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "media profile '{profile_name}' sets {} which the {} backend cannot \
+             honour — set media.backend to a backend that supports it",
+            unsupported.join(", "),
+            backend.kind().as_str(),
+        )));
+    }
+
+    Ok(flags)
+}
 
 /// Resolve which RTP profile to use on the answer side.
 ///
@@ -259,12 +428,19 @@ impl PyRtpEngine {
     /// Args:
     ///     request: A Request or Call object containing the INVITE with SDP.
     ///     profile: RTP profile name (default: "rtp_passthrough").
-    #[pyo3(signature = (request, profile=None))]
+    ///     ws_uri: Bridge this leg's audio to an external WebSocket media server
+    ///             (``siphon-rtp`` backend only), overriding the profile's own
+    ///             ``ws_uri`` for this call. Supports ``{call_id}``,
+    ///             ``{from_tag}``, ``{from_user}`` and ``{to_user}``
+    ///             placeholders. The resolved URI is recorded on the media
+    ///             session, so a later ``answer`` reuses it automatically.
+    #[pyo3(signature = (request, profile=None, ws_uri=None))]
     fn offer<'py>(
         &self,
         python: Python<'py>,
         request: &Bound<'py, PyAny>,
         profile: Option<&str>,
+        ws_uri: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let profile_name = profile.unwrap_or(DEFAULT_PROFILE);
         let entry = self.registry.get(profile_name).ok_or_else(|| {
@@ -277,6 +453,39 @@ impl PyRtpEngine {
 
         let message = extract_message(request)?;
         let (call_id, from_tag, sdp) = extract_offer_params(&message)?;
+
+        // Resolve + template the bridge URI, then finalise the flags. Both run
+        // before the async block so a bad template or an unhonourable flag
+        // raises to the script instead of failing a call already in flight.
+        let source_ip = extract_source_ip(request);
+        let resolved_ws_uri = resolve_ws_uri(
+            ws_uri,
+            &self.sessions,
+            &call_id,
+            entry.offer.ws_uri.as_deref(),
+        );
+        let resolved_ws_uri = match resolved_ws_uri {
+            Some(template) => {
+                let (from_user, to_user) = ws_uri_user_parts(&message);
+                Some(expand_ws_uri(
+                    &template,
+                    &WsUriContext {
+                        call_id: &call_id,
+                        from_tag: &from_tag,
+                        from_user: from_user.as_deref(),
+                        to_user: to_user.as_deref(),
+                    },
+                )?)
+            }
+            None => None,
+        };
+        let flags = finalise_flags(
+            flags,
+            &self.client,
+            resolved_ws_uri.clone(),
+            source_ip.as_deref(),
+            profile_name,
+        )?;
 
         let client = Arc::clone(&self.client);
         let sessions = Arc::clone(&self.sessions);
@@ -306,6 +515,7 @@ impl PyRtpEngine {
                 from_tag,
                 to_tag: None,
                 profile: profile_str,
+                ws_uri: resolved_ws_uri,
                 created_at: std::time::Instant::now(),
             });
 
@@ -340,13 +550,18 @@ impl PyRtpEngine {
     ///     call: Optional Call object — when provided, Call-ID and From-tag are
     ///           taken from this object (matching the earlier `offer`), while
     ///           To-tag and SDP body still come from `reply`.
-    #[pyo3(signature = (reply, profile=None, call=None))]
+    ///     ws_uri: WebSocket bridge URI override for this call (``siphon-rtp``
+    ///             backend only). When omitted, the URI recorded by the matching
+    ///             ``offer`` is reused, then the resolved profile's own —
+    ///             the same precedence as ``profile``.
+    #[pyo3(signature = (reply, profile=None, call=None, ws_uri=None))]
     fn answer<'py>(
         &self,
         python: Python<'py>,
         reply: &Bound<'py, PyAny>,
         profile: Option<&str>,
         call: Option<&Bound<'py, PyAny>>,
+        ws_uri: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let message = extract_message(reply)?;
 
@@ -378,6 +593,41 @@ impl PyRtpEngine {
             ))
         })?;
         let flags = entry.answer.clone();
+
+        // The bridge belongs to the offerer's leg, so template against the A-leg
+        // identifiers resolved above — not the reply's own tags.
+        let resolved_ws_uri = resolve_ws_uri(
+            ws_uri,
+            &self.sessions,
+            &call_id,
+            entry.answer.ws_uri.as_deref(),
+        );
+        let resolved_ws_uri = match resolved_ws_uri {
+            Some(template) => {
+                let (from_user, to_user) =
+                    ws_uri_user_parts(a_leg_msg.as_ref().unwrap_or(&message));
+                Some(expand_ws_uri(
+                    &template,
+                    &WsUriContext {
+                        call_id: &call_id,
+                        from_tag: &from_tag,
+                        from_user: from_user.as_deref(),
+                        to_user: to_user.as_deref(),
+                    },
+                )?)
+            }
+            None => None,
+        };
+        // A reply carries no source address of its own; when the script passed
+        // `call=`, that object does.
+        let source_ip = call.and_then(|object| extract_source_ip(object));
+        let flags = finalise_flags(
+            flags,
+            &self.client,
+            resolved_ws_uri,
+            source_ip.as_deref(),
+            &profile_name,
+        )?;
 
         let client = Arc::clone(&self.client);
         let sessions = Arc::clone(&self.sessions);
@@ -437,17 +687,23 @@ impl PyRtpEngine {
     ///                  no-encodable-codec engine result sets a deferred
     ///                  ``488 Not Acceptable Here`` on the call and returns
     ///                  ``None``.  When ``False`` it raises ``ValueError``.
+    ///     ws_uri: Bridge this leg's audio to an external WebSocket media server
+    ///             instead of a far SIP leg — the shape a voice-AI answer takes,
+    ///             since the WS server *is* the far side. Overrides the
+    ///             profile's own ``ws_uri``; supports the same placeholders as
+    ///             :meth:`offer`.
     ///
     /// Returns:
     ///     The answer SDP as ``str`` on success, or ``None`` when the offer had
     ///     no encodable codec and it was auto-rejected with a 488.
-    #[pyo3(signature = (call, profile=None, auto_reject=true))]
+    #[pyo3(signature = (call, profile=None, auto_reject=true, ws_uri=None))]
     fn answer_local<'py>(
         &self,
         python: Python<'py>,
         call: &Bound<'py, PyAny>,
         profile: Option<&str>,
         auto_reject: bool,
+        ws_uri: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let message = extract_message(call)?;
         let (call_id, from_tag, offer_sdp_bytes) = extract_offer_params(&message)?;
@@ -463,6 +719,36 @@ impl PyRtpEngine {
             ))
         })?;
         let flags = entry.answer.clone();
+
+        let source_ip = extract_source_ip(call);
+        let resolved_ws_uri = resolve_ws_uri(
+            ws_uri,
+            &self.sessions,
+            &call_id,
+            entry.answer.ws_uri.as_deref(),
+        );
+        let resolved_ws_uri = match resolved_ws_uri {
+            Some(template) => {
+                let (from_user, to_user) = ws_uri_user_parts(&message);
+                Some(expand_ws_uri(
+                    &template,
+                    &WsUriContext {
+                        call_id: &call_id,
+                        from_tag: &from_tag,
+                        from_user: from_user.as_deref(),
+                        to_user: to_user.as_deref(),
+                    },
+                )?)
+            }
+            None => None,
+        };
+        let flags = finalise_flags(
+            flags,
+            &self.client,
+            resolved_ws_uri.clone(),
+            source_ip.as_deref(),
+            &profile_name,
+        )?;
 
         // Capture an owned handle to the Call for the auto-488 path, cloned
         // while the GIL is held (free-threaded `Py::clone` rule).  `None` when
@@ -500,6 +786,7 @@ impl PyRtpEngine {
                         from_tag,
                         to_tag: None,
                         profile: profile_str,
+                        ws_uri: resolved_ws_uri,
                         created_at: std::time::Instant::now(),
                     });
                     Ok(Some(answer_sdp))
@@ -1482,7 +1769,160 @@ mod tests {
             from_tag: "tag-a".to_string(),
             to_tag: None,
             profile: profile.to_string(),
+            ws_uri: None,
             created_at: std::time::Instant::now(),
+        }
+    }
+
+    fn make_session_with_ws(call_id: &str, ws_uri: &str) -> MediaSession {
+        MediaSession {
+            ws_uri: Some(ws_uri.to_string()),
+            ..make_session(call_id, "voice_ai")
+        }
+    }
+
+    // -- ws_uri templating ----------------------------------------------------
+
+    fn ws_context<'a>() -> WsUriContext<'a> {
+        WsUriContext {
+            call_id: "abc123@example.invalid",
+            from_tag: "tag-a",
+            from_user: Some("1001"),
+            to_user: Some("2002"),
+        }
+    }
+
+    #[test]
+    fn expand_ws_uri_without_placeholder_is_untouched() {
+        let expanded = expand_ws_uri("wss://ai.invalid/stream", &ws_context()).unwrap();
+        assert_eq!(expanded, "wss://ai.invalid/stream");
+    }
+
+    #[test]
+    fn expand_ws_uri_substitutes_every_placeholder() {
+        let expanded = expand_ws_uri(
+            "wss://ai.invalid/{call_id}/{from_tag}?from={from_user}&to={to_user}",
+            &ws_context(),
+        )
+        .unwrap();
+        assert_eq!(
+            expanded,
+            "wss://ai.invalid/abc123@example.invalid/tag-a?from=1001&to=2002"
+        );
+    }
+
+    #[test]
+    fn expand_ws_uri_substitutes_repeated_placeholder() {
+        let expanded =
+            expand_ws_uri("wss://ai.invalid/{call_id}/{call_id}", &ws_context()).unwrap();
+        assert_eq!(
+            expanded,
+            "wss://ai.invalid/abc123@example.invalid/abc123@example.invalid"
+        );
+    }
+
+    /// A typo'd placeholder must not reach the engine as a literal path segment.
+    #[test]
+    fn expand_ws_uri_rejects_unknown_placeholder() {
+        pyo3::Python::initialize();
+        let error = expand_ws_uri("wss://ai.invalid/{callid}", &ws_context()).unwrap_err();
+        assert!(
+            error.to_string().contains("unknown placeholder {callid}"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn expand_ws_uri_rejects_unclosed_placeholder() {
+        pyo3::Python::initialize();
+        let error = expand_ws_uri("wss://ai.invalid/{call_id", &ws_context()).unwrap_err();
+        assert!(
+            error.to_string().contains("unclosed"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// A placeholder with nothing to substitute is an error too — an empty path
+    /// segment is as wrong as a literal one, just harder to spot.
+    #[test]
+    fn expand_ws_uri_rejects_placeholder_with_no_value() {
+        pyo3::Python::initialize();
+        let context = WsUriContext {
+            from_user: None,
+            ..ws_context()
+        };
+        let error = expand_ws_uri("wss://ai.invalid/{from_user}", &context).unwrap_err();
+        assert!(
+            error.to_string().contains("has no value"),
+            "unexpected error: {error}"
+        );
+    }
+
+    // -- ws_uri resolution precedence -----------------------------------------
+
+    #[test]
+    fn resolve_ws_uri_explicit_arg_wins() {
+        let store = MediaSessionStore::new();
+        store.insert(make_session_with_ws("call-1", "wss://recorded.invalid"));
+        let resolved = resolve_ws_uri(
+            Some("wss://explicit.invalid"),
+            &store,
+            "call-1",
+            Some("wss://profile.invalid"),
+        );
+        assert_eq!(resolved.as_deref(), Some("wss://explicit.invalid"));
+    }
+
+    /// The reason this precedence exists: an `answer` after an `offer` keeps the
+    /// bridge the offer established, without the script re-passing `ws_uri=`.
+    #[test]
+    fn resolve_ws_uri_recovers_from_offer() {
+        let store = MediaSessionStore::new();
+        store.insert(make_session_with_ws("call-1", "wss://recorded.invalid"));
+        let resolved = resolve_ws_uri(None, &store, "call-1", Some("wss://profile.invalid"));
+        assert_eq!(resolved.as_deref(), Some("wss://recorded.invalid"));
+    }
+
+    #[test]
+    fn resolve_ws_uri_falls_back_to_profile() {
+        let store = MediaSessionStore::new();
+        let resolved = resolve_ws_uri(None, &store, "no-such-call", Some("wss://profile.invalid"));
+        assert_eq!(resolved.as_deref(), Some("wss://profile.invalid"));
+    }
+
+    /// An offer recorded *without* a bridge must not inherit the profile's URI on
+    /// the answer — otherwise a script that passed `ws_uri=None` deliberately
+    /// gets a bridge attached behind its back at answer time.
+    #[test]
+    fn resolve_ws_uri_recorded_session_without_bridge_falls_through() {
+        let store = MediaSessionStore::new();
+        store.insert(make_session("call-1", "voice_ai"));
+        let resolved = resolve_ws_uri(None, &store, "call-1", Some("wss://profile.invalid"));
+        assert_eq!(resolved.as_deref(), Some("wss://profile.invalid"));
+    }
+
+    #[test]
+    fn resolve_ws_uri_none_everywhere_is_none() {
+        let store = MediaSessionStore::new();
+        assert!(resolve_ws_uri(None, &store, "no-such-call", None).is_none());
+    }
+
+    // -- the built-in voice_ai profile ----------------------------------------
+
+    /// The profile has to leave `ws_uri` unset (there is no sensible default
+    /// endpoint) but everything else it sets must be live, or naming it would be
+    /// a no-op that reads as configured.
+    #[test]
+    fn builtin_voice_ai_profile_sets_live_flags_but_no_endpoint() {
+        let registry = ProfileRegistry::new();
+        let entry = registry.get("voice_ai").expect("voice_ai profile missing");
+        for flags in [&entry.offer, &entry.answer] {
+            assert!(flags.ws_uri.is_none());
+            assert!(flags.noise_suppression);
+            assert!(flags.echo_cancellation);
+            assert!(flags.ws_vad);
+            assert!(flags.ws_barge_in);
+            assert_eq!(flags.transport_protocol.as_deref(), Some("RTP/AVP"));
         }
     }
 

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -828,6 +828,7 @@ fn media_session_store_lifecycle() {
         from_tag: "alice-tag".to_string(),
         to_tag: None,
         profile: "srtp_to_rtp".to_string(),
+        ws_uri: None,
         created_at: std::time::Instant::now(),
     };
     store.insert(session);

--- a/tests/integration/rtpengine_tests.rs
+++ b/tests/integration/rtpengine_tests.rs
@@ -212,6 +212,7 @@ async fn session_store_tracks_offer_and_answer() {
         from_tag: "tag-a".to_string(),
         to_tag: None,
         profile: "srtp_to_rtp".to_string(),
+        ws_uri: None,
         created_at: std::time::Instant::now(),
     });
 

--- a/tests/rtpengine_tests.rs
+++ b/tests/rtpengine_tests.rs
@@ -223,6 +223,7 @@ async fn session_store_tracks_offer_and_answer() {
         from_tag: "tag-a".to_string(),
         to_tag: None,
         profile: "srtp_to_rtp".to_string(),
+        ws_uri: None,
         created_at: std::time::Instant::now(),
     });
 


### PR DESCRIPTION
## What was wrong

siphon pins `siphon-rtp-proto` 0.1.4, whose `ProfileFlags` carries a WebSocket
audio bridge (`ws_uri`: the engine dials the URI and relays the leg's RTP to it
as L16, acting as that leg's far side) plus VAD, barge-in and DSP controls.

siphon never populated any of them. `profile_flags_from_ng` copied the nine
fields it knew about and defaulted the rest:

```rust
// Proto fields siphon's NgFlags has no source for (ws_uri,
// received_from, rtcp_mux). Default them: each carries
// skip_serializing_if, so the emitted wire form is unchanged.
..ProfileFlags::default()
```

So the bridge was unreachable from signalling — the engine could do it, siphon
could not ask for it, and no configuration turned it on. The comment also
undercounted: `noise_suppression` and `echo_cancellation` were dropped too.

## Changes

**Profile fields.** `NgFlags` and the `media.profiles` YAML schema gain `ws_uri`,
`ws_vad`, `ws_barge_in`, `ws_vad_threshold`, `ws_vad_hangover_ms`,
`noise_suppression`, `echo_cancellation`, `received_from` and `rtcp_mux`.

`profile_flags_from_ng` is now exhaustive — the `..ProfileFlags::default()` tail
is gone, so a proto field siphon fails to carry is a compile error rather than a
silent default. That tail is what allowed this to go unnoticed.

**Per-call `ws_uri=`** on `rtpengine.offer()` / `answer()` / `answer_local()`,
for an endpoint the script computes (session token, tenant lookup). It wins over
the profile's value and is recorded on the `MediaSession`, so a later `answer`
reuses the same bridge without repeating it — the precedence `profile=` already
had. Both forms expand `{call_id}`, `{from_tag}`, `{from_user}`, `{to_user}`; an
unrecognised placeholder raises instead of passing through, so a typo'd
`{callid}` cannot reach the engine as a URI path segment.

**`received_from`** carries the real post-NAT source IP siphon saw the request
arrive from, gating that leg's media ingress to it — a tighter RTPBleed gate than
a NATed UA's unroutable private `c=` allows. Split into two fields internally
(`carry_received_from` policy from YAML, `received_from` address injected per
call) because the policy is resolved at startup and the address only exists once
a message is in hand. Opt-in and off by default, so existing profiles emit a
byte-identical command.

**`rtcp_mux`** takes the RFC 5761 directive list, overriding the mux decision the
engine derives from the offered SDP.

**Built-in `voice_ai` profile** — plain RTP toward the caller with NS, AEC, VAD
and local barge-in. `ws_uri` is left unset (no sensible default endpoint) and
comes from YAML or per call; every flag it does set is live, so it is not a name
that does nothing.

**Backend capability enforcement.** A `media.profiles` entry setting a field its
`media.backend` cannot honour now **fails the boot**, naming the profile, the
direction and the field. Built-in profiles are registered whatever the backend,
so config validation cannot see them — a script naming one gets a `ValueError`
naming the field instead.

This is deliberately harsher than the existing warn-only treatment of
`address_family` on `rtpproxy`, because the failure modes differ in kind: an
ignored `address_family` costs IPv4/IPv6 interworking on a call that still works,
while an ignored `ws_uri` answers the call and bridges it nowhere — silence for
the call's whole duration, nothing logged.

| Field | `siphon-rtp` | `rtpengine` | `rtpproxy` |
|---|---|---|---|
| `ws_uri`, `ws_vad`, `ws_barge_in`, `ws_vad_threshold`, `ws_vad_hangover_ms` | yes | — | — |
| `noise_suppression`, `echo_cancellation` | yes | — | — |
| `received_from`, `rtcp_mux` | yes | yes | — |

`received_from` and `rtcp_mux` are real rtpengine NG keys (`"received from"` as a
`[family, address]` pair, `"rtcp-mux"`), so they are wired on the bencode path
too and only `rtpproxy` rejects them.

Invalid `ws_uri` schemes and `rtcp_mux` tokens fail the config load, matching the
`address_family` precedent — the engines ignore an unknown value silently, which
otherwise lands as a call quietly negotiated the wrong way.

## Docs fix

`docs/media-engines.md` claimed SIPREC/MPTY subscriptions were unimplemented on
`siphon-rtp` and would surface an engine error. All three backends have
dispatched `subscribe_request` / `subscribe_request_siprec` / `subscribe_answer`
/ `unsubscribe` since the native backend shipped, so the page was steering people
away from a working path. Its "media profiles are identical across backends"
statement is now qualified with the capability table above.

## Tests

- `profile_flags_from_ng_maps_every_field` asserted only the nine wired fields,
  so it stayed green while `ws_uri` was dropped. It now compares the whole
  struct against a fully-populated expected value, so a newly-added proto field
  cannot pass by being defaulted on both sides.
- A capturing stub control server asserts the **raw JSON body** of the emitted
  frame. Decoding to `Request` would not catch this class of bug: a field siphon
  never populates round-trips as `None` just as happily as one it does.
- **No-wire-drift guard**: a profile setting none of the new fields serialises to
  the exact byte sequence it did before, asserted as the whole frame rather than
  a substring so a spurious `"ws_vad":false` cannot slip past. Same guard on the
  bencode path (default flags emit no pairs) and for the WS/DSP fields never
  reaching an NG command.
- Templating (each placeholder, repeats, unknown, unclosed, no-value),
  `ws_uri` resolution precedence, per-backend capability reporting, and config
  accept/reject for every field on every backend.

`cargo test` 3615 passed / 0 failed. `cargo clippy --all-targets --all-features
-- -D warnings` clean. `cargo bench --no-run` compiles. SDK 495 passed.

Not run: the 16-row SIPp baseline and `mem_leak_test.sh`. This adds no
per-message work (profile flags resolve per call) and no per-call retained state
beyond one `Option<String>` on the existing `MediaSession`, but that is the
project's pre-commit gate and it has not been executed here.

## Follow-up, not in scope

`ws_tee` is **not** in proto 0.1.4 — no such field, no tee command. A script-side
tee needs the engine's command surface to freeze and a proto bump first, so it is
not stubbed here.
