### PR TITLE
fix(b2bua): answer 481 for an in-dialog request against a torn-down call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,32 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   across backends" statement is now qualified with the per-engine capability
   table.
 
+- **An in-dialog request for a B2BUA call that was just torn down is answered
+  `481 Call/Transaction Does Not Exist` instead of being silently dropped
+  (RFC 3261 §12.2.2, §15.1.2).** Hang-up glare — both parties send BYE within a
+  few hundred milliseconds — left the second BYE arriving after the call was
+  gone. It missed every B2BUA intercept (they gate on the same Call-ID lookup
+  that has just started failing), fell through to the proxy path, and a script
+  with no route for it dropped it. The peer was then left retransmitting to its
+  own timer F: 32 s of silence, answered only by the deferred non-INVITE auto-100
+  (RFC 4320 §4.2). A VoNR UE reads that as a dead IMS and recovers by releasing
+  its IMS PDU session and re-registering, so terminating calls fail for ~40 s.
+
+  `CallActorStore` now remembers the SIP Call-IDs of calls it has torn down —
+  every leg, since the two sides carry different Call-IDs and either peer can
+  lose the race — and the dispatcher answers 481 for any in-dialog request
+  naming one. A live call always wins over a remembered one, so a peer reusing a
+  Call-ID for its next call is unaffected, and a Call-ID this node never tracked
+  is still left to the script (a proxy loose-routes dialogs it does not own).
+  Bounded by both age (32 s, Timer H) and count, so it stays flat under load.
+
+  A re-INVITE for a torn-down call is covered too: it previously reached
+  `on_invite` as if it were a brand-new call.
+
+  Also brought the B2BUA BYE / re-INVITE / UPDATE / REFER / NOTIFY handlers to
+  the same answer when they lose the race with a concurrent teardown — each
+  returned silently where the neighbouring no-dialog-leg path already sent 481.
+
 ## [1.5.1] — 2026-07-29
 
 ### Added

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -228,6 +228,10 @@ if [[ "$RUN_B2BUA" == true ]]; then
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-update up --abort-on-container-exit --exit-code-from sipp-b2bua-update-uac sipp-b2bua-update-uac sipp-b2bua-update-uas
   docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-update rm -sf sipp-b2bua-update-uac sipp-b2bua-update-uas 2>/dev/null || true
 
+  echo "=== B2BUA BYE-glare test (in-dialog BYE after teardown → 481, not a silent drop) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-bye-glare up --abort-on-container-exit --exit-code-from sipp-b2bua-bye-glare-uac sipp-b2bua-bye-glare-uac sipp-b2bua-bye-glare-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-bye-glare rm -sf sipp-b2bua-bye-glare-uac sipp-b2bua-bye-glare-uas 2>/dev/null || true
+
   echo "=== B2BUA REFER test (RFC 3515 transparent blind transfer) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-refer up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-uac sipp-b2bua-refer-uac sipp-b2bua-refer-uas
   docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-refer rm -sf sipp-b2bua-refer-uac sipp-b2bua-refer-uas 2>/dev/null || true

--- a/sipp/b2bua_bye_glare_uac.xml
+++ b/sipp/b2bua_bye_glare_uac.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA BYE-glare UAC scenario (A-leg / UE side):
+  INVITE → 200 → ACK → receive BYE → 200 → send our own BYE → 481
+
+  Hang-up glare. The trunk (b2bua_bye_glare_uas.xml) hangs up first, so by the
+  time this side's own BYE goes out the B2BUA call is gone. RFC 3261 §12.2.2 /
+  §15.1.2: that BYE MUST be answered 481 Call/Transaction Does Not Exist.
+
+  Waiting for the relayed BYE before sending ours makes the ordering
+  deterministic — ours is unambiguously post-teardown, as in the field trace
+  where the two BYEs were ~350 ms apart.
+
+  Against a build without the fix the BYE is silently dropped: this scenario then
+  sees only the NIST auto-100 (RFC 4320 §4.2 defers it to T2 ≈ 3.5 s) and fails
+  on the unanswered-BYE timeout — which is exactly the 32 s of silence that makes
+  a VoNR UE release its IMS PDU session and re-register.
+-->
+<scenario name="B2BUA BYE glare UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-bye-glare-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <!-- Capture the dialog's remote tag + target from the answer, so our own BYE
+       is built from the dialog rather than from whatever arrived last. -->
+  <recv response="200" rtd="true" crlf="true">
+    <action>
+      <ereg regexp="tag=([^;&gt;\r\n ]+)" search_in="hdr" header="To:" assign_to="junk,peer_tag" />
+      <ereg regexp="&lt;([^&gt;]+)>" search_in="hdr" header="Contact:" assign_to="junk,peer_contact" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>;tag=[$peer_tag]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- The trunk's BYE, relayed to us: the call is being torn down. -->
+  <recv request="BYE" timeout="10000" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Our own hang-up, now orphaned. The field gap was ~350 ms. -->
+  <pause milliseconds="300" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [$peer_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>;tag=[$peer_tag]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-bye-glare-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <!-- The fix: answered immediately instead of dropped.
+
+       A regressed build has to FAIL here, not just stall — sipp exits 0 if it is
+       stopped with a call still in progress, which would let the regression pass
+       as green. The container runs with -max_retrans 2, so an unanswered BYE ends
+       the call as failed after ~1.5 s (exit 1). A per-recv timeout= does not do
+       this: it is ignored by the sipp build used here, verified against a
+       pre-fix binary, which sat in retransmits for the whole run and still
+       reported success. -->
+  <recv response="481" rtd="true" />
+
+</scenario>

--- a/sipp/b2bua_bye_glare_uas.xml
+++ b/sipp/b2bua_bye_glare_uas.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA BYE-glare UAS scenario (B-leg / trunk side):
+  Receive INVITE → 200 → ACK → send BYE → 200
+
+  This side wins the hang-up race: its BYE tears the B2BUA call down, which is
+  what leaves the A-leg's own BYE (see b2bua_bye_glare_uac.xml) arriving for a
+  call that no longer exists.
+-->
+<scenario name="B2BUA BYE glare UAS">
+
+  <!-- Receive the B-leg INVITE from the B2BUA and capture dialog state -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="(.*)" search_in="hdr" header="Call-ID:" assign_to="dialog_callid" />
+      <ereg regexp="tag=([^;&gt;\r\n ]+)" search_in="hdr" header="From:" assign_to="junk,remote_tag" />
+      <ereg regexp="&lt;([^&gt;]+)>" search_in="hdr" header="From:" assign_to="junk,remote_from_uri" />
+      <ereg regexp="&lt;([^&gt;]+)>" search_in="hdr" header="Contact:" assign_to="junk,remote_contact" />
+    </action>
+  </recv>
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" timeout="5000" />
+
+  <!-- Let the call settle before hanging up, so the teardown is unambiguously
+       a mid-call BYE and not a race with the ACK. -->
+  <pause milliseconds="500" />
+
+  <!-- Trunk hangs up first: this BYE removes the B2BUA call. -->
+  <send retrans="500">
+    <![CDATA[
+BYE [$remote_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:bob@[local_ip]>;tag=[pid]SIPpTag01[call_number]
+To: <[$remote_from_uri]>;tag=[$remote_tag]
+Call-ID: [$dialog_callid]
+CSeq: 1 BYE
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-bye-glare-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+  <!-- Outlive the UAC, including its 4 s wait for the 481. This pair runs under
+       --abort-on-container-exit, so if this side exits first the UAC is killed
+       before its assertion resolves and the run reports green without having
+       tested anything. -->
+  <pause milliseconds="10000" />
+
+</scenario>

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -859,6 +859,7 @@ services:
       - b2bua-reinvite-reject
       - b2bua-reinvite-breject
       - b2bua-update
+      - b2bua-bye-glare
       - b2bua-cancel
       - b2bua-early-media
       - b2bua-topology
@@ -904,6 +905,7 @@ services:
       - b2bua-reinvite-reject
       - b2bua-reinvite-breject
       - b2bua-update
+      - b2bua-bye-glare
       - b2bua-cancel
       - b2bua-early-media
       - b2bua-topology
@@ -1314,6 +1316,65 @@ services:
       - -trace_err
     profiles:
       - b2bua-update
+
+  # --- B2BUA BYE-glare test (in-dialog BYE after teardown → 481) ---
+
+  sipp-b2bua-bye-glare-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_bye_glare_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-bye-glare
+
+  sipp-b2bua-bye-glare-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua:
+        condition: service_healthy
+      sipp-b2bua-bye-glare-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.50:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_bye_glare_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      # An unanswered BYE must end the call as FAILED (exit 1) instead of sitting
+      # in retransmits until the run is torn down, which sipp reports as success.
+      # Two retries ≈ 1.5 s; the fixed build answers 481 immediately and never
+      # retransmits at all, so this does not weaken the healthy path.
+      - -max_retrans
+      - "2"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-bye-glare
 
   # --- B2BUA REFER test (RFC 3515 transparent blind transfer) ---
 

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -27,12 +27,13 @@
 //! - `LegRegistry` provides SIP-level routing (Call-ID, branch → internal ID).
 //! - Foundation for API-driven calls: create a `Leg` without an inbound INVITE.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::sip::message::SipMessage;
 use crate::transport::{ConnectionId, Transport};
@@ -1268,6 +1269,24 @@ pub enum WinOutcome {
     AlreadyAnswered { b_leg_acked: bool },
 }
 
+/// How long a torn-down call's SIP Call-IDs stay answerable with 481.
+///
+/// 32 s = Timer H / 64·T1 (RFC 3261 §17), the same expiry the zombie re-INVITE
+/// and post-CANCEL absorbers use: once the peer's own client transaction has
+/// timed out it stops retransmitting, so remembering the dialog past that point
+/// buys nothing.
+const TERMINATED_CALL_TTL: Duration = Duration::from_secs(32);
+
+/// Hard ceiling on remembered torn-down Call-IDs.
+///
+/// Unlike the zombie absorbers — which only gain entries on rare paths — this
+/// set gains an entry per leg on *every* teardown, so the TTL alone is not a
+/// bound: at 40k cps it would hold 32 s × 40k ≈ 1.3M Call-IDs. The cap keeps the
+/// footprint flat while still covering ~1.6 s of teardowns at that rate, far
+/// wider than the sub-second glare window this exists for. At realistic per-NF
+/// call rates the TTL evicts long before the cap is in play.
+const TERMINATED_CALL_CAPACITY: usize = 65_536;
+
 /// Manages all active B2BUA calls.
 ///
 /// Stores `CallActor` instances in a concurrent map, indexed by internal
@@ -1283,6 +1302,19 @@ pub struct CallActorStore {
     /// Post-CANCEL glare absorber (RFC 3261 §9.1): a 2xx that raced our CANCEL
     /// is ACKed + BYEd here, keyed by B-leg SIP Call-ID.
     pub zombie_cancelled: DashMap<String, ZombieCancelledLeg>,
+    /// SIP Call-IDs of calls this node has torn down → when they were torn down,
+    /// so a late in-dialog request naming one can be answered 481 instead of
+    /// dropped ([`Self::is_recently_terminated`]). Read on the request path, so
+    /// it is the lock-free half of the pair.
+    terminated: DashMap<String, Instant>,
+    /// Teardown order backing [`Self::terminated`], for eviction by age and by
+    /// capacity. Only touched on teardown, never on the read path.
+    ///
+    /// A Call-ID can appear more than once — a peer may reuse one for its next
+    /// call, and both B2BUA legs may share one. The timestamp doubles as a
+    /// generation stamp so evicting a stale entry can't drop a Call-ID that has
+    /// since been remembered again; see [`Self::evict_terminated`].
+    terminated_order: Mutex<VecDeque<(String, Instant)>>,
 }
 
 impl CallActorStore {
@@ -1292,7 +1324,93 @@ impl CallActorStore {
             registry: LegRegistry::new(),
             zombie_reinvites: DashMap::new(),
             zombie_cancelled: DashMap::new(),
+            terminated: DashMap::new(),
+            terminated_order: Mutex::new(VecDeque::new()),
         }
+    }
+
+    /// Remember `sip_call_id` as a dialog this node has torn down.
+    ///
+    /// Evicts from the front on the way in (amortised O(1), no timer task):
+    /// entries older than [`TERMINATED_CALL_TTL`] first, then any overflow past
+    /// [`TERMINATED_CALL_CAPACITY`].
+    fn remember_terminated(&self, sip_call_id: &str) {
+        if sip_call_id.is_empty() {
+            return;
+        }
+        let mut order = match self.terminated_order.lock() {
+            Ok(guard) => guard,
+            Err(error) => {
+                // Never remember without the order half — nothing would ever
+                // evict it. A late in-dialog request for this call falls through
+                // to the script instead of drawing a 481; that is the lesser
+                // failure next to an unbounded map.
+                warn!("terminated-call order mutex poisoned, not remembering {sip_call_id}: {error}");
+                return;
+            }
+        };
+        // Always stamp and enqueue, even for a Call-ID already present: the
+        // stamp is the generation, and the newest one is what must survive.
+        let now = Instant::now();
+        self.terminated.insert(sip_call_id.to_string(), now);
+        order.push_back((sip_call_id.to_string(), now));
+        Self::evict_terminated(
+            &self.terminated,
+            &mut order,
+            now,
+            TERMINATED_CALL_TTL,
+            TERMINATED_CALL_CAPACITY,
+        );
+    }
+
+    /// Drop remembered Call-IDs from the front of `order`: everything older than
+    /// `ttl` as of `now`, then whatever still overflows `capacity`.
+    ///
+    /// An expiring entry only removes the Call-ID if its stamp is still the
+    /// current generation. Without that check, re-terminating a Call-ID seen
+    /// before would un-remember it: the stale entry ages out and takes the
+    /// freshly-remembered Call-ID with it, which is how a peer that reuses
+    /// Call-IDs across calls lost its 481.
+    ///
+    /// Split out (and given `now` / `ttl` / `capacity` explicitly) so both
+    /// eviction rules are testable without a 32-second sleep.
+    fn evict_terminated(
+        terminated: &DashMap<String, Instant>,
+        order: &mut VecDeque<(String, Instant)>,
+        now: Instant,
+        ttl: Duration,
+        capacity: usize,
+    ) {
+        loop {
+            let evict = match order.front() {
+                Some((_, stamped)) => {
+                    now.saturating_duration_since(*stamped) >= ttl || order.len() > capacity
+                }
+                None => false,
+            };
+            if !evict {
+                break;
+            }
+            if let Some((call_id, stamped)) = order.pop_front() {
+                terminated.remove_if(&call_id, |_, current| *current == stamped);
+            }
+        }
+    }
+
+    /// Did this node recently tear down a call carrying `sip_call_id`?
+    ///
+    /// An in-dialog request naming it can no longer be bridged or routed — both
+    /// dialogs are gone here — so it MUST be answered 481 Call/Transaction Does
+    /// Not Exist (RFC 3261 §12.2.2, §15.1.2 for BYE) rather than dropped.
+    /// Dropping it leaves the peer retransmitting to its own timer F; a VoNR UE
+    /// reads that 32 s silence as a dead IMS and recovers by releasing its IMS
+    /// PDU session and re-registering, which costs ~40 s of terminating service.
+    ///
+    /// Eviction is lazy (it happens on insert), so an entry can outlive the TTL
+    /// by a while. That is harmless — the answer is still correct — and it keeps
+    /// this to a single hash on the request path.
+    pub fn is_recently_terminated(&self, sip_call_id: &str) -> bool {
+        !sip_call_id.is_empty() && self.terminated.contains_key(sip_call_id)
     }
 
     /// Number of active calls.
@@ -1904,6 +2022,12 @@ impl CallActorStore {
     /// Sends `Shutdown` to all active B-leg actor handles before removing.
     /// B-leg entries with `reinvite_done:` or `reinvite:` target_uri are moved
     /// to `zombie_reinvites` so retransmitted 200 OKs can still be ACKed.
+    ///
+    /// Every leg's SIP Call-ID is remembered as terminated on the way out, so an
+    /// in-dialog request that arrives after the teardown — the BYE glare where
+    /// both parties hang up at once — is answered 481 rather than dropped. Both
+    /// sides need it: on a B2BUA the A-leg and B-leg Call-IDs differ, and either
+    /// peer can be the one whose BYE loses the race.
     pub fn remove_call(&self, call_id: &str) {
         if let Some((_, call)) = self.calls.remove(call_id) {
             // Shutdown any active B-leg actors
@@ -1911,10 +2035,12 @@ impl CallActorStore {
             // Clean up A-leg registry entries
             self.registry.remove_call_id(&call.a_leg.dialog.call_id);
             self.registry.remove_branch(&call.a_leg.branch);
+            self.remember_terminated(&call.a_leg.dialog.call_id);
             // Clean up B-leg registry entries, preserving re-INVITE state
             for b_leg in &call.b_legs {
                 self.registry.remove_call_id(&b_leg.dialog.call_id);
                 self.registry.remove_branch(&b_leg.branch);
+                self.remember_terminated(&b_leg.dialog.call_id);
                 // Move re-INVITE tracking entries to zombie map
                 if let Some(ref target) = b_leg.dialog.target_uri {
                     if target.starts_with("reinvite_done:") || target.starts_with("reinvite:") {
@@ -3829,5 +3955,154 @@ mod tests {
                 join,
             ).await.expect("actor did not terminate").unwrap();
         }
+    }
+
+    // --- Recently-terminated Call-IDs (post-teardown 481) ---
+
+    #[test]
+    fn teardown_remembers_every_leg_call_id() {
+        // Hang-up glare: whichever peer's BYE loses the race must still be
+        // answerable, and on a B2BUA that peer may be on either side, so both
+        // the A-leg and every B-leg Call-ID has to be remembered.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.add_b_leg(&call_id, make_b_leg(0));
+        store.add_b_leg(&call_id, make_b_leg(1));
+
+        assert!(!store.is_recently_terminated("call-1@10.0.0.1"));
+
+        store.remove_call(&call_id);
+
+        assert!(store.is_recently_terminated("call-1@10.0.0.1"));
+        assert!(store.is_recently_terminated("b2b-bleg0"));
+        assert!(store.is_recently_terminated("b2b-bleg1"));
+        // A Call-ID this node never saw stays unknown — the dispatcher leaves
+        // those to the script (a proxy loose-routes dialogs it doesn't track).
+        assert!(!store.is_recently_terminated("stranger@10.0.0.9"));
+        assert!(!store.is_recently_terminated(""));
+    }
+
+    #[test]
+    fn live_call_is_never_remembered_as_terminated() {
+        // Guards the dispatcher's ordering: a call that is up must not be able
+        // to answer 481 to its own in-dialog requests.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.add_b_leg(&call_id, make_b_leg(0));
+
+        assert!(!store.is_recently_terminated("call-1@10.0.0.1"));
+        assert!(!store.is_recently_terminated("b2b-bleg0"));
+    }
+
+    #[test]
+    fn legs_sharing_a_call_id_are_remembered_once() {
+        // With preserve_call_id — and for the dispatcher's `reinvite:` tracking
+        // pseudo-legs — a B-leg carries the A-leg's Call-ID. One membership entry
+        // covers both.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        let mut b_leg = make_b_leg(0);
+        b_leg.dialog.call_id = "call-1@10.0.0.1".to_string();
+        store.add_b_leg(&call_id, b_leg);
+
+        store.remove_call(&call_id);
+
+        assert!(store.is_recently_terminated("call-1@10.0.0.1"));
+        assert_eq!(store.terminated.len(), 1);
+    }
+
+    #[test]
+    fn re_terminating_a_reused_call_id_keeps_it_remembered() {
+        // Regression: a peer that reuses one Call-ID across calls used to LOSE its
+        // 481. The second teardown found the Call-ID already present and pushed no
+        // fresh entry, so eviction aged out the first call's entry and removed the
+        // Call-ID that had just been remembered again. The stamp is a generation:
+        // an expiring entry may only remove the Call-ID if it is still current.
+        let terminated = DashMap::new();
+        let mut order = VecDeque::new();
+        let base = Instant::now();
+        let refreshed = base + Duration::from_secs(60);
+        // Remembered at `base`, then again at `refreshed`.
+        terminated.insert("reused@10.0.0.1".to_string(), refreshed);
+        order.push_back(("reused@10.0.0.1".to_string(), base));
+        order.push_back(("reused@10.0.0.1".to_string(), refreshed));
+
+        // The first entry is well past the TTL; the second is not.
+        CallActorStore::evict_terminated(
+            &terminated,
+            &mut order,
+            base + Duration::from_secs(40),
+            TERMINATED_CALL_TTL,
+            TERMINATED_CALL_CAPACITY,
+        );
+
+        assert!(terminated.contains_key("reused@10.0.0.1"));
+        assert_eq!(order.len(), 1);
+    }
+
+    #[test]
+    fn second_teardown_of_the_same_call_id_still_remembered() {
+        // The store-level shape of the regression above: tear down, reuse the
+        // Call-ID for another call, tear that down too. Still answerable.
+        let store = CallActorStore::new();
+        let first = store.create_call(make_a_leg());
+        store.remove_call(&first);
+        let second = store.create_call(make_a_leg());
+        store.remove_call(&second);
+
+        assert!(store.is_recently_terminated("call-1@10.0.0.1"));
+        assert_eq!(store.terminated.len(), 1);
+    }
+
+    #[test]
+    fn terminated_evicts_by_age() {
+        // Past the TTL the peer's own transaction has timed out, so the entry
+        // has nothing left to answer. `now` is moved forward rather than slept.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.remove_call(&call_id);
+        assert!(store.is_recently_terminated("call-1@10.0.0.1"));
+
+        let mut order = store.terminated_order.lock().unwrap();
+        CallActorStore::evict_terminated(
+            &store.terminated,
+            &mut order,
+            Instant::now() + Duration::from_secs(40),
+            TERMINATED_CALL_TTL,
+            TERMINATED_CALL_CAPACITY,
+        );
+        drop(order);
+
+        assert!(!store.is_recently_terminated("call-1@10.0.0.1"));
+        assert_eq!(store.terminated_order.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn terminated_evicts_by_capacity_oldest_first() {
+        // The cap is what keeps a 40k-cps run from holding 32 s of Call-IDs.
+        let terminated = DashMap::new();
+        let mut order = VecDeque::new();
+        let base = Instant::now();
+        for index in 0..5 {
+            let stamp = base + Duration::from_millis(index);
+            terminated.insert(format!("cid-{index}"), stamp);
+            order.push_back((format!("cid-{index}"), stamp));
+        }
+
+        CallActorStore::evict_terminated(
+            &terminated,
+            &mut order,
+            base,
+            TERMINATED_CALL_TTL,
+            2,
+        );
+
+        // Newest two survive, in order.
+        assert_eq!(order.len(), 2);
+        assert!(!terminated.contains_key("cid-0"));
+        assert!(!terminated.contains_key("cid-1"));
+        assert!(!terminated.contains_key("cid-2"));
+        assert!(terminated.contains_key("cid-3"));
+        assert!(terminated.contains_key("cid-4"));
     }
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2515,6 +2515,55 @@ fn handle_inbound(inbound: InboundMessage, state: &Arc<DispatcherState>) {
     }
 }
 
+/// Does this request carry a To-tag, i.e. is it in-dialog (RFC 3261 §12)?
+fn to_has_tag(message: &SipMessage) -> bool {
+    message
+        .headers
+        .get("To")
+        .map(|value| value.split(';').any(|p| p.trim().starts_with("tag=")))
+        .unwrap_or(false)
+}
+
+/// Must this request be answered 481 because its B2BUA dialog is already gone?
+///
+/// RFC 3261 §12.2.2 — a request whose dialog identifier matches no existing
+/// dialog gets 481 Call/Transaction Does Not Exist; §15.1.2 says the same for
+/// BYE specifically. The case that matters in the field is hang-up glare: both
+/// parties send BYE within a few hundred ms, so the second one arrives after the
+/// call was torn down. It then misses every B2BUA intercept (they gate on the
+/// same Call-ID lookup that has just started failing) and falls through to the
+/// proxy path, where a script with no route for it produces a silent drop. The
+/// peer is left retransmitting to its own timer F — 32 s of silence, which a
+/// VoNR UE treats as a dead IMS and answers by releasing its IMS PDU session and
+/// re-registering, costing ~40 s of terminating service.
+///
+/// Conditions are ordered so a live call pays one hash and stops.
+fn terminated_dialog_needs_481(
+    method: &str,
+    message: &SipMessage,
+    calls: &crate::b2bua::actor::CallActorStore,
+) -> bool {
+    // ACK is never answered (RFC 3261 §17.1.1.3). CANCEL for an unknown
+    // transaction is already 481'd by `handle_cancel`'s fall-through.
+    if method == "ACK" || method == "CANCEL" {
+        return false;
+    }
+    let Some(call_id) = message.headers.call_id() else {
+        return false;
+    };
+    if !calls.is_recently_terminated(call_id) {
+        return false;
+    }
+    // In-dialog only. A peer that reuses a Call-ID for a brand-new dialog sends
+    // no To-tag, and must reach the normal INVITE path rather than a 481.
+    if !to_has_tag(message) {
+        return false;
+    }
+    // A live call always beats a tombstone, so Call-ID reuse can't 481 a call
+    // that is up right now.
+    calls.find_by_sip_call_id(call_id).is_none()
+}
+
 /// Handle an inbound SIP request — run through Python handlers.
 fn handle_request(
     inbound: InboundMessage,
@@ -2747,19 +2796,36 @@ fn handle_request(
     // ACK/BYE/PRACK/CANCEL and all responses are unaffected.
     if method == "INVITE"
         && state.is_draining.is_draining.load(std::sync::atomic::Ordering::Relaxed)
+        && !to_has_tag(&message)
     {
-        let to_has_tag = message.headers.get("To")
-            .map(|t| t.split(';').any(|p| p.trim().starts_with("tag=")))
-            .unwrap_or(false);
-        if !to_has_tag {
-            debug!("draining — rejecting new INVITE with 503 Service Unavailable");
-            let response = build_response(
-                &message, 503, "Service Unavailable",
-                state.server_header.as_deref(), &[],
-            );
-            send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
-            return;
-        }
+        debug!("draining — rejecting new INVITE with 503 Service Unavailable");
+        let response = build_response(
+            &message, 503, "Service Unavailable",
+            state.server_header.as_deref(), &[],
+        );
+        send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
+        return;
+    }
+
+    // In-dialog request for a B2BUA call this node already tore down: 481 rather
+    // than a silent drop (see `terminated_dialog_needs_481` for the why). Runs
+    // ahead of the B2BUA intercepts below so a re-INVITE for a dead call is also
+    // caught here — otherwise `handle_b2bua_invite` takes it for a new call.
+    if terminated_dialog_needs_481(&method, &message, &state.call_actors) {
+        debug!(
+            method = %method,
+            call_id = %message.headers.call_id().map(|s| s.as_str()).unwrap_or(""),
+            "in-dialog request for a torn-down B2BUA call — 481",
+        );
+        let response = build_response(
+            &message, 481, "Call/Transaction Does Not Exist",
+            state.server_header.as_deref(), &[],
+        );
+        send_message_from(
+            response, inbound.transport, inbound.remote_addr,
+            inbound.connection_id, Some(inbound.local_addr), state,
+        );
+        return;
     }
 
     // Check if B2BUA mode should handle this INVITE
@@ -14568,7 +14634,18 @@ fn handle_b2bua_bye(
     let call_id = match state.call_actors.find_by_sip_call_id(&sip_call_id) {
         Some(id) => id,
         None => {
-            warn!(sip_call_id = %sip_call_id, "B2BUA BYE: no matching call");
+            // Lost a race with a concurrent teardown — the dispatch gate saw
+            // this call, and it is gone by now. Same answer as the no-dialog-leg
+            // arm below: 481, never a silent drop (RFC 3261 §15.1.2).
+            warn!(sip_call_id = %sip_call_id, "B2BUA BYE: no matching call — 481");
+            let response = build_response(
+                &message, 481, "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(), &[],
+            );
+            send_message_from(
+                response, inbound.transport, inbound.remote_addr,
+                inbound.connection_id, Some(inbound.local_addr), state,
+            );
             return;
         }
     };
@@ -15706,7 +15783,17 @@ fn handle_b2bua_reinvite(
     let call_id = match state.call_actors.find_by_sip_call_id(&sip_call_id) {
         Some(id) => id,
         None => {
-            warn!(sip_call_id = %sip_call_id, "B2BUA re-INVITE: no matching call");
+            // Raced a concurrent teardown (the `is_reinvite` gate had matched).
+            // 481 like the no-dialog-leg arm below, never a silent drop.
+            warn!(sip_call_id = %sip_call_id, "B2BUA re-INVITE: no matching call — 481");
+            let response = build_response(
+                &message, 481, "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(), &[],
+            );
+            send_message_from(
+                response, inbound.transport, inbound.remote_addr,
+                inbound.connection_id, Some(inbound.local_addr), state,
+            );
             return;
         }
     };
@@ -16183,7 +16270,17 @@ fn handle_b2bua_update(
     let call_id = match state.call_actors.find_by_sip_call_id(&sip_call_id) {
         Some(id) => id,
         None => {
-            warn!(sip_call_id = %sip_call_id, "B2BUA UPDATE: no matching call");
+            // Raced a concurrent teardown. 481 like the no-dialog-leg arm below
+            // (RFC 3311 UPDATE, answered per RFC 3261 §12.2.2).
+            warn!(sip_call_id = %sip_call_id, "B2BUA UPDATE: no matching call — 481");
+            let response = build_response(
+                &message, 481, "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(), &[],
+            );
+            send_message_from(
+                response, inbound.transport, inbound.remote_addr,
+                inbound.connection_id, Some(inbound.local_addr), state,
+            );
             return;
         }
     };
@@ -16692,7 +16789,24 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
     let call_id = match state.call_actors.find_by_sip_call_id(&sip_call_id) {
         Some(id) => id,
         None => {
-            warn!(sip_call_id = %sip_call_id, "B2BUA REFER: no matching call");
+            // Raced a concurrent teardown. 481 like the no-dialog-leg arm below,
+            // never a silent drop (RFC 3515 §2.4.2 defers to RFC 3261 §12.2.2).
+            warn!(sip_call_id = %sip_call_id, "B2BUA REFER: no matching call — 481");
+            let response = build_response(
+                &message,
+                481,
+                "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(),
+                &[],
+            );
+            send_message_from(
+                response,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
             return;
         }
     };
@@ -17936,7 +18050,25 @@ fn handle_b2bua_notify(inbound: InboundMessage, message: SipMessage, state: &Dis
     let call_id = match state.call_actors.find_by_sip_call_id(&sip_call_id) {
         Some(id) => id,
         None => {
-            warn!(sip_call_id = %sip_call_id, "B2BUA NOTIFY: no matching call");
+            // Raced a concurrent teardown. 481 like the no-dialog-leg arm below
+            // — RFC 6665 §8.2.1 also answers 481 for a NOTIFY whose
+            // subscription is gone.
+            warn!(sip_call_id = %sip_call_id, "B2BUA NOTIFY: no matching call — 481");
+            let response = build_response(
+                &message,
+                481,
+                "Call/Transaction Does Not Exist",
+                state.server_header.as_deref(),
+                &[],
+            );
+            send_message_from(
+                response,
+                inbound.transport,
+                inbound.remote_addr,
+                inbound.connection_id,
+                Some(inbound.local_addr),
+                state,
+            );
             return;
         }
     };
@@ -22006,6 +22138,177 @@ a=rtpmap:8 PCMA/8000\r\n";
     fn clear_media_session_on_timeout_no_store_is_noop() {
         // Media backend not configured (rtpengine_sessions is None) → false.
         assert!(!clear_media_session_on_timeout(None, "1-1354742@host"));
+    }
+
+    // -----------------------------------------------------------------------
+    // In-dialog request against a torn-down B2BUA call → 481 (RFC 3261 §12.2.2)
+    // -----------------------------------------------------------------------
+
+    fn glare_a_leg(sip_call_id: &str) -> Leg {
+        Leg::new_a_leg(
+            sip_call_id.to_string(),
+            "tag-alice".to_string(),
+            "z9hG4bK-aleg".to_string(),
+            LegTransport {
+                remote_addr: "10.0.0.1:5060".parse().unwrap(),
+                connection_id: ConnectionId::default(),
+                transport: Transport::Udp,
+                local_addr: None,
+            },
+        )
+    }
+
+    /// A store whose only call carried `sip_call_id` and has been torn down —
+    /// the state the trunk's BYE leaves behind in the glare.
+    fn store_after_teardown(sip_call_id: &str) -> CallActorStore {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(glare_a_leg(sip_call_id));
+        store.remove_call(&call_id);
+        store
+    }
+
+    fn in_dialog_request(method: Method, sip_call_id: &str, to_tag: Option<&str>) -> SipMessage {
+        let to = match to_tag {
+            Some(tag) => format!("<sip:bob@example.com>;tag={tag}"),
+            None => "<sip:bob@example.com>".to_string(),
+        };
+        let cseq = format!("2 {}", method.as_str());
+        SipMessageBuilder::new()
+            .request(
+                method,
+                SipUri::new("example.com".to_string()).with_user("bob".to_string()),
+            )
+            .via("SIP/2.0/UDP ue.example.com:5060;branch=z9hG4bK-glare".to_string())
+            .to(to)
+            .from("<sip:alice@example.com>;tag=alice-tag".to_string())
+            .call_id(sip_call_id.to_string())
+            .cseq(cseq)
+            .max_forwards(70)
+            .content_length(0)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn bye_after_teardown_needs_481() {
+        // The field case: the trunk's BYE tore the call down, the UE's own BYE
+        // lands ~350ms later. Silently dropping it costs the UE 32s to timer F
+        // and then a full IMS re-registration.
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        let bye = in_dialog_request(Method::Bye, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        assert!(terminated_dialog_needs_481("BYE", &bye, &store));
+    }
+
+    #[test]
+    fn bye_for_live_call_needs_no_481() {
+        // A live call always wins: its own in-dialog requests must reach the
+        // B2BUA intercepts, never a 481.
+        let store = CallActorStore::new();
+        store.create_call(glare_a_leg("ue-call-id@10.0.0.1"));
+        let bye = in_dialog_request(Method::Bye, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        assert!(!terminated_dialog_needs_481("BYE", &bye, &store));
+    }
+
+    #[test]
+    fn reinvite_after_teardown_needs_481() {
+        // Also stops handle_b2bua_invite from taking a re-INVITE for a dead call
+        // as a brand-new call and dialling out again.
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        let reinvite = in_dialog_request(Method::Invite, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        assert!(terminated_dialog_needs_481("INVITE", &reinvite, &store));
+    }
+
+    #[test]
+    fn update_and_refer_after_teardown_need_481() {
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        let update = in_dialog_request(Method::Update, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        let refer = in_dialog_request(Method::Refer, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        assert!(terminated_dialog_needs_481("UPDATE", &update, &store));
+        assert!(terminated_dialog_needs_481("REFER", &refer, &store));
+    }
+
+    #[test]
+    fn ack_after_teardown_is_never_answered() {
+        // RFC 3261 §17.1.1.3 — an ACK has no response, ever.
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        let ack = in_dialog_request(Method::Ack, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        assert!(!terminated_dialog_needs_481("ACK", &ack, &store));
+    }
+
+    #[test]
+    fn cancel_after_teardown_is_left_to_handle_cancel() {
+        // handle_cancel's fall-through already 481s an unknown transaction, and
+        // it keys on the Via branch rather than the Call-ID.
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        let cancel = in_dialog_request(Method::Cancel, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        assert!(!terminated_dialog_needs_481("CANCEL", &cancel, &store));
+    }
+
+    #[test]
+    fn out_of_dialog_request_reusing_the_call_id_needs_no_481() {
+        // A peer that reuses a Call-ID for a *new* dialog sends no To-tag; it has
+        // to reach the normal INVITE path.
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        let invite = in_dialog_request(Method::Invite, "ue-call-id@10.0.0.1", None);
+        assert!(!terminated_dialog_needs_481("INVITE", &invite, &store));
+    }
+
+    #[test]
+    fn unknown_call_id_is_left_to_the_script() {
+        // Load-bearing for proxy mode: a CSCF loose-routes in-dialog requests for
+        // dialogs it never tracked (topmost Route belongs to another proxy), so
+        // "not a call of ours" must NOT become a 481.
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        let bye = in_dialog_request(Method::Bye, "someone-elses-dialog@10.0.0.9", Some("bob-tag"));
+        assert!(!terminated_dialog_needs_481("BYE", &bye, &store));
+    }
+
+    #[test]
+    fn b_leg_call_id_after_teardown_needs_481() {
+        // Glare can be lost by either peer, and the B2BUA's two legs carry
+        // different Call-IDs.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(glare_a_leg("ue-call-id@10.0.0.1"));
+        store.add_b_leg(
+            &call_id,
+            Leg::new_b_leg(
+                "trunk-call-id@10.0.0.2".to_string(),
+                "tag-b2bua".to_string(),
+                "sip:bob@10.0.0.2".to_string(),
+                "z9hG4bK-bleg".to_string(),
+                LegTransport {
+                    remote_addr: "10.0.0.2:5060".parse().unwrap(),
+                    connection_id: ConnectionId::default(),
+                    transport: Transport::Udp,
+                    local_addr: None,
+                },
+            ),
+        );
+        store.remove_call(&call_id);
+
+        let bye = in_dialog_request(Method::Bye, "trunk-call-id@10.0.0.2", Some("bob-tag"));
+        assert!(terminated_dialog_needs_481("BYE", &bye, &store));
+    }
+
+    #[test]
+    fn recreated_call_id_beats_the_tombstone() {
+        // Eviction is lazy, so a UE that reuses a Call-ID for its next call can
+        // be live and remembered-as-terminated at the same time. The live lookup
+        // has to win, or the new call's own BYE would be 481'd.
+        let store = store_after_teardown("ue-call-id@10.0.0.1");
+        store.create_call(glare_a_leg("ue-call-id@10.0.0.1"));
+        assert!(store.is_recently_terminated("ue-call-id@10.0.0.1"));
+
+        let bye = in_dialog_request(Method::Bye, "ue-call-id@10.0.0.1", Some("bob-tag"));
+        assert!(!terminated_dialog_needs_481("BYE", &bye, &store));
+    }
+
+    #[test]
+    fn to_has_tag_reads_the_dialog_identifier() {
+        let in_dialog = in_dialog_request(Method::Bye, "cid@host", Some("bob-tag"));
+        let out_of_dialog = in_dialog_request(Method::Invite, "cid@host", None);
+        assert!(to_has_tag(&in_dialog));
+        assert!(!to_has_tag(&out_of_dialog));
     }
 
 }


### PR DESCRIPTION
## The problem

Hang-up glare on a B2BUA call: both parties send BYE within a few hundred milliseconds, so the loser's BYE arrives after the call has been torn down. Nothing answers it.

The peer is left retransmitting to its own timer F — 32 s of silence, broken only by the deferred non-INVITE auto-100 (RFC 4320 §4.2 puts it at T2 ≈ 3.5 s). A VoNR UE reads that as a dead IMS and recovers at the modem level: it releases its IMS PDU session (5GSM cause #36) and re-registers. That is roughly 40 s during which a terminating INVITE cannot be delivered.

RFC 3261 §12.2.2 — and §15.1.2 for BYE specifically — requires `481 Call/Transaction Does Not Exist` here.

## Root cause

Not the `find_by_sip_call_id() == None` arms in the B2BUA in-dialog handlers. Those are real defects, but they are not the path this takes: the dispatch site performs the *identical* lookup as a gate before ever calling the handler (BYE at `dispatcher.rs:2671`, `is_reinvite` at `:2652`, UPDATE/REFER/NOTIFY/PRACK below it, CANCEL at `:9067`). A handler's own `None` arm is only reachable if the call vanishes in the microsecond window between gate and handler.

At a few hundred milliseconds the gate misses, so the BYE never enters the B2BUA path at all. It falls through to the proxy path, and a script with no route for an in-dialog BYE returns no action — `RequestAction::None`, the documented silent drop. Reproduced in the lab against a pre-fix binary:

```
processing request method=BYE remote=…:5060
silent drop (no action from script)          ← once per retransmit
```

CANCEL was already correct: `handle_cancel`'s fall-through 481s an unknown transaction at `:9087`.

## The fix

`CallActorStore` remembers the SIP Call-IDs of calls it has torn down — every leg, since the two sides carry different Call-IDs and either peer can lose the race — and the dispatcher answers 481 for any in-dialog request naming one. It runs ahead of the B2BUA intercepts, so a re-INVITE for a dead call is caught too; that previously reached `on_invite` as if it were a brand-new call.

Guard order, so a live call pays one hash and stops:

1. not ACK (never answered) and not CANCEL (already handled);
2. Call-ID is remembered;
3. To-tag present — a peer reusing a Call-ID for a *new* dialog must reach the normal INVITE path;
4. no live call — a live call always beats a remembered one.

A Call-ID this node never tracked is still left to the script. That is load-bearing for proxy mode: a CSCF legitimately loose-routes in-dialog requests for dialogs it does not own, so "not a call of ours" must not become a 481.

Bounded by both age (32 s, Timer H — the same expiry the zombie re-INVITE and post-CANCEL absorbers use) and count. Unlike those absorbers, which only gain entries on rare paths, this one gains an entry per leg on every teardown, so the TTL alone is not a bound: at 40k cps it would hold ~1.3M Call-IDs. The cap keeps the footprint flat while still covering ~1.6 s of teardowns at that rate, far wider than the sub-second window it exists for.

The timestamp doubles as a generation stamp. Without that, re-terminating a Call-ID seen before *un-remembered* it — the insert found it already present and pushed no fresh entry, so eviction aged out the first call's entry and removed the Call-ID that had just been remembered again. Peers do reuse Call-IDs across calls.

Also brings the B2BUA BYE / re-INVITE / UPDATE / REFER / NOTIFY handlers to the same answer when they lose the race with a concurrent teardown. Each returned silently where the neighbouring no-dialog-leg arm already sent 481.

## Testing

New sipp scenario pair under `--b2bua`: the trunk side hangs up first, the UAC waits for the relayed BYE, answers it, then sends its own now-orphaned BYE and asserts 481.

- pre-fix binary: **exit 255**, 1 failed call, BYE retransmitting unanswered
- with the fix: **exit 0**, 1 successful call, BYE answered immediately, no retransmits

Run twice against one long-lived instance so the second run exercises the Call-ID-reuse path above.

Two false-green traps found and closed while building it, both worth knowing about for other scenarios in this suite:

- under `--abort-on-container-exit`, a UAS that finishes first kills the UAC mid-scenario and the run reports green having asserted nothing. The UAS now outlives the UAC.
- a per-`recv` `timeout=` attribute is ignored by the sipp build used here: a pre-fix binary sat in BYE retransmits for the whole run and still exited 0. The container runs with `-max_retrans 2` instead, which ends an unanswered BYE as a failed call.

Unit coverage for the store (every leg remembered, live call never remembered, legs sharing a Call-ID counted once, re-termination, both eviction rules) and for the dispatcher predicate (BYE/re-INVITE/UPDATE/REFER after teardown → 481; ACK, CANCEL, out-of-dialog reuse, unknown Call-ID, live call, recreated Call-ID → no 481).

`cargo test` 3214 lib + 293 integration green, `clippy --all-targets --all-features -D warnings` clean, full `--b2bua` sipp suite green.

## Not done here

The 16-row `scripts/scale_test.sh` matrix and `scripts/run_memleak.sh` still need a run on the baseline hardware. The request path adds a single DashMap hash on in-dialog requests only; the one spot worth watching is `remember_terminated`, which takes a short global mutex per teardown (~80k acquisitions/sec at 40k cps) around a `push_back` and a few `pop_front`s.
