### PR TITLE
feat(control): remote-control plane (ARI/ESL-class) — substrate + adapter API + handover + SIP verbs (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,41 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   binary frames rather than guessing, and `stream_id` correlates the control
   event with the `start` envelope on the socket. Both take the same optional
   `call_id` / `from_tag` filters as `@rtpengine.on_dtmf`.
+- **External remote-control plane (ARI/ESL-class) — Phase 1.** An out-of-process
+  application can now drive B2BUA calls over a WebSocket, in the model Asterisk
+  has with ARI and FreeSWITCH with ESL. A Python `@b2bua.on_invite` handler hands
+  a call over with `call.handover("app")` (the ARI *Stasis* model): siphon holds
+  the INVITE transaction un-dialed and emits a
+  `StasisStart` carrying the full SIP context (real headers, source, R-URI shape,
+  body) plus a stable `{channel, call_id, sip_call_id}` id triple that joins CDR
+  and HEP with no mapping table. The app then answers / progresses / rejects /
+  hangs up / refers the call and reads-writes per-call variables over the socket;
+  each command binds to the shipped imperative B2BUA rail and returns immediately
+  (a far-end outcome — the callee answering / BYEing — arrives later as an event,
+  never as the command reply). New `control:` config block with per-app bearer
+  tokens (constant-time compared, feeding the existing auto-ban store), two
+  connection modes (a persistent inbound WebSocket listener, and outbound
+  per-call-connect where siphon dials the controller at handover — the
+  multi-pod default), exactly-one-owner dispatch with per-tenant scoping
+  (`forbidden` on a cross-app target), a bounded per-connection outbound queue
+  with per-call event/reply ordering and drop-oldest backpressure that can never
+  stall the datapath, a handoff deadline with a safe default action (`503` /
+  fallback) when no controller acts in time, and `resync` reattach after a
+  controller reconnects within the grace window. A parked call is held only by
+  the transaction layer's automatic `100 Trying` — siphon synthesizes no
+  provisional (a 180 would falsely signal ringing before anything is dialed); the
+  controller sends its own `progress` (180 ringback / 183+SDP early media) if it
+  wants one, and the real 18x relay end-to-end once the app routes.
+  `call.handover(answer=…)` reserves the answer-first (AI-park) mode; that mode's
+  `answer_local`/`voice_ai` media round-trip is a follow-on and currently degrades
+  to deferred parking with a loud warning. First-class adapter API
+  (`ControlAdapter` trait + `SiphonServer::register_control_adapter`) with an
+  opaque JSON DTO seam, so a protocol extension registers its own control surface
+  over the same rail; the built-in SIP adapter ships in core. Prometheus metrics
+  `siphon_control_connections`, `siphon_control_controlled_calls`,
+  `siphon_control_commands_total`, `siphon_control_events_dropped_total`,
+  `siphon_control_auth_failures_total` and `siphon_control_handoff_timeouts_total`.
+  SDK: `call.handover(app, on_lost=, deadline_ms=, vars=)`.
 - **Media profiles can drive the `siphon-rtp` WebSocket audio bridge and its DSP
   chain.** The engine has supported handing a leg's audio to an external
   WebSocket media server (decode → L16 uplink, L16 downlink → encode, the WS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   provisional (a 180 would falsely signal ringing before anything is dialed); the
   controller sends its own `progress` (180 ringback / 183+SDP early media) if it
   wants one, and the real 18x relay end-to-end once the app routes.
-  `call.handover(answer=…)` reserves the answer-first (AI-park) mode; that mode's
-  `answer_local`/`voice_ai` media round-trip is a follow-on and currently degrades
-  to deferred parking with a loud warning. First-class adapter API
+  Answer-first (AI-park) mode — `call.handover("ai-app", answer=True, ws_uri=…)` —
+  answers the call (`200 OK`) and anchors its media to the `voice_ai` WebSocket
+  bridge before handing over (via `answer_local` on the `siphon-rtp` backend, with
+  `ws_uri` templated per the media-profile expansion), so the app drives an
+  already-connected channel with the AI audio path open; on a backend that cannot
+  do it (anything but siphon-rtp) the handover fails visibly (`503`), never a fake
+  200. First-class adapter API
   (`ControlAdapter` trait + `SiphonServer::register_control_adapter`) with an
   opaque JSON DTO seam, so a protocol extension registers its own control surface
   over the same rail; the built-in SIP adapter ships in core. Prometheus metrics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -222,8 +223,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 redis = { version = "1", features = ["tokio-comp"], optional = true }
 tokio-postgres = { version = "0.7", optional = true }
 prometheus = { version = "0.14", features = ["process"] }
-axum = { version = "0.8.8", features = ["tokio"] }
+axum = { version = "0.8.8", features = ["tokio", "ws"] }
 tower = { version = "0.5.3", features = ["util"] }
 tower-http = { version = "0.7.0", features = ["cors"] }
 # Embedded operator web UI (opt-in via the `ui` feature). rust-embed bakes the

--- a/examples/remote_control/README.md
+++ b/examples/remote_control/README.md
@@ -1,0 +1,147 @@
+# Remote-control client examples
+
+Two small external applications — one Python, one TypeScript — that drive live
+calls over siphon's control WebSocket (ARI/ESL-class). A B2BUA script hands a
+call over with `call.handover("ivr-app")` (the ARI *Stasis* model); the
+out-of-process app then answers, sets a per-call variable, holds briefly, and
+hangs up. Calls that are not handed over are unaffected.
+
+Both clients support **both connection modes** and default to
+**outbound per-call-connect**.
+
+## Connection modes
+
+Same JSON-over-WebSocket protocol (subprotocol `siphon-control.v1`) on the
+socket in either mode.
+
+- **Outbound per-call-connect (the documented default).** The app runs a
+  WebSocket **server**; siphon dials it once per handed-over call and the
+  accepting socket owns that call (the FreeSWITCH-outbound model). There is **no
+  `hello`** — the first frame the app receives is `StasisStart`. Use this for
+  multi-pod / autoscaled controllers: siphon always dials *out*, so the "which
+  pod owns the call" affinity problem cannot arise. The app must echo the
+  `siphon-control.v1` subprotocol on accept (both example servers do).
+
+- **Inbound persistent.** The app is a WebSocket **client** that connects in to
+  `control.listen` and owns calls assigned to it (round-robin across the app's
+  connections). It sends a first `hello` (whose `app` must match the token's
+  configured application) and can `resync` to re-attach its calls after a
+  reconnect.
+
+Select the mode with `SIPHON_CONTROL_MODE` (`outbound` | `inbound`).
+
+## Wire protocol
+
+Single WebSocket per connection, JSON text frames, request-id correlated.
+Adapter commands carry `module` (`"sip"`); substrate commands (`hello`,
+`resync`, `describe`, `set_var`, `get_var`) omit it.
+
+```
+command  (client → siphon)  { "id":"c-1", "type":"command", "module":"sip",
+                              "verb":"answer", "target":{"channel":"<id>"},
+                              "args":{"code":200} }
+reply    (siphon → client)  { "id":"c-1", "type":"reply", "status":"ok",
+                              "result":{...} }   // or "status":"error", "error":{code,message}
+event    (siphon → client)  { "type":"event", "event":"StasisStart",
+                              "channel":"<id>", "call_id":"<uuid>",
+                              "sip_call_id":"<cid>", "payload":{...} }
+```
+
+Every event carries the stable id triple `{channel, call_id, sip_call_id}` —
+`sip_call_id` is byte-identical to the CDR `call_id` and the HEP correlation
+chunk, so your logs join Homer + billing with no mapping table.
+
+## Phase-1 verb set
+
+| verb | module | args | notes |
+|---|---|---|---|
+| `answer` | sip | `{code, reason?, body?, content_type?}` | send a UAS 2xx to the parked A-leg |
+| `progress` | sip | `{code, reason?, body?, content_type?}` | send a 1xx / early media |
+| `reject` | sip | `{code, reason?}` | final non-2xx + tear down |
+| `hangup` | sip | `{reason?}` | BYE an answered call, or reject an unanswered one |
+| `refer` | sip | `{to, replaces?}` | in-dialog REFER on the A-leg |
+| `set_header` / `get_header` | sip | `{name, value?}` | on the stored A-leg INVITE |
+| `set_var` / `get_var` | — | `{key, value?}` | per-call variables (drain with the call) |
+| `resync` | — | — | re-attach + enumerate this app's owned calls |
+| `describe` | — | — | list the registered adapters + their verb/event schema |
+
+A command against a dead/unknown call returns a typed `not_found`; a command
+targeting another app's call returns `forbidden` — neither ever hangs.
+(`play` / `dtmf` / `bridge` / `originate` / media-stream verbs arrive in later
+phases over the same protocol and envelope.)
+
+## siphon configuration
+
+Add a `control:` block to `siphon.yaml`:
+
+```yaml
+control:
+  # outbound per-call-connect (default) — siphon dials the app per call:
+  apps:
+    - name: "ivr-app"
+      token: "${IVR_APP_TOKEN:-changeme-dev-token}"
+      per_call_connect: true
+      connect_url: "ws://127.0.0.1:8443/siphon"
+  # inbound persistent — the app connects in here instead:
+  # listen: "127.0.0.1:9092"
+  limits:
+    event_queue_depth: 1024
+    reattach_grace_secs: 10
+```
+
+Hand matching calls over from the B2BUA script:
+
+```python
+from siphon import b2bua
+
+@b2bua.on_invite
+async def route(call):
+    if call.to_uri.endswith("@ivr.example.com"):
+        call.handover("ivr-app")          # → external control (deferred / hold)
+    elif call.to_uri.endswith("@ai.example.com"):
+        call.handover("ivr-app", answer=True,   # answer-first (AI-park):
+                      ws_uri="wss://ai.example/stream/{call_id}")  # 200 + media to the AI bridge
+    else:
+        call.dial(call.ruri)              # normal B2BUA
+```
+
+`answer=True` (answer-first / AI-park) answers the call and anchors its media to
+the `voice_ai` WebSocket bridge before handing over, so the app drives an
+already-connected channel; it requires the `siphon-rtp` media backend.
+
+## Run the Python client
+
+```bash
+pip install "websockets>=14"
+
+# outbound (default): this app is the server siphon dials
+SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token python control_client.py
+
+# inbound: this app dials siphon's control.listen
+SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token python control_client.py
+```
+
+## Run the TypeScript client
+
+```bash
+npm install
+
+# outbound (default)
+SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token npm start
+
+# inbound
+SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token npm start
+
+# type-check only
+npm run typecheck
+```
+
+## Environment variables
+
+| var | default | applies to | meaning |
+|---|---|---|---|
+| `SIPHON_CONTROL_MODE` | `outbound` | both | `outbound` (server) or `inbound` (client) |
+| `IVR_APP_TOKEN` | `changeme-dev-token` | both | bearer token (must match `control.apps[].token`) |
+| `SIPHON_CONTROL_APP` | `ivr-app` | inbound | app name asserted in `hello` |
+| `SIPHON_CONTROL_BIND` | `127.0.0.1:8443` | outbound | `host:port` this app listens on for siphon's dials |
+| `SIPHON_CONTROL_URL` | `ws://127.0.0.1:9092/control/ws` | inbound | siphon's control listener URL |

--- a/examples/remote_control/control_client.py
+++ b/examples/remote_control/control_client.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Example external control application for the siphon control plane.
+
+Drives live B2BUA calls a script hands over with ``call.handover("<app>")`` (the
+ARI *Stasis* model) over siphon's control WebSocket. Calls that are not handed
+over are unaffected.
+
+Two connection modes, same wire protocol (subprotocol ``siphon-control.v1``):
+
+  * **outbound per-call-connect (the default)** — this app runs a WebSocket
+    *server*; siphon dials it once per handed-over call and the accepting socket
+    owns that call. No ``hello`` — the first frame is ``StasisStart``. This is
+    the model to use for multi-pod / autoscaled controllers (siphon always dials
+    *out*, so the "which pod owns the call" affinity problem cannot arise).
+
+  * **inbound persistent** — this app is a WebSocket *client* that connects in to
+    ``control.listen`` and owns calls assigned to it (round-robin). It sends a
+    ``hello`` and can ``resync`` to re-attach its calls after a reconnect.
+
+Select the mode with ``SIPHON_CONTROL_MODE`` (``outbound`` | ``inbound``).
+
+The demo call flow answers each handed-over call, stamps a per-call variable,
+holds briefly, then hangs up. The Phase-1 verb set is
+``answer`` / ``progress`` / ``reject`` / ``hangup`` / ``refer`` /
+``set_header`` / ``get_header`` (SIP adapter, ``module: "sip"``) plus the
+substrate verbs ``resync`` / ``describe`` / ``set_var`` / ``get_var``.
+
+Usage::
+
+    pip install "websockets>=14"
+    # outbound (default): siphon dials this server
+    SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token \\
+        python control_client.py
+    # inbound: this app dials siphon
+    SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token \\
+        python control_client.py
+
+See README.md for the matching siphon ``control:`` config and handover script.
+"""
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+import os
+
+import websockets
+
+SUBPROTOCOL = "siphon-control.v1"
+
+MODE = os.environ.get("SIPHON_CONTROL_MODE", "outbound").lower()
+APP_NAME = os.environ.get("SIPHON_CONTROL_APP", "ivr-app")
+TOKEN = os.environ.get("IVR_APP_TOKEN", "changeme-dev-token")
+
+# inbound: where to dial siphon.
+CONTROL_URL = os.environ.get("SIPHON_CONTROL_URL", "ws://127.0.0.1:9092/control/ws")
+# outbound: where this app listens for siphon's per-call dials.
+BIND = os.environ.get("SIPHON_CONTROL_BIND", "127.0.0.1:8443")
+
+ANSWER_HOLD_SECONDS = 5.0
+
+# Verbs the SIP adapter serves (routed with module="sip"); everything else is a
+# substrate verb (hello/resync/describe/set_var/get_var) and omits the module.
+_SIP_VERBS = {
+    "answer", "progress", "reject", "hangup", "refer", "set_header", "get_header",
+}
+
+
+class ControlSession:
+    """One control connection with request/reply correlation + event dispatch."""
+
+    def __init__(self, connection) -> None:
+        self._connection = connection
+        self._ids = itertools.count(1)
+        self._pending: dict[str, asyncio.Future] = {}
+        self._tasks: set[asyncio.Task] = set()
+
+    async def rpc(self, verb: str, *, target: dict | None = None,
+                  args: dict | None = None) -> dict:
+        """Send a command and await its correlated reply frame."""
+        request_id = f"c-{next(self._ids)}"
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        command: dict = {
+            "id": request_id,
+            "type": "command",
+            "verb": verb,
+            "target": target or {},
+            "args": args or {},
+        }
+        if verb in _SIP_VERBS:
+            command["module"] = "sip"
+        await self._connection.send(json.dumps(command))
+        return await future
+
+    async def read_loop(self) -> None:
+        """Dispatch replies + events until the socket closes."""
+        async for raw in self._connection:
+            frame = json.loads(raw)
+            kind = frame.get("type")
+            if kind == "reply":
+                future = self._pending.pop(frame.get("id", ""), None)
+                if future is not None and not future.done():
+                    future.set_result(frame)
+            elif kind == "event":
+                # Handle each event concurrently so a long call flow never blocks
+                # the read loop (and thus never stalls another call).
+                self._spawn(self._on_event(frame))
+
+    def _spawn(self, coro) -> None:
+        task = asyncio.ensure_future(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _on_event(self, event: dict) -> None:
+        name = event.get("event")
+        channel = event.get("channel")
+        if name == "StasisStart":
+            # payload carries the full SIP context; sip_call_id joins CDR / HEP.
+            print(f"[event] StasisStart {channel} sip_call_id={event.get('sip_call_id')}")
+            await self._handle_call(channel)
+        elif name == "StasisEnd":
+            print(f"[event] StasisEnd {channel} reason={event.get('payload', {}).get('reason')}")
+        else:
+            print(f"[event] {name} {channel}")
+
+    async def _handle_call(self, channel: str) -> None:
+        target = {"channel": channel}
+        answered = await self.rpc("answer", target=target, args={"code": 200})
+        if answered.get("status") != "ok":
+            print(f"[call] answer rejected: {answered.get('error')}")
+            return
+        # Per-call variables live on the control channel (drain with the call).
+        await self.rpc("set_var", target=target, args={"key": "demo", "value": "1"})
+        got = await self.rpc("get_var", target=target, args={"key": "demo"})
+        print(f"[call] answered {channel}; demo={got.get('result', {}).get('value')}; "
+              f"holding {ANSWER_HOLD_SECONDS}s")
+        await asyncio.sleep(ANSWER_HOLD_SECONDS)
+        hung = await self.rpc("hangup", target=target)
+        print(f"[call] hangup {channel}: {hung.get('status')}")
+
+
+async def run_inbound() -> None:
+    """Client mode: dial siphon, hello, resync, then drive assigned calls."""
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with websockets.connect(
+        CONTROL_URL, additional_headers=headers, subprotocols=[SUBPROTOCOL]
+    ) as connection:
+        print(f"[control] connected (inbound) to {CONTROL_URL}")
+        session = ControlSession(connection)
+        reader = asyncio.ensure_future(session.read_loop())
+        hello = await session.rpc("hello", args={"app": APP_NAME, "protocol": 1})
+        if hello.get("status") != "ok":
+            reader.cancel()
+            raise RuntimeError(f"hello rejected: {hello.get('error')}")
+        print(f"[control] registered as {APP_NAME!r}")
+        # Re-attach any calls we still own from a previous connection.
+        resync = await session.rpc("resync")
+        owned = resync.get("result", {}).get("channels", [])
+        print(f"[control] resync re-attached {len(owned)} call(s)")
+        for channel in owned:
+            session._spawn(session._handle_call(channel["channel"]))
+        await reader
+
+
+async def _outbound_handler(connection) -> None:
+    """Server mode: siphon dialed us for one call — we already own it."""
+    # Verify the bearer token siphon presents (the app's own policy).
+    presented = connection.request.headers.get("Authorization", "")
+    if presented != f"Bearer {TOKEN}":
+        print("[control] rejected outbound dial: bad/missing token")
+        await connection.close(code=1008, reason="unauthorized")
+        return
+    print("[control] siphon dialed in (outbound per-call-connect) — we own this call")
+    # No hello in outbound mode: the first frame is StasisStart. The websockets
+    # server has already echoed the `siphon-control.v1` subprotocol on accept.
+    await ControlSession(connection).read_loop()
+
+
+async def run_outbound() -> None:
+    """Server mode: listen for siphon's per-call dials."""
+    host, _, port = BIND.partition(":")
+    async with websockets.serve(
+        _outbound_handler, host, int(port), subprotocols=[SUBPROTOCOL]
+    ):
+        print(f"[control] listening (outbound per-call-connect) on ws://{BIND}")
+        await asyncio.Future()  # run forever
+
+
+async def main() -> None:
+    if MODE == "inbound":
+        await run_inbound()
+    elif MODE == "outbound":
+        await run_outbound()
+    else:
+        raise SystemExit(f"SIPHON_CONTROL_MODE must be 'outbound' or 'inbound' (got {MODE!r})")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n[control] interrupted")

--- a/examples/remote_control/control_client.ts
+++ b/examples/remote_control/control_client.ts
@@ -1,0 +1,191 @@
+/**
+ * Example external control application for the siphon control plane.
+ *
+ * Drives live B2BUA calls a script hands over with `call.handover("<app>")` (the
+ * ARI *Stasis* model) over siphon's control WebSocket. Calls that are not handed
+ * over are unaffected.
+ *
+ * Two connection modes, same wire protocol (subprotocol `siphon-control.v1`):
+ *
+ *   - **outbound per-call-connect (the default)** — this app runs a WebSocket
+ *     *server*; siphon dials it once per handed-over call and the accepting
+ *     socket owns that call. No `hello` — the first frame is `StasisStart`. Use
+ *     this for multi-pod / autoscaled controllers (siphon always dials *out*, so
+ *     the "which pod owns the call" affinity problem cannot arise).
+ *   - **inbound persistent** — this app is a WebSocket *client* that connects in
+ *     to `control.listen` and owns calls assigned to it (round-robin). It sends a
+ *     `hello` and can `resync` to re-attach its calls after a reconnect.
+ *
+ * Select the mode with `SIPHON_CONTROL_MODE` (`outbound` | `inbound`).
+ *
+ * The Phase-1 verb set is `answer` / `progress` / `reject` / `hangup` / `refer` /
+ * `set_header` / `get_header` (SIP adapter, `module: "sip"`) plus the substrate
+ * verbs `resync` / `describe` / `set_var` / `get_var`.
+ *
+ * Usage:
+ *   npm install
+ *   # outbound (default): siphon dials this server
+ *   SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token npm start
+ *   # inbound: this app dials siphon
+ *   SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token npm start
+ *
+ * See README.md for the matching siphon `control:` config and handover script.
+ */
+import WebSocket, { WebSocketServer } from "ws";
+
+const SUBPROTOCOL = "siphon-control.v1";
+
+const MODE = (process.env.SIPHON_CONTROL_MODE ?? "outbound").toLowerCase();
+const APP_NAME = process.env.SIPHON_CONTROL_APP ?? "ivr-app";
+const TOKEN = process.env.IVR_APP_TOKEN ?? "changeme-dev-token";
+const CONTROL_URL = process.env.SIPHON_CONTROL_URL ?? "ws://127.0.0.1:9092/control/ws";
+const BIND = process.env.SIPHON_CONTROL_BIND ?? "127.0.0.1:8443";
+const ANSWER_HOLD_MS = 5000;
+
+// Verbs the SIP adapter serves (routed with module="sip"); everything else is a
+// substrate verb (hello/resync/describe/set_var/get_var) and omits the module.
+const SIP_VERBS = new Set([
+  "answer", "progress", "reject", "hangup", "refer", "set_header", "get_header",
+]);
+
+interface ReplyFrame {
+  id: string;
+  type: "reply";
+  status: "ok" | "error";
+  result?: any;
+  error?: { code: string; message: string };
+}
+
+interface EventFrame {
+  type: "event";
+  event: string;
+  channel?: string;
+  call_id?: string;
+  sip_call_id?: string;
+  payload?: any;
+}
+
+type InboundFrame = ReplyFrame | EventFrame;
+
+/** One control connection with request/reply correlation + event dispatch. */
+class ControlSession {
+  private nextId = 1;
+  private readonly pending = new Map<string, (reply: ReplyFrame) => void>();
+
+  constructor(private readonly socket: WebSocket) {
+    socket.on("message", (data) => this.onMessage(data.toString()));
+  }
+
+  /** Send a command and resolve with its correlated reply frame. */
+  rpc(verb: string, target: unknown = {}, args: unknown = {}): Promise<ReplyFrame> {
+    const id = `c-${this.nextId++}`;
+    const command: Record<string, unknown> = { id, type: "command", verb, target, args };
+    if (SIP_VERBS.has(verb)) command.module = "sip";
+    return new Promise((resolve) => {
+      this.pending.set(id, resolve);
+      this.socket.send(JSON.stringify(command));
+    });
+  }
+
+  private onMessage(raw: string): void {
+    const frame = JSON.parse(raw) as InboundFrame;
+    if (frame.type === "reply") {
+      const resolve = this.pending.get(frame.id);
+      if (resolve) {
+        this.pending.delete(frame.id);
+        resolve(frame);
+      }
+    } else if (frame.type === "event") {
+      // Handle each event concurrently so a long call flow never blocks the read
+      // loop (and thus never stalls another call).
+      void this.onEvent(frame);
+    }
+  }
+
+  private async onEvent(event: EventFrame): Promise<void> {
+    if (event.event === "StasisStart" && event.channel) {
+      console.log(`[event] StasisStart ${event.channel} sip_call_id=${event.sip_call_id}`);
+      await this.handleCall(event.channel);
+    } else if (event.event === "StasisEnd") {
+      console.log(`[event] StasisEnd ${event.channel} reason=${event.payload?.reason}`);
+    } else {
+      console.log(`[event] ${event.event} ${event.channel ?? ""}`);
+    }
+  }
+
+  async handleCall(channel: string): Promise<void> {
+    const target = { channel };
+    const answered = await this.rpc("answer", target, { code: 200 });
+    if (answered.status !== "ok") {
+      console.log("[call] answer rejected:", answered.error);
+      return;
+    }
+    // Per-call variables live on the control channel (drain with the call).
+    await this.rpc("set_var", target, { key: "demo", value: "1" });
+    const got = await this.rpc("get_var", target, { key: "demo" });
+    console.log(`[call] answered ${channel}; demo=${got.result?.value}; holding ${ANSWER_HOLD_MS}ms`);
+    await new Promise((resolve) => setTimeout(resolve, ANSWER_HOLD_MS));
+    const hung = await this.rpc("hangup", target);
+    console.log(`[call] hangup ${channel}: ${hung.status}`);
+  }
+
+  /** Register this connection (inbound mode hello handshake) + resync. */
+  async register(): Promise<void> {
+    const hello = await this.rpc("hello", {}, { app: APP_NAME, protocol: 1 });
+    if (hello.status !== "ok") {
+      throw new Error(`hello rejected: ${JSON.stringify(hello.error)}`);
+    }
+    console.log(`[control] registered as ${APP_NAME}`);
+    const resync = await this.rpc("resync");
+    const owned = (resync.result?.channels ?? []) as Array<{ channel: string }>;
+    console.log(`[control] resync re-attached ${owned.length} call(s)`);
+    for (const call of owned) void this.handleCall(call.channel);
+  }
+}
+
+/** Client mode: dial siphon, hello, resync, then drive assigned calls. */
+function runInbound(): void {
+  const socket = new WebSocket(CONTROL_URL, [SUBPROTOCOL], {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+  const session = new ControlSession(socket);
+  socket.on("open", () => {
+    console.log(`[control] connected (inbound) to ${CONTROL_URL}`);
+    session.register().catch((error) => {
+      console.error(error);
+      socket.close();
+    });
+  });
+  socket.on("error", (error) => console.error("[control] socket error:", error));
+  socket.on("close", () => console.log("[control] connection closed"));
+}
+
+/** Server mode: siphon dials us per call — we already own it (no hello). */
+function runOutbound(): void {
+  const [host, port] = BIND.split(":");
+  const server = new WebSocketServer({
+    host,
+    port: Number(port),
+    // Echo the subprotocol siphon offers on the dial (required — the client
+    // rejects the handshake otherwise).
+    handleProtocols: (protocols) => (protocols.has(SUBPROTOCOL) ? SUBPROTOCOL : false),
+    // Verify the bearer token siphon presents (the app's own policy).
+    verifyClient: ({ req }, done) => {
+      const ok = req.headers["authorization"] === `Bearer ${TOKEN}`;
+      done(ok, 401, "unauthorized");
+    },
+  });
+  server.on("connection", (socket) => {
+    console.log("[control] siphon dialed in (outbound per-call-connect) — we own this call");
+    new ControlSession(socket); // the first frame is StasisStart
+  });
+  console.log(`[control] listening (outbound per-call-connect) on ws://${BIND}`);
+}
+
+function main(): void {
+  if (MODE === "inbound") runInbound();
+  else if (MODE === "outbound") runOutbound();
+  else throw new Error(`SIPHON_CONTROL_MODE must be 'outbound' or 'inbound' (got ${MODE})`);
+}
+
+main();

--- a/examples/remote_control/package.json
+++ b/examples/remote_control/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "siphon-control-client-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Example external control application for the siphon control plane",
+  "scripts": {
+    "start": "tsx control_client.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.12",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/remote_control/tsconfig.json
+++ b/examples/remote_control/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["control_client.ts"]
+}

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -432,7 +432,9 @@ class Call:
     def handover(self, app: str, on_lost: str | None = None,
                  deadline_ms: int | None = None,
                  vars: dict[str, str] | None = None,
-                 answer: bool = False) -> None:
+                 answer: bool = False,
+                 profile: str | None = None,
+                 ws_uri: str | None = None) -> None:
         """Hand this call over to an out-of-process control application (the ARI
         *Stasis* model). siphon holds the INVITE transaction un-dialed, sends a
         keep-alive ``180``, registers the call with the control plane, and emits
@@ -459,16 +461,27 @@ class Call:
                 channel (answering commits the call; declining is a BYE, not a
                 4xx). When ``False`` (default), the call is parked un-answered and
                 the controller decides how to respond.
+            profile: Answer-first only — the media profile to anchor with
+                (default ``"voice_ai"``).
+            ws_uri: Answer-first only — the per-call WebSocket bridge URI the media
+                engine dials out for this leg's audio (computed per session /
+                tenant). Supports ``{call_id}`` / ``{from_tag}`` / ``{from_user}``
+                / ``{to_user}`` templating; falls back to the profile's own
+                ``ws_uri`` when omitted.
 
         Raises:
-            ValueError: if ``app`` is empty or ``on_lost`` is not one of
-                ``"hangup"`` / ``"continue"`` / ``"fallback"``.
+            ValueError: if ``app`` is empty, ``on_lost`` is not one of
+                ``"hangup"`` / ``"continue"`` / ``"fallback"``, or ``profile`` /
+                ``ws_uri`` are passed without ``answer=True``.
 
         Example::
 
             @b2bua.on_invite
             async def route(call):
-                if is_ivr_number(call.to_uri):
+                if is_ai_number(call.to_uri):
+                    call.handover("ai-app", answer=True,
+                                  ws_uri="wss://ai.example/stream/{call_id}")
+                elif is_ivr_number(call.to_uri):
                     call.handover("ivr-app", on_lost="hangup", deadline_ms=3000,
                                   vars={"queue": "support"})
                 else:
@@ -481,6 +494,11 @@ class Call:
                 "call.handover(on_lost=…) must be 'hangup', 'continue', or "
                 f"'fallback' (got {on_lost!r})"
             )
+        if not answer and (profile is not None or ws_uri is not None):
+            raise ValueError(
+                "call.handover(profile=…/ws_uri=…) requires answer=True "
+                "(they only apply to answer-first mode)"
+            )
         self._actions.append(Action(
             kind="handover",
             extras={
@@ -489,6 +507,8 @@ class Call:
                 "deadline_ms": deadline_ms,
                 "vars": dict(vars) if vars else {},
                 "answer": answer,
+                "profile": profile,
+                "ws_uri": ws_uri,
             },
         ))
 

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -429,6 +429,69 @@ class Call:
             extras={"body": body, "content_type": content_type},
         ))
 
+    def handover(self, app: str, on_lost: str | None = None,
+                 deadline_ms: int | None = None,
+                 vars: dict[str, str] | None = None,
+                 answer: bool = False) -> None:
+        """Hand this call over to an out-of-process control application (the ARI
+        *Stasis* model). siphon holds the INVITE transaction un-dialed, sends a
+        keep-alive ``180``, registers the call with the control plane, and emits
+        a ``StasisStart`` (with the full SIP context) to the owning connection.
+        The external app then drives the call (answer / play / dtmf / bridge /
+        hangup) over the control WebSocket.
+
+        A handoff deadline protects against an absent/slow controller: if no
+        controller accepts and acts in time, a default action fires (``503`` by
+        default, or a fallback re-dispatch), so a dead controller degrades
+        instead of hanging calls.
+
+        Args:
+            app: The control app name (must be configured under ``control.apps``).
+            on_lost: What to do if the owning connection is lost mid-call —
+                ``"hangup"`` (default), ``"continue"``, or ``"fallback"``.
+            deadline_ms: Handoff deadline in milliseconds; ``None`` uses
+                ``control.limits.handoff_deadline_ms``.
+            vars: Per-call variables seeded into the control channel, readable +
+                writable by the app via ``get_var`` / ``set_var``.
+            answer: Answer-first (AI-park) mode. When ``True``, siphon answers
+                (``200 OK``) and anchors media to the ``voice_ai`` bridge before
+                handing over, so the controller drives an already-connected
+                channel (answering commits the call; declining is a BYE, not a
+                4xx). When ``False`` (default), the call is parked un-answered and
+                the controller decides how to respond.
+
+        Raises:
+            ValueError: if ``app`` is empty or ``on_lost`` is not one of
+                ``"hangup"`` / ``"continue"`` / ``"fallback"``.
+
+        Example::
+
+            @b2bua.on_invite
+            async def route(call):
+                if is_ivr_number(call.to_uri):
+                    call.handover("ivr-app", on_lost="hangup", deadline_ms=3000,
+                                  vars={"queue": "support"})
+                else:
+                    call.dial(call.ruri)
+        """
+        if not app:
+            raise ValueError("call.handover() requires a non-empty app name")
+        if on_lost is not None and on_lost not in ("hangup", "continue", "fallback"):
+            raise ValueError(
+                "call.handover(on_lost=…) must be 'hangup', 'continue', or "
+                f"'fallback' (got {on_lost!r})"
+            )
+        self._actions.append(Action(
+            kind="handover",
+            extras={
+                "app": app,
+                "on_lost": on_lost,
+                "deadline_ms": deadline_ms,
+                "vars": dict(vars) if vars else {},
+                "answer": answer,
+            },
+        ))
+
     def dial(
         self,
         uri: str,

--- a/sdk/siphon_sdk/types.py
+++ b/sdk/siphon_sdk/types.py
@@ -224,7 +224,8 @@ class Action:
 
     kind: str
     """Action type: ``"reply"``, ``"relay"``, ``"fork"``, ``"reject"``,
-    ``"dial"``, ``"terminate"``, ``"record_route"``, ``"silent_drop"``."""
+    ``"dial"``, ``"terminate"``, ``"handover"``, ``"record_route"``,
+    ``"silent_drop"``."""
 
     status_code: Optional[int] = None
     """For ``reply`` / ``reject`` — the SIP status code (e.g. 200, 404)."""

--- a/sdk/tests/test_call_handover.py
+++ b/sdk/tests/test_call_handover.py
@@ -1,0 +1,50 @@
+"""Tests for ``call.handover()`` — the ARI-*Stasis* handoff to an out-of-process
+control application. Mirrors the Rust ``PyCall::handover`` / ``CallAction::Handover``.
+"""
+
+import pytest
+
+from siphon_sdk.call import Call
+
+
+class TestCallHandover:
+    def test_handover_records_action_with_full_args(self):
+        call = Call()
+        call.handover("ivr-app", on_lost="hangup", deadline_ms=3000,
+                      vars={"queue": "support"})
+        action = call._actions[-1]
+        assert action.kind == "handover"
+        assert action.extras["app"] == "ivr-app"
+        assert action.extras["on_lost"] == "hangup"
+        assert action.extras["deadline_ms"] == 3000
+        assert action.extras["vars"] == {"queue": "support"}
+
+    def test_handover_defaults(self):
+        call = Call()
+        call.handover("ivr-app")
+        action = call._actions[-1]
+        assert action.extras["on_lost"] is None
+        assert action.extras["deadline_ms"] is None
+        assert action.extras["vars"] == {}
+        assert action.extras["answer"] is False
+
+    def test_handover_answer_first_mode(self):
+        call = Call()
+        call.handover("ivr-app", answer=True)
+        assert call._actions[-1].extras["answer"] is True
+
+    def test_handover_rejects_empty_app(self):
+        call = Call()
+        with pytest.raises(ValueError):
+            call.handover("")
+
+    def test_handover_rejects_bad_on_lost(self):
+        call = Call()
+        with pytest.raises(ValueError):
+            call.handover("ivr-app", on_lost="explode")
+
+    @pytest.mark.parametrize("policy", ["hangup", "continue", "fallback"])
+    def test_handover_accepts_valid_on_lost(self, policy):
+        call = Call()
+        call.handover("ivr-app", on_lost=policy)
+        assert call._actions[-1].extras["on_lost"] == policy

--- a/sdk/tests/test_call_handover.py
+++ b/sdk/tests/test_call_handover.py
@@ -27,11 +27,24 @@ class TestCallHandover:
         assert action.extras["deadline_ms"] is None
         assert action.extras["vars"] == {}
         assert action.extras["answer"] is False
+        assert action.extras["profile"] is None
+        assert action.extras["ws_uri"] is None
 
-    def test_handover_answer_first_mode(self):
+    def test_handover_answer_first_mode_with_media_args(self):
         call = Call()
-        call.handover("ivr-app", answer=True)
-        assert call._actions[-1].extras["answer"] is True
+        call.handover("ai-app", answer=True, profile="voice_ai",
+                      ws_uri="wss://ai.example/stream/{call_id}")
+        extras = call._actions[-1].extras
+        assert extras["answer"] is True
+        assert extras["profile"] == "voice_ai"
+        assert extras["ws_uri"] == "wss://ai.example/stream/{call_id}"
+
+    def test_handover_media_args_require_answer(self):
+        call = Call()
+        with pytest.raises(ValueError):
+            call.handover("app", profile="voice_ai")
+        with pytest.raises(ValueError):
+            call.handover("app", ws_uri="wss://ai")
 
     def test_handover_rejects_empty_app(self):
         call = Call()

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -1205,3 +1205,28 @@ log:
   level: info      # debug | info | warn | error
   format: pretty   # pretty (human-readable) | json (structured, for log aggregators)
   # file: /var/log/siphon.log   # optional: also write logs to file (for logrotate)
+
+# External remote-control plane (ARI/ESL-class). A management plane — OFF by
+# default. An out-of-process app drives calls a Python @b2bua.on_invite handler
+# hands over with call.handover("<app>"). Two connection modes (both speak the
+# same JSON-over-WebSocket protocol, subprotocol "siphon-control.v1"):
+#   - persistent inbound WS  (the app connects in to `listen`)
+#   - outbound per-call-connect (siphon dials the app's connect_url per call —
+#     the documented default for multi-pod controllers).
+# control:
+#   listen: "127.0.0.1:9092"        # inbound WebSocket listener (GET /control/ws)
+#   # A parked call is held by the transaction layer's automatic 100 Trying;
+#   # siphon sends no synthesized provisional. The controller sends its own
+#   # ringback/early-media via the `progress` verb if it wants one.
+#   apps:
+#     - name: "ivr-app"
+#       token: "${IVR_APP_TOKEN}"   # bearer token (constant-time compared)
+#       # production default — siphon dials the controller once per call:
+#       per_call_connect: true
+#       connect_url: "wss://controller.internal:8443/siphon"
+#       on_lost: "hangup"           # owner-disconnect policy: hangup|continue|fallback
+#   limits:
+#     event_queue_depth: 1024       # bounded per-connection outbound queue
+#     slow_consumer: drop_oldest    # drop_oldest | disconnect
+#     reattach_grace_secs: 10       # window for a reconnecting app to `resync`
+#     handoff_deadline_ms: 3000     # default deadline before the parked call degrades

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -841,6 +841,21 @@ pub struct CallActor {
     /// Sequential-failover (LCR / `fork(strategy="sequential")`) state. `None`
     /// for a plain single dial or a parallel fork. See [`RouteSequenceState`].
     pub route_sequence: Option<RouteSequenceState>,
+    /// The external control app this call was handed over to
+    /// (`call.handover("app")`), if any. When `Some`, the call is *parked under
+    /// control*: siphon holds the INVITE transaction un-dialed while the
+    /// out-of-process app decides, and the answer-deadline sweep applies the
+    /// handoff default action (not the 408 path) if the app never acts.
+    pub control_app: Option<String>,
+    /// Control-loss policy for a handed-over call ("hangup"/"continue"/
+    /// "fallback"). Owned by the control plane on owner disconnect; stored here
+    /// for observability.
+    pub on_control_loss: Option<String>,
+    /// True while a handed-over call is still awaiting the controller's first
+    /// action. The answer-deadline sweep reads this to apply the handoff default
+    /// instead of the 408 timeout teardown. Cleared once the controller acts
+    /// (answer/progress transitions the state) or the call is torn down.
+    pub handoff_pending: bool,
 }
 
 impl CallActor {
@@ -877,7 +892,17 @@ impl CallActor {
             answer_deadline: None,
             auth_passthrough: false,
             route_sequence: None,
+            control_app: None,
+            on_control_loss: None,
+            handoff_pending: false,
         }
+    }
+
+    /// Whether this call is parked under external control awaiting the
+    /// controller's first action (the answer-deadline sweep uses this to apply
+    /// the handoff default rather than the 408 teardown).
+    pub fn is_handoff_pending(&self) -> bool {
+        self.control_app.is_some() && self.handoff_pending
     }
 
     /// Pop the next carrier from the failover queue, mark it active, and return
@@ -2164,6 +2189,34 @@ impl CallActorStore {
     pub fn set_answer_deadline(&self, call_id: &str, deadline: std::time::Instant) {
         if let Some(mut call) = self.calls.get_mut(call_id) {
             call.answer_deadline = Some(deadline);
+        }
+    }
+
+    /// Mark a call parked under external control (`call.handover("app")`).
+    /// Sets the control app + control-loss policy and flags the call as awaiting
+    /// the controller's first action.
+    pub fn set_control_owner(&self, call_id: &str, app: &str, on_control_loss: Option<&str>) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            call.control_app = Some(app.to_string());
+            call.on_control_loss = on_control_loss.map(String::from);
+            call.handoff_pending = true;
+        }
+    }
+
+    /// The control app owning a call, if any (cloned).
+    pub fn control_app(&self, call_id: &str) -> Option<String> {
+        self.calls.get(call_id).and_then(|call| call.control_app.clone())
+    }
+
+    /// Record that the controlling app has acted on a parked call: clear the
+    /// handoff deadline so the sweep no longer applies the default action, and
+    /// clear the pending flag. Idempotent.
+    pub fn mark_controller_acted(&self, call_id: &str) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            if call.control_app.is_some() {
+                call.handoff_pending = false;
+                call.answer_deadline = None;
+            }
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,9 @@ pub struct Config {
     /// `None` = disabled.
     pub admin: Option<AdminConfig>,
 
+    /// External remote-control plane (ARI/ESL-class). `None` = disabled.
+    pub control: Option<ControlConfig>,
+
     /// Server and User-Agent header values injected into responses.
     pub server: Option<ServerIdentityConfig>,
 
@@ -1659,6 +1662,113 @@ pub struct AdminUiConfig {
     /// warning is logged and no UI is served.
     #[serde(default)]
     pub enabled: bool,
+}
+
+// ---------------------------------------------------------------------------
+// External remote-control plane (ARI/ESL-class)
+// ---------------------------------------------------------------------------
+
+/// External remote-control plane listener + per-app registry.
+///
+/// An out-of-process application drives B2BUA calls that a Python
+/// `@b2bua.on_invite` handler explicitly hands over with `call.handover("app")`
+/// (the ARI *Stasis* model). Two connection modes, same wire protocol:
+/// a persistent inbound WebSocket per app (`listen`), and outbound
+/// per-call-connect where siphon dials the app's `connect_url` at handover.
+///
+/// A management plane — treat it like the admin API. Off by default; enable it
+/// deliberately and set per-app bearer tokens.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ControlConfig {
+    /// Address for the inbound persistent-WebSocket listener
+    /// (e.g. "127.0.0.1:9092"). `None` = only outbound per-call-connect apps
+    /// are usable.
+    #[serde(default)]
+    pub listen: Option<String>,
+    /// Registered control applications. An app not listed here can neither
+    /// connect (unknown token) nor receive a handover (unknown app name).
+    #[serde(default)]
+    pub apps: Vec<ControlAppConfig>,
+    /// Global resource caps + backpressure policy.
+    #[serde(default)]
+    pub limits: ControlLimits,
+}
+
+/// A single registered control application.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ControlAppConfig {
+    /// The application name. `call.handover("<name>")` routes to this app, and
+    /// the connection's `hello.args.app` must equal it.
+    pub name: String,
+    /// The bearer token this app presents (`Authorization: Bearer <token>` on
+    /// the inbound upgrade, or the token siphon presents when dialing
+    /// `connect_url`). Supports `${VAR}` expansion — keep the literal out of the
+    /// YAML.
+    #[serde(default)]
+    pub token: String,
+    /// When true, siphon dials `connect_url` per handed-over call and the
+    /// accepting socket owns that call (the FreeSWITCH-outbound model — the
+    /// documented default for multi-pod controllers). When false (default), the
+    /// app connects in over `listen` and owns per round-robin assignment.
+    #[serde(default)]
+    pub per_call_connect: bool,
+    /// The controller's WebSocket URL for `per_call_connect` mode
+    /// (e.g. "ws://controller.internal:8443/siphon").
+    #[serde(default)]
+    pub connect_url: Option<String>,
+    /// What to do if the owning connection is lost mid-call (owner disconnects):
+    /// "hangup" (default), "continue", or "fallback".
+    #[serde(default)]
+    pub on_lost: Option<String>,
+}
+
+/// Global control-plane resource caps + backpressure policy.
+#[derive(Debug, Deserialize, Clone)]
+pub struct ControlLimits {
+    /// Bounded per-connection outbound event-queue depth. On overflow the
+    /// `slow_consumer` policy applies (events only — replies are never dropped).
+    #[serde(default = "ControlLimits::default_event_queue_depth")]
+    pub event_queue_depth: usize,
+    /// Overflow policy for a slow/stuck consumer: "drop_oldest" (default) or
+    /// "disconnect".
+    #[serde(default = "ControlLimits::default_slow_consumer")]
+    pub slow_consumer: String,
+    /// Grace window (seconds) after an owner disconnects during which a
+    /// reconnecting controller of the same app may `resync` and re-claim its
+    /// calls before `on_lost` fires. Default 10.
+    #[serde(default = "ControlLimits::default_reattach_grace_secs")]
+    pub reattach_grace_secs: u64,
+    /// Default handoff deadline (milliseconds) applied when `call.handover()`
+    /// does not pass an explicit `deadline_ms`. If no controller accepts and
+    /// acts within it, the call degrades (503 / fallback). Default 3000.
+    #[serde(default = "ControlLimits::default_handoff_deadline_ms")]
+    pub handoff_deadline_ms: u64,
+}
+
+impl Default for ControlLimits {
+    fn default() -> Self {
+        Self {
+            event_queue_depth: Self::default_event_queue_depth(),
+            slow_consumer: Self::default_slow_consumer(),
+            reattach_grace_secs: Self::default_reattach_grace_secs(),
+            handoff_deadline_ms: Self::default_handoff_deadline_ms(),
+        }
+    }
+}
+
+impl ControlLimits {
+    fn default_event_queue_depth() -> usize {
+        1024
+    }
+    fn default_slow_consumer() -> String {
+        "drop_oldest".to_string()
+    }
+    fn default_reattach_grace_secs() -> u64 {
+        10
+    }
+    fn default_handoff_deadline_ms() -> u64 {
+        3000
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/control/listener.rs
+++ b/src/control/listener.rs
@@ -1,0 +1,610 @@
+//! The inbound control-plane WebSocket listener (axum) + the shared,
+//! transport-agnostic per-connection frame logic reused by the outbound
+//! per-call-connect dialer.
+//!
+//! ## I/O discipline (the whole point)
+//!
+//! Per connection there are exactly two async tokio tasks and nothing else:
+//!
+//! - a **read task** that parses inbound frames, hands each command to the
+//!   consumer over an **unbounded** `flume` channel (a send that never blocks)
+//!   and then `.await`s a `oneshot` for the *local* reply, and
+//! - a **write task** that drains the connection's **bounded** outbound queue
+//!   (replies + events, one ordered stream) onto the socket.
+//!
+//! No control I/O ever runs on `py_executor` or the dispatcher; a slow/dead peer
+//! stalls only its own two tasks.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{ConnectInfo, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use futures_util::stream::SplitSink;
+use futures_util::{SinkExt, StreamExt};
+use tracing::{debug, info, warn};
+
+use super::protocol::{
+    CommandFrame, ControlErrorCode, ControlResult, HelloArgs, PROTOCOL_VERSION, SUBPROTOCOL,
+};
+use super::registry::{ConnHandle, ControlBus, ControlCommand, OutboundFrame, OutboundQueue};
+
+/// Start the inbound control-plane WebSocket server. Mirrors `admin::serve`:
+/// logs and returns on bind error rather than panicking.
+pub async fn serve(listen_addr: SocketAddr, bus: Arc<ControlBus>) {
+    let app = router(bus);
+
+    let listener = match tokio::net::TcpListener::bind(listen_addr).await {
+        Ok(listener) => listener,
+        Err(error) => {
+            warn!(%listen_addr, %error, "failed to bind control plane listener");
+            return;
+        }
+    };
+    info!(%listen_addr, "control plane listening (inbound WebSocket)");
+
+    let make_service = app.into_make_service_with_connect_info::<SocketAddr>();
+    if let Err(error) = axum::serve(listener, make_service).await {
+        warn!(%error, "control plane server error");
+    }
+}
+
+/// Build the control router (also used by tests without binding a port).
+pub fn router(bus: Arc<ControlBus>) -> Router {
+    Router::new()
+        .route("/control/ws", get(ws_handler))
+        .with_state(bus)
+}
+
+/// Extract the `Authorization: Bearer <token>` header and match it against the
+/// configured apps. Returns the matching app name, or `None`.
+fn authenticate(headers: &HeaderMap, bus: &ControlBus) -> Option<String> {
+    let value = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let token = value
+        .strip_prefix("Bearer ")
+        .or_else(|| value.strip_prefix("bearer "))?;
+    bus.authenticate_token(token)
+}
+
+/// The WS upgrade handler. Rejects a bad/missing token with `401` **before** the
+/// socket exists (no half-open state for unauthenticated peers) and feeds the
+/// auto-ban store so brute-forcing tokens gets the source IP banned.
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(bus): State<Arc<ControlBus>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Response {
+    let app = match authenticate(&headers, &bus) {
+        Some(app) => app,
+        None => {
+            crate::security::record_handshake_failure(peer.ip(), "control");
+            crate::metrics::try_metrics().inspect(|m| m.control_auth_failures_total.inc());
+            warn!(remote = %peer, "control plane: rejected unauthenticated upgrade");
+            return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+        }
+    };
+
+    ws.protocols([SUBPROTOCOL])
+        .on_upgrade(move |socket| handle_inbound_socket(socket, app, bus, peer))
+}
+
+/// Drive one authenticated inbound control connection to completion.
+async fn handle_inbound_socket(
+    socket: WebSocket,
+    app: String,
+    bus: Arc<ControlBus>,
+    peer: SocketAddr,
+) {
+    let conn = bus.register_connection(&app);
+    info!(remote = %peer, %app, conn_id = conn.id, "control plane: connection open");
+    crate::metrics::try_metrics().inspect(|m| m.control_connections.with_label_values(&[&app]).inc());
+
+    let (ws_sink, mut ws_source) = socket.split();
+    let writer_events = Arc::clone(&conn.events);
+    let writer = tokio::spawn(inbound_write_task(ws_sink, writer_events));
+
+    let mut said_hello = false;
+    while let Some(message) = ws_source.next().await {
+        let message = match message {
+            Ok(message) => message,
+            Err(error) => {
+                debug!(conn_id = conn.id, %error, "control plane: read error");
+                break;
+            }
+        };
+        match message {
+            Message::Text(text) => {
+                if !process_text(text.as_str(), &mut said_hello, &conn, &bus).await {
+                    break;
+                }
+            }
+            Message::Close(_) => {
+                debug!(conn_id = conn.id, "control plane: client closed");
+                break;
+            }
+            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Binary(_) => {
+                warn!(conn_id = conn.id, "control plane: ignoring binary frame");
+            }
+        }
+    }
+
+    conn.events.close();
+    bus.unregister_connection(&conn);
+    crate::metrics::try_metrics().inspect(|m| m.control_connections.with_label_values(&[&app]).dec());
+    let _ = writer.await;
+    info!(remote = %peer, %app, conn_id = conn.id, "control plane: connection closed");
+}
+
+/// The inbound connection's single write task: drains the ordered outbound queue
+/// (replies + events) onto the axum socket.
+async fn inbound_write_task(mut ws_sink: SplitSink<WebSocket, Message>, events: Arc<OutboundQueue>) {
+    loop {
+        let frames = events.recv_many().await;
+        if frames.is_empty() {
+            break; // queue closed on teardown
+        }
+        for frame in frames {
+            match frame.to_json() {
+                Ok(text) => {
+                    if ws_sink.send(Message::Text(text.into())).await.is_err() {
+                        let _ = ws_sink.send(Message::Close(None)).await;
+                        return;
+                    }
+                }
+                Err(error) => warn!(%error, "control plane: failed to serialize outbound frame"),
+            }
+        }
+        if events.disconnect_requested() {
+            break;
+        }
+    }
+    let _ = ws_sink.send(Message::Close(None)).await;
+}
+
+// ---------------------------------------------------------------------------
+// Shared, transport-agnostic frame processing (reused by outbound.rs).
+// ---------------------------------------------------------------------------
+
+/// Handle one inbound text frame on an authenticated connection. Returns `false`
+/// when the connection should close (fatal protocol error / handshake failure).
+pub(crate) async fn process_text(
+    text: &str,
+    said_hello: &mut bool,
+    conn: &Arc<ConnHandle>,
+    bus: &Arc<ControlBus>,
+) -> bool {
+    let frame: CommandFrame = match serde_json::from_str(text) {
+        Ok(frame) => frame,
+        Err(error) => {
+            warn!(%error, "control plane: malformed frame");
+            return true; // no id to correlate; drop the frame, keep the connection
+        }
+    };
+    let id = frame.id.clone();
+
+    if !*said_hello {
+        return handle_hello(&frame, id, said_hello, &conn.app, conn);
+    }
+
+    handle_command(frame, id, conn, bus).await;
+    true
+}
+
+/// Process the mandatory first `hello` frame. On success the reply carries the
+/// negotiated protocol + subprotocol; a mismatch closes the connection.
+fn handle_hello(
+    frame: &CommandFrame,
+    id: String,
+    said_hello: &mut bool,
+    app: &str,
+    conn: &Arc<ConnHandle>,
+) -> bool {
+    if frame.verb != "hello" {
+        conn.events.push_reply(
+            ControlResult::error(
+                ControlErrorCode::ProtocolError,
+                "first frame must be a hello command",
+            )
+            .into_reply(id),
+        );
+        return false;
+    }
+
+    let hello: HelloArgs = match serde_json::from_value(frame.args.clone()) {
+        Ok(hello) => hello,
+        Err(error) => {
+            conn.events.push_reply(
+                ControlResult::error(
+                    ControlErrorCode::BadRequest,
+                    format!("invalid hello args: {error}"),
+                )
+                .into_reply(id),
+            );
+            return false;
+        }
+    };
+
+    if hello.app != app {
+        conn.events.push_reply(
+            ControlResult::error(
+                ControlErrorCode::Forbidden,
+                "hello app does not match the authenticated token",
+            )
+            .into_reply(id),
+        );
+        return false;
+    }
+
+    if let Some(protocol) = hello.protocol {
+        if protocol != PROTOCOL_VERSION {
+            conn.events.push_reply(
+                ControlResult::error(
+                    ControlErrorCode::UnsupportedVersion,
+                    format!("unsupported protocol version {protocol} (this build speaks {PROTOCOL_VERSION})"),
+                )
+                .into_reply(id),
+            );
+            return false;
+        }
+    }
+
+    *said_hello = true;
+    conn.events.push_reply(
+        ControlResult::Ok(serde_json::json!({
+            "app": app,
+            "protocol": PROTOCOL_VERSION,
+            "subprotocol": SUBPROTOCOL,
+        }))
+        .into_reply(id),
+    );
+    true
+}
+
+/// Route a command to the consumer and, when its *local* reply arrives, enqueue
+/// it on the connection's ordered outbound queue (so replies + events for a call
+/// are totally ordered on the owner socket).
+async fn handle_command(
+    frame: CommandFrame,
+    id: String,
+    conn: &Arc<ConnHandle>,
+    bus: &Arc<ControlBus>,
+) {
+    let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+    let verb = frame.verb.clone();
+    let command = ControlCommand {
+        id: frame.id,
+        app: conn.app.clone(),
+        conn_id: conn.id,
+        module: frame.module,
+        verb: frame.verb,
+        target: frame.target,
+        args: frame.args,
+        response_tx,
+    };
+
+    if bus.command_sender().send(command).is_err() {
+        conn.events.push_reply(
+            ControlResult::error(
+                ControlErrorCode::Unavailable,
+                "control command consumer is not running",
+            )
+            .into_reply(id),
+        );
+        return;
+    }
+    crate::metrics::try_metrics()
+        .inspect(|m| m.control_commands_total.with_label_values(&[&conn.app, &verb]).inc());
+
+    // Async wait for the *local* result — never a far-end wait, never a thread
+    // block (rules 4/5). The far-end outcome arrives later as an event.
+    let result = match response_rx.await {
+        Ok(result) => result,
+        Err(_) => ControlResult::error(ControlErrorCode::Unavailable, "control command was dropped"),
+    };
+    conn.events.push_reply(result.into_reply(id));
+}
+
+/// Serialize a single outbound frame to a WS text payload (shared with the
+/// outbound dialer's write task).
+pub(crate) fn frame_to_text(frame: &OutboundFrame) -> Option<String> {
+    match frame.to_json() {
+        Ok(text) => Some(text),
+        Err(error) => {
+            warn!(%error, "control plane: failed to serialize outbound frame");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ControlAppConfig;
+    use crate::control::registry::SlowConsumerPolicy;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    use tokio_tungstenite::tungstenite::http::HeaderValue;
+    use tokio_tungstenite::tungstenite::Message as ClientMessage;
+
+    fn app_cfg(name: &str, token: &str) -> ControlAppConfig {
+        ControlAppConfig {
+            name: name.to_string(),
+            token: token.to_string(),
+            per_call_connect: false,
+            connect_url: None,
+            on_lost: Some("hangup".to_string()),
+        }
+    }
+
+    fn test_bus() -> Arc<ControlBus> {
+        let (command_tx, command_rx) = flume::unbounded();
+        let bus = ControlBus::new(
+            command_tx,
+            vec![app_cfg("ivr-app", "s3cr3t")],
+            64,
+            SlowConsumerPolicy::DropOldest,
+            10,
+            3000,
+        );
+        // Stand-in consumer: echo every command Ok (no real adapter in this test).
+        tokio::spawn(async move {
+            while let Ok(command) = command_rx.recv_async().await {
+                let _ = command
+                    .response_tx
+                    .send(ControlResult::Ok(serde_json::json!({ "verb": command.verb })));
+            }
+        });
+        bus
+    }
+
+    async fn start_server(bus: Arc<ControlBus>) -> SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let make_service = router(bus).into_make_service_with_connect_info::<SocketAddr>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, make_service).await;
+        });
+        addr
+    }
+
+    fn client_request(
+        addr: SocketAddr,
+        token: &str,
+    ) -> tokio_tungstenite::tungstenite::handshake::client::Request {
+        let mut request = format!("ws://{addr}/control/ws").into_client_request().unwrap();
+        request.headers_mut().insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+        request
+    }
+
+    #[tokio::test]
+    async fn bad_token_rejected_with_401_before_upgrade() {
+        let addr = start_server(test_bus()).await;
+        let result = tokio_tungstenite::connect_async(client_request(addr, "wrong")).await;
+        match result {
+            Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            }
+            other => panic!("expected HTTP 401, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn good_token_hello_then_event_then_command() {
+        let bus = test_bus();
+        let addr = start_server(Arc::clone(&bus)).await;
+
+        let (mut ws, _response) = tokio_tungstenite::connect_async(client_request(addr, "s3cr3t"))
+            .await
+            .expect("handshake with good token must succeed");
+
+        ws.send(ClientMessage::Text(
+            serde_json::json!({"id":"1","type":"command","verb":"hello","args":{"app":"ivr-app","protocol":1}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+
+        let hello_reply = next_json(&mut ws).await;
+        assert_eq!(hello_reply["type"], "reply");
+        assert_eq!(hello_reply["id"], "1");
+        assert_eq!(hello_reply["status"], "ok");
+        assert_eq!(hello_reply["result"]["subprotocol"], "siphon-control.v1");
+
+        // Register a channel server-side + push StasisStart.
+        let conn = {
+            let mut found = None;
+            for _ in 0..100 {
+                if let Some(conn) = bus.pick_connection("ivr-app") {
+                    found = Some(conn);
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            found.expect("connection registered after hello")
+        };
+        bus.register_channel("ch1", &conn, "call-uuid", "sipcid@h", "hangup", Default::default());
+        assert!(bus.publish_to_channel(
+            "ch1",
+            crate::control::protocol::EventFrame::new(
+                "StasisStart", "ch1", "ivr-app", "call-uuid", "sipcid@h", serde_json::json!({}),
+            ),
+        ));
+
+        let event = next_json(&mut ws).await;
+        assert_eq!(event["type"], "event");
+        assert_eq!(event["event"], "StasisStart");
+        assert_eq!(event["channel"], "ch1");
+        assert_eq!(event["sip_call_id"], "sipcid@h");
+
+        // A command → correlated reply (via the stand-in consumer).
+        ws.send(ClientMessage::Text(
+            serde_json::json!({"id":"42","type":"command","module":"sip","verb":"answer","target":{"channel":"ch1"},"args":{"code":200}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let reply = next_json(&mut ws).await;
+        assert_eq!(reply["id"], "42");
+        assert_eq!(reply["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn hello_with_wrong_app_is_forbidden() {
+        let addr = start_server(test_bus()).await;
+        let (mut ws, _response) = tokio_tungstenite::connect_async(client_request(addr, "s3cr3t"))
+            .await
+            .unwrap();
+        ws.send(ClientMessage::Text(
+            serde_json::json!({"id":"1","type":"command","verb":"hello","args":{"app":"someone-else"}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let reply = next_json(&mut ws).await;
+        assert_eq!(reply["status"], "error");
+        assert_eq!(reply["error"]["code"], "forbidden");
+    }
+
+    /// A bus wired to the *real* command consumer + SIP adapter (so substrate
+    /// verbs like `resync` are actually dispatched, not echoed).
+    fn test_bus_real_consumer() -> Arc<ControlBus> {
+        use std::collections::HashMap;
+        let (command_tx, command_rx) = flume::unbounded();
+        let bus = ControlBus::new(
+            command_tx,
+            vec![app_cfg("ivr-app", "s3cr3t")],
+            64,
+            SlowConsumerPolicy::DropOldest,
+            10,
+            3000,
+        );
+        let mut adapters: HashMap<String, Arc<dyn crate::control::ControlAdapter>> = HashMap::new();
+        adapters.insert(
+            "sip".to_string(),
+            Arc::new(crate::control::sip_adapter::SipControlAdapter::new()),
+        );
+        tokio::spawn(crate::control::run_consumer(
+            Arc::clone(&bus),
+            Arc::new(adapters),
+            command_rx,
+        ));
+        bus
+    }
+
+    #[tokio::test]
+    async fn resync_reattaches_owned_channels_after_reconnect() {
+        let bus = test_bus_real_consumer();
+        let addr = start_server(Arc::clone(&bus)).await;
+
+        // First connection: hello, then a channel is handed to it.
+        let (mut ws1, _r) = tokio_tungstenite::connect_async(client_request(addr, "s3cr3t"))
+            .await
+            .unwrap();
+        ws1.send(ClientMessage::Text(
+            serde_json::json!({"id":"1","type":"command","verb":"hello","args":{"app":"ivr-app"}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let _ = next_json(&mut ws1).await;
+
+        let conn1 = {
+            let mut found = None;
+            for _ in 0..100 {
+                if let Some(conn) = bus.pick_connection("ivr-app") {
+                    found = Some(conn);
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            found.unwrap()
+        };
+        bus.register_channel("ch-live", &conn1, "call-uuid", "sipcid@h", "hangup", Default::default());
+
+        // Owner disconnects (drop the client socket) — the channel is orphaned
+        // but kept for the reattach grace window.
+        drop(ws1);
+        for _ in 0..100 {
+            if bus.app_connection_count("ivr-app") == 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert_eq!(bus.channel_count(), 1, "channel kept for reattach grace");
+
+        // Reconnect + resync re-claims the orphaned channel.
+        let (mut ws2, _r) = tokio_tungstenite::connect_async(client_request(addr, "s3cr3t"))
+            .await
+            .unwrap();
+        ws2.send(ClientMessage::Text(
+            serde_json::json!({"id":"1","type":"command","verb":"hello","args":{"app":"ivr-app"}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let _ = next_json(&mut ws2).await;
+        ws2.send(ClientMessage::Text(
+            serde_json::json!({"id":"2","type":"command","verb":"resync"})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let reply = next_json(&mut ws2).await;
+        assert_eq!(reply["id"], "2");
+        assert_eq!(reply["status"], "ok");
+        let channels = reply["result"]["channels"].as_array().unwrap();
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0]["channel"], "ch-live");
+    }
+
+    #[tokio::test]
+    async fn unknown_protocol_version_is_rejected() {
+        let addr = start_server(test_bus()).await;
+        let (mut ws, _response) = tokio_tungstenite::connect_async(client_request(addr, "s3cr3t"))
+            .await
+            .unwrap();
+        ws.send(ClientMessage::Text(
+            serde_json::json!({"id":"1","type":"command","verb":"hello","args":{"app":"ivr-app","protocol":99}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let reply = next_json(&mut ws).await;
+        assert_eq!(reply["error"]["code"], "unsupported_version");
+    }
+
+    async fn next_json(
+        ws: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    ) -> serde_json::Value {
+        loop {
+            let message = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+                .await
+                .expect("timed out waiting for a frame")
+                .expect("stream closed")
+                .expect("ws error");
+            if let ClientMessage::Text(text) = message {
+                return serde_json::from_str(text.as_str()).unwrap();
+            }
+        }
+    }
+}

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,0 +1,539 @@
+//! External remote-control plane (ARI/ESL-class) — protocol-agnostic substrate
+//! + per-protocol adapters.
+//!
+//! An out-of-process application connects over a WebSocket (either inbound
+//! persistent, or siphon dials it per handed-over call) and drives calls that a
+//! Python `@b2bua.on_invite` handler explicitly hands over with
+//! `call.handover("app")` (the ARI *Stasis* model). Calls not handed over cost
+//! nothing.
+//!
+//! ## Substrate vs adapter
+//!
+//! The **substrate** ([`listener`], [`outbound`], [`registry`], [`protocol`])
+//! owns the WebSocket transport, JSON envelope, auth, app registry, ownership,
+//! event bus + backpressure, and command routing *by module*. It knows nothing
+//! about SIP — it moves opaque `serde_json::Value` DTOs between apps and
+//! adapters.
+//!
+//! An **adapter** ([`ControlAdapter`]) owns one protocol's resource model + maps
+//! generic verbs onto its internal machinery. The SIP adapter
+//! ([`sip_adapter`]) lives in core (and would move with SIP if extracted); other
+//! protocols register their own via [`register_control_adapter`](crate::server::SiphonServer::register_control_adapter).
+//!
+//! ## I/O discipline (the load-bearing rule)
+//!
+//! Control-socket I/O is pure async tokio; event fan-out is `try_push` on a
+//! bounded per-connection queue (never `.await`); command ingress is an
+//! unbounded flume send then an awaited `oneshot`; and `apply` performs only the
+//! bounded local action and returns immediately — a far-end outcome (the callee
+//! answering / BYEing) arrives later as an event, never as the command reply.
+
+pub mod listener;
+pub mod outbound;
+pub mod protocol;
+pub mod registry;
+pub mod sip_adapter;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use futures_util::future::BoxFuture;
+use serde::Serialize;
+use tracing::{error, info, warn};
+
+use crate::config::ControlConfig;
+
+pub use protocol::{
+    CommandFrame, ControlErrorCode, ControlResult, EventFrame, HelloArgs, ReplyFrame, ReplyStatus,
+    PROTOCOL_VERSION, SUBPROTOCOL,
+};
+pub use registry::{
+    ChannelRef, ConnHandle, ControlBus, ControlCommand, OfferOutcome, OutboundFrame, OutboundQueue,
+    Ownership, PushOutcome, SlowConsumerPolicy,
+};
+
+/// The resolved target of an adapter command. The substrate resolves + ownership
+/// -checks a `{channel}` target before handing the command to the adapter, so an
+/// adapter never sees a channel its connection does not own.
+#[derive(Debug, Clone)]
+pub enum ResolvedTarget {
+    /// A channel the commanding connection owns.
+    Channel(ChannelRef),
+    /// No addressable resource (module-level verb).
+    None,
+}
+
+/// A command handed to an adapter, with its target already resolved +
+/// ownership-checked by the substrate. `verb`/`args` are opaque to the substrate.
+#[derive(Debug, Clone)]
+pub struct AdapterCommand {
+    /// The verb to apply (adapter-defined).
+    pub verb: String,
+    /// The arguments (adapter-defined opaque JSON).
+    pub args: serde_json::Value,
+    /// The resolved, ownership-checked target.
+    pub target: ResolvedTarget,
+}
+
+/// Introspection schema for one adapter (`describe`).
+#[derive(Debug, Clone, Serialize)]
+pub struct AdapterSchema {
+    /// The routing key (`"sip"`, `"smpp"`, …).
+    pub module: String,
+    /// The verbs this adapter accepts.
+    pub verbs: Vec<VerbSchema>,
+    /// The events this adapter emits.
+    pub events: Vec<String>,
+}
+
+/// One verb in an [`AdapterSchema`].
+#[derive(Debug, Clone, Serialize)]
+pub struct VerbSchema {
+    /// The verb name.
+    pub verb: String,
+    /// A one-line human summary.
+    pub summary: String,
+}
+
+/// A per-protocol control adapter. Implementors map generic verbs onto their
+/// own machinery and (de)serialize their own `args`/`payload` — the substrate
+/// never parses them.
+pub trait ControlAdapter: Send + Sync {
+    /// The routing key (`"sip"`, `"smpp"`, …).
+    fn module(&self) -> &str;
+
+    /// Apply one command's **local, bounded** action and return immediately.
+    /// Must never wait on a far-end outcome (rule #4): the callee's answer / ACK
+    /// / BYE-200 arrive later as events.
+    fn apply<'a>(&'a self, command: AdapterCommand) -> BoxFuture<'a, ControlResult>;
+
+    /// The adapter's verb/event schema (for `describe` + generated docs/SDKs).
+    fn describe(&self) -> AdapterSchema;
+}
+
+/// Boot the control plane: build + install the [`ControlBus`], spawn the command
+/// consumer, and start the inbound WebSocket listener (if `control.listen` is
+/// set). Per-call-connect apps are dialed lazily at handover, so they need no
+/// boot-time listener.
+///
+/// `extra_adapters` are the adapters registered by a host binary via
+/// `SiphonServer::register_control_adapter`; the built-in SIP adapter is always
+/// registered.
+pub fn spawn_control_plane(config: &ControlConfig, extra_adapters: Vec<Arc<dyn ControlAdapter>>) {
+    let mut adapters: HashMap<String, Arc<dyn ControlAdapter>> = HashMap::new();
+    let sip: Arc<dyn ControlAdapter> = Arc::new(sip_adapter::SipControlAdapter::new());
+    adapters.insert(sip.module().to_string(), sip);
+    for adapter in extra_adapters {
+        let module = adapter.module().to_string();
+        if adapters.insert(module.clone(), adapter).is_some() {
+            warn!(module = %module, "control plane: duplicate adapter module — later registration wins");
+        }
+    }
+
+    let (command_tx, command_rx) = flume::unbounded();
+    let policy = SlowConsumerPolicy::from_config(&config.limits.slow_consumer);
+    let bus = ControlBus::new(
+        command_tx,
+        config.apps.clone(),
+        config.limits.event_queue_depth,
+        policy,
+        config.limits.reattach_grace_secs,
+        config.limits.handoff_deadline_ms,
+    );
+    if ControlBus::install(Arc::clone(&bus)).is_err() {
+        warn!("control plane already installed — ignoring second boot");
+        return;
+    }
+
+    let adapters = Arc::new(adapters);
+
+    // Command consumer: routes each command to its adapter (or handles a
+    // substrate verb) as a plain async task — zero blocking-pool slots.
+    tokio::spawn(run_consumer(Arc::clone(&bus), Arc::clone(&adapters), command_rx));
+
+    if let Some(listen) = config.listen.as_deref() {
+        match listen.parse::<SocketAddr>() {
+            Ok(addr) => {
+                tokio::spawn(listener::serve(addr, Arc::clone(&bus)));
+            }
+            Err(error) => {
+                error!(%listen, %error, "invalid control.listen address — inbound control disabled");
+            }
+        }
+    }
+
+    let modules: Vec<String> = adapters.keys().cloned().collect();
+    info!(
+        apps = config.apps.len(),
+        listen = ?config.listen,
+        ?modules,
+        "control plane started"
+    );
+}
+
+/// The command consumer. One task; each command is applied on its own spawned
+/// task so a slow adapter for one command never head-of-line-blocks another.
+async fn run_consumer(
+    bus: Arc<ControlBus>,
+    adapters: Arc<HashMap<String, Arc<dyn ControlAdapter>>>,
+    command_rx: flume::Receiver<ControlCommand>,
+) {
+    while let Ok(command) = command_rx.recv_async().await {
+        let bus = Arc::clone(&bus);
+        let adapters = Arc::clone(&adapters);
+        tokio::spawn(async move {
+            let ControlCommand {
+                app,
+                conn_id,
+                module,
+                verb,
+                target,
+                args,
+                response_tx,
+                ..
+            } = command;
+            let result = dispatch(&bus, &adapters, &app, conn_id, module.as_deref(), &verb, target, args).await;
+            let _ = response_tx.send(result);
+        });
+    }
+}
+
+/// Route one command: substrate verbs (`resync`/`describe`/`set_var`/`get_var`)
+/// are handled here; everything else routes to the adapter named by `module`
+/// after the target is resolved + ownership-checked.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch(
+    bus: &Arc<ControlBus>,
+    adapters: &HashMap<String, Arc<dyn ControlAdapter>>,
+    app: &str,
+    conn_id: u64,
+    module: Option<&str>,
+    verb: &str,
+    target: serde_json::Value,
+    args: serde_json::Value,
+) -> ControlResult {
+    match verb {
+        "resync" => {
+            let owned = bus.resync(app, conn_id);
+            let channels: Vec<serde_json::Value> = owned
+                .into_iter()
+                .map(|channel| channel_snapshot(bus, &channel))
+                .collect();
+            return ControlResult::Ok(serde_json::json!({ "channels": channels }));
+        }
+        "describe" => {
+            let schemas: Vec<AdapterSchema> = adapters.values().map(|a| a.describe()).collect();
+            return match serde_json::to_value(&schemas) {
+                Ok(value) => ControlResult::Ok(serde_json::json!({ "adapters": value })),
+                Err(error) => ControlResult::error(
+                    ControlErrorCode::Unavailable,
+                    format!("failed to serialize schema: {error}"),
+                ),
+            };
+        }
+        "set_var" | "get_var" => {
+            let channel_id = match target.get("channel").and_then(|v| v.as_str()) {
+                Some(id) => id.to_string(),
+                None => {
+                    return ControlResult::error(
+                        ControlErrorCode::BadRequest,
+                        "set_var/get_var require target.channel",
+                    );
+                }
+            };
+            match bus.owns(&channel_id, app, conn_id) {
+                Ownership::Unknown => {
+                    return ControlResult::error(ControlErrorCode::NotFound, "no such channel");
+                }
+                Ownership::Forbidden => {
+                    return ControlResult::error(
+                        ControlErrorCode::Forbidden,
+                        "channel owned by another app",
+                    );
+                }
+                Ownership::Owned(_) => {}
+            }
+            if verb == "set_var" {
+                let key = args.get("key").and_then(|v| v.as_str());
+                let value = args.get("value").and_then(|v| v.as_str());
+                return match (key, value) {
+                    (Some(key), Some(value)) => {
+                        bus.set_var(&channel_id, key, value);
+                        ControlResult::Ok(serde_json::json!({ "channel": channel_id, "key": key }))
+                    }
+                    _ => ControlResult::error(
+                        ControlErrorCode::BadRequest,
+                        "set_var requires args.key and args.value",
+                    ),
+                };
+            } else {
+                let key = match args.get("key").and_then(|v| v.as_str()) {
+                    Some(key) => key,
+                    None => {
+                        return ControlResult::error(
+                            ControlErrorCode::BadRequest,
+                            "get_var requires args.key",
+                        );
+                    }
+                };
+                let value = bus.get_var(&channel_id, key);
+                return ControlResult::Ok(serde_json::json!({ "channel": channel_id, "key": key, "value": value }));
+            }
+        }
+        _ => {}
+    }
+
+    // Adapter verb: route by module. Default to the sole adapter when a single
+    // one is registered and the client omitted `module`.
+    let module_name = match module {
+        Some(name) => name.to_string(),
+        None if adapters.len() == 1 => adapters.keys().next().cloned().unwrap_or_default(),
+        None => {
+            return ControlResult::error(
+                ControlErrorCode::BadRequest,
+                "command is missing a 'module' (adapter routing key)",
+            );
+        }
+    };
+    let adapter = match adapters.get(&module_name) {
+        Some(adapter) => adapter,
+        None => {
+            return ControlResult::error(
+                ControlErrorCode::BadRequest,
+                format!("unknown module '{module_name}'"),
+            );
+        }
+    };
+
+    // Resolve + ownership-check a channel target when present.
+    let resolved = match target.get("channel").and_then(|v| v.as_str()) {
+        Some(channel_id) => match bus.owns(channel_id, app, conn_id) {
+            Ownership::Owned(channel) => ResolvedTarget::Channel(channel),
+            Ownership::Forbidden => {
+                return ControlResult::error(
+                    ControlErrorCode::Forbidden,
+                    "channel owned by another app",
+                );
+            }
+            Ownership::Unknown => {
+                return ControlResult::error(
+                    ControlErrorCode::NotFound,
+                    "no such channel (already gone?)",
+                );
+            }
+        },
+        None => ResolvedTarget::None,
+    };
+
+    adapter
+        .apply(AdapterCommand {
+            verb: verb.to_string(),
+            args,
+            target: resolved,
+        })
+        .await
+}
+
+/// Build a resync channel snapshot (ids + current state + vars).
+fn channel_snapshot(bus: &Arc<ControlBus>, channel: &ChannelRef) -> serde_json::Value {
+    let state = crate::b2bua::actor::global_call_store()
+        .and_then(|store| store.get_call(&channel.call_actor_id).map(|call| call_state_str(&call.state)))
+        .unwrap_or("gone");
+    serde_json::json!({
+        "channel": channel.channel_id,
+        "call_id": channel.call_actor_id,
+        "sip_call_id": channel.sip_call_id,
+        "state": state,
+        "vars": bus.vars(&channel.channel_id),
+    })
+}
+
+/// Render a `CallState` to the wire string the control app sees.
+fn call_state_str(state: &crate::b2bua::actor::CallState) -> &'static str {
+    match state {
+        crate::b2bua::actor::CallState::Calling => "calling",
+        crate::b2bua::actor::CallState::Ringing => "ringing",
+        crate::b2bua::actor::CallState::Answered => "answered",
+        crate::b2bua::actor::CallState::Terminated => "terminated",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ControlAppConfig;
+
+    fn app_cfg(name: &str) -> ControlAppConfig {
+        ControlAppConfig {
+            name: name.to_string(),
+            token: "tok".to_string(),
+            per_call_connect: false,
+            connect_url: None,
+            on_lost: Some("hangup".to_string()),
+        }
+    }
+
+    fn sip_only() -> HashMap<String, Arc<dyn ControlAdapter>> {
+        let mut adapters: HashMap<String, Arc<dyn ControlAdapter>> = HashMap::new();
+        adapters.insert("sip".to_string(), Arc::new(sip_adapter::SipControlAdapter::new()));
+        adapters
+    }
+
+    fn bus_with_channel() -> (Arc<ControlBus>, Arc<ConnHandle>) {
+        let (command_tx, _rx) = flume::unbounded();
+        let bus = ControlBus::new(
+            command_tx,
+            vec![app_cfg("ivr-app"), app_cfg("other")],
+            64,
+            SlowConsumerPolicy::DropOldest,
+            10,
+            3000,
+        );
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("ch1", &conn, "call-uuid", "sipcid@h", "hangup", Default::default());
+        (bus, conn)
+    }
+
+    #[tokio::test]
+    async fn describe_lists_registered_adapters() {
+        let (bus, conn) = bus_with_channel();
+        let result = dispatch(
+            &bus,
+            &sip_only(),
+            "ivr-app",
+            conn.id,
+            None,
+            "describe",
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
+        .await;
+        match result {
+            ControlResult::Ok(value) => {
+                let adapters = value["adapters"].as_array().unwrap();
+                assert!(adapters.iter().any(|a| a["module"] == "sip"));
+            }
+            other => panic!("expected ok, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_var_then_get_var_roundtrips_with_ownership() {
+        let (bus, conn) = bus_with_channel();
+        let set = dispatch(
+            &bus,
+            &sip_only(),
+            "ivr-app",
+            conn.id,
+            None,
+            "set_var",
+            serde_json::json!({ "channel": "ch1" }),
+            serde_json::json!({ "key": "queue", "value": "support" }),
+        )
+        .await;
+        assert!(matches!(set, ControlResult::Ok(_)));
+
+        let get = dispatch(
+            &bus,
+            &sip_only(),
+            "ivr-app",
+            conn.id,
+            None,
+            "get_var",
+            serde_json::json!({ "channel": "ch1" }),
+            serde_json::json!({ "key": "queue" }),
+        )
+        .await;
+        match get {
+            ControlResult::Ok(value) => assert_eq!(value["value"], "support"),
+            other => panic!("expected ok, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cross_app_target_is_forbidden() {
+        let (bus, _conn) = bus_with_channel();
+        let intruder = bus.register_connection("other");
+        let result = dispatch(
+            &bus,
+            &sip_only(),
+            "other",
+            intruder.id,
+            Some("sip"),
+            "answer",
+            serde_json::json!({ "channel": "ch1" }),
+            serde_json::json!({ "code": 200 }),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::Forbidden, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn unknown_channel_is_not_found() {
+        let (bus, conn) = bus_with_channel();
+        let result = dispatch(
+            &bus,
+            &sip_only(),
+            "ivr-app",
+            conn.id,
+            Some("sip"),
+            "answer",
+            serde_json::json!({ "channel": "nope" }),
+            serde_json::json!({ "code": 200 }),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn unknown_module_is_bad_request() {
+        let (bus, conn) = bus_with_channel();
+        let result = dispatch(
+            &bus,
+            &sip_only(),
+            "ivr-app",
+            conn.id,
+            Some("smpp"),
+            "submit_sm",
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn resync_enumerates_owned_channels() {
+        let (bus, conn) = bus_with_channel();
+        let result = dispatch(
+            &bus,
+            &sip_only(),
+            "ivr-app",
+            conn.id,
+            None,
+            "resync",
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
+        .await;
+        match result {
+            ControlResult::Ok(value) => {
+                let channels = value["channels"].as_array().unwrap();
+                assert_eq!(channels.len(), 1);
+                assert_eq!(channels[0]["channel"], "ch1");
+                assert_eq!(channels[0]["sip_call_id"], "sipcid@h");
+            }
+            other => panic!("expected ok, got {other:?}"),
+        }
+    }
+}

--- a/src/control/outbound.rs
+++ b/src/control/outbound.rs
@@ -1,0 +1,291 @@
+//! Outbound per-call-connect mode: siphon dials the controller's WebSocket at
+//! handover and the accepting socket owns that call (the FreeSWITCH-outbound
+//! model — the documented default for multi-pod controllers).
+//!
+//! Both rails dial **out from siphon** (this control WS + the media WS the
+//! engine dials for `ws_uri`), so the "audio socket lands on a pod that doesn't
+//! own the call" affinity bug is structurally impossible.
+//!
+//! Reuses the transport-agnostic frame logic in [`super::listener`]; only the
+//! socket acquisition + write task differ (tungstenite client vs axum server).
+
+use std::sync::Arc;
+
+use futures_util::stream::SplitSink;
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tracing::{debug, info, warn};
+
+use super::listener::process_text;
+use super::protocol::{EventFrame, SUBPROTOCOL};
+use super::registry::{ControlBus, OutboundQueue};
+
+/// How long to wait for the controller to accept the per-call dial before giving
+/// up (the handoff deadline is the ultimate backstop, but a bounded connect
+/// keeps a dead controller from holding the dial task).
+const DIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Everything needed to take ownership of a handed-over call once the dial
+/// succeeds.
+#[derive(Debug, Clone)]
+pub struct PendingOwn {
+    /// The leg-scoped channel id.
+    pub channel_id: String,
+    /// The internal `CallActor` id.
+    pub call_actor_id: String,
+    /// The per-leg SIP Call-ID.
+    pub sip_call_id: String,
+    /// Control-loss policy for the call.
+    pub on_lost: String,
+    /// Per-call variables set at handover.
+    pub vars: std::collections::HashMap<String, String>,
+    /// The `StasisStart` payload (full SIP context) to push on connect.
+    pub stasis_payload: serde_json::Value,
+}
+
+/// Dial the controller and, on success, take ownership of the pending call.
+/// Fire-and-forget: spawns a task and returns immediately (rule #4 — the
+/// handover reply is not the dial result). A dial failure logs and lets the
+/// handoff deadline apply the default action.
+pub fn dial_and_own(
+    bus: Arc<ControlBus>,
+    app: String,
+    token: String,
+    connect_url: String,
+    pending: PendingOwn,
+) {
+    tokio::spawn(async move {
+        let socket = match connect(&connect_url, &token).await {
+            Ok(socket) => socket,
+            Err(error) => {
+                warn!(%app, %connect_url, %error, "control plane: per-call-connect dial failed");
+                return;
+            }
+        };
+        info!(%app, %connect_url, channel = %pending.channel_id, "control plane: per-call-connect established");
+        drive_outbound_socket(socket, app, bus, pending).await;
+    });
+}
+
+/// Dial the controller with the app token + subprotocol, bounded by a connect
+/// timeout.
+async fn connect(
+    connect_url: &str,
+    token: &str,
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, String> {
+    let mut request = connect_url
+        .into_client_request()
+        .map_err(|error| format!("invalid connect_url: {error}"))?;
+    let headers = request.headers_mut();
+    headers.insert(
+        "Authorization",
+        HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|error| format!("invalid token header: {error}"))?,
+    );
+    headers.insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_static(SUBPROTOCOL),
+    );
+
+    let (socket, _response) = tokio::time::timeout(DIAL_TIMEOUT, tokio_tungstenite::connect_async(request))
+        .await
+        .map_err(|_| "dial timed out".to_string())?
+        .map_err(|error| format!("dial error: {error}"))?;
+    Ok(socket)
+}
+
+/// Register ownership, push `StasisStart`, then run the read/write driver for one
+/// outbound control connection.
+async fn drive_outbound_socket(
+    socket: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    app: String,
+    bus: Arc<ControlBus>,
+    pending: PendingOwn,
+) {
+    let conn = bus.register_connection(&app);
+    crate::metrics::try_metrics().inspect(|m| m.control_connections.with_label_values(&[&app]).inc());
+
+    // The accepting socket owns the call. Register + push StasisStart before
+    // reading commands so the very first thing the controller sees is its call.
+    bus.register_channel(
+        &pending.channel_id,
+        &conn,
+        &pending.call_actor_id,
+        &pending.sip_call_id,
+        &pending.on_lost,
+        pending.vars,
+    );
+    conn.events.try_push_event(EventFrame::new(
+        "StasisStart",
+        &pending.channel_id,
+        &app,
+        &pending.call_actor_id,
+        &pending.sip_call_id,
+        pending.stasis_payload,
+    ));
+
+    let (ws_sink, mut ws_source) = socket.split();
+    let writer_events = Arc::clone(&conn.events);
+    let writer = tokio::spawn(outbound_write_task(ws_sink, writer_events));
+
+    // In per-call-connect mode siphon presented the token in the dial headers, so
+    // ownership is already established — no `hello` is expected from the
+    // controller. Commands flow straight in.
+    let mut said_hello = true;
+    while let Some(message) = ws_source.next().await {
+        let message = match message {
+            Ok(message) => message,
+            Err(error) => {
+                debug!(conn_id = conn.id, %error, "control plane: outbound read error");
+                break;
+            }
+        };
+        match message {
+            Message::Text(text) => {
+                if !process_text(text.as_str(), &mut said_hello, &conn, &bus).await {
+                    break;
+                }
+            }
+            Message::Close(_) => break,
+            Message::Ping(_) | Message::Pong(_) => {}
+            other => {
+                warn!(conn_id = conn.id, kind = ?std::mem::discriminant(&other), "control plane: ignoring non-text frame (outbound)");
+            }
+        }
+    }
+
+    conn.events.close();
+    bus.unregister_connection(&conn);
+    crate::metrics::try_metrics().inspect(|m| m.control_connections.with_label_values(&[&app]).dec());
+    let _ = writer.await;
+    debug!(conn_id = conn.id, %app, "control plane: outbound connection closed");
+}
+
+/// The outbound connection's single write task: drains the ordered outbound
+/// queue onto the tungstenite socket.
+async fn outbound_write_task(
+    mut ws_sink: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
+    events: Arc<OutboundQueue>,
+) {
+    loop {
+        let frames = events.recv_many().await;
+        if frames.is_empty() {
+            break;
+        }
+        for frame in frames {
+            if let Some(text) = super::listener::frame_to_text(&frame) {
+                if ws_sink.send(Message::Text(text.into())).await.is_err() {
+                    let _ = ws_sink.send(Message::Close(None)).await;
+                    return;
+                }
+            }
+        }
+        if events.disconnect_requested() {
+            break;
+        }
+    }
+    let _ = ws_sink.send(Message::Close(None)).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ControlAppConfig;
+    use crate::control::registry::SlowConsumerPolicy;
+    use tokio_tungstenite::tungstenite::Message as ServerMessage;
+
+    fn app_cfg(name: &str, token: &str, connect_url: &str) -> ControlAppConfig {
+        ControlAppConfig {
+            name: name.to_string(),
+            token: token.to_string(),
+            per_call_connect: true,
+            connect_url: Some(connect_url.to_string()),
+            on_lost: Some("hangup".to_string()),
+        }
+    }
+
+    /// A stub controller: accepts one WS connection and returns the first frame
+    /// it receives (or a signal that the socket owned the call via StasisStart).
+    // The accept-callback's `ErrorResponse` type is fixed by tungstenite's API.
+    #[allow(clippy::result_large_err)]
+    #[tokio::test]
+    async fn per_call_connect_dials_and_socket_owns_the_call() {
+        // Stub controller listening on an ephemeral port.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connect_url = format!("ws://{addr}/siphon");
+
+        let (got_stasis_tx, got_stasis_rx) = tokio::sync::oneshot::channel::<serde_json::Value>();
+        tokio::spawn(async move {
+            let (stream, _peer) = listener.accept().await.unwrap();
+            // A real controller echoes the negotiated subprotocol on accept —
+            // tungstenite's client rejects the handshake otherwise.
+            use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+            let echo_subprotocol = |_request: &Request, mut response: Response| {
+                response.headers_mut().insert(
+                    "Sec-WebSocket-Protocol",
+                    tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                        "siphon-control.v1",
+                    ),
+                );
+                Ok(response)
+            };
+            let mut ws = tokio_tungstenite::accept_hdr_async(stream, echo_subprotocol)
+                .await
+                .unwrap();
+            // The very first frame siphon pushes must be StasisStart (ownership).
+            while let Some(Ok(message)) = ws.next().await {
+                if let ServerMessage::Text(text) = message {
+                    let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+                    if value["event"] == "StasisStart" {
+                        let _ = got_stasis_tx.send(value);
+                        break;
+                    }
+                }
+            }
+        });
+
+        let (command_tx, _command_rx) = flume::unbounded();
+        let bus = ControlBus::new(
+            command_tx,
+            vec![app_cfg("ivr-app", "tok", &connect_url)],
+            64,
+            SlowConsumerPolicy::DropOldest,
+            10,
+            3000,
+        );
+
+        // Offer a channel to the per-call-connect app → siphon dials the stub.
+        let outcome = bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid@host",
+            "hangup",
+            Default::default(),
+            serde_json::json!({ "source_ip": "203.0.113.7" }),
+        );
+        assert_eq!(outcome, crate::control::OfferOutcome::Dialing);
+
+        let stasis = tokio::time::timeout(std::time::Duration::from_secs(5), got_stasis_rx)
+            .await
+            .expect("controller should receive StasisStart")
+            .expect("stasis channel");
+        assert_eq!(stasis["channel"], "ch1");
+        assert_eq!(stasis["sip_call_id"], "sipcid@host");
+        assert_eq!(stasis["payload"]["source_ip"], "203.0.113.7");
+
+        // The dialed socket now owns the channel.
+        for _ in 0..100 {
+            if bus.channel_count() == 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert_eq!(bus.channel_count(), 1);
+    }
+}

--- a/src/control/protocol.rs
+++ b/src/control/protocol.rs
@@ -1,0 +1,356 @@
+//! Wire protocol for the external control plane (`siphon-control.v1`).
+//!
+//! Single WebSocket per connection (inbound-persistent or outbound
+//! per-call-connect), JSON text frames both directions:
+//!
+//! - **command** (client → siphon):
+//!   `{id, type:"command", module, verb, target, args}`
+//! - **reply** (siphon → client, `id` echoed):
+//!   `{id, type:"reply", status, result|error}`
+//! - **event** (siphon → client, un-id'd, pushed):
+//!   `{type:"event", event, channel, call_id, sip_call_id, payload}`
+//!
+//! `module` routes a command to the registered adapter (`sip`|`smpp`|`ss7`);
+//! the substrate never interprets `verb`/`args`/`target` beyond the routing +
+//! ownership checks — they are handed opaquely (`serde_json::Value`) to the
+//! adapter that applies them.
+
+use serde::{Deserialize, Serialize};
+
+/// Discriminator for the `type` field of every frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FrameType {
+    /// A command from the client.
+    Command,
+    /// A correlated reply to a command.
+    Reply,
+    /// A pushed event (no id).
+    Event,
+}
+
+/// A command frame received from a control application (client → siphon).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandFrame {
+    /// Client-owned request id, echoed verbatim in the reply.
+    pub id: String,
+    /// Always [`FrameType::Command`].
+    #[serde(rename = "type")]
+    pub frame_type: FrameType,
+    /// The adapter routing key (`"sip"`, `"smpp"`, …). Substrate verbs
+    /// (`hello`, `resync`, `describe`, `set_var`, `get_var`) omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+    /// The verb to apply (e.g. `"answer"`, `"hangup"`, `"hello"`).
+    pub verb: String,
+    /// Adapter-defined target (e.g. `{"channel": "…"}`). Absent → JSON null.
+    #[serde(default)]
+    pub target: serde_json::Value,
+    /// Adapter-defined arguments. Absent → JSON null.
+    #[serde(default)]
+    pub args: serde_json::Value,
+}
+
+impl CommandFrame {
+    /// Extract the `target.channel` string when present.
+    pub fn channel_target(&self) -> Option<String> {
+        self.target
+            .get("channel")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+    }
+}
+
+/// Status of a reply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReplyStatus {
+    /// The command was accepted (the *local* action was performed).
+    Ok,
+    /// The command was rejected.
+    Error,
+}
+
+/// Stable error codes returned in a reply's `error.code`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlErrorCode {
+    /// Authentication failed (bad/missing token).
+    Unauthorized,
+    /// The connection's app does not own the target resource.
+    Forbidden,
+    /// The target channel does not exist / the call is already gone.
+    NotFound,
+    /// The frame or its arguments were malformed.
+    BadRequest,
+    /// The command exceeded a rate limit.
+    RateLimited,
+    /// An originate was denied by the toll-fraud gates.
+    OriginateDenied,
+    /// The verb is not implemented / not supported by the adapter or backend.
+    UnsupportedVerb,
+    /// The client asked for an unknown protocol version.
+    UnsupportedVersion,
+    /// The frame violated the protocol (e.g. duplicate id, bad handshake).
+    ProtocolError,
+    /// The control plane could not service the command right now.
+    Unavailable,
+}
+
+/// The error body of a failed reply.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplyError {
+    /// Stable machine-readable code.
+    pub code: ControlErrorCode,
+    /// Human-readable detail.
+    pub message: String,
+}
+
+/// A reply frame (siphon → client, `id` echoed).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplyFrame {
+    /// The command id this reply correlates to.
+    pub id: String,
+    /// Always [`FrameType::Reply`].
+    #[serde(rename = "type")]
+    pub frame_type: FrameType,
+    /// Whether the command was accepted.
+    pub status: ReplyStatus,
+    /// Present on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Present on failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ReplyError>,
+}
+
+/// A pushed event frame (siphon → client, un-id'd).
+///
+/// Carries the **stable id triple** `{channel, call_id, sip_call_id}` so a
+/// controller joins CDR + HEP with no mapping table: `sip_call_id` is
+/// byte-identical to the CDR `call_id` and the HEP correlation chunk.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventFrame {
+    /// Always [`FrameType::Event`].
+    #[serde(rename = "type")]
+    pub frame_type: FrameType,
+    /// Event name (e.g. `"StasisStart"`, `"StasisEnd"`).
+    pub event: String,
+    /// The channel this event concerns (leg-scoped id), when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// The application the channel was handed to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app: Option<String>,
+    /// The internal call UUID (`CallActor.id`) — the grouping key across legs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
+    /// The per-leg SIP Call-ID — the CDR / HEP join key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sip_call_id: Option<String>,
+    /// Event-specific payload.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub payload: serde_json::Value,
+}
+
+impl EventFrame {
+    /// Build an event frame for a channel, carrying the stable id triple.
+    pub fn new(
+        event: impl Into<String>,
+        channel: impl Into<String>,
+        app: impl Into<String>,
+        call_id: impl Into<String>,
+        sip_call_id: impl Into<String>,
+        payload: serde_json::Value,
+    ) -> Self {
+        Self {
+            frame_type: FrameType::Event,
+            event: event.into(),
+            channel: Some(channel.into()),
+            app: Some(app.into()),
+            call_id: Some(call_id.into()),
+            sip_call_id: Some(sip_call_id.into()),
+            payload,
+        }
+    }
+}
+
+/// The outcome of applying a command — carried back to the connection's read
+/// task and rendered into a [`ReplyFrame`].
+///
+/// A `ControlResult` is the reply to the *local* action only. It is emphatically
+/// **not** a far-end outcome: an accepted `answer`/`hangup` returns `Ok`
+/// immediately, and the callee's actual answer / BYE-200 arrive later as events.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlResult {
+    /// The local action was accepted.
+    Ok(serde_json::Value),
+    /// The command was rejected.
+    Error {
+        /// Machine-readable error code.
+        code: ControlErrorCode,
+        /// Human-readable detail.
+        message: String,
+    },
+}
+
+impl ControlResult {
+    /// Convenience constructor for an error result.
+    pub fn error(code: ControlErrorCode, message: impl Into<String>) -> Self {
+        ControlResult::Error {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Render into a wire reply frame for the given command id.
+    pub fn into_reply(self, id: String) -> ReplyFrame {
+        match self {
+            ControlResult::Ok(result) => ReplyFrame {
+                id,
+                frame_type: FrameType::Reply,
+                status: ReplyStatus::Ok,
+                result: Some(result),
+                error: None,
+            },
+            ControlResult::Error { code, message } => ReplyFrame {
+                id,
+                frame_type: FrameType::Reply,
+                status: ReplyStatus::Error,
+                result: None,
+                error: Some(ReplyError { code, message }),
+            },
+        }
+    }
+}
+
+/// Arguments of the `hello` handshake command (`args`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelloArgs {
+    /// The application name — must equal the token's configured app.
+    pub app: String,
+    /// Protocol version the client speaks. Optional; defaults to 1.
+    #[serde(default)]
+    pub protocol: Option<u32>,
+}
+
+/// The WebSocket subprotocol token this rail speaks.
+pub const SUBPROTOCOL: &str = "siphon-control.v1";
+
+/// The protocol version this build implements.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_frame_round_trip() {
+        let frame = CommandFrame {
+            id: "c-42".to_string(),
+            frame_type: FrameType::Command,
+            module: Some("sip".to_string()),
+            verb: "answer".to_string(),
+            target: serde_json::json!({ "channel": "ch_9f3a" }),
+            args: serde_json::json!({ "code": 200 }),
+        };
+        let text = serde_json::to_string(&frame).unwrap();
+        assert!(text.contains("\"type\":\"command\""));
+        assert!(text.contains("\"module\":\"sip\""));
+        let parsed: CommandFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, frame);
+        assert_eq!(parsed.channel_target().as_deref(), Some("ch_9f3a"));
+    }
+
+    #[test]
+    fn command_frame_defaults_missing_module_target_and_args() {
+        let text = r#"{"id":"1","type":"command","verb":"hello"}"#;
+        let parsed: CommandFrame = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed.verb, "hello");
+        assert!(parsed.module.is_none());
+        assert!(parsed.target.is_null());
+        assert!(parsed.args.is_null());
+        assert_eq!(parsed.channel_target(), None);
+    }
+
+    #[test]
+    fn ok_reply_round_trip() {
+        let reply = ControlResult::Ok(serde_json::json!({ "state": "answered" }))
+            .into_reply("c-42".to_string());
+        let text = serde_json::to_string(&reply).unwrap();
+        assert!(text.contains("\"status\":\"ok\""));
+        assert!(!text.contains("\"error\""));
+        let parsed: ReplyFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, reply);
+        assert_eq!(parsed.status, ReplyStatus::Ok);
+    }
+
+    #[test]
+    fn error_reply_round_trip() {
+        let reply = ControlResult::error(ControlErrorCode::NotFound, "no such channel")
+            .into_reply("c-7".to_string());
+        let text = serde_json::to_string(&reply).unwrap();
+        assert!(text.contains("\"status\":\"error\""));
+        assert!(text.contains("\"code\":\"not_found\""));
+        assert!(!text.contains("\"result\""));
+        let parsed: ReplyFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, reply);
+    }
+
+    #[test]
+    fn event_frame_round_trip_carries_id_triple() {
+        let event = EventFrame::new(
+            "StasisStart",
+            "ch_9f3a",
+            "ivr-app",
+            "6f0e-uuid",
+            "a84b4c76e66710@pc33",
+            serde_json::json!({ "source_ip": "203.0.113.7" }),
+        );
+        let text = serde_json::to_string(&event).unwrap();
+        assert!(text.contains("\"type\":\"event\""));
+        assert!(text.contains("\"event\":\"StasisStart\""));
+        assert!(text.contains("\"sip_call_id\":\"a84b4c76e66710@pc33\""));
+        let parsed: EventFrame = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed, event);
+        assert_eq!(parsed.call_id.as_deref(), Some("6f0e-uuid"));
+    }
+
+    #[test]
+    fn event_frame_omits_null_payload() {
+        let event = EventFrame::new(
+            "StasisEnd",
+            "ch_1",
+            "ivr-app",
+            "uuid",
+            "sipcid",
+            serde_json::Value::Null,
+        );
+        let text = serde_json::to_string(&event).unwrap();
+        assert!(!text.contains("payload"));
+    }
+
+    #[test]
+    fn hello_args_parse() {
+        let args = serde_json::json!({ "app": "ivr-app", "protocol": 1 });
+        let hello: HelloArgs = serde_json::from_value(args).unwrap();
+        assert_eq!(hello.app, "ivr-app");
+        assert_eq!(hello.protocol, Some(1));
+    }
+
+    #[test]
+    fn error_code_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::UnsupportedVerb).unwrap(),
+            "\"unsupported_verb\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::OriginateDenied).unwrap(),
+            "\"originate_denied\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::UnsupportedVersion).unwrap(),
+            "\"unsupported_version\""
+        );
+    }
+}

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -1008,6 +1008,47 @@ mod tests {
         assert_eq!(bus.owns("nope", "ivr-app", owner.id), Ownership::Unknown);
     }
 
+    #[tokio::test]
+    async fn cancel_while_parked_emits_stasis_end_and_drains() {
+        // Models the teardown the CANCEL path (`handle_b2bua_cancel`) now runs
+        // for a handed-over call the caller CANCELs before the controller acts:
+        // control_notify_terminated → on_call_terminated. The owning app must be
+        // told (StasisEnd) and every bus entry must drain — the leak the report
+        // flagged (channel/app_calls/owner cleaned only on app disconnect).
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid@h",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+        assert_eq!(bus.channel_count(), 1);
+        assert_eq!(bus.owned_channels("ivr-app").len(), 1);
+
+        // Caller CANCEL, keyed on the A-leg Call-ID.
+        bus.on_call_terminated("sipcid@h", "cancelled");
+
+        // The owning connection received StasisStart then StasisEnd(cancelled).
+        let frames = conn.events.recv_many().await;
+        let stasis_end = frames
+            .iter()
+            .find_map(|frame| match frame {
+                OutboundFrame::Event(event) if event.event == "StasisEnd" => Some(event),
+                _ => None,
+            })
+            .expect("owning app must receive StasisEnd on CANCEL");
+        assert_eq!(stasis_end.payload["reason"], "cancelled");
+        assert_eq!(stasis_end.channel.as_deref(), Some("ch1"));
+
+        // Every per-call entry drained to baseline (no leak).
+        assert_eq!(bus.channel_count(), 0, "channel leaked after CANCEL");
+        assert!(bus.owned_channels("ivr-app").is_empty(), "app_calls leaked after CANCEL");
+    }
+
     #[test]
     fn per_call_vars_get_set_and_drain() {
         let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
@@ -1098,22 +1139,31 @@ mod tests {
             for index in 0..8 {
                 let conn = bus.register_connection("ivr-app");
                 let channel = format!("ch-{cycle}-{index}");
+                let sip_call_id = format!("sip-{cycle}-{index}");
                 bus.register_channel(
                     &channel,
                     &conn,
                     &format!("call-{cycle}-{index}"),
-                    &format!("sip-{cycle}-{index}"),
+                    &sip_call_id,
                     "hangup",
                     HashMap::new(),
                 );
                 bus.publish_to_channel(&channel, stasis_start(&channel, "ivr-app"));
-                conns.push((conn, channel));
+                conns.push((conn, channel, sip_call_id));
             }
             assert_eq!(bus.channel_count(), 8);
             assert_eq!(bus.app_connection_count("ivr-app"), 8);
 
-            for (conn, channel) in conns {
-                bus.remove_channel(&channel);
+            for (position, (conn, channel, sip_call_id)) in conns.into_iter().enumerate() {
+                // Alternate the teardown trigger: half via a direct hangup
+                // (remove_channel), half via the CANCEL/BYE path
+                // (on_call_terminated by sip_call_id) — the latter is what the
+                // report's leak fix restored on the CANCEL-while-parked path.
+                if position % 2 == 0 {
+                    bus.remove_channel(&channel);
+                } else {
+                    bus.on_call_terminated(&sip_call_id, "cancelled");
+                }
                 // Directly remove the fanout entry (no grace timer in a
                 // non-tokio test context).
                 if let Some(fanout) = bus.apps.get(&conn.app) {

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -1,0 +1,1168 @@
+//! `ControlBus` — the process-global app/connection/channel registry, the
+//! bounded per-connection outbound queue, and the ownership + resync bookkeeping.
+//!
+//! Installed once at boot (like `registrar_arc()` / `B2BUA_CONTROL`), read by
+//! the dispatcher when a controlled call needs an event pushed and by the
+//! control listener when a connection registers or a command arrives.
+//!
+//! ## Isolation invariant
+//!
+//! Publishing an event to a connection is a **non-blocking `try_push`** onto a
+//! **bounded** queue — it never `.await`s and never parks the caller (the
+//! dispatcher / a leg actor). A stalled application backs up only its own queue;
+//! on overflow the oldest *event* is dropped (default) or the connection is
+//! marked for disconnect. Replies are never dropped. Pressure never reaches the
+//! signaling plane.
+//!
+//! ## Ownership (exactly-one-owner)
+//!
+//! A channel is owned by exactly one connection. `offer_channel` assigns the
+//! owner: round-robin over the app's persistent connections, or (per-call-connect
+//! apps) the socket siphon dials for that call. Every command's `target` is
+//! looked up here and its owner checked against the commanding connection —
+//! server-authoritative, never client-asserted.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use dashmap::DashMap;
+use tokio::sync::{oneshot, Notify};
+use tracing::{debug, info, warn};
+
+use crate::config::ControlAppConfig;
+
+use super::protocol::{ControlResult, EventFrame, ReplyFrame};
+
+/// Overflow policy for a per-connection outbound queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SlowConsumerPolicy {
+    /// Drop the oldest queued *event* to make room (default). Replies are never
+    /// dropped.
+    #[default]
+    DropOldest,
+    /// Mark the connection for disconnect (the writer task closes it).
+    Disconnect,
+}
+
+impl SlowConsumerPolicy {
+    /// Parse the config string (`"drop_oldest"` / `"disconnect"`), defaulting to
+    /// `DropOldest` for anything else.
+    pub fn from_config(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "disconnect" => SlowConsumerPolicy::Disconnect,
+            _ => SlowConsumerPolicy::DropOldest,
+        }
+    }
+}
+
+/// A frame queued for a connection's single write task: either a correlated
+/// reply or a pushed event. Both travel through the one queue so replies and
+/// events for any given call are totally ordered on the owner socket.
+#[derive(Debug, Clone)]
+pub enum OutboundFrame {
+    /// A correlated reply (never dropped by backpressure).
+    Reply(ReplyFrame),
+    /// A pushed event (subject to drop-oldest under backpressure).
+    Event(EventFrame),
+}
+
+impl OutboundFrame {
+    fn is_event(&self) -> bool {
+        matches!(self, OutboundFrame::Event(_))
+    }
+
+    /// Serialize to a JSON text frame.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        match self {
+            OutboundFrame::Reply(reply) => serde_json::to_string(reply),
+            OutboundFrame::Event(event) => serde_json::to_string(event),
+        }
+    }
+}
+
+/// Result of a single [`OutboundQueue::try_push_event`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushOutcome {
+    /// The frame was queued.
+    Delivered,
+    /// The queue was full; the oldest event was dropped to make room.
+    DroppedOldest,
+    /// The queue was full and the policy is `Disconnect`; the event was dropped
+    /// and the connection is now flagged for disconnect.
+    OverflowDisconnect,
+}
+
+/// A bounded, non-blocking outbound queue for one connection.
+///
+/// Producers (dispatcher / leg actor for events; the read task for replies)
+/// call [`try_push_event`](Self::try_push_event) / [`push_reply`](Self::push_reply)
+/// — a brief lock, never held across an `.await`. The connection's async writer
+/// task calls [`recv_many`](Self::recv_many), parking on a `Notify` until frames
+/// are available, then draining them under one lock.
+#[derive(Debug)]
+pub struct OutboundQueue {
+    inner: Mutex<std::collections::VecDeque<OutboundFrame>>,
+    notify: Notify,
+    capacity: usize,
+    policy: SlowConsumerPolicy,
+    dropped: AtomicU64,
+    disconnect: AtomicBool,
+    closed: AtomicBool,
+}
+
+impl OutboundQueue {
+    /// Create a queue with the given event capacity and overflow policy.
+    pub fn new(capacity: usize, policy: SlowConsumerPolicy) -> Self {
+        Self {
+            inner: Mutex::new(std::collections::VecDeque::with_capacity(capacity.min(64))),
+            notify: Notify::new(),
+            capacity: capacity.max(1),
+            policy,
+            dropped: AtomicU64::new(0),
+            disconnect: AtomicBool::new(false),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, std::collections::VecDeque<OutboundFrame>> {
+        match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    /// Push one event without ever blocking or awaiting. Under overflow the
+    /// oldest *event* is dropped (never a reply).
+    pub fn try_push_event(&self, event: EventFrame) -> PushOutcome {
+        let outcome = {
+            let mut queue = self.lock();
+            let event_count = queue.iter().filter(|frame| frame.is_event()).count();
+            if event_count >= self.capacity {
+                match self.policy {
+                    SlowConsumerPolicy::DropOldest => {
+                        drop_oldest_event(&mut queue);
+                        self.dropped.fetch_add(1, Ordering::Relaxed);
+                        queue.push_back(OutboundFrame::Event(event));
+                        PushOutcome::DroppedOldest
+                    }
+                    SlowConsumerPolicy::Disconnect => {
+                        self.dropped.fetch_add(1, Ordering::Relaxed);
+                        self.disconnect.store(true, Ordering::SeqCst);
+                        PushOutcome::OverflowDisconnect
+                    }
+                }
+            } else {
+                queue.push_back(OutboundFrame::Event(event));
+                PushOutcome::Delivered
+            }
+        };
+        self.notify.notify_one();
+        outcome
+    }
+
+    /// Push a reply. Replies are **never** dropped: if the queue is at capacity
+    /// the oldest *event* is dropped to make room, so a burst of events can
+    /// never starve a command's correlated reply.
+    pub fn push_reply(&self, reply: ReplyFrame) {
+        {
+            let mut queue = self.lock();
+            let event_count = queue.iter().filter(|frame| frame.is_event()).count();
+            if event_count >= self.capacity && drop_oldest_event(&mut queue) {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+            }
+            queue.push_back(OutboundFrame::Reply(reply));
+        }
+        self.notify.notify_one();
+    }
+
+    /// Await and drain all currently-queued frames. Returns an empty vector only
+    /// when the queue has been [`closed`](Self::close).
+    pub async fn recv_many(&self) -> Vec<OutboundFrame> {
+        loop {
+            {
+                let mut queue = self.lock();
+                if !queue.is_empty() {
+                    return queue.drain(..).collect();
+                }
+            }
+            if self.closed.load(Ordering::SeqCst) {
+                return Vec::new();
+            }
+            self.notify.notified().await;
+        }
+    }
+
+    /// Signal the writer to stop (used on connection teardown).
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::SeqCst);
+        self.notify.notify_one();
+    }
+
+    /// Number of events dropped so far due to overflow.
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Whether the queue has requested a disconnect (overflow under the
+    /// `Disconnect` policy).
+    pub fn disconnect_requested(&self) -> bool {
+        self.disconnect.load(Ordering::SeqCst)
+    }
+
+    /// Current queued depth (test/observability only).
+    pub fn depth(&self) -> usize {
+        self.lock().len()
+    }
+}
+
+/// Length-checked constant-time byte comparison (bearer tokens). Length may leak
+/// — a token's length is not the secret.
+pub(crate) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference: u8 = 0;
+    for (a, b) in left.iter().zip(right.iter()) {
+        difference |= a ^ b;
+    }
+    difference == 0
+}
+
+/// Remove the oldest event frame in the queue (leaving replies in place).
+/// Returns true if an event was removed.
+fn drop_oldest_event(queue: &mut std::collections::VecDeque<OutboundFrame>) -> bool {
+    if let Some(index) = queue.iter().position(|frame| frame.is_event()) {
+        queue.remove(index);
+        true
+    } else {
+        false
+    }
+}
+
+/// A single control connection registered with the bus.
+#[derive(Debug)]
+pub struct ConnHandle {
+    /// Process-unique connection id.
+    pub id: u64,
+    /// The application this connection authenticated as.
+    pub app: String,
+    /// The connection's bounded outbound queue (replies + events).
+    pub events: Arc<OutboundQueue>,
+}
+
+/// A controlled channel entry (owner + resync/leak bookkeeping).
+#[derive(Debug)]
+struct ChannelEntry {
+    /// The application that owns the channel.
+    app: String,
+    /// The owning connection id, or 0 when orphaned (owner disconnected).
+    conn_id: AtomicU64,
+    /// The internal `CallActor` id backing this channel.
+    call_actor_id: String,
+    /// The per-leg SIP Call-ID (CDR/HEP join key + `b2bua_*` routing).
+    sip_call_id: String,
+    /// Control-loss policy for this call ("hangup"/"continue"/"fallback").
+    on_lost: String,
+    /// Per-call variables (drain with the channel — never on `CallActor`).
+    vars: Mutex<HashMap<String, String>>,
+}
+
+/// A read-only snapshot of a channel a connection owns (for command resolution
+/// + resync enumeration).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelRef {
+    /// The leg-scoped channel id.
+    pub channel_id: String,
+    /// The internal `CallActor` id.
+    pub call_actor_id: String,
+    /// The per-leg SIP Call-ID.
+    pub sip_call_id: String,
+    /// The owning application.
+    pub app: String,
+}
+
+/// The set of connections for one application, with a round-robin cursor.
+#[derive(Debug, Default)]
+struct AppFanout {
+    conns: Mutex<Vec<Arc<ConnHandle>>>,
+    cursor: AtomicUsize,
+}
+
+impl AppFanout {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<Arc<ConnHandle>>> {
+        match self.conns.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn add(&self, conn: Arc<ConnHandle>) {
+        self.lock().push(conn);
+    }
+
+    fn remove(&self, id: u64) {
+        self.lock().retain(|conn| conn.id != id);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.lock().is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    fn get(&self, id: u64) -> Option<Arc<ConnHandle>> {
+        self.lock().iter().find(|conn| conn.id == id).map(Arc::clone)
+    }
+
+    fn contains(&self, id: u64) -> bool {
+        self.lock().iter().any(|conn| conn.id == id)
+    }
+
+    fn pick(&self) -> Option<Arc<ConnHandle>> {
+        let conns = self.lock();
+        if conns.is_empty() {
+            return None;
+        }
+        let index = self.cursor.fetch_add(1, Ordering::Relaxed) % conns.len();
+        Some(Arc::clone(&conns[index]))
+    }
+}
+
+/// A command received from a control connection, en route to the substrate's
+/// apply consumer. `response_tx` carries the *local* [`ControlResult`] back.
+#[derive(Debug)]
+pub struct ControlCommand {
+    /// Client-owned request id (echoed in the reply).
+    pub id: String,
+    /// The authenticated app of the originating connection.
+    pub app: String,
+    /// The originating connection id (for reattach / resync).
+    pub conn_id: u64,
+    /// The adapter routing key (absent for substrate verbs).
+    pub module: Option<String>,
+    /// The verb to apply.
+    pub verb: String,
+    /// Adapter-defined target (`serde_json::Value`).
+    pub target: serde_json::Value,
+    /// Adapter-defined arguments (`serde_json::Value`).
+    pub args: serde_json::Value,
+    /// Channel back to the connection's read task with the local result.
+    pub response_tx: oneshot::Sender<ControlResult>,
+}
+
+impl ControlCommand {
+    /// Extract the `target.channel` string when present.
+    pub fn channel_target(&self) -> Option<String> {
+        self.target
+            .get("channel")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string())
+    }
+}
+
+/// The outcome of offering a handed-over call to an app.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OfferOutcome {
+    /// A persistent connection was assigned as owner and `StasisStart` pushed.
+    Assigned,
+    /// A per-call-connect dial was launched; ownership completes on connect (or
+    /// the handoff deadline fires).
+    Dialing,
+    /// No controller is available (no connection, or a per-call-connect app with
+    /// no `connect_url`) — the caller must apply the handoff default action now.
+    NoController,
+}
+
+/// Process-global control-plane registry.
+#[derive(Debug)]
+pub struct ControlBus {
+    apps: DashMap<String, AppFanout>,
+    channels: DashMap<String, Arc<ChannelEntry>>,
+    /// app → set of owned channel ids (disconnect cleanup + resync index).
+    app_calls: DashMap<String, HashSet<String>>,
+    app_config: HashMap<String, ControlAppConfig>,
+    command_tx: flume::Sender<ControlCommand>,
+    event_queue_depth: usize,
+    slow_consumer: SlowConsumerPolicy,
+    reattach_grace_secs: u64,
+    handoff_deadline_ms: u64,
+    next_conn_id: AtomicU64,
+}
+
+static CONTROL_BUS: OnceLock<Arc<ControlBus>> = OnceLock::new();
+
+impl ControlBus {
+    /// Build a new bus. `command_tx` feeds the substrate's apply consumer.
+    pub fn new(
+        command_tx: flume::Sender<ControlCommand>,
+        apps: Vec<ControlAppConfig>,
+        event_queue_depth: usize,
+        slow_consumer: SlowConsumerPolicy,
+        reattach_grace_secs: u64,
+        handoff_deadline_ms: u64,
+    ) -> Arc<Self> {
+        let app_config = apps
+            .into_iter()
+            .map(|app| (app.name.clone(), app))
+            .collect();
+        Arc::new(Self {
+            apps: DashMap::new(),
+            channels: DashMap::new(),
+            app_calls: DashMap::new(),
+            app_config,
+            command_tx,
+            event_queue_depth: event_queue_depth.max(1),
+            slow_consumer,
+            reattach_grace_secs,
+            handoff_deadline_ms,
+            next_conn_id: AtomicU64::new(1),
+        })
+    }
+
+    /// The default handoff deadline (ms) applied when `call.handover()` passes
+    /// none.
+    pub fn handoff_deadline_ms(&self) -> u64 {
+        self.handoff_deadline_ms
+    }
+
+    /// Reattach an app's orphaned channels to the connection identified by
+    /// `conn_id` and return the snapshot it now owns (the `resync` reply). Falls
+    /// back to a read-only enumeration when the connection is not live.
+    pub fn resync(&self, app: &str, conn_id: u64) -> Vec<ChannelRef> {
+        match self.connection(app, conn_id) {
+            Some(conn) => self.reattach(&conn),
+            None => self.owned_channels(app),
+        }
+    }
+
+    /// Install the process-global bus. Returns `Err` if already installed.
+    pub fn install(bus: Arc<ControlBus>) -> Result<(), Arc<ControlBus>> {
+        CONTROL_BUS.set(bus)
+    }
+
+    /// The process-global bus, if installed.
+    pub fn global() -> Option<Arc<ControlBus>> {
+        CONTROL_BUS.get().cloned()
+    }
+
+    /// A cloneable sender for the command channel (used by the listener).
+    pub fn command_sender(&self) -> flume::Sender<ControlCommand> {
+        self.command_tx.clone()
+    }
+
+    /// Whether `app` is a known, configured control application.
+    pub fn app_configured(&self, app: &str) -> bool {
+        self.app_config.contains_key(app)
+    }
+
+    /// Match a presented bearer token against the configured apps, constant-time.
+    /// Returns the matching app name, or `None` for an unknown token. An app with
+    /// an empty token can never authenticate (fail-closed).
+    pub fn authenticate_token(&self, token: &str) -> Option<String> {
+        for config in self.app_config.values() {
+            if !config.token.is_empty()
+                && constant_time_eq(token.as_bytes(), config.token.as_bytes())
+            {
+                return Some(config.name.clone());
+            }
+        }
+        None
+    }
+
+    /// The configured app entry, if any.
+    pub fn app_config(&self, app: &str) -> Option<&ControlAppConfig> {
+        self.app_config.get(app)
+    }
+
+    /// Register a new connection for `app`. Returns the handle whose `events`
+    /// queue the connection's writer task drains.
+    pub fn register_connection(&self, app: &str) -> Arc<ConnHandle> {
+        let id = self.next_conn_id.fetch_add(1, Ordering::Relaxed);
+        let handle = Arc::new(ConnHandle {
+            id,
+            app: app.to_string(),
+            events: Arc::new(OutboundQueue::new(self.event_queue_depth, self.slow_consumer)),
+        });
+        self.apps
+            .entry(app.to_string())
+            .or_default()
+            .add(Arc::clone(&handle));
+        handle
+    }
+
+    /// Remove a connection from its application fanout, orphan the channels it
+    /// owned, and schedule the control-loss (`on_lost`) grace timer for each.
+    /// A reconnecting controller of the same app may `resync` within the grace
+    /// window to re-claim ownership.
+    pub fn unregister_connection(self: &Arc<Self>, conn: &ConnHandle) {
+        if let Some(fanout) = self.apps.get(&conn.app) {
+            fanout.remove(conn.id);
+        }
+        conn.events.close();
+        self.apps.remove_if(&conn.app, |_, fanout| fanout.is_empty());
+
+        // Orphan every channel this connection owned + arm the grace timer.
+        let orphaned: Vec<String> = self
+            .app_calls
+            .get(&conn.app)
+            .map(|entry| entry.value().iter().cloned().collect())
+            .unwrap_or_default();
+        for channel_id in orphaned {
+            if let Some(entry) = self.channels.get(&channel_id) {
+                if entry.conn_id.load(Ordering::SeqCst) == conn.id {
+                    entry.conn_id.store(0, Ordering::SeqCst);
+                    self.schedule_control_loss(&channel_id);
+                }
+            }
+        }
+    }
+
+    /// Arm the control-loss grace timer for an orphaned channel. After the grace
+    /// window, if it has not been re-claimed (`conn_id` still 0), apply the
+    /// call's `on_lost` policy.
+    fn schedule_control_loss(self: &Arc<Self>, channel_id: &str) {
+        let bus = Arc::clone(self);
+        let channel_id = channel_id.to_string();
+        let grace = std::time::Duration::from_secs(self.reattach_grace_secs);
+        tokio::spawn(async move {
+            tokio::time::sleep(grace).await;
+            bus.apply_control_loss_if_orphaned(&channel_id);
+        });
+    }
+
+    fn apply_control_loss_if_orphaned(&self, channel_id: &str) {
+        let (still_orphaned, on_lost, sip_call_id, app) = match self.channels.get(channel_id) {
+            Some(entry) => (
+                entry.conn_id.load(Ordering::SeqCst) == 0,
+                entry.on_lost.clone(),
+                entry.sip_call_id.clone(),
+                entry.app.clone(),
+            ),
+            None => return,
+        };
+        if !still_orphaned {
+            return; // reattached within the grace window
+        }
+        info!(
+            %channel_id,
+            %app,
+            on_lost = %on_lost,
+            "control plane: owner lost past grace — applying control-loss policy"
+        );
+        self.remove_channel(channel_id);
+        match on_lost.as_str() {
+            "continue" => {
+                // Leave the call running autonomously; nothing to tear down.
+            }
+            // "fallback" re-dispatch through Python handlers is a Phase-2 item;
+            // degrade to hangup so a lost controller never silently strands a call.
+            _ => {
+                crate::dispatcher::b2bua_terminate_call(
+                    &sip_call_id,
+                    Some("control plane owner lost"),
+                );
+            }
+        }
+    }
+
+    /// Round-robin select a connection of `app` (the `StasisStart` owner).
+    pub fn pick_connection(&self, app: &str) -> Option<Arc<ConnHandle>> {
+        self.apps.get(app).and_then(|fanout| fanout.pick())
+    }
+
+    /// Look up a live connection of `app` by id.
+    fn connection(&self, app: &str, conn_id: u64) -> Option<Arc<ConnHandle>> {
+        self.apps.get(app).and_then(|fanout| fanout.get(conn_id))
+    }
+
+    /// Register a controlled channel to an owning connection.
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_channel(
+        &self,
+        channel_id: &str,
+        conn: &ConnHandle,
+        call_actor_id: &str,
+        sip_call_id: &str,
+        on_lost: &str,
+        vars: HashMap<String, String>,
+    ) {
+        self.channels.insert(
+            channel_id.to_string(),
+            Arc::new(ChannelEntry {
+                app: conn.app.clone(),
+                conn_id: AtomicU64::new(conn.id),
+                call_actor_id: call_actor_id.to_string(),
+                sip_call_id: sip_call_id.to_string(),
+                on_lost: on_lost.to_string(),
+                vars: Mutex::new(vars),
+            }),
+        );
+        self.app_calls
+            .entry(conn.app.clone())
+            .or_default()
+            .insert(channel_id.to_string());
+        crate::metrics::try_metrics()
+            .inspect(|m| m.control_controlled_calls.with_label_values(&[&conn.app]).inc());
+    }
+
+    /// Remove a channel and drop it from the app index. Returns whether it was
+    /// present.
+    pub fn remove_channel(&self, channel_id: &str) -> bool {
+        match self.channels.remove(channel_id) {
+            Some((_, entry)) => {
+                if let Some(mut set) = self.app_calls.get_mut(&entry.app) {
+                    set.remove(channel_id);
+                }
+                self.app_calls
+                    .remove_if(&entry.app, |_, set| set.is_empty());
+                crate::metrics::try_metrics()
+                    .inspect(|m| m.control_controlled_calls.with_label_values(&[&entry.app]).dec());
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Remove the channel owning `sip_call_id`, returning its owning app + the
+    /// channel id (for a `StasisEnd` before removal). O(channels) — a per-call
+    /// teardown path, not per-packet.
+    fn channel_id_for_sip_call_id(&self, sip_call_id: &str) -> Option<String> {
+        self.channels
+            .iter()
+            .find(|entry| entry.value().sip_call_id == sip_call_id)
+            .map(|entry| entry.key().clone())
+    }
+
+    /// Whether the given connection owns the channel (authZ for a command).
+    pub fn owns(&self, channel_id: &str, app: &str, conn_id: u64) -> Ownership {
+        match self.channels.get(channel_id) {
+            None => Ownership::Unknown,
+            Some(entry) => {
+                if entry.app != app {
+                    Ownership::Forbidden
+                } else if entry.conn_id.load(Ordering::SeqCst) == conn_id
+                    || entry.conn_id.load(Ordering::SeqCst) == 0
+                {
+                    // Same connection, or an orphaned channel of the same app
+                    // being addressed by a reconnecting owner (post-resync).
+                    Ownership::Owned(ChannelRef {
+                        channel_id: channel_id.to_string(),
+                        call_actor_id: entry.call_actor_id.clone(),
+                        sip_call_id: entry.sip_call_id.clone(),
+                        app: entry.app.clone(),
+                    })
+                } else {
+                    Ownership::Forbidden
+                }
+            }
+        }
+    }
+
+    /// Publish an event to a channel's owning connection (non-blocking).
+    /// Returns `false` if the channel is unknown or currently orphaned.
+    pub fn publish_to_channel(&self, channel_id: &str, frame: EventFrame) -> bool {
+        let (app, conn_id) = match self.channels.get(channel_id) {
+            Some(entry) => (entry.app.clone(), entry.conn_id.load(Ordering::SeqCst)),
+            None => return false,
+        };
+        if conn_id == 0 {
+            return false;
+        }
+        match self.connection(&app, conn_id) {
+            Some(conn) => {
+                conn.events.try_push_event(frame);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Emit a `StasisEnd` for the call identified by `sip_call_id` and remove
+    /// the channel. Idempotent — a no-op when the call is not controlled.
+    /// Called from every B2BUA teardown junction, guarded internally.
+    pub fn on_call_terminated(&self, sip_call_id: &str, reason: &str) {
+        let Some(channel_id) = self.channel_id_for_sip_call_id(sip_call_id) else {
+            return;
+        };
+        let (app, call_actor_id) = match self.channels.get(&channel_id) {
+            Some(entry) => (entry.app.clone(), entry.call_actor_id.clone()),
+            None => return,
+        };
+        self.publish_to_channel(
+            &channel_id,
+            EventFrame::new(
+                "StasisEnd",
+                &channel_id,
+                &app,
+                &call_actor_id,
+                sip_call_id,
+                serde_json::json!({ "reason": reason }),
+            ),
+        );
+        self.remove_channel(&channel_id);
+        debug!(%channel_id, %sip_call_id, reason, "control plane: StasisEnd + channel removed");
+    }
+
+    /// Offer a handed-over call to an app: assign a persistent owner (round
+    /// robin) and push `StasisStart`, or launch a per-call-connect dial. Returns
+    /// the outcome so the dispatcher knows whether to arm the handoff deadline
+    /// or apply the default action immediately.
+    #[allow(clippy::too_many_arguments)]
+    pub fn offer_channel(
+        self: &Arc<Self>,
+        app: &str,
+        channel_id: &str,
+        call_actor_id: &str,
+        sip_call_id: &str,
+        on_lost: &str,
+        vars: HashMap<String, String>,
+        stasis_payload: serde_json::Value,
+    ) -> OfferOutcome {
+        let per_call_connect = self
+            .app_config
+            .get(app)
+            .map(|config| config.per_call_connect)
+            .unwrap_or(false);
+
+        if per_call_connect {
+            let config = match self.app_config.get(app) {
+                Some(config) => config.clone(),
+                None => return OfferOutcome::NoController,
+            };
+            let Some(connect_url) = config.connect_url.clone() else {
+                warn!(%app, "control plane: per_call_connect app has no connect_url");
+                return OfferOutcome::NoController;
+            };
+            super::outbound::dial_and_own(
+                Arc::clone(self),
+                config.name.clone(),
+                config.token.clone(),
+                connect_url,
+                super::outbound::PendingOwn {
+                    channel_id: channel_id.to_string(),
+                    call_actor_id: call_actor_id.to_string(),
+                    sip_call_id: sip_call_id.to_string(),
+                    on_lost: on_lost.to_string(),
+                    vars,
+                    stasis_payload,
+                },
+            );
+            return OfferOutcome::Dialing;
+        }
+
+        // Persistent inbound mode: round-robin a live connection.
+        match self.pick_connection(app) {
+            Some(conn) => {
+                self.register_channel(channel_id, &conn, call_actor_id, sip_call_id, on_lost, vars);
+                conn.events.try_push_event(EventFrame::new(
+                    "StasisStart",
+                    channel_id,
+                    app,
+                    call_actor_id,
+                    sip_call_id,
+                    stasis_payload,
+                ));
+                OfferOutcome::Assigned
+            }
+            None => OfferOutcome::NoController,
+        }
+    }
+
+    /// Re-claim (reattach) an app's orphaned channels to a reconnecting
+    /// connection, and return the current snapshot of everything it now owns
+    /// (for the `resync` reply).
+    pub fn reattach(&self, conn: &ConnHandle) -> Vec<ChannelRef> {
+        let channel_ids: Vec<String> = self
+            .app_calls
+            .get(&conn.app)
+            .map(|entry| entry.value().iter().cloned().collect())
+            .unwrap_or_default();
+        let mut owned = Vec::new();
+        for channel_id in channel_ids {
+            if let Some(entry) = self.channels.get(&channel_id) {
+                let current = entry.conn_id.load(Ordering::SeqCst);
+                // Re-point orphaned channels (or channels whose owner conn is no
+                // longer live) at this connection.
+                if current == 0 || !self.is_conn_live(&conn.app, current) {
+                    entry.conn_id.store(conn.id, Ordering::SeqCst);
+                }
+                owned.push(ChannelRef {
+                    channel_id: channel_id.clone(),
+                    call_actor_id: entry.call_actor_id.clone(),
+                    sip_call_id: entry.sip_call_id.clone(),
+                    app: entry.app.clone(),
+                });
+            }
+        }
+        owned
+    }
+
+    fn is_conn_live(&self, app: &str, conn_id: u64) -> bool {
+        self.apps
+            .get(app)
+            .map(|fanout| fanout.contains(conn_id))
+            .unwrap_or(false)
+    }
+
+    /// Snapshot the channels an app owns (for resync enumeration + `/admin`).
+    pub fn owned_channels(&self, app: &str) -> Vec<ChannelRef> {
+        self.app_calls
+            .get(app)
+            .map(|entry| {
+                entry
+                    .value()
+                    .iter()
+                    .filter_map(|channel_id| {
+                        self.channels.get(channel_id).map(|entry| ChannelRef {
+                            channel_id: channel_id.clone(),
+                            call_actor_id: entry.call_actor_id.clone(),
+                            sip_call_id: entry.sip_call_id.clone(),
+                            app: entry.app.clone(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Set a per-call variable. Returns false when the channel is unknown.
+    pub fn set_var(&self, channel_id: &str, key: &str, value: &str) -> bool {
+        match self.channels.get(channel_id) {
+            Some(entry) => {
+                if let Ok(mut vars) = entry.vars.lock() {
+                    vars.insert(key.to_string(), value.to_string());
+                }
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Read a per-call variable (None when the channel or key is unknown).
+    pub fn get_var(&self, channel_id: &str, key: &str) -> Option<String> {
+        let entry = self.channels.get(channel_id)?;
+        let vars = entry.vars.lock().ok()?;
+        vars.get(key).cloned()
+    }
+
+    /// Snapshot all per-call variables for a channel.
+    pub fn vars(&self, channel_id: &str) -> HashMap<String, String> {
+        self.channels
+            .get(channel_id)
+            .and_then(|entry| entry.vars.lock().ok().map(|vars| vars.clone()))
+            .unwrap_or_default()
+    }
+
+    /// The app that owns the call identified by `sip_call_id`, if controlled.
+    pub fn controlling_app(&self, sip_call_id: &str) -> Option<String> {
+        self.channels
+            .iter()
+            .find(|entry| entry.value().sip_call_id == sip_call_id)
+            .map(|entry| entry.value().app.clone())
+    }
+
+    /// Number of registered channels (drains to baseline — leak gate).
+    pub fn channel_count(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Number of applications with at least one connection.
+    pub fn app_count(&self) -> usize {
+        self.apps.len()
+    }
+
+    /// Number of connections registered for `app`.
+    pub fn app_connection_count(&self, app: &str) -> usize {
+        self.apps.get(app).map(|fanout| fanout.len()).unwrap_or(0)
+    }
+}
+
+/// Outcome of an ownership check for a command target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Ownership {
+    /// The connection owns the channel — carries the resolved ids.
+    Owned(ChannelRef),
+    /// The channel exists but is owned by a different app → `forbidden`.
+    Forbidden,
+    /// No such channel → `not_found`.
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::protocol::ControlResult;
+
+    fn app_cfg(name: &str) -> ControlAppConfig {
+        ControlAppConfig {
+            name: name.to_string(),
+            token: "tok".to_string(),
+            per_call_connect: false,
+            connect_url: None,
+            on_lost: Some("hangup".to_string()),
+        }
+    }
+
+    fn test_bus(depth: usize, policy: SlowConsumerPolicy) -> Arc<ControlBus> {
+        let (command_tx, _command_rx) = flume::unbounded();
+        ControlBus::new(command_tx, vec![app_cfg("ivr-app")], depth, policy, 10, 3000)
+    }
+
+    fn stasis_start(channel: &str, app: &str) -> EventFrame {
+        EventFrame::new("StasisStart", channel, app, "call-uuid", "sipcid", serde_json::json!({}))
+    }
+
+    #[test]
+    fn authenticate_token_matches_configured_app() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        assert_eq!(bus.authenticate_token("tok").as_deref(), Some("ivr-app"));
+        assert!(bus.authenticate_token("wrong").is_none());
+        assert!(bus.authenticate_token("").is_none());
+    }
+
+    #[test]
+    fn register_and_pick_connection() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        assert_eq!(bus.app_count(), 0);
+        let conn = bus.register_connection("ivr-app");
+        assert_eq!(bus.app_count(), 1);
+        assert_eq!(bus.app_connection_count("ivr-app"), 1);
+        let picked = bus.pick_connection("ivr-app").unwrap();
+        assert_eq!(picked.id, conn.id);
+        assert!(bus.pick_connection("other-app").is_none());
+    }
+
+    #[test]
+    fn round_robin_pick_rotates() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let a = bus.register_connection("ivr-app");
+        let b = bus.register_connection("ivr-app");
+        let first = bus.pick_connection("ivr-app").unwrap().id;
+        let second = bus.pick_connection("ivr-app").unwrap().id;
+        assert_ne!(first, second);
+        let mut ids = [first, second];
+        ids.sort_unstable();
+        let mut expected = [a.id, b.id];
+        expected.sort_unstable();
+        assert_eq!(ids, expected);
+    }
+
+    #[test]
+    fn offer_assigns_exactly_one_owner() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        let outcome = bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+        assert_eq!(outcome, OfferOutcome::Assigned);
+        assert_eq!(bus.channel_count(), 1);
+        // Exactly one owner: the round-robin winner got the StasisStart.
+        assert_eq!(conn.events.depth(), 1);
+        match bus.owns("ch1", "ivr-app", conn.id) {
+            Ownership::Owned(channel) => assert_eq!(channel.call_actor_id, "call-uuid"),
+            other => panic!("expected owned, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn offer_without_connection_reports_no_controller() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let outcome = bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+        assert_eq!(outcome, OfferOutcome::NoController);
+        assert_eq!(bus.channel_count(), 0);
+    }
+
+    #[test]
+    fn cross_app_target_is_forbidden() {
+        let (command_tx, _rx) = flume::unbounded();
+        let bus = ControlBus::new(
+            command_tx,
+            vec![app_cfg("ivr-app"), app_cfg("other")],
+            16,
+            SlowConsumerPolicy::DropOldest,
+            10,
+            3000,
+        );
+        let owner = bus.register_connection("ivr-app");
+        let intruder = bus.register_connection("other");
+        bus.register_channel("ch1", &owner, "call", "sipcid", "hangup", HashMap::new());
+        assert!(matches!(bus.owns("ch1", "ivr-app", owner.id), Ownership::Owned(_)));
+        assert_eq!(bus.owns("ch1", "other", intruder.id), Ownership::Forbidden);
+        assert_eq!(bus.owns("nope", "ivr-app", owner.id), Ownership::Unknown);
+    }
+
+    #[test]
+    fn per_call_vars_get_set_and_drain() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("ch1", &conn, "call", "sipcid", "hangup", HashMap::new());
+        assert!(bus.set_var("ch1", "queue", "support"));
+        assert_eq!(bus.get_var("ch1", "queue").as_deref(), Some("support"));
+        assert!(!bus.set_var("nope", "k", "v"));
+        bus.remove_channel("ch1");
+        assert_eq!(bus.get_var("ch1", "queue"), None);
+    }
+
+    #[tokio::test]
+    async fn resync_enumerates_and_reattaches_owned_channels() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let first = bus.register_connection("ivr-app");
+        bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+        // Owner disconnects; the channel is orphaned but not (yet) torn down.
+        bus.unregister_connection(&first);
+        assert_eq!(bus.channel_count(), 1);
+        assert!(!bus.publish_to_channel("ch1", stasis_start("ch1", "ivr-app")));
+
+        // A fresh connection of the same app resyncs and re-claims it.
+        let second = bus.register_connection("ivr-app");
+        let owned = bus.reattach(&second);
+        assert_eq!(owned.len(), 1);
+        assert_eq!(owned[0].channel_id, "ch1");
+        // Now events route to the reattached connection.
+        assert!(bus.publish_to_channel("ch1", stasis_start("ch1", "ivr-app")));
+        assert_eq!(second.events.depth(), 1);
+    }
+
+    #[tokio::test]
+    async fn ordering_events_and_replies_share_one_queue_in_order() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("ch1", &conn, "call", "sipcid", "hangup", HashMap::new());
+        // Interleave an event, a reply, an event — the single queue preserves
+        // submission order for the call.
+        bus.publish_to_channel("ch1", stasis_start("ch1", "ivr-app"));
+        conn.events.push_reply(
+            ControlResult::Ok(serde_json::json!({"ok": true})).into_reply("c-1".to_string()),
+        );
+        bus.publish_to_channel(
+            "ch1",
+            EventFrame::new("StasisEnd", "ch1", "ivr-app", "call", "sipcid", serde_json::json!({})),
+        );
+        let drained = conn.events.recv_many().await;
+        assert_eq!(drained.len(), 3);
+        assert!(matches!(drained[0], OutboundFrame::Event(_)));
+        assert!(matches!(drained[1], OutboundFrame::Reply(_)));
+        assert!(matches!(drained[2], OutboundFrame::Event(_)));
+    }
+
+    #[tokio::test]
+    async fn reply_never_dropped_even_when_event_queue_full() {
+        let queue = OutboundQueue::new(2, SlowConsumerPolicy::DropOldest);
+        let event = || EventFrame::new("E", "c", "a", "call", "sip", serde_json::json!({}));
+        queue.try_push_event(event());
+        queue.try_push_event(event());
+        // Queue full of events; a reply must still get in (an event is dropped).
+        queue.push_reply(ControlResult::Ok(serde_json::json!({})).into_reply("c-9".to_string()));
+        let drained = queue.recv_many().await;
+        assert!(drained.iter().any(|frame| matches!(frame, OutboundFrame::Reply(_))));
+        assert_eq!(queue.dropped_count(), 1);
+    }
+
+    /// Steady-state leak gate: N cycles of register-conn + offer-channel +
+    /// hangup + disconnect → both maps drain to their starting `len()`. The
+    /// co-located analogue of `mem_leak_test.sh` gating
+    /// `siphon_proxy_dialog_sessions → 0`.
+    #[test]
+    fn steady_state_drains_to_baseline() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        assert_eq!(bus.app_count(), 0);
+        assert_eq!(bus.channel_count(), 0);
+
+        for cycle in 0..5 {
+            let mut conns = Vec::new();
+            for index in 0..8 {
+                let conn = bus.register_connection("ivr-app");
+                let channel = format!("ch-{cycle}-{index}");
+                bus.register_channel(
+                    &channel,
+                    &conn,
+                    &format!("call-{cycle}-{index}"),
+                    &format!("sip-{cycle}-{index}"),
+                    "hangup",
+                    HashMap::new(),
+                );
+                bus.publish_to_channel(&channel, stasis_start(&channel, "ivr-app"));
+                conns.push((conn, channel));
+            }
+            assert_eq!(bus.channel_count(), 8);
+            assert_eq!(bus.app_connection_count("ivr-app"), 8);
+
+            for (conn, channel) in conns {
+                bus.remove_channel(&channel);
+                // Directly remove the fanout entry (no grace timer in a
+                // non-tokio test context).
+                if let Some(fanout) = bus.apps.get(&conn.app) {
+                    fanout.remove(conn.id);
+                }
+                conn.events.close();
+                bus.apps.remove_if(&conn.app, |_, fanout| fanout.is_empty());
+            }
+
+            assert_eq!(bus.channel_count(), 0, "channels leaked on cycle {cycle}");
+            assert_eq!(bus.app_count(), 0, "apps leaked on cycle {cycle}");
+            assert!(bus.app_calls.is_empty(), "app_calls index leaked on cycle {cycle}");
+        }
+    }
+
+    #[test]
+    fn event_queue_bounded_drop_oldest() {
+        let queue = OutboundQueue::new(2, SlowConsumerPolicy::DropOldest);
+        let event = || EventFrame::new("E", "c", "a", "call", "sip", serde_json::json!({}));
+        assert_eq!(queue.try_push_event(event()), PushOutcome::Delivered);
+        assert_eq!(queue.try_push_event(event()), PushOutcome::Delivered);
+        assert_eq!(queue.try_push_event(event()), PushOutcome::DroppedOldest);
+        assert_eq!(queue.try_push_event(event()), PushOutcome::DroppedOldest);
+        assert_eq!(queue.depth(), 2, "queue must stay bounded at capacity");
+        assert_eq!(queue.dropped_count(), 2);
+        assert!(!queue.disconnect_requested());
+    }
+
+    #[test]
+    fn event_queue_disconnect_policy_flags_slow_consumer() {
+        let queue = OutboundQueue::new(1, SlowConsumerPolicy::Disconnect);
+        let event = || EventFrame::new("E", "c", "a", "call", "sip", serde_json::json!({}));
+        assert_eq!(queue.try_push_event(event()), PushOutcome::Delivered);
+        assert_eq!(queue.try_push_event(event()), PushOutcome::OverflowDisconnect);
+        assert!(queue.disconnect_requested());
+        assert_eq!(queue.depth(), 1, "queue must stay bounded at capacity");
+    }
+
+    #[test]
+    fn publishing_never_blocks_a_stuck_consumer() {
+        // A consumer that never drains: publishing must return immediately and
+        // the queue must stay bounded rather than grow without limit.
+        let bus = test_bus(4, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("ch", &conn, "call", "sipcid", "hangup", HashMap::new());
+        for _ in 0..1000 {
+            bus.publish_to_channel("ch", stasis_start("ch", "ivr-app"));
+        }
+        assert_eq!(conn.events.depth(), 4);
+        assert_eq!(conn.events.dropped_count(), 996);
+    }
+}

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -1,0 +1,412 @@
+//! The SIP control adapter — binds generic control verbs onto siphon's shipped
+//! imperative B2BUA rail (`b2bua_answer_call` / `b2bua_progress_call` /
+//! `b2bua_terminate_call` / `b2bua_refer_call`).
+//!
+//! Every verb is a **synchronous decision core over the call store** — it
+//! performs the one bounded local action (send a SIP message / mark the store)
+//! and returns "accepted" in microseconds. It **never** waits for the far end;
+//! the callee's answer / ACK / BYE-200 arrive later as events. A command against
+//! a dead/unknown call returns a typed `not_found`, never hangs.
+
+use futures_util::future::BoxFuture;
+
+use super::protocol::{ControlErrorCode, ControlResult};
+use super::registry::ChannelRef;
+use super::{AdapterCommand, AdapterSchema, ControlAdapter, ResolvedTarget, VerbSchema};
+
+/// The SIP adapter (`module() == "sip"`).
+#[derive(Debug, Default)]
+pub struct SipControlAdapter;
+
+impl SipControlAdapter {
+    /// Construct the SIP adapter.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ControlAdapter for SipControlAdapter {
+    fn module(&self) -> &str {
+        "sip"
+    }
+
+    fn apply<'a>(&'a self, command: AdapterCommand) -> BoxFuture<'a, ControlResult> {
+        Box::pin(async move { apply_sip(command) })
+    }
+
+    fn describe(&self) -> AdapterSchema {
+        AdapterSchema {
+            module: "sip".to_string(),
+            verbs: vec![
+                verb("answer", "Send a UAS 2xx to the parked A-leg (args: code, reason, body, content_type)"),
+                verb("progress", "Send a UAS 1xx / early media (args: code, reason, body, content_type)"),
+                verb("reject", "Send a final non-2xx and tear the call down (args: code, reason)"),
+                verb("hangup", "BYE an answered call, or reject an unanswered one (args: reason)"),
+                verb("refer", "Send an in-dialog REFER on the A-leg (args: to, replaces)"),
+                verb("set_header", "Set a header on the stored A-leg INVITE (args: name, value)"),
+                verb("get_header", "Read a header from the stored A-leg INVITE (args: name)"),
+            ],
+            events: vec![
+                "StasisStart".to_string(),
+                "StasisEnd".to_string(),
+                "ChannelStateChange".to_string(),
+                "ChannelHangupRequest".to_string(),
+            ],
+        }
+    }
+}
+
+fn verb(name: &str, summary: &str) -> VerbSchema {
+    VerbSchema {
+        verb: name.to_string(),
+        summary: summary.to_string(),
+    }
+}
+
+/// Dispatch one SIP verb. Synchronous (the imperative rail is non-blocking) —
+/// returns the local result immediately.
+fn apply_sip(command: AdapterCommand) -> ControlResult {
+    // All SIP verbs act on a channel.
+    let channel = match &command.target {
+        ResolvedTarget::Channel(channel) => channel.clone(),
+        ResolvedTarget::None => {
+            return ControlResult::error(
+                ControlErrorCode::BadRequest,
+                format!("verb '{}' requires a channel target", command.verb),
+            );
+        }
+    };
+
+    // The controller has acted: clear the handoff deadline so the answer-timeout
+    // sweep no longer applies the parked default action to this call.
+    if let Some(store) = crate::b2bua::actor::global_call_store() {
+        store.mark_controller_acted(&channel.call_actor_id);
+    }
+
+    match command.verb.as_str() {
+        "answer" => answer(&channel, &command.args, true),
+        "progress" => answer(&channel, &command.args, false),
+        "reject" => reject(&channel, &command.args),
+        "hangup" => hangup(&channel, &command.args),
+        "refer" => refer(&channel, &command.args),
+        "set_header" => set_header(&channel, &command.args),
+        "get_header" => get_header(&channel, &command.args),
+        // Media verbs (play/stop/dtmf/collect_dtmf) bind to MediaBackend and land
+        // with the AI-park mode — a typed error, never a hang.
+        other => ControlResult::error(
+            ControlErrorCode::UnsupportedVerb,
+            format!("sip adapter does not implement verb '{other}' in this build"),
+        ),
+    }
+}
+
+/// Fetch a clone of the stored A-leg INVITE Arc for a controlled call.
+fn stored_invite(call_actor_id: &str) -> Option<std::sync::Arc<std::sync::Mutex<crate::sip::message::SipMessage>>> {
+    let store = crate::b2bua::actor::global_call_store()?;
+    let call = store.get_call(call_actor_id)?;
+    call.a_leg_invite.clone()
+}
+
+/// Read `code`/`reason`/`body`/`content_type` from a verb's args.
+fn response_args(args: &serde_json::Value, default_code: u16, default_reason: &str) -> (u16, String, Option<Vec<u8>>, Option<String>) {
+    let code = args
+        .get("code")
+        .and_then(|v| v.as_u64())
+        .map(|c| c as u16)
+        .unwrap_or(default_code);
+    let reason = args
+        .get("reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or(default_reason)
+        .to_string();
+    let body = args
+        .get("body")
+        .and_then(|v| v.as_str())
+        .map(|b| b.as_bytes().to_vec());
+    let content_type = args
+        .get("content_type")
+        .and_then(|v| v.as_str())
+        .map(|c| c.to_string());
+    (code, reason, body, content_type)
+}
+
+fn answer(channel: &ChannelRef, args: &serde_json::Value, final_response: bool) -> ControlResult {
+    let (default_code, default_reason) = if final_response { (200, "OK") } else { (183, "Session Progress") };
+    let (code, reason, body, content_type) = response_args(args, default_code, default_reason);
+
+    if final_response && !(200..300).contains(&code) {
+        return ControlResult::error(ControlErrorCode::BadRequest, "answer requires a 2xx code");
+    }
+    if !final_response && !(100..200).contains(&code) {
+        return ControlResult::error(ControlErrorCode::BadRequest, "progress requires a 1xx code");
+    }
+
+    let Some(invite_arc) = stored_invite(&channel.call_actor_id) else {
+        return ControlResult::error(ControlErrorCode::NotFound, "call is gone");
+    };
+    let Ok(invite) = invite_arc.lock() else {
+        return ControlResult::error(ControlErrorCode::Unavailable, "call invite lock poisoned");
+    };
+    let sent = if final_response {
+        crate::dispatcher::b2bua_answer_call(
+            &channel.call_actor_id,
+            &invite,
+            code,
+            &reason,
+            body,
+            content_type.as_deref(),
+        )
+    } else {
+        crate::dispatcher::b2bua_progress_call(
+            &channel.call_actor_id,
+            &invite,
+            code,
+            &reason,
+            body,
+            content_type.as_deref(),
+        )
+    };
+    if !sent {
+        return ControlResult::error(ControlErrorCode::NotFound, "call is gone");
+    }
+    let state = if final_response { "answered" } else { "ringing" };
+    ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "state": state, "code": code }))
+}
+
+fn reject(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let (code, reason, _, _) = response_args(args, 603, "Decline");
+    if !(300..700).contains(&code) {
+        return ControlResult::error(ControlErrorCode::BadRequest, "reject requires a 3xx-6xx code");
+    }
+    if crate::dispatcher::b2bua_reject_call(&channel.call_actor_id, code, &reason) {
+        ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "state": "terminated", "code": code }))
+    } else {
+        ControlResult::error(ControlErrorCode::NotFound, "call is gone")
+    }
+}
+
+fn hangup(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let reason = args.get("reason").and_then(|v| v.as_str());
+    let answered = crate::b2bua::actor::global_call_store()
+        .and_then(|store| {
+            store
+                .get_call(&channel.call_actor_id)
+                .map(|call| matches!(call.state, crate::b2bua::actor::CallState::Answered))
+        })
+        .unwrap_or(false);
+
+    let ok = if answered {
+        // Answered: BYE both legs via the full teardown funnel (Rf/Ro/CDR/media).
+        crate::dispatcher::b2bua_terminate_call(&channel.sip_call_id, reason)
+    } else {
+        // Unanswered/parked: send a final non-2xx and tear down (no B-leg to CANCEL
+        // in Phase 1's single-CallActor model).
+        crate::dispatcher::b2bua_reject_call(&channel.call_actor_id, 603, reason.unwrap_or("Decline"))
+    };
+    if ok {
+        ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "state": "terminated" }))
+    } else {
+        ControlResult::error(ControlErrorCode::NotFound, "call is gone")
+    }
+}
+
+fn refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let Some(to) = args.get("to").and_then(|v| v.as_str()) else {
+        return ControlResult::error(ControlErrorCode::BadRequest, "refer requires args.to");
+    };
+    if let Err(error) = crate::sip::parser::parse_uri_standalone(to) {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            format!("invalid refer target: {error}"),
+        );
+    }
+    let replaces = match parse_replaces_arg(args.get("replaces")) {
+        Ok(replaces) => replaces,
+        Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
+    };
+    let refer_to = crate::sip::headers::refer::ReferTo {
+        uri: to.to_string(),
+        replaces,
+    };
+    if crate::dispatcher::b2bua_refer_call(&channel.sip_call_id, refer_to) {
+        ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "refer": "sent" }))
+    } else {
+        ControlResult::error(ControlErrorCode::NotFound, "call is gone")
+    }
+}
+
+/// Parse an optional `replaces` arg (`{call_id, from_tag, to_tag, early_only?}`).
+fn parse_replaces_arg(
+    value: Option<&serde_json::Value>,
+) -> Result<Option<crate::sip::headers::refer::Replaces>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let field = |key: &str| -> Result<String, String> {
+        value
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| format!("replaces requires a string '{key}'"))
+    };
+    Ok(Some(crate::sip::headers::refer::Replaces {
+        call_id: field("call_id")?,
+        from_tag: field("from_tag")?,
+        to_tag: field("to_tag")?,
+        early_only: value
+            .get("early_only")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    }))
+}
+
+fn set_header(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let (Some(name), Some(header_value)) = (
+        args.get("name").and_then(|v| v.as_str()),
+        args.get("value").and_then(|v| v.as_str()),
+    ) else {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "set_header requires args.name and args.value",
+        );
+    };
+    let Some(invite_arc) = stored_invite(&channel.call_actor_id) else {
+        return ControlResult::error(ControlErrorCode::NotFound, "call is gone");
+    };
+    let Ok(mut invite) = invite_arc.lock() else {
+        return ControlResult::error(ControlErrorCode::Unavailable, "call invite lock poisoned");
+    };
+    invite.headers.set(name, header_value.to_string());
+    ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "header": name }))
+}
+
+fn get_header(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let Some(name) = args.get("name").and_then(|v| v.as_str()) else {
+        return ControlResult::error(ControlErrorCode::BadRequest, "get_header requires args.name");
+    };
+    let Some(invite_arc) = stored_invite(&channel.call_actor_id) else {
+        return ControlResult::error(ControlErrorCode::NotFound, "call is gone");
+    };
+    let Ok(invite) = invite_arc.lock() else {
+        return ControlResult::error(ControlErrorCode::Unavailable, "call invite lock poisoned");
+    };
+    let value = invite.headers.get(name).cloned();
+    ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "header": name, "value": value }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel() -> ChannelRef {
+        ChannelRef {
+            channel_id: "ch1".to_string(),
+            call_actor_id: "call-uuid".to_string(),
+            sip_call_id: "sipcid@host".to_string(),
+            app: "ivr-app".to_string(),
+        }
+    }
+
+    #[test]
+    fn module_is_sip() {
+        assert_eq!(SipControlAdapter::new().module(), "sip");
+    }
+
+    #[test]
+    fn describe_lists_core_verbs() {
+        let schema = SipControlAdapter::new().describe();
+        assert_eq!(schema.module, "sip");
+        let verbs: Vec<&str> = schema.verbs.iter().map(|v| v.verb.as_str()).collect();
+        for expected in ["answer", "progress", "reject", "hangup", "refer"] {
+            assert!(verbs.contains(&expected), "missing verb {expected}");
+        }
+    }
+
+    #[test]
+    fn verb_without_channel_target_is_bad_request() {
+        let result = apply_sip(AdapterCommand {
+            verb: "answer".to_string(),
+            args: serde_json::json!({}),
+            target: ResolvedTarget::None,
+        });
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_verb_is_unsupported() {
+        let result = apply_sip(AdapterCommand {
+            verb: "teleport".to_string(),
+            args: serde_json::json!({}),
+            target: ResolvedTarget::Channel(channel()),
+        });
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::UnsupportedVerb, .. }
+        ));
+    }
+
+    #[test]
+    fn media_verb_is_unsupported_not_a_hang() {
+        for verb in ["play", "stop", "dtmf", "collect_dtmf"] {
+            let result = apply_sip(AdapterCommand {
+                verb: verb.to_string(),
+                args: serde_json::json!({}),
+                target: ResolvedTarget::Channel(channel()),
+            });
+            assert!(
+                matches!(result, ControlResult::Error { code: ControlErrorCode::UnsupportedVerb, .. }),
+                "verb {verb} should be a typed unsupported error"
+            );
+        }
+    }
+
+    #[test]
+    fn answer_rejects_non_2xx_before_touching_the_store() {
+        // No call store in a unit context; a bad code must be caught first so
+        // this returns bad_request, not a store lookup.
+        let result = answer(&channel(), &serde_json::json!({ "code": 486 }), true);
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn refer_without_target_is_bad_request() {
+        let result = refer(&channel(), &serde_json::json!({}));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn dead_call_returns_not_found_never_hangs() {
+        // With no global call store installed, stored_invite() is None → the
+        // synchronous core returns not_found immediately (it cannot await a far
+        // end — there is no far end to await).
+        let result = answer(&channel(), &serde_json::json!({ "code": 200 }), true);
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[test]
+    fn parse_replaces_arg_roundtrips() {
+        let value = serde_json::json!({
+            "call_id": "abc", "from_tag": "ft", "to_tag": "tt", "early_only": true
+        });
+        let replaces = parse_replaces_arg(Some(&value)).unwrap().unwrap();
+        assert_eq!(replaces.call_id, "abc");
+        assert!(replaces.early_only);
+        assert!(parse_replaces_arg(None).unwrap().is_none());
+        assert!(parse_replaces_arg(Some(&serde_json::Value::Null)).unwrap().is_none());
+    }
+}

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11164,6 +11164,21 @@ fn b2bua_advance_route(
 /// [`CallActorStore::remove_call_after_cancel`] (so a 2xx that raced our CANCEL
 /// is still ACK+BYEd). Driven from [`sweep_stale_entries`].
 fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
+    // Control-plane handoff deadline: a call parked under external control whose
+    // controller never accepted + acted in time. Apply the parked default action
+    // (503) instead of the 408 answer-timeout path.
+    let handoff = state
+        .call_actors
+        .get_call(call_id)
+        .map(|call| (call.is_handoff_pending(), call.control_app.clone().unwrap_or_default()));
+    if let Some((true, app)) = handoff {
+        warn!(call_id = %call_id, %app, "control plane: handoff deadline — no controller acted, applying default (503)");
+        crate::metrics::try_metrics()
+            .inspect(|m| m.control_handoff_timeouts_total.with_label_values(&[&app]).inc());
+        b2bua_reject_call(call_id, 503, "No Controller Response");
+        return;
+    }
+
     // Snapshot everything needed, then drop the DashMap ref before the CANCEL
     // sends, Python, and the A-leg response.
     let (a_leg, a_leg_invite, a_leg_local_addr, cancel_targets, handle_txs) =
@@ -11320,6 +11335,9 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
 
     // RTPEngine safety-net cleanup (mirrors the B-leg failure path).
     let a_sip_call_id = a_leg.dialog.call_id.clone();
+    // Control plane: emit StasisEnd for a controlled call that failed (no-op
+    // otherwise).
+    control_notify_terminated(&a_sip_call_id, "failed");
     if let (Some(rtpengine_set), Some(media_sessions)) =
         (&state.rtpengine_set, &state.rtpengine_sessions)
     {
@@ -11849,7 +11867,163 @@ fn handle_b2bua_invite(
             // confirmed and @b2bua.on_bye takes over when the UAC BYEs.
             debug!(call_id = %call_id, "B2BUA: UAS-mode answer already sent (imperative)");
         }
+        CallAction::Handover { app, on_lost, deadline_ms, vars, answer } => {
+            control_handover(
+                &call_id,
+                &message_guard,
+                &inbound,
+                &app,
+                on_lost.as_deref(),
+                deadline_ms,
+                vars,
+                answer,
+                state,
+            );
+        }
     }
+}
+
+/// Park a call under external control (`call.handover("app")`): hold the INVITE
+/// transaction un-dialed, send a keep-alive `180`, register the call with the
+/// control plane, emit `StasisStart` with the full SIP context, and arm the
+/// handoff deadline. If no controller is available (or the control plane is not
+/// configured), the handoff default action fires immediately — never a silent
+/// black-hole.
+#[allow(clippy::too_many_arguments)]
+fn control_handover(
+    call_id: &str,
+    invite: &SipMessage,
+    inbound: &InboundMessage,
+    app: &str,
+    on_lost: Option<&str>,
+    deadline_ms: Option<u64>,
+    vars: std::collections::HashMap<String, String>,
+    answer: bool,
+    state: &DispatcherState,
+) {
+    let Some(bus) = crate::control::ControlBus::global() else {
+        warn!(call_id = %call_id, %app, "handover requested but control plane is not configured — rejecting 503");
+        let response = build_response(invite, 503, "Service Unavailable", state.server_header.as_deref(), &[]);
+        send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
+        state.call_actors.remove_call(call_id);
+        state.call_event_receivers.remove(call_id);
+        return;
+    };
+    if !bus.app_configured(app) {
+        warn!(call_id = %call_id, %app, "handover to an unknown control app — rejecting 503");
+        let response = build_response(invite, 503, "Service Unavailable", state.server_header.as_deref(), &[]);
+        send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
+        state.call_actors.remove_call(call_id);
+        state.call_event_receivers.remove(call_id);
+        return;
+    }
+
+    // Answer-first (AI-park) mode binds to answer_local(profile="voice_ai",
+    // ws_uri=…) + a 200 OK — the media-anchor round-trip that lands with the
+    // demo WP's media plumbing. It is NOT wired in this build. Rather than fake
+    // a 200 (which would commit the call + start CDR answer-time without media),
+    // degrade honestly to deferred parking with a loud warning: the controller
+    // still receives the call and can answer it with the `answer` verb.
+    // TODO(control): wire answer-first — MediaBackend::answer_local → 200 OK with
+    // the synthesized SDP, gated to the siphon-rtp backend, before offer_channel.
+    if answer {
+        warn!(
+            call_id = %call_id,
+            %app,
+            "handover(answer=True): answer-first (AI-park) mode is not yet wired \
+             (needs the answer_local voice_ai media round-trip) — parking the call \
+             un-answered instead; the controller must answer it via the `answer` verb"
+        );
+    }
+
+    let sip_call_id = invite.headers.call_id().cloned().unwrap_or_default();
+    let channel_id = format!("ch-{call_id}");
+    let stasis_payload = build_stasis_payload(invite, inbound, &vars);
+
+    // Park the call: record the control owner + mark it awaiting the controller's
+    // first action. Send NO synthesized provisional — the caller's INVITE
+    // transaction is already kept alive by the automatic 100 Trying the
+    // transaction layer sent (client txn in Proceeding — Timer A stopped, Timer B
+    // cancelled). A 180 here would falsely tell the caller a phone is ringing when
+    // nothing has been dialed yet; the real 18x/early-media relay end-to-end from
+    // the downstream carrier once the app routes (Phase 2), and the app may
+    // explicitly send a provisional via the `progress` verb — never automatic.
+    state.call_actors.set_control_owner(call_id, app, on_lost);
+    state.call_actors.set_state(call_id, CallState::Ringing);
+
+    let outcome = bus.offer_channel(
+        app,
+        &channel_id,
+        call_id,
+        &sip_call_id,
+        on_lost.unwrap_or("hangup"),
+        vars,
+        stasis_payload,
+    );
+
+    match outcome {
+        crate::control::OfferOutcome::Assigned | crate::control::OfferOutcome::Dialing => {
+            let deadline_ms = deadline_ms.unwrap_or_else(|| bus.handoff_deadline_ms());
+            if deadline_ms > 0 {
+                let deadline = std::time::Instant::now()
+                    + std::time::Duration::from_millis(deadline_ms);
+                state.call_actors.set_answer_deadline(call_id, deadline);
+            }
+            info!(call_id = %call_id, %app, channel = %channel_id, "B2BUA: call handed over to control plane");
+        }
+        crate::control::OfferOutcome::NoController => {
+            warn!(call_id = %call_id, %app, "handover: no controller available — applying default (503)");
+            crate::metrics::try_metrics()
+                .inspect(|m| m.control_handoff_timeouts_total.with_label_values(&[app]).inc());
+            // Send the final response ourselves (a 180 already went out).
+            b2bua_reject_call(call_id, 503, "No Controller Available");
+        }
+    }
+}
+
+/// Build the `StasisStart` payload: the full SIP context (all headers, source,
+/// R-URI shape, body) + the handover vars. Requirement #5 — the controller sees
+/// the real headers, not a normalized summary.
+fn build_stasis_payload(
+    invite: &SipMessage,
+    inbound: &InboundMessage,
+    vars: &std::collections::HashMap<String, String>,
+) -> serde_json::Value {
+    let (method, ruri) = match &invite.start_line {
+        StartLine::Request(request_line) => (
+            request_line.method.as_str().to_string(),
+            request_line.request_uri.to_string(),
+        ),
+        _ => (String::new(), String::new()),
+    };
+    let mut headers: Vec<[String; 2]> = Vec::new();
+    for (name, values) in invite.headers.iter_original() {
+        for value in values {
+            headers.push([name.clone(), value.clone()]);
+        }
+    }
+    let body = if invite.body.is_empty() {
+        None
+    } else {
+        // SDP is text; surface it directly when valid UTF-8 (avoids a base64 dep
+        // on the control rail). Non-text bodies report their length only.
+        match std::str::from_utf8(&invite.body) {
+            Ok(text) => Some(serde_json::json!({ "content_type": invite.headers.get("Content-Type").cloned(), "text": text })),
+            Err(_) => Some(serde_json::json!({ "content_type": invite.headers.get("Content-Type").cloned(), "bytes": invite.body.len() })),
+        }
+    };
+    serde_json::json!({
+        "invite": {
+            "method": method,
+            "ruri": ruri,
+            "headers": headers,
+            "body": body,
+        },
+        "source_ip": inbound.remote_addr.ip().to_string(),
+        "source_port": inbound.remote_addr.port(),
+        "transport": format!("{}", inbound.transport).to_lowercase(),
+        "vars": vars,
+    })
 }
 
 /// Build the B-leg Contact header value.
@@ -15612,15 +15786,21 @@ fn handle_b2bua_bye(
     };
 
     // Extract the rest from the DashMap ref and drop it before entering Python
-    let (a_leg_invite, a_leg_source_ip, a_leg_transport) =
+    let (a_leg_invite, a_leg_source_ip, a_leg_transport, a_leg_call_id) =
         match state.call_actors.get_call(&call_id) {
             Some(call) => (
                 call.a_leg_invite.clone(),
                 call.a_leg.transport.remote_addr.ip().to_string(),
                 format!("{}", call.a_leg.transport.transport).to_lowercase(),
+                call.a_leg.dialog.call_id.clone(),
             ),
             None => return,
         };
+
+    // Control plane: emit StasisEnd if this call was controlled (keyed on the
+    // A-leg Call-ID, so a BYE from either leg reaches the owning app). No-op
+    // otherwise.
+    control_notify_terminated(&a_leg_call_id, "bye");
 
     // Invoke @b2bua.on_bye handlers with (PyCall, PyByeInitiator)
     let engine_state = state.engine.state();
@@ -16251,12 +16431,84 @@ fn b2bua_terminate_call_inner(
     // SIPREC: stop any active recording sessions for this call.
     b2bua_stop_siprec(internal_call_id, state);
 
+    // Control plane: emit StasisEnd + drop the channel if this call was
+    // controlled (no-op otherwise).
+    control_notify_terminated(&sip_call_id, reason_header.unwrap_or("terminated"));
+
     state.call_actors.set_state(internal_call_id, CallState::Terminated);
     // remove_call sends Shutdown to any remaining actors, cleans up registry,
     // and moves re-INVITE tracking entries to the zombie map.
     state.call_actors.remove_call(internal_call_id);
     state.call_event_receivers.remove(internal_call_id);
     schedule_zombie_reinvite_cleanup(&state.call_actors);
+    true
+}
+
+/// Emit a control-plane `StasisEnd` for a controlled call at teardown (no-op
+/// when the control plane isn't configured or the call isn't controlled).
+fn control_notify_terminated(sip_call_id: &str, reason: &str) {
+    if let Some(bus) = crate::control::ControlBus::global() {
+        bus.on_call_terminated(sip_call_id, reason);
+    }
+}
+
+/// Imperatively reject / tear down a *controlled* B2BUA call that has not been
+/// answered (a parked call the app declined, the handoff deadline elapsing, or a
+/// hangup of an unanswered call). Sends a final non-2xx to the A-leg (tagged to
+/// the A-leg dialog), finalizes the CDR as failed, emits `StasisEnd`, and removes
+/// the call. Returns `false` (never panics) when the call is gone / dispatcher
+/// down. Distinct from [`b2bua_terminate_call`] (which BYEs an *answered* call).
+pub fn b2bua_reject_call(internal_call_id: &str, code: u16, reason: &str) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let state = &control.state;
+    let (invite_arc, transport, remote_addr, connection_id, local_addr, local_tag, sip_call_id) =
+        match state.call_actors.get_call(internal_call_id) {
+            Some(call) => (
+                call.a_leg_invite.clone(),
+                call.a_leg.transport.transport,
+                call.a_leg.transport.remote_addr,
+                call.a_leg.transport.connection_id,
+                call.a_leg_local_addr,
+                call.a_leg.dialog.local_tag.clone(),
+                call.a_leg.dialog.call_id.clone(),
+            ),
+            None => return false,
+        };
+    let Some(invite_arc) = invite_arc else {
+        return false;
+    };
+    let _enter = control.runtime.enter();
+    let Ok(invite) = invite_arc.lock() else {
+        error!(call_id = %internal_call_id, "b2bua_reject_call: invite lock poisoned");
+        return false;
+    };
+
+    // RFC 3261 §12.1.1: tag the To header with the A-leg dialog local_tag so the
+    // final response terminates the same dialog the 180 opened.
+    let mut reply_headers: Vec<(crate::script::api::request::ReplyHeaderOp, String, String)> =
+        Vec::new();
+    if let Some(to_value) = invite.headers.to() {
+        if !to_value.contains(";tag=") {
+            reply_headers.push((
+                crate::script::api::request::ReplyHeaderOp::Replace,
+                "To".to_string(),
+                crate::b2bua::actor::ensure_tag(to_value, Some(&local_tag)),
+            ));
+        }
+    }
+    let response =
+        build_response(&invite, code, reason, state.server_header.as_deref(), &reply_headers);
+    drop(invite);
+    send_message_from(response, transport, remote_addr, connection_id, local_addr, state);
+
+    if crate::cdr::auto_emit_enabled() {
+        cdr_finalize_b2bua_fail(state, internal_call_id, code);
+    }
+    control_notify_terminated(&sip_call_id, reason);
+    state.call_actors.remove_call(internal_call_id);
+    state.call_event_receivers.remove(internal_call_id);
     true
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -10886,6 +10886,13 @@ fn handle_b2bua_cancel(
         state,
     );
 
+    // Control plane: a handed-over call CANCELled before the controller acted is
+    // the same teardown the answered/failed paths hook — emit StasisEnd + drop
+    // the ControlBus channel so the owning app learns to abort and no owner
+    // entry leaks (keyed on the A-leg Call-ID == this CANCEL's Call-ID; no-op for
+    // an uncontrolled call).
+    control_notify_terminated(&sip_call_id, "cancelled");
+
     // CDR: the caller CANCELled before answer (cdr.auto_emit) → 487.
     cdr_finalize_b2bua_fail(state, &call_id, 487);
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11874,89 +11874,111 @@ fn handle_b2bua_invite(
             // confirmed and @b2bua.on_bye takes over when the UAC BYEs.
             debug!(call_id = %call_id, "B2BUA: UAS-mode answer already sent (imperative)");
         }
-        CallAction::Handover { app, on_lost, deadline_ms, vars, answer } => {
+        CallAction::Handover { app, on_lost, deadline_ms, vars, answer, profile, ws_uri } => {
             control_handover(
                 &call_id,
                 &message_guard,
                 &inbound,
-                &app,
-                on_lost.as_deref(),
-                deadline_ms,
-                vars,
-                answer,
+                ControlHandoverParams {
+                    app: &app,
+                    on_lost: on_lost.as_deref(),
+                    deadline_ms,
+                    vars,
+                    answer,
+                    profile: profile.as_deref(),
+                    ws_uri: ws_uri.as_deref(),
+                },
                 state,
             );
         }
     }
 }
 
-/// Park a call under external control (`call.handover("app")`): hold the INVITE
-/// transaction un-dialed, send a keep-alive `180`, register the call with the
-/// control plane, emit `StasisStart` with the full SIP context, and arm the
-/// handoff deadline. If no controller is available (or the control plane is not
-/// configured), the handoff default action fires immediately — never a silent
-/// black-hole.
-#[allow(clippy::too_many_arguments)]
+/// Parameters for [`control_handover`], grouped to keep the arity sane.
+struct ControlHandoverParams<'a> {
+    app: &'a str,
+    on_lost: Option<&'a str>,
+    deadline_ms: Option<u64>,
+    vars: std::collections::HashMap<String, String>,
+    /// Answer-first (AI-park): answer + anchor media before handing over.
+    answer: bool,
+    /// Answer-first only: media profile (default `voice_ai`).
+    profile: Option<&'a str>,
+    /// Answer-first only: per-call WS bridge URI (templated).
+    ws_uri: Option<&'a str>,
+}
+
+/// Hand a call over to external control (`call.handover(...)`).
+///
+/// **Deferred mode** (`answer=false`): hold the INVITE transaction un-dialed
+/// (kept alive by the automatic 100 Trying — no synthesized provisional),
+/// register the call with the control plane, emit `StasisStart`, and arm the
+/// handoff deadline. **Answer-first / AI-park** (`answer=true`): answer `200 OK`
+/// with an `answer_local`-synthesized SDP that anchors the A-leg media to the
+/// `voice_ai` WebSocket bridge, THEN register — the controller drives an already
+/// -connected channel with the AI audio path open. If no controller is available
+/// (or control is not configured) the handoff default fires immediately — never a
+/// silent black-hole. Answer-first on a backend that cannot `answer_local`
+/// (anything but siphon-rtp) is a hard, visible failure (503) — never a fake 200.
 fn control_handover(
     call_id: &str,
     invite: &SipMessage,
     inbound: &InboundMessage,
-    app: &str,
-    on_lost: Option<&str>,
-    deadline_ms: Option<u64>,
-    vars: std::collections::HashMap<String, String>,
-    answer: bool,
+    params: ControlHandoverParams<'_>,
     state: &DispatcherState,
 ) {
-    let Some(bus) = crate::control::ControlBus::global() else {
-        warn!(call_id = %call_id, %app, "handover requested but control plane is not configured — rejecting 503");
-        let response = build_response(invite, 503, "Service Unavailable", state.server_header.as_deref(), &[]);
+    let ControlHandoverParams { app, on_lost, deadline_ms, vars, answer, profile, ws_uri } = params;
+
+    let reject_and_drop = |code: u16, reason: &str| {
+        let response = build_response(invite, code, reason, state.server_header.as_deref(), &[]);
         send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
         state.call_actors.remove_call(call_id);
         state.call_event_receivers.remove(call_id);
+    };
+
+    let Some(bus) = crate::control::ControlBus::global() else {
+        warn!(call_id = %call_id, %app, "handover requested but control plane is not configured — rejecting 503");
+        reject_and_drop(503, "Service Unavailable");
         return;
     };
     if !bus.app_configured(app) {
         warn!(call_id = %call_id, %app, "handover to an unknown control app — rejecting 503");
-        let response = build_response(invite, 503, "Service Unavailable", state.server_header.as_deref(), &[]);
-        send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
-        state.call_actors.remove_call(call_id);
-        state.call_event_receivers.remove(call_id);
+        reject_and_drop(503, "Service Unavailable");
         return;
     }
 
-    // Answer-first (AI-park) mode binds to answer_local(profile="voice_ai",
-    // ws_uri=…) + a 200 OK — the media-anchor round-trip that lands with the
-    // demo WP's media plumbing. It is NOT wired in this build. Rather than fake
-    // a 200 (which would commit the call + start CDR answer-time without media),
-    // degrade honestly to deferred parking with a loud warning: the controller
-    // still receives the call and can answer it with the `answer` verb.
-    // TODO(control): wire answer-first — MediaBackend::answer_local → 200 OK with
-    // the synthesized SDP, gated to the siphon-rtp backend, before offer_channel.
+    // Answer-first: synthesize the RFC 3264 answer + anchor media BEFORE handing
+    // over. On any failure (no siphon-rtp backend, profile/flag/ws_uri error, or
+    // engine error) reject visibly — a script asking for answer-first on a
+    // backend that can't must fail, never fake a 200.
     if answer {
-        warn!(
-            call_id = %call_id,
-            %app,
-            "handover(answer=True): answer-first (AI-park) mode is not yet wired \
-             (needs the answer_local voice_ai media round-trip) — parking the call \
-             un-answered instead; the controller must answer it via the `answer` verb"
-        );
+        match answer_first_anchor(call_id, invite, inbound, profile, ws_uri, state) {
+            Ok(()) => {
+                // b2bua_answer_call set the A-leg to Answered + stamped the CDR
+                // answer time; the media now flows to the voice_ai bridge.
+                info!(call_id = %call_id, %app, "B2BUA: answer-first handover — 200 OK sent, media anchored to voice_ai bridge");
+            }
+            Err(reason) => {
+                warn!(call_id = %call_id, %app, %reason, "handover(answer=True) failed — rejecting 503 (no fake 200)");
+                reject_and_drop(503, "AI Media Unavailable");
+                return;
+            }
+        }
     }
 
     let sip_call_id = invite.headers.call_id().cloned().unwrap_or_default();
     let channel_id = format!("ch-{call_id}");
     let stasis_payload = build_stasis_payload(invite, inbound, &vars);
 
-    // Park the call: record the control owner + mark it awaiting the controller's
-    // first action. Send NO synthesized provisional — the caller's INVITE
-    // transaction is already kept alive by the automatic 100 Trying the
-    // transaction layer sent (client txn in Proceeding — Timer A stopped, Timer B
-    // cancelled). A 180 here would falsely tell the caller a phone is ringing when
-    // nothing has been dialed yet; the real 18x/early-media relay end-to-end from
-    // the downstream carrier once the app routes (Phase 2), and the app may
-    // explicitly send a provisional via the `progress` verb — never automatic.
+    // Record the control owner + mark awaiting the controller's first action. In
+    // deferred mode send NO synthesized provisional — the caller's INVITE txn is
+    // already kept alive by the automatic 100 Trying (a 180 would falsely signal
+    // ringing before anything is dialed); the app sends its own via `progress`.
+    // In answer-first mode the 200 already went out and the state is Answered.
     state.call_actors.set_control_owner(call_id, app, on_lost);
-    state.call_actors.set_state(call_id, CallState::Ringing);
+    if !answer {
+        state.call_actors.set_state(call_id, CallState::Ringing);
+    }
 
     let outcome = bus.offer_channel(
         app,
@@ -11970,22 +11992,217 @@ fn control_handover(
 
     match outcome {
         crate::control::OfferOutcome::Assigned | crate::control::OfferOutcome::Dialing => {
-            let deadline_ms = deadline_ms.unwrap_or_else(|| bus.handoff_deadline_ms());
-            if deadline_ms > 0 {
-                let deadline = std::time::Instant::now()
-                    + std::time::Duration::from_millis(deadline_ms);
-                state.call_actors.set_answer_deadline(call_id, deadline);
+            // A handoff deadline only applies to a *parked, un-answered* call
+            // (deferred mode) — the sweep degrades it if no controller acts. An
+            // answer-first call is already answered + media-anchored (a real
+            // call), so it is driven by the AI on its own timeline; control-loss
+            // (owner disconnect) still applies via `on_lost`.
+            if !answer {
+                let deadline_ms = deadline_ms.unwrap_or_else(|| bus.handoff_deadline_ms());
+                if deadline_ms > 0 {
+                    let deadline = std::time::Instant::now()
+                        + std::time::Duration::from_millis(deadline_ms);
+                    state.call_actors.set_answer_deadline(call_id, deadline);
+                }
             }
-            info!(call_id = %call_id, %app, channel = %channel_id, "B2BUA: call handed over to control plane");
+            info!(call_id = %call_id, %app, channel = %channel_id, answer, "B2BUA: call handed over to control plane");
         }
         crate::control::OfferOutcome::NoController => {
-            warn!(call_id = %call_id, %app, "handover: no controller available — applying default (503)");
+            warn!(call_id = %call_id, %app, answer, "handover: no controller available — applying default");
             crate::metrics::try_metrics()
                 .inspect(|m| m.control_handoff_timeouts_total.with_label_values(&[app]).inc());
-            // Send the final response ourselves (a 180 already went out).
-            b2bua_reject_call(call_id, 503, "No Controller Available");
+            if answer {
+                // The call was already answered + media-anchored; there is no
+                // controller to drive it, so tear it down cleanly (BYE + media
+                // delete + StasisEnd) rather than leave an orphaned answered call.
+                b2bua_terminate_call(&sip_call_id, Some("no control app connected"));
+            } else {
+                b2bua_reject_call(call_id, 503, "No Controller Available");
+            }
         }
     }
+}
+
+/// Answer-first media anchor: resolve the profile (`voice_ai` by default),
+/// template the per-call `ws_uri`, `answer_local` the A-leg offer to synthesize
+/// the RFC 3264 answer with the media engine as the far side, record the media
+/// session, and send the `200 OK` with that SDP. Returns `Err(reason)` (a short
+/// human string) on any failure so the caller rejects the handover visibly
+/// instead of faking a 200. Reuses #131's `expand_ws_uri` + the profile registry
+/// — no duplicated media logic.
+fn answer_first_anchor(
+    call_id: &str,
+    invite: &SipMessage,
+    inbound: &InboundMessage,
+    profile: Option<&str>,
+    ws_uri: Option<&str>,
+    state: &DispatcherState,
+) -> Result<(), String> {
+    let Some(backend) = state.rtpengine_set.as_ref() else {
+        return Err("answer-first requires a media backend (media.backend), none configured".to_string());
+    };
+    let Some(registry) = state.rtpengine_profiles.as_ref() else {
+        return Err("answer-first requires media profiles, none configured".to_string());
+    };
+
+    // Resolve + validate the media plan (backend gate, profile, ws_uri template,
+    // capability check) — pure, unit-tested. No I/O here.
+    let plan = answer_first_prepare(
+        invite,
+        inbound.remote_addr.ip(),
+        backend,
+        registry,
+        profile,
+        ws_uri,
+    )?;
+
+    // Media round-trip on the SIP-processing path (block_in_place is consistent
+    // with the existing B2BUA answer paths — NOT the control-command path).
+    let answer_sdp = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(backend.answer_local(
+            &plan.media_call_id,
+            &plan.from_tag,
+            &plan.offer_sdp,
+            &plan.flags,
+        ))
+    })
+    .map_err(|error| format!("answer_local failed: {error}"))?;
+
+    // Record the media session (so a later delete / control-app media correlation
+    // works), exactly as rtpengine.offer / answer_local do.
+    if let Some(sessions) = state.rtpengine_sessions.as_ref() {
+        sessions.insert(crate::rtpengine::session::MediaSession {
+            rtpengine_call_id: plan.media_call_id.clone(),
+            call_id: plan.media_call_id.clone(),
+            from_tag: plan.from_tag.clone(),
+            to_tag: None,
+            profile: plan.profile_name.clone(),
+            ws_uri: plan.flags.ws_uri.clone(),
+            created_at: std::time::Instant::now(),
+        });
+    }
+
+    // Send the 200 OK with the synthesized answer SDP (marks the A-leg Answered +
+    // stamps the CDR answer time).
+    if !b2bua_answer_call(
+        call_id,
+        invite,
+        200,
+        "OK",
+        Some(answer_sdp.into_bytes()),
+        Some("application/sdp"),
+    ) {
+        return Err("failed to send 200 OK (call gone / dispatcher down)".to_string());
+    }
+    Ok(())
+}
+
+/// The resolved, validated plan for an answer-first media anchor.
+#[derive(Debug)]
+struct AnswerFirstPlan {
+    flags: crate::rtpengine::NgFlags,
+    media_call_id: String,
+    from_tag: String,
+    offer_sdp: String,
+    profile_name: String,
+}
+
+/// Pure decision for answer-first: gate the backend (siphon-rtp only), resolve
+/// the profile (default `voice_ai`), template the per-call `ws_uri` with #131's
+/// expander, apply the `received_from` gate, and run the backend-capability
+/// check. Returns `Err(reason)` on any failure so the caller rejects the
+/// handover visibly instead of faking a 200. No I/O — unit-testable.
+fn answer_first_prepare(
+    invite: &SipMessage,
+    source_ip: std::net::IpAddr,
+    backend: &crate::rtpengine::MediaBackend,
+    registry: &crate::rtpengine::ProfileRegistry,
+    profile: Option<&str>,
+    ws_uri: Option<&str>,
+) -> Result<AnswerFirstPlan, String> {
+    // answer_local is siphon-rtp only — fail visibly on rtpengine/rtpproxy.
+    if !matches!(backend.kind(), crate::config::MediaBackendKind::SiphonRtp) {
+        return Err(format!(
+            "answer-first (voice_ai) requires the siphon-rtp media backend; media.backend is {}",
+            backend.kind().as_str()
+        ));
+    }
+    let profile_name = profile.unwrap_or("voice_ai");
+    let Some(entry) = registry.get(profile_name) else {
+        return Err(format!("unknown media profile '{profile_name}' for answer-first"));
+    };
+    let mut flags = entry.answer.clone();
+
+    // Identifiers off the A-leg INVITE (call_id / From-tag / From+To user parts).
+    let media_call_id = invite.headers.call_id().cloned().unwrap_or_default();
+    let from_tag = invite
+        .headers
+        .from()
+        .and_then(|from| {
+            from.split(';')
+                .find_map(|part| part.trim().strip_prefix("tag=").map(|tag| tag.to_string()))
+        })
+        .unwrap_or_default();
+    let user_of = |name: &str| -> Option<String> {
+        invite
+            .headers
+            .get(name)
+            .and_then(|value| crate::sip::headers::nameaddr::NameAddr::parse(value).ok())
+            .and_then(|nameaddr| nameaddr.uri.user)
+    };
+    let from_user = user_of("From");
+    let to_user = user_of("To");
+
+    // ws_uri precedence: explicit arg → profile's own → none. Template it with
+    // #131's expander (unknown/empty placeholder is an error, not a literal).
+    let ws_uri_template = ws_uri.map(str::to_string).or_else(|| flags.ws_uri.clone());
+    match ws_uri_template {
+        Some(template) => {
+            let context = crate::script::api::rtpengine::WsUriContext {
+                call_id: &media_call_id,
+                from_tag: &from_tag,
+                from_user: from_user.as_deref(),
+                to_user: to_user.as_deref(),
+            };
+            let expanded = crate::script::api::rtpengine::expand_ws_uri(&template, &context)
+                .map_err(|error| format!("ws_uri templating failed: {error:?}"))?;
+            flags.ws_uri = Some(expanded);
+        }
+        None => {
+            return Err(format!(
+                "answer-first profile '{profile_name}' has no ws_uri and none was passed — nowhere to bridge the AI audio"
+            ));
+        }
+    }
+
+    // received_from gate: pin media ingress to the caller's real source IP.
+    if flags.carry_received_from {
+        flags.received_from = Some(source_ip);
+    }
+
+    // Final backend-capability guard (mirrors finalise_flags) — should pass on
+    // siphon-rtp, but never answer a call whose flags the engine cannot honour.
+    let unsupported = backend.unsupported_flags(&flags);
+    if !unsupported.is_empty() {
+        return Err(format!(
+            "media profile '{profile_name}' sets {} which the {} backend cannot honour",
+            unsupported.join(", "),
+            backend.kind().as_str()
+        ));
+    }
+
+    let offer_sdp = String::from_utf8_lossy(&invite.body).into_owned();
+    if offer_sdp.trim().is_empty() {
+        return Err("answer-first requires an SDP offer on the INVITE; none present".to_string());
+    }
+
+    Ok(AnswerFirstPlan {
+        flags,
+        media_call_id,
+        from_tag,
+        offer_sdp,
+        profile_name: profile_name.to_string(),
+    })
 }
 
 /// Build the `StasisStart` payload: the full SIP context (all headers, source,
@@ -20288,6 +20505,150 @@ mod tests {
         let invite = parse_sip_message(raw).expect("test fixture must parse").1;
         assert!(!b2bua_answer_call("nope", &invite, 200, "OK", None, None));
         assert!(!b2bua_progress_call("nope", &invite, 183, "Session Progress", None, None));
+    }
+
+    // -----------------------------------------------------------------------
+    // Answer-first (AI-park) handover — the pure media-plan decision
+    // (`answer_first_prepare`): backend gate, profile resolution, ws_uri
+    // templating, honest failure. The I/O glue (answer_local round-trip +
+    // b2bua_answer_call) is thin over already-tested pieces.
+    // -----------------------------------------------------------------------
+
+    fn invite_with_offer(body: &[u8]) -> SipMessage {
+        let raw = concat!(
+            "INVITE sip:ai@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1\r\n",
+            "From: <sip:alice@example.com>;tag=alice-tag\r\n",
+            "To: <sip:ai@example.com>\r\n",
+            "Call-ID: call-abc@pc\r\n",
+            "CSeq: 1 INVITE\r\n",
+            "Max-Forwards: 70\r\n",
+            "Content-Type: application/sdp\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        );
+        let mut invite = parse_sip_message(raw).expect("answer-first fixture must parse").1;
+        invite.body = body.to_vec();
+        invite
+    }
+
+    fn siphon_rtp_backend() -> crate::rtpengine::MediaBackend {
+        // A native-backend handle over a dead address — `answer_first_prepare`
+        // never does I/O (only `kind()` / `unsupported_flags()`), so no server
+        // is needed. Construction spawns a connection task, hence #[tokio::test].
+        let (event_tx, _rx) = tokio::sync::mpsc::channel::<crate::rtpengine::events::RtpEngineEvent>(16);
+        let set = crate::rtpengine::siphon_rtp::SiphonRtpClientSet::new(
+            vec![("127.0.0.1:1".parse().unwrap(), 200, 1)],
+            None,
+            5_000,
+            event_tx,
+        )
+        .unwrap();
+        crate::rtpengine::MediaBackend::SiphonRtp(set)
+    }
+
+    fn local_ip() -> std::net::IpAddr {
+        "127.0.0.1".parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn answer_first_prepare_templates_ws_uri_on_siphon_rtp() {
+        let backend = siphon_rtp_backend();
+        let registry = crate::rtpengine::ProfileRegistry::new();
+        let invite = invite_with_offer(
+            b"v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio 40000 RTP/AVP 0\r\n",
+        );
+        let plan = answer_first_prepare(
+            &invite,
+            "203.0.113.7".parse().unwrap(),
+            &backend,
+            &registry,
+            None, // default voice_ai
+            Some("wss://ai.example/stream/{call_id}"),
+        )
+        .expect("prepare must succeed on siphon-rtp with a ws_uri");
+        assert_eq!(
+            plan.flags.ws_uri.as_deref(),
+            Some("wss://ai.example/stream/call-abc@pc"),
+            "ws_uri must be #131-templated"
+        );
+        assert_eq!(plan.from_tag, "alice-tag");
+        assert_eq!(plan.profile_name, "voice_ai");
+        assert!(!plan.offer_sdp.trim().is_empty());
+    }
+
+    #[tokio::test]
+    async fn answer_first_prepare_rejects_non_siphon_rtp_backend() {
+        // The honest-failure case: answer-first on rtpengine must NOT fake a 200.
+        let set = crate::rtpengine::client::RtpEngineSet::new(vec![(
+            "127.0.0.1:1".parse().unwrap(),
+            200,
+            1,
+        )])
+        .await
+        .unwrap();
+        let backend = crate::rtpengine::MediaBackend::RtpEngine(std::sync::Arc::new(set));
+        let registry = crate::rtpengine::ProfileRegistry::new();
+        let invite = invite_with_offer(b"v=0\r\n");
+        let error = answer_first_prepare(
+            &invite,
+            local_ip(),
+            &backend,
+            &registry,
+            None,
+            Some("wss://ai/{call_id}"),
+        )
+        .unwrap_err();
+        assert!(error.contains("siphon-rtp"), "expected a backend-gate error, got: {error}");
+    }
+
+    #[tokio::test]
+    async fn answer_first_prepare_requires_ws_uri() {
+        // The built-in voice_ai profile leaves ws_uri deliberately unset (#131);
+        // with none passed there is nowhere to bridge — a hard error.
+        let backend = siphon_rtp_backend();
+        let registry = crate::rtpengine::ProfileRegistry::new();
+        let invite = invite_with_offer(b"v=0\r\n");
+        let error =
+            answer_first_prepare(&invite, local_ip(), &backend, &registry, None, None).unwrap_err();
+        assert!(
+            error.contains("ws_uri") || error.contains("bridge"),
+            "expected a missing-ws_uri error, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn answer_first_prepare_unknown_profile() {
+        let backend = siphon_rtp_backend();
+        let registry = crate::rtpengine::ProfileRegistry::new();
+        let invite = invite_with_offer(b"v=0\r\n");
+        let error = answer_first_prepare(
+            &invite,
+            local_ip(),
+            &backend,
+            &registry,
+            Some("does-not-exist"),
+            Some("wss://ai"),
+        )
+        .unwrap_err();
+        assert!(error.contains("unknown media profile"), "got: {error}");
+    }
+
+    #[tokio::test]
+    async fn answer_first_prepare_requires_sdp_offer() {
+        let backend = siphon_rtp_backend();
+        let registry = crate::rtpengine::ProfileRegistry::new();
+        let invite = invite_with_offer(b""); // no offer body
+        let error = answer_first_prepare(
+            &invite,
+            local_ip(),
+            &backend,
+            &registry,
+            None,
+            Some("wss://ai"),
+        )
+        .unwrap_err();
+        assert!(error.contains("SDP offer"), "got: {error}");
     }
 
     /// Save a stream P-CSCF cache binding directly against a bare `Registrar`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod b2bua;
 pub mod cache;
 pub mod config;
+pub mod control;
 pub mod cors;
 pub mod diameter;
 pub mod dialog;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -253,6 +253,22 @@ pub struct SiphonMetrics {
     /// Number of arenas (heaps). Each is a ~64 MB reservation; a rising count
     /// is per-thread-arena proliferation under free-threaded concurrency.
     pub glibc_arena_count: IntGauge,
+
+    // --- External remote-control plane ---
+    /// Live control-plane connections per app (drains to 0 on disconnect).
+    pub control_connections: IntGaugeVec,
+    /// Live controlled calls (handed over, not yet ended) per app — a
+    /// drain-to-zero gauge, the control-plane analogue of proxy_dialog_sessions.
+    pub control_controlled_calls: IntGaugeVec,
+    /// Commands applied, by app + verb.
+    pub control_commands_total: IntCounterVec,
+    /// Events dropped by slow-consumer backpressure, by app.
+    pub control_events_dropped_total: IntCounterVec,
+    /// Control-plane auth failures (bad/missing token on the upgrade).
+    pub control_auth_failures_total: IntCounter,
+    /// Handoff deadlines that fired (no controller accepted + acted in time),
+    /// by app.
+    pub control_handoff_timeouts_total: IntCounterVec,
 }
 
 impl SiphonMetrics {
@@ -533,7 +549,47 @@ impl SiphonMetrics {
             "Number of glibc malloc arenas (each a ~64 MB reservation; rises with per-thread contention)",
         )?;
 
+        let control_connections = IntGaugeVec::new(
+            Opts::new("siphon_control_connections", "Live control-plane connections per app"),
+            &["app"],
+        )?;
+        let control_controlled_calls = IntGaugeVec::new(
+            Opts::new(
+                "siphon_control_controlled_calls",
+                "Live controlled calls per app (handed over, not yet ended)",
+            ),
+            &["app"],
+        )?;
+        let control_commands_total = IntCounterVec::new(
+            Opts::new("siphon_control_commands_total", "Control-plane commands applied"),
+            &["app", "verb"],
+        )?;
+        let control_events_dropped_total = IntCounterVec::new(
+            Opts::new(
+                "siphon_control_events_dropped_total",
+                "Control-plane events dropped by slow-consumer backpressure",
+            ),
+            &["app"],
+        )?;
+        let control_auth_failures_total = IntCounter::new(
+            "siphon_control_auth_failures_total",
+            "Control-plane auth failures (bad/missing token on the upgrade)",
+        )?;
+        let control_handoff_timeouts_total = IntCounterVec::new(
+            Opts::new(
+                "siphon_control_handoff_timeouts_total",
+                "Control-plane handoff deadlines that fired (no controller acted in time)",
+            ),
+            &["app"],
+        )?;
+
         // Register all metrics
+        registry.register(Box::new(control_connections.clone()))?;
+        registry.register(Box::new(control_controlled_calls.clone()))?;
+        registry.register(Box::new(control_commands_total.clone()))?;
+        registry.register(Box::new(control_events_dropped_total.clone()))?;
+        registry.register(Box::new(control_auth_failures_total.clone()))?;
+        registry.register(Box::new(control_handoff_timeouts_total.clone()))?;
         registry.register(Box::new(requests_total.clone()))?;
         registry.register(Box::new(responses_total.clone()))?;
         registry.register(Box::new(transactions_active.clone()))?;
@@ -645,6 +701,12 @@ impl SiphonMetrics {
             glibc_free_bytes,
             glibc_mmap_bytes,
             glibc_arena_count,
+            control_connections,
+            control_controlled_calls,
+            control_commands_total,
+            control_events_dropped_total,
+            control_auth_failures_total,
+            control_handoff_timeouts_total,
         })
     }
 }

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -114,6 +114,15 @@ pub enum CallAction {
         /// (default), the call is parked un-answered (deferred mode) and the
         /// controller decides how to respond.
         answer: bool,
+        /// Answer-first only: the media profile to anchor with (default
+        /// `"voice_ai"`). Ignored when `answer` is `false`.
+        profile: Option<String>,
+        /// Answer-first only: the per-call WebSocket bridge URI the media engine
+        /// dials out for this leg's audio. Supports `{call_id}` / `{from_tag}` /
+        /// `{from_user}` / `{to_user}` templating (RFC-3264-answer side). Falls
+        /// back to the profile's own `ws_uri` when omitted. Ignored when `answer`
+        /// is `false`.
+        ws_uri: Option<String>,
     },
     /// Sequential failover across an ordered list of carrier routes — LCR
     /// (`call.route(...)`) or `call.fork(strategy="sequential")`. The dispatcher
@@ -1188,16 +1197,27 @@ impl PyCall {
     ///         channel — answering commits the call (CDR answer-time starts;
     ///         declining is a BYE, not a 4xx). When ``False`` (default), the call
     ///         is parked un-answered and the controller decides how to respond.
+    ///     profile: Answer-first only — the media profile to anchor with (default
+    ///         ``"voice_ai"``).
+    ///     ws_uri: Answer-first only — the per-call WebSocket bridge URI the media
+    ///         engine dials out for this leg's audio, so the app computes it per
+    ///         session/tenant. Supports ``{call_id}`` / ``{from_tag}`` /
+    ///         ``{from_user}`` / ``{to_user}`` templating; falls back to the
+    ///         profile's own ``ws_uri`` when omitted.
     ///
     /// Example:
     ///     @b2bua.on_invite
     ///     async def route(call):
-    ///         if is_ivr_number(call.to_uri):
+    ///         if is_ai_number(call.to_uri):
+    ///             call.handover("ai-app", answer=True,
+    ///                           ws_uri="wss://ai.example/stream/{call_id}")
+    ///         elif is_ivr_number(call.to_uri):
     ///             call.handover("ivr-app", on_lost="hangup", deadline_ms=3000,
     ///                           vars={"queue": "support"})
     ///         else:
     ///             call.dial(call.ruri)
-    #[pyo3(signature = (app, on_lost=None, deadline_ms=None, vars=None, answer=false))]
+    #[pyo3(signature = (app, on_lost=None, deadline_ms=None, vars=None, answer=false, profile=None, ws_uri=None))]
+    #[allow(clippy::too_many_arguments)]
     fn handover(
         &mut self,
         app: &str,
@@ -1205,6 +1225,8 @@ impl PyCall {
         deadline_ms: Option<u64>,
         vars: Option<std::collections::HashMap<String, String>>,
         answer: bool,
+        profile: Option<&str>,
+        ws_uri: Option<&str>,
     ) -> PyResult<()> {
         if app.is_empty() {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -1218,12 +1240,19 @@ impl PyCall {
                 )));
             }
         }
+        if !answer && (profile.is_some() || ws_uri.is_some()) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "call.handover(profile=…/ws_uri=…) requires answer=True (they only apply to answer-first mode)",
+            ));
+        }
         self.action = CallAction::Handover {
             app: app.to_string(),
             on_lost: on_lost.map(String::from),
             deadline_ms,
             vars: vars.unwrap_or_default(),
             answer,
+            profile: profile.map(String::from),
+            ws_uri: ws_uri.map(String::from),
         };
         Ok(())
     }
@@ -2056,7 +2085,7 @@ mod tests {
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
         let mut vars = std::collections::HashMap::new();
         vars.insert("queue".to_string(), "support".to_string());
-        call.handover("ivr-app", Some("hangup"), Some(3000), Some(vars.clone()), false)
+        call.handover("ivr-app", Some("hangup"), Some(3000), Some(vars.clone()), false, None, None)
             .unwrap();
         assert_eq!(
             call.action(),
@@ -2066,30 +2095,47 @@ mod tests {
                 deadline_ms: Some(3000),
                 vars,
                 answer: false,
+                profile: None,
+                ws_uri: None,
             }
         );
     }
 
     #[test]
-    fn call_handover_answer_mode_sets_flag() {
+    fn call_handover_answer_mode_sets_flag_and_media_args() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        call.handover("ivr-app", None, None, None, true).unwrap();
+        call.handover("ai-app", None, None, None, true, Some("voice_ai"), Some("wss://ai/{call_id}"))
+            .unwrap();
         assert!(matches!(
             call.action(),
-            CallAction::Handover { answer: true, .. }
+            CallAction::Handover {
+                answer: true,
+                profile: Some(ref p),
+                ws_uri: Some(ref u),
+                ..
+            } if p == "voice_ai" && u == "wss://ai/{call_id}"
         ));
+    }
+
+    #[test]
+    fn call_handover_media_args_require_answer_true() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        // profile/ws_uri without answer=True is a programming error.
+        assert!(call.handover("app", None, None, None, false, Some("voice_ai"), None).is_err());
+        assert!(call.handover("app", None, None, None, false, None, Some("wss://ai")).is_err());
     }
 
     #[test]
     fn call_handover_rejects_empty_app_and_bad_on_lost() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        assert!(call.handover("", None, None, None, false).is_err());
-        assert!(call.handover("app", Some("explode"), None, None, false).is_err());
+        assert!(call.handover("", None, None, None, false, None, None).is_err());
+        assert!(call.handover("app", Some("explode"), None, None, false, None, None).is_err());
         // Valid policies are accepted.
-        assert!(call.handover("app", Some("continue"), None, None, false).is_ok());
-        assert!(call.handover("app", Some("fallback"), None, None, false).is_ok());
+        assert!(call.handover("app", Some("continue"), None, None, false, None, None).is_ok());
+        assert!(call.handover("app", Some("fallback"), None, None, false, None, None).is_ok());
     }
 
     #[test]

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -93,6 +93,28 @@ pub enum CallAction {
     /// This marker only tells the dispatcher the call was answered so it keeps
     /// the actor alive instead of removing it as a silent (no-action) drop.
     Answered,
+    /// Hand the call over to an out-of-process control application
+    /// (`call.handover("app")`, the ARI *Stasis* model). The dispatcher holds the
+    /// INVITE transaction un-dialed, sends a keep-alive 180, registers the call
+    /// with the control plane, emits `StasisStart` with the full SIP context, and
+    /// arms a handoff deadline whose default action (503 / fallback) fires if no
+    /// controller accepts and acts in time.
+    Handover {
+        /// The target control app (must be configured in `control.apps`).
+        app: String,
+        /// Control-loss policy: "hangup" (default) / "continue" / "fallback".
+        on_lost: Option<String>,
+        /// Handoff deadline in ms; `None` uses `control.limits.handoff_deadline_ms`.
+        deadline_ms: Option<u64>,
+        /// Per-call variables seeded into the control plane's channel entry.
+        vars: std::collections::HashMap<String, String>,
+        /// Answer-first (AI-park) mode: when `true`, siphon answers with `200 OK`
+        /// and anchors media to the `voice_ai` bridge *before* handing over, so
+        /// the controller drives an already-connected channel. When `false`
+        /// (default), the call is parked un-answered (deferred mode) and the
+        /// controller decides how to respond.
+        answer: bool,
+    },
     /// Sequential failover across an ordered list of carrier routes — LCR
     /// (`call.route(...)`) or `call.fork(strategy="sequential")`. The dispatcher
     /// dials the first routable carrier, stores the rest as the call's failover
@@ -1140,6 +1162,72 @@ impl PyCall {
         };
     }
 
+    /// Hand this call over to an out-of-process control application (ARI
+    /// *Stasis* model). siphon holds the INVITE transaction un-dialed, sends a
+    /// keep-alive ``180``, registers the call with the control plane and emits a
+    /// ``StasisStart`` carrying the full SIP context to the owning connection.
+    /// The out-of-process app then drives the call (answer / play / dtmf /
+    /// bridge / hangup) over the control WebSocket.
+    ///
+    /// A handoff deadline protects against an absent/slow controller: if no
+    /// controller accepts and acts in time, ``on_lost``'s sibling default action
+    /// fires (a ``503`` by default, or a fallback re-dispatch), so a dead
+    /// controller degrades instead of hanging calls.
+    ///
+    /// Args:
+    ///     app: The control app name (must be configured in ``control.apps``).
+    ///     on_lost: What to do if the owning connection is lost mid-call —
+    ///         ``"hangup"`` (default), ``"continue"``, or ``"fallback"``.
+    ///     deadline_ms: Handoff deadline in milliseconds; ``None`` uses
+    ///         ``control.limits.handoff_deadline_ms``.
+    ///     vars: Per-call variables seeded into the control channel, readable +
+    ///         writable by the app via ``get_var`` / ``set_var``.
+    ///     answer: Answer-first (AI-park) mode. When ``True``, siphon answers the
+    ///         call (``200 OK``) and anchors media to the ``voice_ai`` bridge
+    ///         before handing over, so the controller drives an already-connected
+    ///         channel — answering commits the call (CDR answer-time starts;
+    ///         declining is a BYE, not a 4xx). When ``False`` (default), the call
+    ///         is parked un-answered and the controller decides how to respond.
+    ///
+    /// Example:
+    ///     @b2bua.on_invite
+    ///     async def route(call):
+    ///         if is_ivr_number(call.to_uri):
+    ///             call.handover("ivr-app", on_lost="hangup", deadline_ms=3000,
+    ///                           vars={"queue": "support"})
+    ///         else:
+    ///             call.dial(call.ruri)
+    #[pyo3(signature = (app, on_lost=None, deadline_ms=None, vars=None, answer=false))]
+    fn handover(
+        &mut self,
+        app: &str,
+        on_lost: Option<&str>,
+        deadline_ms: Option<u64>,
+        vars: Option<std::collections::HashMap<String, String>>,
+        answer: bool,
+    ) -> PyResult<()> {
+        if app.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "call.handover() requires a non-empty app name",
+            ));
+        }
+        if let Some(policy) = on_lost {
+            if !matches!(policy, "hangup" | "continue" | "fallback") {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "call.handover(on_lost=…) must be 'hangup', 'continue', or 'fallback' (got '{policy}')"
+                )));
+            }
+        }
+        self.action = CallAction::Handover {
+            app: app.to_string(),
+            on_lost: on_lost.map(String::from),
+            deadline_ms,
+            vars: vars.unwrap_or_default(),
+            answer,
+        };
+        Ok(())
+    }
+
     /// UAS-mode answer — send a final 2xx response to the A-leg INVITE
     /// **immediately**, instead of bridging to a B-leg. Useful for MRF /
     /// announcement / echo / IVR servers that own the dialog themselves.
@@ -1960,6 +2048,48 @@ mod tests {
                 reason: "Not Acceptable Here".to_string()
             }
         );
+    }
+
+    #[test]
+    fn call_handover_sets_handover_action() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("queue".to_string(), "support".to_string());
+        call.handover("ivr-app", Some("hangup"), Some(3000), Some(vars.clone()), false)
+            .unwrap();
+        assert_eq!(
+            call.action(),
+            &CallAction::Handover {
+                app: "ivr-app".to_string(),
+                on_lost: Some("hangup".to_string()),
+                deadline_ms: Some(3000),
+                vars,
+                answer: false,
+            }
+        );
+    }
+
+    #[test]
+    fn call_handover_answer_mode_sets_flag() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.handover("ivr-app", None, None, None, true).unwrap();
+        assert!(matches!(
+            call.action(),
+            CallAction::Handover { answer: true, .. }
+        ));
+    }
+
+    #[test]
+    fn call_handover_rejects_empty_app_and_bad_on_lost() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        assert!(call.handover("", None, None, None, false).is_err());
+        assert!(call.handover("app", Some("explode"), None, None, false).is_err());
+        // Valid policies are accepted.
+        assert!(call.handover("app", Some("continue"), None, None, false).is_ok());
+        assert!(call.handover("app", Some("fallback"), None, None, false).is_ok());
     }
 
     #[test]

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -110,11 +110,14 @@ fn resolve_play_media_source(
 const DEFAULT_PROFILE: &str = "rtp_passthrough";
 
 /// The per-call values a `ws_uri` template can interpolate.
-struct WsUriContext<'a> {
-    call_id: &'a str,
-    from_tag: &'a str,
-    from_user: Option<&'a str>,
-    to_user: Option<&'a str>,
+///
+/// `pub(crate)` so the dispatcher's answer-first handover path reuses the exact
+/// #131 templating (`expand_ws_uri`) instead of duplicating it.
+pub(crate) struct WsUriContext<'a> {
+    pub(crate) call_id: &'a str,
+    pub(crate) from_tag: &'a str,
+    pub(crate) from_user: Option<&'a str>,
+    pub(crate) to_user: Option<&'a str>,
 }
 
 /// The From/To user parts of a message, for `ws_uri` templating.
@@ -163,7 +166,9 @@ fn extract_source_ip(object: &Bound<'_, PyAny>) -> Option<String> {
 ///
 /// A URI with no `{` is returned untouched, so the common non-templated case
 /// costs one scan and no allocation decisions.
-fn expand_ws_uri(template: &str, context: &WsUriContext<'_>) -> PyResult<String> {
+///
+/// `pub(crate)` so the dispatcher's answer-first handover path reuses it.
+pub(crate) fn expand_ws_uri(template: &str, context: &WsUriContext<'_>) -> PyResult<String> {
     if !template.contains('{') {
         return Ok(template.to_string());
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,6 +29,10 @@ type UserNamespaceFactory = Box<dyn FnOnce(Python<'_>) -> PyResult<Py<PyAny>> + 
 /// install long-running background work.
 type ExtensionTask = Box<dyn FnOnce(ScriptHandle) + Send>;
 
+/// A per-protocol control adapter registered by a host binary (the built-in SIP
+/// adapter is always registered; extensions add their own — e.g. SMPP).
+type ControlAdapterHandle = Arc<dyn crate::control::ControlAdapter>;
+
 /// Builder for running a siphon server instance.
 ///
 /// # Examples
@@ -51,6 +55,7 @@ pub struct SiphonServer {
     product_version: Option<&'static str>,
     user_namespaces: Vec<(String, UserNamespaceFactory)>,
     extension_tasks: Vec<ExtensionTask>,
+    control_adapters: Vec<ControlAdapterHandle>,
 }
 
 impl SiphonServer {
@@ -66,6 +71,7 @@ impl SiphonServer {
             product_version: None,
             user_namespaces: Vec::new(),
             extension_tasks: Vec::new(),
+            control_adapters: Vec::new(),
         }
     }
 
@@ -223,6 +229,39 @@ impl SiphonServer {
     /// log how many tasks they've wired up before `.run()`.
     pub fn extension_task_count(&self) -> usize {
         self.extension_tasks.len()
+    }
+
+    /// Register a per-protocol control adapter for the external remote-control
+    /// plane (sibling of [`register_namespace`](Self::register_namespace) /
+    /// [`register_task`](Self::register_task)).
+    ///
+    /// The built-in SIP adapter is always registered. A protocol extension
+    /// (e.g. `siphon-smpp`) registers its own adapter here so its resource model
+    /// and verbs are reachable over the same control WebSocket. Command routing
+    /// is by `module()`; the substrate never parses the adapter's args/payload.
+    ///
+    /// No-op unless a `control:` block is configured.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use std::sync::Arc;
+    /// use siphon::SiphonServer;
+    ///
+    /// SiphonServer::builder()
+    ///     .config_path("siphon.yaml")
+    ///     .register_control_adapter(Arc::new(MySmppAdapter::new()))
+    ///     .run();
+    /// ```
+    pub fn register_control_adapter(mut self, adapter: ControlAdapterHandle) -> Self {
+        self.control_adapters.push(adapter);
+        self
+    }
+
+    /// Number of host-registered control adapters (excludes the always-on SIP
+    /// adapter). Exposed for tests + host logging.
+    pub fn control_adapter_count(&self) -> usize {
+        self.control_adapters.len()
     }
 
     /// Run the siphon server. This blocks until shutdown (SIGINT/SIGTERM).
@@ -2015,6 +2054,20 @@ impl SiphonServer {
                     error!(listen = %admin_config.listen, "invalid admin.listen address: {error}");
                 }
             }
+        }
+
+        // --- External remote-control plane (ARI/ESL-class) ---
+        // Installs the ControlBus, spawns the command consumer + inbound WS
+        // listener, and registers the built-in SIP adapter plus any host adapters
+        // (e.g. SMPP). Per-call-connect apps are dialed lazily at handover.
+        if let Some(ref control_config) = config.control {
+            let control_adapters = std::mem::take(&mut self.control_adapters);
+            crate::control::spawn_control_plane(control_config, control_adapters);
+        } else if !self.control_adapters.is_empty() {
+            warn!(
+                adapters = self.control_adapters.len(),
+                "control adapters registered but no `control:` config block — control plane not started"
+            );
         }
 
         let dispatcher_handle = tokio::spawn(dispatcher::run(


### PR DESCRIPTION
## Phase 1 — external remote-control plane (ARI/ESL-class)

Adds the missing plane that turns siphon from a SIP switch into a programmable
telephony platform: an out-of-process application drives B2BUA calls over a
WebSocket, the way Asterisk has ARI and FreeSWITCH has ESL. This is the real
feature (substrate + adapter API + SIP adapter), staged — channels/bridges,
originate, media-stream verbs and the SMPP adapter are explicitly out of scope
for this PR.

### What Phase 1 delivers

- **`call.handover("app")`** from `@b2bua.on_invite` (the ARI *Stasis* model):
  siphon holds the INVITE transaction un-dialed (kept alive by the transaction
  layer's automatic `100 Trying` — no synthesized provisional; a 180 would
  falsely signal ringing before anything is dialed), registers the call with the
  control plane, and emits a **`StasisStart`** carrying the **full SIP context**
  (real headers, source IP/port, R-URI shape, body) plus the stable id triple
  `{channel, call_id, sip_call_id}` — `sip_call_id` is byte-identical to the CDR
  `call_id` and the HEP correlation chunk, so a controller joins Homer + billing
  with no mapping table. `call.handover(answer=…)` reserves the answer-first
  (AI-park) mode (`answer_local`/`voice_ai` + `200 OK` before handover) — see
  below.
- **Substrate (`src/control/`)** — protocol-agnostic: WS transport, JSON
  envelope (`siphon-control.v1`), per-app bearer auth, app/owner/channel
  registry, event bus + backpressure, resync bookkeeping, command routing by
  `module`.
- **Two connection modes, exactly-one-owner:**
  - *inbound persistent* WS listener (`control.listen`, `GET /control/ws`), owner
    assigned round-robin per call;
  - *outbound per-call-connect* — siphon dials the app's `connect_url` at
    handover and the accepting socket owns the call (the FreeSWITCH-outbound
    model, the documented multi-pod default).
- **Adapter API** — `ControlAdapter` trait (`module` / `apply` / `describe`) +
  a `SiphonServer::register_control_adapter` builder hook + an opaque
  `serde_json::Value` DTO seam. The substrate never parses verb/args. The
  built-in **SIP adapter** registers from core; a protocol extension (e.g. SMPP)
  registers its own over the same rail.
- **SIP verbs bound to the shipped imperative rail:** `answer` →
  `b2bua_answer_call`, `progress` → `b2bua_progress_call`, `hangup` →
  `b2bua_terminate_call` (answered) / `b2bua_reject_call` (parked), `reject`,
  `refer` → `b2bua_refer_call`, plus `set_header`/`get_header` on the stored
  A-leg INVITE. Substrate verbs `resync` / `describe` / `set_var` / `get_var`.
  A command against a dead/unknown call returns a typed `not_found`; a cross-app
  target returns `forbidden` — never a hang.
- **Ordering + backpressure:** one bounded outbound queue per connection carries
  **both replies and events**, drained by a single write task → per-call total
  order on the owner socket. Overflow drops the oldest *event* (never a reply);
  a stuck consumer stalls only its own queue.
- **Control-loss & deadlines:** a handoff deadline (reusing the answer-timeout
  sweep) fires a safe default (`503` / fallback) if no controller accepts + acts
  in time; on owner disconnect the call is orphaned and, after
  `reattach_grace_secs`, `on_lost` (`hangup` default) applies — unless a
  reconnecting controller `resync`s and re-claims it first.
- Prometheus metrics (`siphon_control_*`), SDK mirror
  (`call.handover(app, on_lost=, deadline_ms=, vars=)`), CHANGELOG, a commented
  `control:` block in the reference `siphon.yaml`.

### The I/O contract it upholds (the whole thesis)

1. Control-socket I/O is pure async tokio — never `py_executor`, never a
   blocking call on an async thread.
2. Event fan-out is `try_push` on a bounded per-connection queue, never `.await`;
   full → drop-oldest, never parks the dispatcher/leg-actor.
3. Command ingress: WS read task → **unbounded** flume send → `.await` a
   `oneshot` (async wait, not a thread block).
4. **A command reply ≠ a far-end result.** `apply` does only the bounded local
   action (build+send one SIP message / mutate the store) and returns "accepted"
   immediately; the callee's answer / ACK / BYE-200 arrive later as async events.
5. `apply` runs as a plain async task — zero blocking-pool slots; serialization
   via the existing `CallActorStore` per-key lock. No Python handler is involved
   in these verbs, so `py_executor` is never touched.
6. No sync `Mutex` across `.await`; every queue bounded except ingress.

Where each await lands on the command path: WS read task awaits the `oneshot`
(async) → the consumer spawns `adapter.apply` (async task) → the SIP adapter
calls a synchronous imperative fn (`b2bua_*`, which only queue-pushes a SIP
message and `tokio::spawn`s any media/CDR side-effects, all non-blocking) and
returns → the result goes back over the `oneshot` and is enqueued on the ordered
outbound queue for the single write task. No pool ever sees a network wait.

### Ownership model

Server-authoritative. A channel is owned by exactly one connection (the
round-robin winner in persistent mode, the accepting socket in per-call-connect).
Every command's target is looked up in the `ControlBus` and its owner checked
against the commanding connection (`forbidden` on mismatch). `StasisStart` routes
only to the owner. On disconnect the channel is orphaned for the grace window,
then `on_lost` applies; `resync` from a reconnecting connection of the same app
re-points ownership.

### Two handover modes

- **Deferred / hold (this PR, solid).** siphon does not answer; the call is
  parked under control, held only by the automatic `100 Trying`. No synthesized
  provisional — the controller drives the caller UX with the `progress` verb
  (180 ringback / 183+SDP early media) if it wants one, and the real 18x relay
  end-to-end once the app routes (Phase 2). The call stays rejectable (the
  controller can return a real 4xx via `reject`).
- **Answer-first / AI-park (`handover(answer=True, ws_uri=…)`) — wired.** siphon
  synthesizes the RFC 3264 answer for the A-leg offer via
  `MediaBackend::answer_local` (siphon-rtp only), anchors the media to the
  `voice_ai` WebSocket bridge with the `ws_uri` templated by #131's
  `{call_id}`/`{from_tag}`/`{from_user}`/`{to_user}` expander (script arg wins
  over the profile's own), sends the `200 OK` with that SDP via `b2bua_answer_call`
  and records the media session, THEN registers with the control plane — the app
  drives an already-answered, media-anchored channel. The round-trip runs on the
  **SIP-processing path** (`block_in_place`, same as the existing B2BUA answer
  paths), never the control-command path. **Honest failure, never a fake 200:**
  answer-first on a backend that can't `answer_local` (rtpengine/rtpproxy/none),
  an unknown profile, a missing `ws_uri`, unsupported flags, or no SDP offer
  rejects `503` and tears down; if no controller connects after answering, the
  answered call is BYE'd rather than orphaned. New `profile`/`ws_uri` kwargs on
  `call.handover` (rejected without `answer=True`), mirrored in the SDK. The
  decision core `answer_first_prepare` is pure and unit-tested (backend gate,
  profile resolution, `ws_uri` templating, SDP/flags guards).

### Best-effort / deferred (loudly, not silently)

- **TLS on the inbound control listener + `wss://` outbound dial** are **not
  wired** in this PR (plain WS; put it behind a TLS-terminating ingress, or use
  per-call-connect over a private network for now). The bearer token is
  constant-time compared and feeds the existing **auto-ban** store; tenant
  isolation + ownership are enforced. TLS/mTLS + the non-loopback-plaintext
  startup refusal + `TransportAcl` at accept are a Phase-2 security-hardening
  follow-up.
- **Media verbs** (`play`/`stop`/`dtmf`/`collect_dtmf`) return a typed
  `unsupported_verb` — they bind to `MediaBackend`, a follow-on.
- `set_var`/`get_var` and `set_header`/`get_header` are included and wired
  (vars drain with the channel; headers mutate the stored A-leg INVITE).

### Example clients

`examples/remote_control/` (Python + TypeScript) drive a handed-over call over
the shipped protocol: the full Phase-1 verb set (`answer`/`progress`/`reject`/
`hangup`/`refer`/`set_header`/`get_header` + `set_var`/`get_var`/`resync`/
`describe`), `module` routing, the `hello` handshake, and **both** connection
modes — outbound per-call-connect (siphon dials the app, the app echoes the
subprotocol) is the documented default.

### Out of scope (not built)

Media-stream start/stop verbs, channels/bridges resource model, originate,
conference/observers, generated SDKs, durable event log, SMPP adapter.

### How to run

```yaml
control:
  listen: "127.0.0.1:9092"
  apps:
    - name: "ivr-app"
      token: "${IVR_APP_TOKEN}"
      # or per_call_connect: true + connect_url: "ws://controller:8443/siphon"
```
```python
@b2bua.on_invite
async def route(call):
    if is_ivr_number(call.to_uri):
        call.handover("ivr-app", on_lost="hangup", deadline_ms=3000,
                      vars={"queue": "support"})
    else:
        call.dial(call.ruri)
```
Controller: connect to `ws://siphon:9092/control/ws` with
`Authorization: Bearer <token>` + subprotocol `siphon-control.v1`, send
`hello`, then answer/play/hangup the `StasisStart` you receive.

### Tests

- `PYO3_PYTHON=python3 cargo test` — **3684 passed / 7 ignored**. Control tests:
  protocol serde round-trips, config parse, ControlBus
  ownership/ordering/resync/reattach, steady-state leak drain (incl. a
  CANCEL-while-parked teardown cycle), bounded drop-oldest / never-blocks-a-stuck
  -consumer, each SIP verb binding + synchronous-decision-core + typed dead-call
  error, handoff-deadline default, `CallAction::Handover` set/read (incl. the
  `answer`/`profile`/`ws_uri` kwargs + validation), the answer-first decision core
  `answer_first_prepare` (siphon-rtp gate / honest-failure on rtpengine /
  ws_uri templating / profile + SDP guards), CANCEL-while-parked emits StasisEnd +
  drains, and WS integration via `tokio-tungstenite`: bad-token→401-before-upgrade
  / hello→ok / StasisStart delivered / command→reply / wrong-app→forbidden /
  unknown-version→rejected / resync-after-reconnect / per-call-connect dials a
  stub controller and the socket owns the call.
- `PYO3_PYTHON=python3 cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cd sdk && python -m pytest tests/` — **504 passed**.

Perf + mem-leak baseline (16-row SIPp + `mem_leak_test.sh` both modes) not run in
this environment — the datapath is untouched (one `controlled` check per B2BUA
junction, no dispatcher-loop change) and the new stores ship a co-located
steady-state leak test; the full baseline should run on the reference hardware
before release.
