### PR TITLE
feat(media): WebSocket tee — stream a copy of a live call's audio without taking the call over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   registrar.lookup(uri) if c.age_secs < 3600]`). Monotonic, and preserved
   across a restart for bindings restored from a persistence backend; a stored
   record written before age tracking reports `0`.
+- **WebSocket tee — stream a copy of a live call's audio without taking the call
+  over.** The existing `ws_uri` bridge is a *takeover*: the WebSocket server
+  becomes leg A's far side and the A↔B relay is not wired, which is right for
+  voice-AI answering a call and wrong for everything else. A tee is send-only and
+  additive — the call relays or transcodes exactly as it would otherwise, and a
+  copy of its decoded audio streams out, leaving any SIPREC subscription and
+  recording on the leg untouched. That is the shape live transcription,
+  agent-assist and compliance monitoring need. Available declaratively as the
+  `ws_tee`, `ws_tee_direction` (`both` | `caller` | `callee`) and
+  `ws_tee_channels` (2 = caller/callee stereo, 1 = mixed mono) media-profile
+  fields, and imperatively mid-call as `rtpengine.attach_ws_tee(target, ws_uri,
+  direction="both", channels=None)` / `rtpengine.detach_ws_tee(target)`. Requires
+  `media.backend: siphon-rtp` (`siphon-rtp-proto` 0.1.5 `AttachWsTee` /
+  `DetachWsTee`); rtpengine and rtpproxy reject a tee profile at config load and
+  raise on the per-call verbs rather than returning a hollow success that streams
+  nothing.
+- **`@rtpengine.on_ws_tee_started` / `@rtpengine.on_ws_tee_ended`** — a tee can
+  end while the call carries on (the server closes the socket, the transport
+  fails), which is otherwise invisible: nothing about the call changes and the
+  consumer simply stops receiving audio. `on_ws_tee_ended` reports `reason`
+  (`detached` is the only orderly one), plus `frames_sent` and `frames_dropped`
+  so a slow consumer is distinguishable from a dead one; an unexpected end is
+  logged at WARN whether or not a handler is registered. `on_ws_tee_started`
+  carries the negotiated `channels` and `sample_rate` so a consumer decodes the
+  binary frames rather than guessing, and `stream_id` correlates the control
+  event with the `start` envelope on the socket. Both take the same optional
+  `call_id` / `from_tag` filters as `@rtpengine.on_dtmf`.
 - **Media profiles can drive the `siphon-rtp` WebSocket audio bridge and its DSP
   chain.** The engine has supported handing a leg's audio to an external
   WebSocket media server (decode → L16 uplink, L16 downlink → encode, the WS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,9 +3090,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226aef8325e781c170039a9a580312c28aa52aa6dac5c5f797a0df9a513f1309"
+checksum = "26afa6b54b21e7ba5c89a57bda3743ce2d2b829955f454e2663ba4b983f4e134"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.1.4"
+siphon-rtp-proto = "0.1.5"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -180,7 +180,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.1.4"
+siphon-rtp-proto = "0.1.5"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/docs/media-engines.md
+++ b/docs/media-engines.md
@@ -36,6 +36,7 @@ it nowhere, with nothing logged and silence on the line.
 | Profile field | `siphon-rtp` | `rtpengine` | `rtpproxy` |
 |---|---|---|---|
 | `ws_uri`, `ws_vad`, `ws_barge_in`, `ws_vad_threshold`, `ws_vad_hangover_ms` | yes | — | — |
+| `ws_tee`, `ws_tee_direction`, `ws_tee_channels` | yes | — | — |
 | `noise_suppression`, `echo_cancellation` | yes | — | — |
 | `received_from`, `rtcp_mux` | yes | yes | — |
 | `address_family` | yes | yes | — [^af] |
@@ -44,6 +45,91 @@ it nowhere, with nothing logged and silence on the line.
     `address_family` on `rtpproxy` warns at boot rather than failing the load:
     rtpproxy's `6` modifier states the family of the address the command already
     carries, so the call still works and only IPv4/IPv6 interworking is lost.
+
+---
+
+## WebSocket audio: bridge vs tee
+
+`siphon-rtp` can stream a call's decoded audio to a WebSocket media server in
+two different shapes. They look similar in config and are not interchangeable —
+picking the wrong one is the most likely way to get this wrong.
+
+| | `ws_uri` — **bridge** | `ws_tee` / `attach_ws_tee` — **tee** |
+|---|---|---|
+| The WS server is | leg A's far side | an extra listener |
+| A↔B relay | **not wired** | stays wired |
+| Audio direction | bidirectional | send-only |
+| SIPREC / recording on the leg | n/a (there is no B leg) | keep running |
+| Typical use | voice-AI answers the call | live transcription, agent assist, compliance |
+
+**Bridge (`ws_uri`).** The engine dials the URI and the WS server *becomes* the
+far end: it receives the caller's audio as L16 and what it sends back is encoded
+toward the caller. There is no second SIP leg. This is the voice-AI
+answer-the-call shape, usually paired with `rtpengine.answer_local(...)` and the
+built-in `voice_ai` profile.
+
+**Tee (`ws_tee`).** The call relays or transcodes exactly as it otherwise would,
+*and* a copy of the decoded audio is streamed out. Additive: one decode feeds
+the peer, the recorder, any SIPREC fork and the tee — there is no second jitter
+buffer and no second decode. A plain in-kernel relay is promoted to the
+userspace pipeline for the tee's lifetime and demoted again on detach.
+
+A tee never affects the call. If the consumer stalls the engine drops frames
+rather than backing up the media path, and reports the count on the
+`ws_tee_ended` event.
+
+Declare a tee on a profile:
+
+```yaml
+media:
+  backend: siphon-rtp
+  profiles:
+    recorded_call:
+      offer:
+        ws_tee: "wss://asr.internal/stream/{call_id}"
+        ws_tee_direction: both      # both (default) | caller | callee
+        ws_tee_channels: 2          # 2 = caller/callee stereo, 1 = mixed mono
+      answer: {}
+```
+
+…or attach and detach one mid-call from a script:
+
+```python
+@b2bua.on_answer
+async def on_answer(call, reply):
+    await rtpengine.answer(reply)
+    try:
+        await rtpengine.attach_ws_tee(call, f"wss://asr.internal/{call.call_id}")
+    except RuntimeError as error:
+        log.warn(f"transcription tee unavailable: {error}")   # never fail the call
+
+@b2bua.on_bye
+async def on_bye(call):
+    await rtpengine.detach_ws_tee(call)      # idempotent; the call teardown also does it
+```
+
+`ws_tee_channels` only means anything with `ws_tee_direction: both` — a
+single-leg tee is always mono. Unset leaves the engine's default: 2 channels
+for both legs, 1 for one.
+
+**Know when a tee dies.** A tee can end without the call ending — the server
+closes the socket, or the transport fails. Nothing about the call changes, so
+this is invisible unless you watch for it:
+
+```python
+@rtpengine.on_ws_tee_ended
+def tee_down(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+    if reason != "detached":                  # the only orderly end
+        log.warn(f"tee {stream_id} died: {reason} after {frames_sent} frames")
+    if frames_dropped:
+        log.warn(f"tee {stream_id} dropped {frames_dropped} frames — consumer too slow")
+```
+
+siphon also logs an unexpected tee end at WARN whether or not a handler is
+registered. `@rtpengine.on_ws_tee_started` gives the matching start, carrying
+the negotiated `channels` and `sample_rate` so a consumer decodes the binary
+frames rather than guessing; `stream_id` correlates the control event with the
+`start` envelope on the socket.
 
 ---
 

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -1954,6 +1954,8 @@ class MockRtpEngine:
         self._subscribe_answer_sdp: bytes = b""
         self._dtmf_handlers: list[dict[str, Any]] = []
         self._media_timeout_handlers: list[dict[str, Any]] = []
+        self._ws_tee_started_handlers: list[dict[str, Any]] = []
+        self._ws_tee_ended_handlers: list[dict[str, Any]] = []
 
     @property
     def active_sessions(self) -> int:
@@ -2467,6 +2469,107 @@ class MockRtpEngine:
         })
         return True
 
+    async def attach_ws_tee(
+        self,
+        target: Any,
+        ws_uri: str,
+        direction: str = "both",
+        channels: Optional[int] = None,
+    ) -> bool:
+        """Attach a **WebSocket tee** to a live call — stream a copy of its
+        decoded audio to a WebSocket media server while the call keeps relaying.
+
+        The distinction from the ``ws_uri`` media-profile flag matters:
+
+        * ``ws_uri`` is a **takeover** — the WebSocket server *becomes* leg A's
+          far side and the A↔B relay is not wired.  That is the voice-AI
+          answer-the-call shape.
+        * A tee is **send-only and additive** — the call relays (or transcodes)
+          normally *and* streams a copy of its audio out.  Any SIPREC
+          subscription and recording on the same leg keep running untouched.
+
+        Use a tee for live transcription, agent-assist, sentiment or compliance
+        monitoring on a call that is otherwise a normal two-party call.
+
+        A tee never affects the call: the engine drops frames rather than
+        stalling the media path if the consumer cannot keep up, and a failure
+        raises rather than tearing anything down — catch it and carry on.
+
+        Requires ``media.backend: siphon-rtp``; the rtpengine and rtpproxy
+        backends raise rather than silently doing nothing.
+
+        Args:
+            target: Request, Reply, or Call object.
+            ws_uri: ``ws://`` or ``wss://`` URI the engine dials as a client.
+            direction: Which leg(s) to stream — ``"both"`` (default),
+                ``"caller"`` (the offerer) or ``"callee"`` (the answerer).
+            channels: Wire channel count — ``2`` interleaves caller/callee as
+                stereo, ``1`` mixes them to mono. Only meaningful with
+                ``direction="both"``; a single-leg tee is always mono. ``None``
+                (default) leaves the engine's choice: 2 for both legs, 1 for one.
+
+        Returns:
+            ``True`` on success.
+
+        Example::
+
+            @b2bua.on_answer
+            async def on_answer(call, reply):
+                await rtpengine.answer(reply)
+                try:
+                    await rtpengine.attach_ws_tee(call, f"wss://asr.internal/{call.call_id}")
+                except RuntimeError as error:
+                    log.warn(f"transcription tee unavailable: {error}")
+        """
+        if direction not in ("both", "caller", "callee"):
+            raise ValueError(
+                "attach_ws_tee direction must be one of both / caller / callee, "
+                f"got {direction!r}"
+            )
+        if channels is not None and channels not in (1, 2):
+            raise ValueError(
+                f"attach_ws_tee channels must be 1 or 2, got {channels}"
+            )
+        call_id, from_tag = _resolve_media_target(target)
+        self.operations.append(("attach_ws_tee", ws_uri))
+        self.media_calls.append({
+            "op": "attach_ws_tee",
+            "call_id": call_id,
+            "from_tag": from_tag,
+            "ws_uri": ws_uri,
+            "direction": direction,
+            "channels": channels,
+        })
+        return True
+
+    async def detach_ws_tee(self, target: Any) -> bool:
+        """Detach a call's **WebSocket tee**, closing its stream.
+
+        Idempotent — detaching a call with no tee is not an error. A tee is
+        also torn down automatically when the call ends, so an explicit detach
+        is only needed to stop streaming mid-call.
+
+        Requires ``media.backend: siphon-rtp``.
+
+        Args:
+            target: Request, Reply, or Call object.
+
+        Returns:
+            ``True`` on success.
+
+        Example::
+
+            await rtpengine.detach_ws_tee(call)
+        """
+        call_id, from_tag = _resolve_media_target(target)
+        self.operations.append(("detach_ws_tee", None))
+        self.media_calls.append({
+            "op": "detach_ws_tee",
+            "call_id": call_id,
+            "from_tag": from_tag,
+        })
+        return True
+
     def on_dtmf(self, func_or_none: Any = None, *,
                 call_id: Optional[str] = None,
                 from_tag: Optional[str] = None) -> Any:
@@ -2550,6 +2653,111 @@ class MockRtpEngine:
             fired += 1
         return fired
 
+    def on_ws_tee_started(self, func_or_none: Any = None, *,
+                          call_id: Optional[str] = None,
+                          from_tag: Optional[str] = None) -> Any:
+        """Register a handler for **WebSocket tee started** events.
+
+        Fires once the engine has dialled the tee's WebSocket server, sent its
+        ``start`` envelope, and begun streaming. The handler receives the
+        negotiated wire shape, so it can decode the binary frames without
+        guessing — ``stream_id`` is the correlator between this control event
+        and the media stream on the socket.
+
+        Delivered by the native **siphon-rtp** backend only.
+
+        Usage::
+
+            @rtpengine.on_ws_tee_started
+            def tee_up(call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate):
+                log.info(f"tee {stream_id}: {channels}ch @ {sample_rate}Hz -> {ws_uri}")
+
+            @rtpengine.on_ws_tee_started(call_id="abc", from_tag="ftag1")
+            def tee_up_specific(call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate):
+                ...
+        """
+        def decorator(fn: Any) -> Any:
+            self._ws_tee_started_handlers.append({
+                "fn": fn,
+                "call_id": call_id,
+                "from_tag": from_tag,
+            })
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
+    def fire_ws_tee_started(self, call_id: str, from_tag: str, stream_id: str,
+                            ws_uri: str, direction: str = "both",
+                            channels: int = 2, sample_rate: int = 8000) -> int:
+        """Test helper: fire a ws-tee-started event.  Returns the number of
+        handlers that matched (and were invoked)."""
+        fired = 0
+        for entry in self._ws_tee_started_handlers:
+            if entry["call_id"] is not None and entry["call_id"] != call_id:
+                continue
+            if entry["from_tag"] is not None and entry["from_tag"] != from_tag:
+                continue
+            entry["fn"](call_id, from_tag, stream_id, ws_uri, direction,
+                        channels, sample_rate)
+            fired += 1
+        return fired
+
+    def on_ws_tee_ended(self, func_or_none: Any = None, *,
+                        call_id: Optional[str] = None,
+                        from_tag: Optional[str] = None) -> Any:
+        """Register a handler for **WebSocket tee ended** events.
+
+        Fires exactly once per started tee, **including when the server ends
+        it**. That is the point of the hook: any ``reason`` other than
+        ``"detached"`` means the audio stream died while the call is still up,
+        which is otherwise invisible — the call carries on and nothing reaches
+        the consumer. Re-attach, fail over, or alert from here.
+
+        ``reason`` is one of ``"detached"`` (the script or the call teardown
+        asked for it — the only orderly end), ``"server_closed"``,
+        ``"server_stopped"``, ``"call_ended"`` or ``"transport_error"``.
+
+        ``frames_dropped`` non-zero means the consumer could not keep up; the
+        call itself was never affected.
+
+        Delivered by the native **siphon-rtp** backend only.
+
+        Usage::
+
+            @rtpengine.on_ws_tee_ended
+            async def tee_down(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+                if reason != "detached":
+                    log.warn(f"tee {stream_id} died: {reason}")
+        """
+        def decorator(fn: Any) -> Any:
+            self._ws_tee_ended_handlers.append({
+                "fn": fn,
+                "call_id": call_id,
+                "from_tag": from_tag,
+            })
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
+    def fire_ws_tee_ended(self, call_id: str, from_tag: str, stream_id: str,
+                          reason: str = "detached",
+                          frames_sent: Optional[int] = None,
+                          frames_dropped: Optional[int] = None) -> int:
+        """Test helper: fire a ws-tee-ended event.  Returns the number of
+        handlers that matched (and were invoked)."""
+        fired = 0
+        for entry in self._ws_tee_ended_handlers:
+            if entry["call_id"] is not None and entry["call_id"] != call_id:
+                continue
+            if entry["from_tag"] is not None and entry["from_tag"] != from_tag:
+                continue
+            entry["fn"](call_id, from_tag, stream_id, reason, frames_sent,
+                        frames_dropped)
+            fired += 1
+        return fired
+
     def set_subscribe_request_sdp(self, sdp: bytes) -> None:
         """Configure the SDP returned by :meth:`subscribe_request` (test helper)."""
         self._subscribe_request_sdp = sdp
@@ -2578,6 +2786,8 @@ class MockRtpEngine:
         self.media_calls.clear()
         self._dtmf_handlers.clear()
         self._media_timeout_handlers.clear()
+        self._ws_tee_started_handlers.clear()
+        self._ws_tee_ended_handlers.clear()
         self._answer_local_no_codec = False
 
 

--- a/sdk/tests/test_rtpengine_media.py
+++ b/sdk/tests/test_rtpengine_media.py
@@ -473,3 +473,133 @@ async def on_invite(call):
         operation, uri = harness.rtpengine.ws_uris[-1]
         assert operation == "answer_local"
         assert uri.startswith("wss://ai.example.com/stream/")
+
+
+class TestWebSocketTee:
+    """``attach_ws_tee`` / ``detach_ws_tee`` — the additive send-only stream.
+
+    Distinct from ``ws_uri``, which is a *takeover*: with a tee the A-to-B
+    relay stays wired and any SIPREC subscription keeps running, so this is
+    the shape for live transcription / agent-assist on an ordinary call.
+    """
+
+    def test_attach_records_defaults(self, harness):
+        call = Call(call_id="tee-1@example.invalid")
+        asyncio.run(
+            harness.rtpengine.attach_ws_tee(call, "wss://asr.example.com/s")
+        )
+        assert ("attach_ws_tee", "wss://asr.example.com/s") in harness.rtpengine.operations
+        recorded = harness.rtpengine.media_calls[-1]
+        assert recorded["op"] == "attach_ws_tee"
+        assert recorded["call_id"] == "tee-1@example.invalid"
+        assert recorded["ws_uri"] == "wss://asr.example.com/s"
+        assert recorded["direction"] == "both"
+        assert recorded["channels"] is None
+
+    def test_attach_records_direction_and_channels(self, harness):
+        asyncio.run(
+            harness.rtpengine.attach_ws_tee(
+                Call(), "wss://asr.example.com/s", direction="caller", channels=1
+            )
+        )
+        recorded = harness.rtpengine.media_calls[-1]
+        assert recorded["direction"] == "caller"
+        assert recorded["channels"] == 1
+
+    def test_attach_rejects_unknown_direction(self, harness):
+        # "send" is the obvious wrong guess: a tee is send-only by definition,
+        # so the axis the engine exposes is which leg(s), not which way.
+        with pytest.raises(ValueError, match="direction"):
+            asyncio.run(
+                harness.rtpengine.attach_ws_tee(
+                    Call(), "wss://asr.example.com/s", direction="send"
+                )
+            )
+
+    def test_attach_rejects_bad_channel_count(self, harness):
+        with pytest.raises(ValueError, match="channels"):
+            asyncio.run(
+                harness.rtpengine.attach_ws_tee(
+                    Call(), "wss://asr.example.com/s", channels=3
+                )
+            )
+
+    def test_detach_records_call(self, harness):
+        call = Call(call_id="tee-2@example.invalid")
+        asyncio.run(harness.rtpengine.detach_ws_tee(call))
+        recorded = harness.rtpengine.media_calls[-1]
+        assert recorded["op"] == "detach_ws_tee"
+        assert recorded["call_id"] == "tee-2@example.invalid"
+
+    def test_target_forms_resolve_equivalently(self, harness):
+        # Same (call_id, from_tag) resolution as the other media verbs.
+        asyncio.run(
+            harness.rtpengine.attach_ws_tee(("call-5", "ftag-5"), "wss://h/s")
+        )
+        recorded = harness.rtpengine.media_calls[-1]
+        assert recorded["call_id"] == "call-5"
+        assert recorded["from_tag"] == "ftag-5"
+
+    def test_tee_started_handler_receives_the_wire_shape(self, harness):
+        # The wire shape is the payload's point: a consumer decodes the binary
+        # frames from these values rather than guessing.
+        seen = []
+
+        @harness.rtpengine.on_ws_tee_started
+        def tee_up(call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate):
+            seen.append((call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate))
+
+        fired = harness.rtpengine.fire_ws_tee_started(
+            "c", "f", "s-1", "wss://asr.example.com/s",
+            direction="caller", channels=1, sample_rate=16000,
+        )
+        assert fired == 1
+        assert seen == [
+            ("c", "f", "s-1", "wss://asr.example.com/s", "caller", 1, 16000)
+        ]
+
+    def test_tee_ended_handler_sees_an_unexpected_reason(self, harness):
+        # The reason a handler exists: the server going away is otherwise
+        # invisible — the call carries on and nothing reaches the consumer.
+        dead = []
+
+        @harness.rtpengine.on_ws_tee_ended
+        def tee_down(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+            if reason != "detached":
+                dead.append((stream_id, reason, frames_sent, frames_dropped))
+
+        harness.rtpengine.fire_ws_tee_ended("c", "f", "s-1", reason="detached")
+        assert dead == []
+
+        harness.rtpengine.fire_ws_tee_ended(
+            "c", "f", "s-2", reason="transport_error",
+            frames_sent=4200, frames_dropped=3,
+        )
+        assert dead == [("s-2", "transport_error", 4200, 3)]
+
+    def test_tee_ended_handler_filters_by_call_id_and_from_tag(self, harness):
+        hits = []
+
+        @harness.rtpengine.on_ws_tee_ended(call_id="abc", from_tag="ftag1")
+        def only_ours(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+            hits.append(stream_id)
+
+        assert harness.rtpengine.fire_ws_tee_ended("other", "ftag1", "s-1") == 0
+        assert harness.rtpengine.fire_ws_tee_ended("abc", "wrong", "s-2") == 0
+        assert harness.rtpengine.fire_ws_tee_ended("abc", "ftag1", "s-3") == 1
+        assert hits == ["s-3"]
+
+    def test_clear_drops_registered_tee_handlers(self, harness):
+        @harness.rtpengine.on_ws_tee_started
+        def tee_up(*args):
+            pass
+
+        @harness.rtpengine.on_ws_tee_ended
+        def tee_down(*args):
+            pass
+
+        assert harness.rtpengine.fire_ws_tee_started("c", "f", "s", "ws://h/s") == 1
+        assert harness.rtpengine.fire_ws_tee_ended("c", "f", "s") == 1
+        harness.rtpengine.clear()
+        assert harness.rtpengine.fire_ws_tee_started("c", "f", "s", "ws://h/s") == 0
+        assert harness.rtpengine.fire_ws_tee_ended("c", "f", "s") == 0

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -673,6 +673,27 @@ auth:
 #                       higher is less sensitive.
 #   ws_vad_hangover_ms  How long speech is held after energy drops before the
 #                       turn endpoint fires. Unset uses the engine's ~200 ms.
+#   ws_tee              Stream a COPY of this call's decoded audio to a WebSocket
+#                       media server. Not the same thing as ws_uri, and the
+#                       difference matters: ws_uri is a TAKEOVER (the WS server
+#                       becomes leg A's far side, A<->B is not wired), a tee is
+#                       SEND-ONLY and ADDITIVE (the call relays or transcodes
+#                       normally and a copy goes out, so any SIPREC fork and
+#                       recording on the leg keep running). Use it for live
+#                       transcription / agent assist / compliance on an otherwise
+#                       ordinary call. Same ws:// | wss:// rule and same
+#                       {call_id}/{from_tag}/{from_user}/{to_user} expansion as
+#                       ws_uri. A script can attach or detach one mid-call with
+#                       rtpengine.attach_ws_tee(...) / detach_ws_tee(...), and
+#                       learn when one dies via @rtpengine.on_ws_tee_ended.
+#   ws_tee_direction    Which leg(s) ws_tee streams: both (default) | caller
+#                       (the offerer) | callee (the answerer). Inert without
+#                       ws_tee.
+#   ws_tee_channels     Wire channels for ws_tee: 2 interleaves caller/callee as
+#                       stereo, 1 mixes them to mono. Only meaningful with
+#                       ws_tee_direction: both — a single-leg tee is always mono.
+#                       Unset uses the engine default (2 for both legs, 1 for
+#                       one). Inert without ws_tee.
 #   noise_suppression   Single-channel noise suppression on this leg's decoded
 #                       ingress audio. Engaged only on a userspace-transcoded leg
 #                       whose ingress codec runs at 8 or 16 kHz, and forces the
@@ -702,6 +723,21 @@ auth:
 #         noise_suppression: true
 #         echo_cancellation: true
 #       answer: *voice_ai_flags
+#
+# WebSocket tee — an ordinary relayed call, plus a copy of its audio streamed to
+# a transcription/analytics backend (the call keeps relaying; SIPREC unaffected):
+# media:
+#   backend: siphon-rtp
+#   siphon_rtp:
+#     address: "127.0.0.1:9000"
+#   profiles:
+#     recorded_call:
+#       offer: &tee_flags
+#         replace: ["origin"]
+#         ws_tee: "wss://asr.example.com/stream/{call_id}"
+#         ws_tee_direction: both        # both | caller | callee
+#         ws_tee_channels: 2            # 2 = caller/callee stereo, 1 = mixed mono
+#       answer: *tee_flags
 #
 # IPv4/IPv6 interworking — v6 access leg, v4 core:
 # media:

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::path::Path;
 use std::sync::LazyLock;
 use crate::error::{Result, SiphonError};
+use crate::rtpengine::profile::WsTeeDirection;
 
 // ---------------------------------------------------------------------------
 // Environment variable expansion — `${VAR}` and `${VAR:-default}`
@@ -1805,9 +1806,9 @@ impl MediaBackendKind {
 
     /// Which of `flags`' set fields this backend has no way to express.
     ///
-    /// The WebSocket bridge and the DSP knobs are native `siphon-rtp`
-    /// extensions; `received_from` and `rtcp_mux` are also real rtpengine NG
-    /// keys but have no `rtpproxy` equivalent.
+    /// The WebSocket bridge, the WebSocket tee and the DSP knobs are native
+    /// `siphon-rtp` extensions; `received_from` and `rtcp_mux` are also real
+    /// rtpengine NG keys but have no `rtpproxy` equivalent.
     ///
     /// A field the engine cannot honour is not a degraded call, it is a dead
     /// one — a `ws_uri` the engine never sees means the leg is answered and
@@ -1839,6 +1840,15 @@ impl MediaBackendKind {
             }
             if flags.echo_cancellation {
                 unsupported.push("echo_cancellation");
+            }
+            if flags.ws_tee.is_some() {
+                unsupported.push("ws_tee");
+            }
+            if flags.ws_tee_direction.is_some() {
+                unsupported.push("ws_tee_direction");
+            }
+            if flags.ws_tee_channels.is_some() {
+                unsupported.push("ws_tee_channels");
             }
         }
 
@@ -2125,12 +2135,52 @@ where
         .collect()
 }
 
-/// Serde deserializer for a media profile's `ws_uri`.
+/// Validate a WebSocket URI field, naming `field` in the error.
 ///
-/// The engine dials this as a WebSocket client, so anything that is not
+/// The engine dials these as a WebSocket client, so anything that is not
 /// `ws://` / `wss://` can never connect.  Caught here rather than as a
-/// connect failure per call.
+/// connect failure per call.  `field` is threaded through so an operator with
+/// a bad `ws_tee` is not told about `ws_uri`, a field they never set.
+fn validate_ws_uri_field<E>(value: Option<String>, field: &str) -> std::result::Result<Option<String>, E>
+where
+    E: serde::de::Error,
+{
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    let scheme = trimmed.split("://").next().unwrap_or_default();
+    match scheme.to_ascii_lowercase().as_str() {
+        "ws" | "wss" if trimmed.contains("://") => Ok(Some(trimmed.to_string())),
+        _ => Err(E::custom(format!(
+            "media profile {field} must be a ws:// or wss:// URI, got {value:?}"
+        ))),
+    }
+}
+
+/// Serde deserializer for a media profile's `ws_uri`.
 fn deserialize_ws_uri<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    validate_ws_uri_field(Option::deserialize(deserializer)?, "ws_uri")
+}
+
+/// Serde deserializer for a media profile's `ws_tee`.
+fn deserialize_ws_tee<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    validate_ws_uri_field(Option::deserialize(deserializer)?, "ws_tee")
+}
+
+/// Validate `ws_tee_direction` against the three values the engine accepts.
+///
+/// A direction the engine would reject is a config error rather than a value
+/// relayed onto the wire, matching how `address_family` is validated at load.
+fn deserialize_ws_tee_direction<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<WsTeeDirection>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -2140,14 +2190,12 @@ where
     let Some(value) = value else {
         return Ok(None);
     };
-    let trimmed = value.trim();
-    let scheme = trimmed.split("://").next().unwrap_or_default();
-    match scheme.to_ascii_lowercase().as_str() {
-        "ws" | "wss" if trimmed.contains("://") => Ok(Some(trimmed.to_string())),
-        _ => Err(de::Error::custom(format!(
-            "media profile ws_uri must be a ws:// or wss:// URI, got {value:?}"
-        ))),
-    }
+    WsTeeDirection::parse(&value).map(Some).ok_or_else(|| {
+        de::Error::custom(format!(
+            "media profile ws_tee_direction must be one of {}, got {value:?}",
+            WsTeeDirection::VALUES.join(" / ")
+        ))
+    })
 }
 
 /// A user-defined RTPEngine media profile with separate offer/answer NG flags.
@@ -2227,6 +2275,31 @@ pub struct NgFlagsConfig {
     /// uses the engine default.
     #[serde(default)]
     pub ws_vad_hangover_ms: Option<u32>,
+    /// Attach a **WebSocket tee** to this call: the engine dials this URI and
+    /// streams a copy of the call's decoded audio to it as L16.  `siphon-rtp`
+    /// backend only.
+    ///
+    /// Distinct from `ws_uri`, and the distinction matters: `ws_uri` is a
+    /// *takeover* (the WS server becomes leg A's far side, the A↔B relay is not
+    /// wired), a tee is *send-only and additive* (the call relays normally and
+    /// the tee streams a copy, leaving SIPREC and recording untouched).
+    ///
+    /// Supports the same `{call_id}`, `{from_tag}`, `{from_user}` and
+    /// `{to_user}` placeholders as `ws_uri`, expanded per call.  A script can
+    /// attach or detach a tee on a live call with
+    /// `rtpengine.attach_ws_tee(...)` / `rtpengine.detach_ws_tee(...)`.
+    #[serde(default, deserialize_with = "deserialize_ws_tee")]
+    pub ws_tee: Option<String>,
+    /// Which leg(s) `ws_tee` streams: `both` (default), `caller` or `callee`.
+    /// Inert without `ws_tee`.
+    #[serde(default, deserialize_with = "deserialize_ws_tee_direction")]
+    pub ws_tee_direction: Option<WsTeeDirection>,
+    /// Wire channel count for `ws_tee`: `2` interleaves caller/callee as stereo,
+    /// `1` mixes them to mono.  Only meaningful with `ws_tee_direction: both` —
+    /// a single-leg tee is always mono.  Unset uses the engine default (2 for
+    /// both legs, 1 for one).  Inert without `ws_tee`.
+    #[serde(default)]
+    pub ws_tee_channels: Option<u8>,
     /// Carry the real post-NAT source IP the proxy saw the request arrive from
     /// (rtpengine's `received from`), gating the leg's media ingress to it.
     ///
@@ -4986,6 +5059,121 @@ media:
         assert!(
             message.contains("voice_ai_custom"),
             "error should name the profile: {message}"
+        );
+    }
+
+    #[test]
+    fn parses_media_profile_websocket_tee_fields() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_tee: \"wss://asr.example.com/{call_id}\"\n        \
+             ws_tee_direction: \"callee\"\n        ws_tee_channels: 1\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let media = config.media.unwrap();
+        let offer = &media.profiles.get("voice_ai_custom").unwrap().offer;
+        assert_eq!(
+            offer.ws_tee.as_deref(),
+            Some("wss://asr.example.com/{call_id}")
+        );
+        assert_eq!(offer.ws_tee_direction, Some(WsTeeDirection::Callee));
+        assert_eq!(offer.ws_tee_channels, Some(1));
+    }
+
+    /// A profile that does not ask for a tee must stay byte-identical on the
+    /// wire to what it emitted before these knobs existed.
+    #[test]
+    fn media_profile_websocket_tee_fields_default_off() {
+        let yaml = ws_profile_yaml(
+            RTPENGINE_BACKEND,
+            "      offer:\n        replace: [\"origin\"]\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let media = config.media.unwrap();
+        let offer = &media.profiles.get("voice_ai_custom").unwrap().offer;
+        assert!(offer.ws_tee.is_none());
+        assert!(offer.ws_tee_direction.is_none());
+        assert!(offer.ws_tee_channels.is_none());
+    }
+
+    #[test]
+    fn accepts_media_profile_ws_tee_direction_case_insensitively() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_tee: \"wss://asr.example.com/s\"\n        \
+             ws_tee_direction: \" Caller \"\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let media = config.media.unwrap();
+        assert_eq!(
+            media
+                .profiles
+                .get("voice_ai_custom")
+                .unwrap()
+                .offer
+                .ws_tee_direction,
+            Some(WsTeeDirection::Caller)
+        );
+    }
+
+    #[test]
+    fn rejects_media_profile_bad_ws_tee_direction() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_tee: \"wss://asr.example.com/s\"\n        \
+             ws_tee_direction: \"send\"\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("unknown direction must be rejected");
+        assert!(
+            error.to_string().contains("ws_tee_direction"),
+            "error should name the field: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_media_profile_non_websocket_ws_tee_scheme() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_tee: \"https://asr.example.com/s\"\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("https:// must be rejected");
+        assert!(
+            error.to_string().contains("ws_tee"),
+            "error should name the field: {error}"
+        );
+    }
+
+    /// Same reasoning as `ws_uri`: a tee the engine never receives streams
+    /// nothing, so the consumer sits silent on a call that looks healthy.
+    #[test]
+    fn rejects_websocket_tee_profile_on_rtpengine_backend() {
+        let yaml = ws_profile_yaml(
+            RTPENGINE_BACKEND,
+            "      offer:\n        ws_tee: \"wss://asr.example.com/s\"\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("ws_tee on rtpengine must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("ws_tee") && message.contains("rtpengine"),
+            "error should name the field and the backend: {message}"
+        );
+        assert!(
+            message.contains("voice_ai_custom"),
+            "error should name the profile: {message}"
+        );
+    }
+
+    #[test]
+    fn rejects_websocket_tee_profile_on_rtpproxy_backend() {
+        let yaml = ws_profile_yaml(
+            RTPPROXY_BACKEND,
+            "      offer:\n        ws_tee: \"wss://asr.example.com/s\"\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("ws_tee on rtpproxy must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("ws_tee") && message.contains("rtpproxy"),
+            "error should name the field and the backend: {message}"
         );
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1213,6 +1213,138 @@ pub async fn run(
                             crate::cdr::write(media_summary_to_cdr(&summary));
                         }
                     }
+                    crate::rtpengine::events::RtpEngineEvent::WsTeeStarted(tee) => {
+                        tracing::debug!(
+                            call_id = %tee.call_id,
+                            from_tag = %tee.from_tag,
+                            stream_id = %tee.stream_id,
+                            ws_uri = %tee.ws_uri,
+                            direction = %tee.direction.as_str(),
+                            channels = tee.channels,
+                            sample_rate = tee.sample_rate,
+                            "media engine started a websocket tee"
+                        );
+                        let engine_state = state_for_events.engine.state();
+                        let handlers =
+                            engine_state.ws_tee_started_handlers(&tee.call_id, &tee.from_tag);
+                        if handlers.is_empty() {
+                            continue;
+                        }
+                        let state_ref = Arc::clone(&state_for_events);
+                        let tee_clone = tee.clone();
+                        let _ = crate::script::py_executor::try_run(move || {
+                            let engine_state = state_ref.engine.state();
+                            let handlers = engine_state
+                                .ws_tee_started_handlers(&tee_clone.call_id, &tee_clone.from_tag);
+                            pyo3::Python::attach(|python| {
+                                for handler in handlers {
+                                    let callable = handler.callable.bind(python);
+                                    let result = callable.call1((
+                                        tee_clone.call_id.as_str(),
+                                        tee_clone.from_tag.as_str(),
+                                        tee_clone.stream_id.as_str(),
+                                        tee_clone.ws_uri.as_str(),
+                                        tee_clone.direction.as_str(),
+                                        tee_clone.channels,
+                                        tee_clone.sample_rate,
+                                    ));
+                                    match result {
+                                        Ok(ret) => {
+                                            if handler.is_async {
+                                                if let Err(error) = run_coroutine(python, &ret) {
+                                                    tracing::error!(
+                                                        %error,
+                                                        "async rtpengine.on_ws_tee_started handler error"
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        Err(error) => {
+                                            tracing::error!(
+                                                %error,
+                                                "rtpengine.on_ws_tee_started handler failed"
+                                            );
+                                        }
+                                    }
+                                }
+                            });
+                        })
+                        .await;
+                    }
+                    crate::rtpengine::events::RtpEngineEvent::WsTeeEnded(tee) => {
+                        // A tee that ends for anything other than an explicit
+                        // detach means audio stopped reaching the consumer while
+                        // the call is still up — the AI backend went away and the
+                        // caller is now talking to nothing.  Log that at WARN even
+                        // when no handler is registered, so it is visible rather
+                        // than inferred from missing audio.
+                        if tee.reason.is_unexpected() {
+                            tracing::warn!(
+                                call_id = %tee.call_id,
+                                from_tag = %tee.from_tag,
+                                stream_id = %tee.stream_id,
+                                reason = %tee.reason.as_str(),
+                                frames_sent = ?tee.frames_sent,
+                                frames_dropped = ?tee.frames_dropped,
+                                "websocket tee ended unexpectedly (call still up, audio no longer streaming)"
+                            );
+                        } else {
+                            tracing::debug!(
+                                call_id = %tee.call_id,
+                                from_tag = %tee.from_tag,
+                                stream_id = %tee.stream_id,
+                                reason = %tee.reason.as_str(),
+                                frames_sent = ?tee.frames_sent,
+                                frames_dropped = ?tee.frames_dropped,
+                                "websocket tee ended"
+                            );
+                        }
+                        let engine_state = state_for_events.engine.state();
+                        let handlers =
+                            engine_state.ws_tee_ended_handlers(&tee.call_id, &tee.from_tag);
+                        if handlers.is_empty() {
+                            continue;
+                        }
+                        let state_ref = Arc::clone(&state_for_events);
+                        let tee_clone = tee.clone();
+                        let _ = crate::script::py_executor::try_run(move || {
+                            let engine_state = state_ref.engine.state();
+                            let handlers = engine_state
+                                .ws_tee_ended_handlers(&tee_clone.call_id, &tee_clone.from_tag);
+                            pyo3::Python::attach(|python| {
+                                for handler in handlers {
+                                    let callable = handler.callable.bind(python);
+                                    let result = callable.call1((
+                                        tee_clone.call_id.as_str(),
+                                        tee_clone.from_tag.as_str(),
+                                        tee_clone.stream_id.as_str(),
+                                        tee_clone.reason.as_str(),
+                                        tee_clone.frames_sent,
+                                        tee_clone.frames_dropped,
+                                    ));
+                                    match result {
+                                        Ok(ret) => {
+                                            if handler.is_async {
+                                                if let Err(error) = run_coroutine(python, &ret) {
+                                                    tracing::error!(
+                                                        %error,
+                                                        "async rtpengine.on_ws_tee_ended handler error"
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        Err(error) => {
+                                            tracing::error!(
+                                                %error,
+                                                "rtpengine.on_ws_tee_ended handler failed"
+                                            );
+                                        }
+                                    }
+                                }
+                            });
+                        })
+                        .await;
+                    }
                     crate::rtpengine::events::RtpEngineEvent::Unknown { event, call_id, .. } => {
                         tracing::debug!(
                             %event,

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -25,7 +25,7 @@ use tracing::debug;
 
 use super::client::{PlayMediaSource, RtpEngineSet};
 use super::error::RtpEngineError;
-use super::profile::NgFlags;
+use super::profile::{NgFlags, WsTeeDirection};
 use super::rtpproxy::RtpProxyClientSet;
 use super::siphon_rtp::SiphonRtpClientSet;
 
@@ -391,6 +391,59 @@ impl MediaBackend {
             Self::RtpEngine(set) => set.unsubscribe(call_id, from_tag, to_tag).await,
             Self::SiphonRtp(client) => client.unsubscribe(call_id, from_tag, to_tag).await,
             Self::RtpProxy(client) => client.unsubscribe(call_id, from_tag, to_tag).await,
+        }
+    }
+
+    /// Attach a WebSocket tee to a live call — stream a copy of its decoded
+    /// audio to `ws_uri` while the call keeps relaying.
+    ///
+    /// A native `siphon-rtp` extension.  The rtpengine and rtpproxy backends
+    /// return [`RtpEngineError::Unsupported`] rather than `Ok(())`: a hollow
+    /// success would read as "the tee is attached" while nothing ever reaches
+    /// the consumer.  The declarative twin (`ws_tee` on a media profile) is
+    /// rejected at config load for the same reason.
+    pub async fn attach_ws_tee(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        ws_uri: &str,
+        direction: WsTeeDirection,
+        channels: Option<u8>,
+    ) -> Result<(), RtpEngineError> {
+        match self {
+            Self::SiphonRtp(client) => {
+                client
+                    .attach_ws_tee(call_id, from_tag, ws_uri, direction, channels)
+                    .await
+            }
+            Self::RtpEngine(_) => Err(RtpEngineError::Unsupported {
+                operation: "attach_ws_tee",
+                backend: "rtpengine",
+            }),
+            Self::RtpProxy(_) => Err(RtpEngineError::Unsupported {
+                operation: "attach_ws_tee",
+                backend: "rtpproxy",
+            }),
+        }
+    }
+
+    /// Detach a call's WebSocket tee.  Idempotent on `siphon-rtp`; unsupported
+    /// on the other backends for the same reason as [`Self::attach_ws_tee`].
+    pub async fn detach_ws_tee(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+    ) -> Result<(), RtpEngineError> {
+        match self {
+            Self::SiphonRtp(client) => client.detach_ws_tee(call_id, from_tag).await,
+            Self::RtpEngine(_) => Err(RtpEngineError::Unsupported {
+                operation: "detach_ws_tee",
+                backend: "rtpengine",
+            }),
+            Self::RtpProxy(_) => Err(RtpEngineError::Unsupported {
+                operation: "detach_ws_tee",
+                backend: "rtpproxy",
+            }),
         }
     }
 

--- a/src/rtpengine/error.rs
+++ b/src/rtpengine/error.rs
@@ -18,6 +18,22 @@ pub enum RtpEngineError {
 
     #[error("RTPEngine returned error: {0}")]
     EngineError(String),
+
+    /// The configured media backend has no way to perform this operation.
+    ///
+    /// Returned rather than a silent `Ok(())` — a hollow success on, say, an
+    /// `attach_ws_tee` against rtpengine reads as "the tee is attached" while no
+    /// audio ever reaches the consumer, which is exactly the failure the
+    /// config-load rejection of WS profile fields exists to prevent.  The
+    /// declarative path is caught at boot; this is its per-call twin for
+    /// operations a script issues directly.
+    #[error("{operation} is not supported by the {backend} media backend")]
+    Unsupported {
+        /// The operation asked for, e.g. `"attach_ws_tee"`.
+        operation: &'static str,
+        /// The configured backend's name as it appears in `media.backend`.
+        backend: &'static str,
+    },
 }
 
 impl RtpEngineError {
@@ -131,5 +147,20 @@ mod tests {
         assert!(!RtpEngineError::from(io_error).is_call_not_found());
         // An engine error that is NOT a not-found must still warn.
         assert!(!RtpEngineError::EngineError("no-encodable-codec".to_string()).is_call_not_found());
+    }
+
+    #[test]
+    fn unsupported_error_names_the_operation_and_backend() {
+        let error = RtpEngineError::Unsupported {
+            operation: "attach_ws_tee",
+            backend: "rtpengine",
+        };
+        assert_eq!(
+            error.to_string(),
+            "attach_ws_tee is not supported by the rtpengine media backend"
+        );
+        // Never mistaken for "the call is already gone" — a safety-net delete
+        // must not treat an unsupported operation as success.
+        assert!(!error.is_call_not_found());
     }
 }

--- a/src/rtpengine/events.rs
+++ b/src/rtpengine/events.rs
@@ -22,6 +22,7 @@ use tracing::{debug, info, warn};
 
 use super::bencode::{self, BencodeValue};
 use super::error::RtpEngineError;
+use super::profile::WsTeeDirection;
 
 /// One decoded media-engine event.
 #[derive(Debug, Clone)]
@@ -43,6 +44,14 @@ pub enum RtpEngineEvent {
     /// scraping logs.  Emitted by the `siphon-rtp` native backend only; the
     /// rtpengine NG backend does not surface it.
     CallSummary(CallSummary),
+    /// A WebSocket tee started streaming — the engine dialled the server, sent
+    /// `start`, and the call's decoded audio is now flowing.  Emitted by the
+    /// `siphon-rtp` native backend only.
+    WsTeeStarted(WsTeeStarted),
+    /// A WebSocket tee stopped, for any reason including the *server* ending it.
+    /// Emitted exactly once per started tee, so a script learns the stream died
+    /// rather than silently losing audio.  `siphon-rtp` native backend only.
+    WsTeeEnded(WsTeeEnded),
     /// An event we didn't recognise — passed through for logging.
     Unknown {
         event: String,
@@ -124,6 +133,88 @@ pub struct CallLegSummary {
     /// `"full"` (MOS includes the G.107 delay term) or `"loss+jitter"` — how the
     /// MOS was derived.
     pub mos_basis: Option<String>,
+}
+
+/// A WebSocket tee started streaming, carried by
+/// [`RtpEngineEvent::WsTeeStarted`].  Carries the negotiated wire shape so a
+/// consumer can decode the binary frames without guessing.
+#[derive(Debug, Clone)]
+pub struct WsTeeStarted {
+    /// SIP Call-ID the media session is keyed on.
+    pub call_id: String,
+    /// The teed leg's from-tag.
+    pub from_tag: String,
+    /// The tee's stream id, matching the `start` frame on the WebSocket — the
+    /// correlator between this control event and the media stream itself.
+    pub stream_id: String,
+    /// The URI the engine dialled.
+    pub ws_uri: String,
+    /// Which leg(s) are being streamed.
+    pub direction: WsTeeDirection,
+    /// Wire channels: 1 = mono/mixed, 2 = caller/callee interleaved.
+    pub channels: u8,
+    /// Wire sample rate in Hz (L16, little-endian).
+    pub sample_rate: u32,
+}
+
+/// A WebSocket tee stopped, carried by [`RtpEngineEvent::WsTeeEnded`].
+#[derive(Debug, Clone)]
+pub struct WsTeeEnded {
+    pub call_id: String,
+    pub from_tag: String,
+    /// The stream id from the matching [`WsTeeStarted`].
+    pub stream_id: String,
+    /// Why the stream ended.
+    pub reason: WsTeeEndReason,
+    /// Wire frames handed to the transport over the tee's lifetime.
+    pub frames_sent: Option<u64>,
+    /// Frames dropped because the server stalled (bounded queue full) or a
+    /// channel ring overflowed.  Non-zero means the consumer could not keep up;
+    /// the call itself was never affected.
+    pub frames_dropped: Option<u64>,
+}
+
+/// Why a WebSocket tee stream ended.  A siphon-side mirror of the native
+/// backend's `siphon_rtp_proto::WsTeeEndReason`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WsTeeEndReason {
+    /// The script detached it, or the call was torn down.
+    Detached,
+    /// The WebSocket server closed the connection.
+    ServerClosed,
+    /// The WebSocket server sent a `stop` control frame.
+    ServerStopped,
+    /// The call's media path went away, so no further audio can be teed.
+    CallEnded,
+    /// A WebSocket/transport error ended the stream.
+    TransportError,
+    /// A reason this build of siphon does not know — a newer engine.  Carries
+    /// the wire spelling so a script can still act on it rather than seeing the
+    /// tee end for no stated reason.
+    Other(&'static str),
+}
+
+impl WsTeeEndReason {
+    /// The wire spelling, as handed to Python handlers.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Detached => "detached",
+            Self::ServerClosed => "server_closed",
+            Self::ServerStopped => "server_stopped",
+            Self::CallEnded => "call_ended",
+            Self::TransportError => "transport_error",
+            Self::Other(reason) => reason,
+        }
+    }
+
+    /// Whether the tee ended for a reason the script did not ask for.
+    ///
+    /// `detached` is the only orderly end — every other reason means audio
+    /// stopped reaching the consumer while the call was still up, which is the
+    /// silent-failure case a handler exists to catch.
+    pub fn is_unexpected(self) -> bool {
+        !matches!(self, Self::Detached)
+    }
 }
 
 /// Helpers for extracting values from a bencoded event dict.

--- a/src/rtpengine/mod.rs
+++ b/src/rtpengine/mod.rs
@@ -22,7 +22,7 @@ pub mod siphon_rtp;
 pub use backend::MediaBackend;
 pub use client::{RtpEngineClient, RtpEngineSet};
 pub use error::RtpEngineError;
-pub use profile::{NgFlags, ProfileEntry, ProfileRegistry};
+pub use profile::{NgFlags, ProfileEntry, ProfileRegistry, WsTeeDirection};
 pub use rtpproxy::{RtpProxyClient, RtpProxyClientSet};
 pub use session::{MediaSession, MediaSessionStore};
 pub use siphon_rtp::{SiphonRtpClient, SiphonRtpClientSet};

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -11,9 +11,10 @@
 //! Operators can define additional profiles (or override built-ins) in the YAML
 //! config under `media.profiles`.
 //!
-//! Not every flag is honourable by every media backend — the WebSocket bridge
-//! and DSP knobs are native `siphon-rtp` extensions, and `rtpproxy` has no
-//! equivalent for `address_family`, `received_from` or `rtcp_mux`.  A profile
+//! Not every flag is honourable by every media backend — the WebSocket bridge,
+//! the WebSocket tee and the DSP knobs are native `siphon-rtp` extensions, and
+//! `rtpproxy` has no equivalent for `address_family`, `received_from` or
+//! `rtcp_mux`.  A profile
 //! asking for something its configured backend cannot do is rejected at config
 //! load; see `MediaBackendKind::unsupported_profile_fields`.
 
@@ -270,6 +271,50 @@ impl Default for ProfileRegistry {
     }
 }
 
+/// Which leg(s) of a call a WebSocket tee streams.
+///
+/// A siphon-side mirror of the native backend's `siphon_rtp_proto::WsTeeDirection`,
+/// so the config and profile layers stay free of the proto type — the same posture
+/// [`super::events::CallSummary`] takes for the call-summary event.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WsTeeDirection {
+    /// Both legs: stereo (channel 0 = caller, channel 1 = callee) unless
+    /// [`NgFlags::ws_tee_channels`] is 1, which mixes them to mono.
+    #[default]
+    Both,
+    /// Only the caller's (offerer's) audio, as a mono monologue.
+    Caller,
+    /// Only the callee's (answerer's) audio, as a mono monologue.
+    Callee,
+}
+
+impl WsTeeDirection {
+    /// The YAML / Python spelling, matching the proto's `snake_case` wire form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Both => "both",
+            Self::Caller => "caller",
+            Self::Callee => "callee",
+        }
+    }
+
+    /// Parse the YAML / Python spelling, case-insensitively.
+    ///
+    /// Returns `None` for anything else so the caller can raise a named error
+    /// rather than silently relaying a direction the engine would reject.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "both" => Some(Self::Both),
+            "caller" => Some(Self::Caller),
+            "callee" => Some(Self::Callee),
+            _ => None,
+        }
+    }
+
+    /// The accepted values, for error messages.
+    pub const VALUES: [&'static str; 3] = ["both", "caller", "callee"];
+}
+
 /// NG protocol flags sent with offer/answer commands.
 #[derive(Debug, Clone, Default)]
 pub struct NgFlags {
@@ -346,6 +391,31 @@ pub struct NgFlags {
     /// fires.  `None` uses the engine's ~200 ms default.  Only meaningful with
     /// [`NgFlags::ws_vad`] / [`NgFlags::ws_barge_in`].
     pub ws_vad_hangover_ms: Option<u32>,
+    /// Attach a **WebSocket tee** to this call at offer/answer time — the
+    /// declarative twin of `rtpengine.attach_ws_tee(...)`, so a profile can turn
+    /// the tee on without a second round-trip.
+    ///
+    /// The critical distinction from [`NgFlags::ws_uri`]: `ws_uri` is a
+    /// **takeover** — the WS server *becomes* leg A's far side and the A↔B relay
+    /// is not wired.  A tee is **send-only and additive** — the call relays (or
+    /// transcodes) normally *and* streams a copy of its decoded audio to this
+    /// URI, leaving any SIPREC subscription and recording untouched.  Setting
+    /// both on one profile is legal but almost never what you want.
+    ///
+    /// Applied once the call's media path exists (on `answer` / `answer_local`)
+    /// and torn down with the call.
+    ///
+    /// A native `siphon-rtp` extension: the NG/bencode and rtpproxy backends
+    /// have no equivalent and cannot honour it.
+    pub ws_tee: Option<String>,
+    /// Which leg(s) [`NgFlags::ws_tee`] streams.  `None` leaves the engine's
+    /// default (both).  Inert without [`NgFlags::ws_tee`].
+    pub ws_tee_direction: Option<WsTeeDirection>,
+    /// Wire channel count for [`NgFlags::ws_tee`]: `2` interleaves caller/callee
+    /// as stereo, `1` mixes them to mono.  Only meaningful streaming both legs —
+    /// a single-leg tee is always mono.  `None` leaves the engine's default (2
+    /// for both legs, 1 for one).  Inert without [`NgFlags::ws_tee`].
+    pub ws_tee_channels: Option<u8>,
     /// Profile **policy**: carry the real post-NAT source IP the proxy saw this
     /// request arrive from (rtpengine's `received from`) on offer/answer.
     ///
@@ -397,6 +467,9 @@ impl NgFlags {
             ws_barge_in: config.ws_barge_in,
             ws_vad_threshold: config.ws_vad_threshold,
             ws_vad_hangover_ms: config.ws_vad_hangover_ms,
+            ws_tee: config.ws_tee.clone(),
+            ws_tee_direction: config.ws_tee_direction,
+            ws_tee_channels: config.ws_tee_channels,
             carry_received_from: config.received_from,
             received_from: None,
             rtcp_mux: config.rtcp_mux.clone(),
@@ -464,12 +537,13 @@ impl NgFlags {
             let items: Vec<&str> = self.rtcp_mux.iter().map(|s| s.as_str()).collect();
             pairs.push(("rtcp-mux", BencodeValue::string_list(&items)));
         }
-        // The WS bridge and DSP knobs (ws_uri, ws_vad, ws_barge_in,
-        // ws_vad_threshold, ws_vad_hangover_ms, noise_suppression,
-        // echo_cancellation) are native siphon-rtp extensions with no NG
-        // equivalent, so they are deliberately not emitted here.  A profile that
-        // sets them on this backend is rejected at config load rather than
-        // silently degraded — see `MediaBackendKind::unsupported_profile_fields`.
+        // The WS bridge, WS tee and DSP knobs (ws_uri, ws_vad, ws_barge_in,
+        // ws_vad_threshold, ws_vad_hangover_ms, ws_tee, ws_tee_direction,
+        // ws_tee_channels, noise_suppression, echo_cancellation) are native
+        // siphon-rtp extensions with no NG equivalent, so they are deliberately
+        // not emitted here.  A profile that sets them on this backend is rejected
+        // at config load rather than silently degraded — see
+        // `MediaBackendKind::unsupported_profile_fields`.
 
         pairs
     }

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -30,6 +30,7 @@ use futures_util::future::join_all;
 use siphon_rtp_proto::{
     frame, CmdResult, Command, Event, LegSummary as ProtoLegSummary, PlayEndReason,
     PlayMediaSource as ProtoPlayMediaSource, ProfileFlags, Request, Response,
+    WsTeeDirection as ProtoWsTeeDirection, WsTeeEndReason as ProtoWsTeeEndReason,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -39,8 +40,11 @@ use tracing::{debug, info, trace, warn};
 
 use super::client::PlayMediaSource;
 use super::error::RtpEngineError;
-use super::events::{CallLegSummary, CallSummary, DtmfEvent, RtpEngineEvent};
-use super::profile::NgFlags;
+use super::events::{
+    CallLegSummary, CallSummary, DtmfEvent, RtpEngineEvent, WsTeeEndReason, WsTeeStarted,
+    WsTeeEnded,
+};
+use super::profile::{NgFlags, WsTeeDirection};
 
 /// Reserved request id for the auth handshake (real requests start at 1).
 const AUTH_REQUEST_ID: u64 = 0;
@@ -81,11 +85,33 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         ws_barge_in: flags.ws_barge_in,
         ws_vad_threshold: flags.ws_vad_threshold,
         ws_vad_hangover_ms: flags.ws_vad_hangover_ms,
+        ws_tee: flags.ws_tee.clone(),
+        ws_tee_direction: flags.ws_tee_direction.map(proto_ws_tee_direction),
+        ws_tee_channels: flags.ws_tee_channels,
         // The per-call address, not the `carry_received_from` policy bit — the
         // script API injects the former only when the latter is set, so an
         // opted-out profile leaves this `None` and serialises away.
         received_from: flags.received_from,
         rtcp_mux: flags.rtcp_mux.clone(),
+    }
+}
+
+/// Map siphon's [`WsTeeDirection`] onto the proto twin.
+pub(crate) fn proto_ws_tee_direction(direction: WsTeeDirection) -> ProtoWsTeeDirection {
+    match direction {
+        WsTeeDirection::Both => ProtoWsTeeDirection::Both,
+        WsTeeDirection::Caller => ProtoWsTeeDirection::Caller,
+        WsTeeDirection::Callee => ProtoWsTeeDirection::Callee,
+    }
+}
+
+/// Map the proto [`ProtoWsTeeDirection`] back onto siphon's own enum, so the
+/// generic event type stays free of the proto.
+fn ws_tee_direction_from_proto(direction: ProtoWsTeeDirection) -> WsTeeDirection {
+    match direction {
+        ProtoWsTeeDirection::Both => WsTeeDirection::Both,
+        ProtoWsTeeDirection::Caller => WsTeeDirection::Caller,
+        ProtoWsTeeDirection::Callee => WsTeeDirection::Callee,
     }
 }
 
@@ -624,6 +650,49 @@ impl SiphonRtpClient {
         )
     }
 
+    /// Attach a WebSocket tee to a live call — stream a copy of its decoded
+    /// audio to `ws_uri` while the call keeps relaying.
+    ///
+    /// Additive, unlike the `ws_uri` profile flag: the relay/transcode path, any
+    /// SIPREC subscription and the recording all keep running.  The engine
+    /// promotes a plain in-kernel relay to the userspace pipeline for the tee's
+    /// lifetime and demotes it again on detach.
+    pub async fn attach_ws_tee(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        ws_uri: &str,
+        direction: WsTeeDirection,
+        channels: Option<u8>,
+    ) -> Result<(), RtpEngineError> {
+        expect_ok(
+            self.request(Command::AttachWsTee {
+                call_id: call_id.to_string(),
+                from_tag: from_tag.to_string(),
+                ws_uri: ws_uri.to_string(),
+                direction: proto_ws_tee_direction(direction),
+                channels,
+            })
+            .await?,
+        )
+    }
+
+    /// Detach a call's WebSocket tee, closing its stream.  Idempotent — the
+    /// engine does not treat detaching a call with no tee as an error.
+    pub async fn detach_ws_tee(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+    ) -> Result<(), RtpEngineError> {
+        expect_ok(
+            self.request(Command::DetachWsTee {
+                call_id: call_id.to_string(),
+                from_tag: from_tag.to_string(),
+            })
+            .await?,
+        )
+    }
+
     /// Liveness check — `Ping` → `Pong`.
     pub async fn ping(&self) -> Result<(), RtpEngineError> {
         match self.request(Command::Ping).await? {
@@ -942,6 +1011,29 @@ impl SiphonRtpClientSet {
         self.select(call_id).unsubscribe(call_id, from_tag, to_tag).await
     }
 
+    /// Attach a WebSocket tee on the instance owning this call.
+    pub async fn attach_ws_tee(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        ws_uri: &str,
+        direction: WsTeeDirection,
+        channels: Option<u8>,
+    ) -> Result<(), RtpEngineError> {
+        self.select(call_id)
+            .attach_ws_tee(call_id, from_tag, ws_uri, direction, channels)
+            .await
+    }
+
+    /// Detach the WebSocket tee on the instance owning this call.
+    pub async fn detach_ws_tee(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+    ) -> Result<(), RtpEngineError> {
+        self.select(call_id).detach_ws_tee(call_id, from_tag).await
+    }
+
     /// Ping any one instance (the first). For quick health checks.
     pub async fn ping(&self) -> Result<(), RtpEngineError> {
         match self.clients.first() {
@@ -1099,11 +1191,54 @@ fn convert_event(event: Event) -> RtpEngineEvent {
             call_id: Some(call_id),
             from_tag: Some(from_tag),
         },
+        Event::WsTeeStarted {
+            call_id,
+            from_tag,
+            stream_id,
+            ws_uri,
+            direction,
+            channels,
+            sample_rate,
+        } => RtpEngineEvent::WsTeeStarted(WsTeeStarted {
+            call_id,
+            from_tag,
+            stream_id,
+            ws_uri,
+            direction: ws_tee_direction_from_proto(direction),
+            channels,
+            sample_rate,
+        }),
+        Event::WsTeeEnded {
+            call_id,
+            from_tag,
+            stream_id,
+            reason,
+            frames_sent,
+            frames_dropped,
+        } => RtpEngineEvent::WsTeeEnded(WsTeeEnded {
+            call_id,
+            from_tag,
+            stream_id,
+            reason: ws_tee_end_reason_from_proto(reason),
+            frames_sent,
+            frames_dropped,
+        }),
         Event::Unknown => RtpEngineEvent::Unknown {
             event: "unknown".to_string(),
             call_id: None,
             from_tag: None,
         },
+    }
+}
+
+/// Map the proto tee end-reason onto siphon's own enum.
+fn ws_tee_end_reason_from_proto(reason: ProtoWsTeeEndReason) -> WsTeeEndReason {
+    match reason {
+        ProtoWsTeeEndReason::Detached => WsTeeEndReason::Detached,
+        ProtoWsTeeEndReason::ServerClosed => WsTeeEndReason::ServerClosed,
+        ProtoWsTeeEndReason::ServerStopped => WsTeeEndReason::ServerStopped,
+        ProtoWsTeeEndReason::CallEnded => WsTeeEndReason::CallEnded,
+        ProtoWsTeeEndReason::TransportError => WsTeeEndReason::TransportError,
     }
 }
 
@@ -1701,6 +1836,9 @@ mod tests {
             ws_barge_in: true,
             ws_vad_threshold: Some(2_000_000),
             ws_vad_hangover_ms: Some(300),
+            ws_tee: Some("wss://asr.invalid/tee".into()),
+            ws_tee_direction: Some(WsTeeDirection::Callee),
+            ws_tee_channels: Some(1),
             carry_received_from: true,
             received_from: Some("198.51.100.7".parse().unwrap()),
             rtcp_mux: vec!["require".into()],
@@ -1723,6 +1861,9 @@ mod tests {
             ws_barge_in: true,
             ws_vad_threshold: Some(2_000_000),
             ws_vad_hangover_ms: Some(300),
+            ws_tee: Some("wss://asr.invalid/tee".into()),
+            ws_tee_direction: Some(ProtoWsTeeDirection::Callee),
+            ws_tee_channels: Some(1),
             received_from: Some("198.51.100.7".parse().unwrap()),
             rtcp_mux: vec!["require".into()],
         };
@@ -1788,6 +1929,70 @@ mod tests {
                 assert_eq!(from_tag, "f");
             }
             other => panic!("expected MediaTimeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_event_ws_tee_started_carries_the_negotiated_wire_shape() {
+        // The wire shape is the point: a consumer decodes the binary frames
+        // from these values rather than guessing.
+        match convert_event(Event::WsTeeStarted {
+            call_id: "c".into(),
+            from_tag: "f".into(),
+            stream_id: "s-1".into(),
+            ws_uri: "wss://asr.invalid/tee".into(),
+            direction: ProtoWsTeeDirection::Caller,
+            channels: 1,
+            sample_rate: 16_000,
+        }) {
+            RtpEngineEvent::WsTeeStarted(tee) => {
+                assert_eq!(tee.call_id, "c");
+                assert_eq!(tee.from_tag, "f");
+                assert_eq!(tee.stream_id, "s-1");
+                assert_eq!(tee.ws_uri, "wss://asr.invalid/tee");
+                assert_eq!(tee.direction, WsTeeDirection::Caller);
+                assert_eq!(tee.channels, 1);
+                assert_eq!(tee.sample_rate, 16_000);
+            }
+            other => panic!("expected WsTeeStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_event_ws_tee_ended_maps_every_reason() {
+        // Each reason must survive the proto -> siphon hop with its wire
+        // spelling intact: a script branches on this string.
+        let cases = [
+            (ProtoWsTeeEndReason::Detached, "detached", false),
+            (ProtoWsTeeEndReason::ServerClosed, "server_closed", true),
+            (ProtoWsTeeEndReason::ServerStopped, "server_stopped", true),
+            (ProtoWsTeeEndReason::CallEnded, "call_ended", true),
+            (ProtoWsTeeEndReason::TransportError, "transport_error", true),
+        ];
+        for (proto_reason, expected, expected_unexpected) in cases {
+            match convert_event(Event::WsTeeEnded {
+                call_id: "c".into(),
+                from_tag: "f".into(),
+                stream_id: "s-1".into(),
+                reason: proto_reason,
+                frames_sent: Some(4_200),
+                frames_dropped: Some(3),
+            }) {
+                RtpEngineEvent::WsTeeEnded(tee) => {
+                    assert_eq!(tee.stream_id, "s-1");
+                    assert_eq!(tee.reason.as_str(), expected);
+                    assert_eq!(tee.frames_sent, Some(4_200));
+                    assert_eq!(tee.frames_dropped, Some(3));
+                    // Only an explicit detach is an orderly end; everything else
+                    // means audio stopped while the call is still up.
+                    assert_eq!(
+                        tee.reason.is_unexpected(),
+                        expected_unexpected,
+                        "{expected} classified wrongly"
+                    );
+                }
+                other => panic!("expected WsTeeEnded, got {other:?}"),
+            }
         }
     }
 

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -16,7 +16,7 @@ use pyo3::types::PyDict;
 use tracing::{debug, warn};
 
 use crate::rtpengine::client::PlayMediaSource;
-use crate::rtpengine::profile::{NgFlags, ProfileRegistry};
+use crate::rtpengine::profile::{NgFlags, ProfileRegistry, WsTeeDirection};
 use crate::rtpengine::MediaBackend;
 use crate::rtpengine::RtpEngineError;
 use crate::rtpengine::session::{MediaSession, MediaSessionStore};
@@ -1235,6 +1235,139 @@ impl PyRtpEngine {
         })
     }
 
+    /// Attach a **WebSocket tee** to a live call — stream a copy of its decoded
+    /// audio to a WebSocket media server while the call keeps relaying.
+    ///
+    /// The distinction from the ``ws_uri`` media-profile flag matters:
+    ///
+    /// * ``ws_uri`` is a **takeover** — the WebSocket server *becomes* leg A's
+    ///   far side and the A↔B relay is not wired.  That is the voice-AI
+    ///   answer-the-call shape.
+    /// * A tee is **send-only and additive** — the call relays (or transcodes)
+    ///   normally *and* streams a copy of its audio out.  Any SIPREC
+    ///   subscription and recording on the same leg keep running untouched.
+    ///
+    /// Use a tee for live transcription, agent-assist, sentiment or compliance
+    /// monitoring on a call that is otherwise a normal two-party call.
+    ///
+    /// A tee never affects the call: the engine drops frames rather than
+    /// stalling the media path if the consumer cannot keep up, and a failure
+    /// here raises rather than tearing anything down — catch it and carry on.
+    ///
+    /// Requires ``media.backend: siphon-rtp``; the rtpengine and rtpproxy
+    /// backends raise rather than silently doing nothing.
+    ///
+    /// ```python,ignore
+    /// @b2bua.on_answer
+    /// async def on_answer(call, reply):
+    ///     await rtpengine.answer(reply)
+    ///     try:
+    ///         await rtpengine.attach_ws_tee(call, f"wss://asr.internal/{call.call_id}")
+    ///     except RuntimeError as error:
+    ///         log.warn(f"transcription tee unavailable: {error}")
+    /// ```
+    ///
+    /// Args:
+    ///     target: Request, Reply or Call identifying the media session.
+    ///     ws_uri: ``ws://`` or ``wss://`` URI the engine dials as a client.
+    ///     direction: Which leg(s) to stream — ``"both"`` (default),
+    ///         ``"caller"`` (the offerer) or ``"callee"`` (the answerer).
+    ///     channels: Wire channel count — ``2`` interleaves caller/callee as
+    ///         stereo, ``1`` mixes them to mono.  Only meaningful with
+    ///         ``direction="both"``; a single-leg tee is always mono.  ``None``
+    ///         (default) leaves the engine's choice: 2 for both legs, 1 for one.
+    #[pyo3(signature = (target, ws_uri, direction="both", channels=None))]
+    fn attach_ws_tee<'py>(
+        &self,
+        python: Python<'py>,
+        target: &Bound<'py, PyAny>,
+        ws_uri: String,
+        direction: &str,
+        channels: Option<u8>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
+
+        let direction = WsTeeDirection::parse(direction).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "rtpengine.attach_ws_tee direction must be one of {}, got {direction:?}",
+                WsTeeDirection::VALUES.join(" / ")
+            ))
+        })?;
+
+        // Caught here rather than at the engine so the script gets a precise
+        // error instead of a generic engine rejection.
+        if let Some(channels) = channels {
+            if channels != 1 && channels != 2 {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "rtpengine.attach_ws_tee channels must be 1 or 2, got {channels}"
+                )));
+            }
+        }
+
+        let client = Arc::clone(&self.client);
+
+        pyo3_async_runtimes::tokio::future_into_py(python, async move {
+            client
+                .attach_ws_tee(&call_id, &from_tag, &ws_uri, direction, channels)
+                .await
+                .map_err(|error| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "rtpengine.attach_ws_tee failed: {error}"
+                    ))
+                })?;
+            debug!(
+                call_id = %call_id,
+                from_tag = %from_tag,
+                ws_uri = %ws_uri,
+                direction = %direction.as_str(),
+                ?channels,
+                "rtpengine attach_ws_tee"
+            );
+            Ok(true)
+        })
+    }
+
+    /// Detach a call's **WebSocket tee**, closing its stream.
+    ///
+    /// Idempotent — detaching a call with no tee is not an error.  A tee is
+    /// also torn down automatically when the call ends, so an explicit detach
+    /// is only needed to stop streaming mid-call.
+    ///
+    /// Requires ``media.backend: siphon-rtp``.
+    ///
+    /// ```python,ignore
+    /// await rtpengine.detach_ws_tee(call)
+    /// ```
+    ///
+    /// Args:
+    ///     target: Request, Reply or Call identifying the media session.
+    #[pyo3(signature = (target))]
+    fn detach_ws_tee<'py>(
+        &self,
+        python: Python<'py>,
+        target: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
+        let client = Arc::clone(&self.client);
+
+        pyo3_async_runtimes::tokio::future_into_py(python, async move {
+            client
+                .detach_ws_tee(&call_id, &from_tag)
+                .await
+                .map_err(|error| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "rtpengine.detach_ws_tee failed: {error}"
+                    ))
+                })?;
+            debug!(
+                call_id = %call_id,
+                from_tag = %from_tag,
+                "rtpengine detach_ws_tee"
+            );
+            Ok(true)
+        })
+    }
+
     /// Register a handler for inbound DTMF events from rtpengine.
     ///
     /// rtpengine must be configured with ``dtmf-log-ng-tcp-uri=tcp://<siphon>``
@@ -1354,6 +1487,126 @@ def make_decorator(call_id, from_tag):
 
         // Support both `@on_media_timeout` (bare) and
         // `@on_media_timeout(call_id=...)` forms.
+        match func_or_none {
+            Some(func) => decorator.call1((func.bind(python),)),
+            None => Ok(decorator),
+        }
+    }
+
+    /// Register a handler for **WebSocket tee started** events.
+    ///
+    /// Fires once the engine has dialled the tee's WebSocket server, sent its
+    /// ``start`` envelope, and begun streaming.  The handler receives the
+    /// negotiated wire shape, so it can decode the binary frames without
+    /// guessing — ``stream_id`` is the correlator between this control event
+    /// and the media stream on the socket.
+    ///
+    /// Delivered by the native **siphon-rtp** backend only.
+    ///
+    /// ```python,ignore
+    /// @rtpengine.on_ws_tee_started
+    /// def tee_up(call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate):
+    ///     log.info(f"tee {stream_id}: {channels}ch @ {sample_rate}Hz -> {ws_uri}")
+    /// ```
+    ///
+    /// Args:
+    ///     func_or_none: When applied directly (``@rtpengine.on_ws_tee_started``)
+    ///         this is the function.  When called with keyword filters the
+    ///         return value is a decorator.
+    ///     call_id: Optional engine call-id filter.
+    ///     from_tag: Optional from-tag filter.
+    #[pyo3(signature = (func_or_none=None, *, call_id=None, from_tag=None))]
+    fn on_ws_tee_started<'py>(
+        &self,
+        python: Python<'py>,
+        func_or_none: Option<Py<PyAny>>,
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let code = r#"
+def make_decorator(call_id, from_tag):
+    import asyncio
+    import _siphon_registry
+    def decorator(fn):
+        is_async = asyncio.iscoroutinefunction(fn)
+        metadata = {"call_id": call_id, "from_tag": from_tag}
+        _siphon_registry.register("rtpengine.on_ws_tee_started", None, fn, is_async, metadata)
+        return fn
+    return decorator
+"#;
+        let globals = PyDict::new(python);
+        python.run(&std::ffi::CString::new(code).unwrap(), Some(&globals), None)?;
+        let make_decorator = globals.get_item("make_decorator")?.ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("failed to build on_ws_tee_started decorator")
+        })?;
+        let decorator = make_decorator.call1((call_id, from_tag))?;
+
+        // Support both `@on_ws_tee_started` (bare) and
+        // `@on_ws_tee_started(call_id=...)` forms.
+        match func_or_none {
+            Some(func) => decorator.call1((func.bind(python),)),
+            None => Ok(decorator),
+        }
+    }
+
+    /// Register a handler for **WebSocket tee ended** events.
+    ///
+    /// Fires exactly once per started tee, **including when the server ends
+    /// it**.  That is the point of the hook: any ``reason`` other than
+    /// ``"detached"`` means the audio stream died while the call is still up,
+    /// which is otherwise invisible — the call carries on and nothing reaches
+    /// the consumer.  Re-attach, fail over, or alert from here.
+    ///
+    /// ``reason`` is one of ``"detached"`` (the script or the call teardown
+    /// asked for it — the only orderly end), ``"server_closed"``,
+    /// ``"server_stopped"``, ``"call_ended"`` or ``"transport_error"``.
+    ///
+    /// ``frames_dropped`` non-zero means the consumer could not keep up; the
+    /// call itself was never affected.
+    ///
+    /// Delivered by the native **siphon-rtp** backend only.
+    ///
+    /// ```python,ignore
+    /// @rtpengine.on_ws_tee_ended
+    /// async def tee_down(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+    ///     if reason != "detached":
+    ///         log.warn(f"tee {stream_id} died: {reason}")
+    /// ```
+    ///
+    /// Args:
+    ///     func_or_none: When applied directly (``@rtpengine.on_ws_tee_ended``)
+    ///         this is the function.  When called with keyword filters the
+    ///         return value is a decorator.
+    ///     call_id: Optional engine call-id filter.
+    ///     from_tag: Optional from-tag filter.
+    #[pyo3(signature = (func_or_none=None, *, call_id=None, from_tag=None))]
+    fn on_ws_tee_ended<'py>(
+        &self,
+        python: Python<'py>,
+        func_or_none: Option<Py<PyAny>>,
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let code = r#"
+def make_decorator(call_id, from_tag):
+    import asyncio
+    import _siphon_registry
+    def decorator(fn):
+        is_async = asyncio.iscoroutinefunction(fn)
+        metadata = {"call_id": call_id, "from_tag": from_tag}
+        _siphon_registry.register("rtpengine.on_ws_tee_ended", None, fn, is_async, metadata)
+        return fn
+    return decorator
+"#;
+        let globals = PyDict::new(python);
+        python.run(&std::ffi::CString::new(code).unwrap(), Some(&globals), None)?;
+        let make_decorator = globals.get_item("make_decorator")?.ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("failed to build on_ws_tee_ended decorator")
+        })?;
+        let decorator = make_decorator.call1((call_id, from_tag))?;
+
+        // Support both `@on_ws_tee_ended` (bare) and
+        // `@on_ws_tee_ended(call_id=...)` forms.
         match func_or_none {
             Some(func) => decorator.call1((func.bind(python),)),
             None => Ok(decorator),

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -415,6 +415,12 @@ class _RtpEngineNamespace:
     async def unsubscribe(self, call_id, from_tag, to_tag):
         raise NotImplementedError("rtpengine.unsubscribe() not available — no media.rtpengine in config")
 
+    async def attach_ws_tee(self, target, ws_uri, direction="both", channels=None):
+        raise NotImplementedError("rtpengine.attach_ws_tee() not available — no media.rtpengine in config")
+
+    async def detach_ws_tee(self, target):
+        raise NotImplementedError("rtpengine.detach_ws_tee() not available — no media.rtpengine in config")
+
     def on_dtmf(self, func_or_none=None, *, call_id=None, from_tag=None):
         """Register a handler for inbound DTMF events from rtpengine.
 
@@ -456,6 +462,55 @@ class _RtpEngineNamespace:
             is_async = _asyncio.iscoroutinefunction(fn)
             metadata = {"call_id": call_id, "from_tag": from_tag}
             _registry.register("rtpengine.on_media_timeout", None, fn, is_async, metadata)
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
+    def on_ws_tee_started(self, func_or_none=None, *, call_id=None, from_tag=None):
+        """Register a handler for WebSocket tee started events.
+
+        Fires once the engine has dialled the tee's server and audio is
+        flowing; ``stream_id`` correlates this event with the media stream.
+
+        Usage:
+            @rtpengine.on_ws_tee_started
+            def handle_any(call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate):
+                ...
+
+            @rtpengine.on_ws_tee_started(call_id="abc")
+            def handle_specific(call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate):
+                ...
+        """
+        def decorator(fn):
+            is_async = _asyncio.iscoroutinefunction(fn)
+            metadata = {"call_id": call_id, "from_tag": from_tag}
+            _registry.register("rtpengine.on_ws_tee_started", None, fn, is_async, metadata)
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
+    def on_ws_tee_ended(self, func_or_none=None, *, call_id=None, from_tag=None):
+        """Register a handler for WebSocket tee ended events.
+
+        Fires exactly once per started tee, including when the *server* ends
+        it — any ``reason`` other than ``"detached"`` means the audio stream
+        died while the call is still up.
+
+        Usage:
+            @rtpengine.on_ws_tee_ended
+            def handle_any(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+                ...
+
+            @rtpengine.on_ws_tee_ended(call_id="abc")
+            def handle_specific(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+                ...
+        """
+        def decorator(fn):
+            is_async = _asyncio.iscoroutinefunction(fn)
+            metadata = {"call_id": call_id, "from_tag": from_tag}
+            _registry.register("rtpengine.on_ws_tee_ended", None, fn, is_async, metadata)
             return fn
         if func_or_none is not None:
             return decorator(func_or_none)

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -126,6 +126,25 @@ pub enum HandlerKind {
         call_id: Option<String>,
         from_tag: Option<String>,
     },
+    /// `@rtpengine.on_ws_tee_started` — a WebSocket tee began streaming a
+    /// call's audio. The handler receives the negotiated wire shape so it can
+    /// correlate the control event with the media stream.
+    ///
+    /// ``call_id`` and ``from_tag`` are optional filters.
+    RtpEngineOnWsTeeStarted {
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    },
+    /// `@rtpengine.on_ws_tee_ended` — a WebSocket tee stopped, for any reason
+    /// including the *server* ending it. Emitted exactly once per started tee,
+    /// so a script learns the stream died rather than silently losing audio on
+    /// a call that is still up.
+    ///
+    /// ``call_id`` and ``from_tag`` are optional filters.
+    RtpEngineOnWsTeeEnded {
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    },
     /// Open extension point for handler kinds owned by host extensions.
     /// The string is the registry key the extension wrote (e.g.
     /// `"audit.sink"`); siphon-core does not interpret it. Per-handler
@@ -233,6 +252,46 @@ impl ScriptState {
             .iter()
             .filter(|h| match &h.kind {
                 HandlerKind::RtpEngineOnMediaTimeout { call_id: filter_cid, from_tag: filter_ftag } => {
+                    filter_cid.as_deref().map_or(true, |v| v == call_id)
+                        && filter_ftag.as_deref().map_or(true, |v| v == from_tag)
+                }
+                _ => false,
+            })
+            .collect()
+    }
+
+    /// Return all `RtpEngineOnWsTeeStarted` handlers whose optional
+    /// call-id/from-tag filters match the event.  `None` filters match
+    /// everything.
+    pub fn ws_tee_started_handlers(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+    ) -> Vec<&HandlerEntry> {
+        self.handlers
+            .iter()
+            .filter(|h| match &h.kind {
+                HandlerKind::RtpEngineOnWsTeeStarted { call_id: filter_cid, from_tag: filter_ftag } => {
+                    filter_cid.as_deref().map_or(true, |v| v == call_id)
+                        && filter_ftag.as_deref().map_or(true, |v| v == from_tag)
+                }
+                _ => false,
+            })
+            .collect()
+    }
+
+    /// Return all `RtpEngineOnWsTeeEnded` handlers whose optional
+    /// call-id/from-tag filters match the event.  `None` filters match
+    /// everything.
+    pub fn ws_tee_ended_handlers(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+    ) -> Vec<&HandlerEntry> {
+        self.handlers
+            .iter()
+            .filter(|h| match &h.kind {
+                HandlerKind::RtpEngineOnWsTeeEnded { call_id: filter_cid, from_tag: filter_ftag } => {
                     filter_cid.as_deref().map_or(true, |v| v == call_id)
                         && filter_ftag.as_deref().map_or(true, |v| v == from_tag)
                 }
@@ -1091,6 +1150,28 @@ fn extract_handlers(
                     .and_then(|v| v.extract().ok());
                 HandlerKind::RtpEngineOnMediaTimeout { call_id, from_tag }
             }
+            "rtpengine.on_ws_tee_started" => {
+                let call_id: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("call_id").ok())
+                    .and_then(|v| v.extract().ok());
+                let from_tag: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("from_tag").ok())
+                    .and_then(|v| v.extract().ok());
+                HandlerKind::RtpEngineOnWsTeeStarted { call_id, from_tag }
+            }
+            "rtpengine.on_ws_tee_ended" => {
+                let call_id: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("call_id").ok())
+                    .and_then(|v| v.extract().ok());
+                let from_tag: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("from_tag").ok())
+                    .and_then(|v| v.extract().ok());
+                HandlerKind::RtpEngineOnWsTeeEnded { call_id, from_tag }
+            }
             other => HandlerKind::Custom { kind: other.to_owned() },
         };
 
@@ -1750,6 +1831,48 @@ async def specific_timeout(call_id, from_tag):
                 HandlerKind::RtpEngineOnMediaTimeout { call_id: Some(c), .. } if c == "abc"
             ))
             .expect("filtered media-timeout handler registered");
+        assert!(specific.is_async);
+    }
+
+    #[test]
+    fn rtpengine_on_ws_tee_decorators_register_and_filter() {
+        // Both hooks take the same (call_id, from_tag) filters as on_dtmf /
+        // on_media_timeout; a bare handler is a catch-all.
+        let source = r#"
+from siphon import rtpengine
+
+@rtpengine.on_ws_tee_started
+def any_start(call_id, from_tag, stream_id, ws_uri, direction, channels, sample_rate):
+    pass
+
+@rtpengine.on_ws_tee_ended
+def any_end(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+    pass
+
+@rtpengine.on_ws_tee_ended(call_id="abc", from_tag="ftag1")
+async def specific_end(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+    pass
+"#;
+        let state = compile_temp_script(source).unwrap();
+        assert_eq!(state.handlers.len(), 3);
+
+        // Started: catch-all only, and it does not pick up the ended handlers.
+        assert_eq!(state.ws_tee_started_handlers("abc", "ftag1").len(), 1);
+
+        // Ended: catch-all everywhere, plus the filtered one on an exact match.
+        assert_eq!(state.ws_tee_ended_handlers("xyz", "other").len(), 1);
+        assert_eq!(state.ws_tee_ended_handlers("abc", "ftag1").len(), 2);
+        assert_eq!(state.ws_tee_ended_handlers("abc", "wrong").len(), 1);
+
+        // The filtered handler is the async one.
+        let specific = state
+            .handlers
+            .iter()
+            .find(|h| matches!(
+                &h.kind,
+                HandlerKind::RtpEngineOnWsTeeEnded { call_id: Some(c), .. } if c == "abc"
+            ))
+            .expect("filtered ws-tee-ended handler registered");
         assert!(specific.is_async);
     }
 

--- a/tests/integration/siphon_rtp_tests.rs
+++ b/tests/integration/siphon_rtp_tests.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use siphon::rtpengine::profile::NgFlags;
+use siphon::rtpengine::profile::{NgFlags, WsTeeDirection};
 use siphon::rtpengine::{MediaBackend, RtpEngineSet, SiphonRtpClient, SiphonRtpClientSet};
 use siphon::sip::parser::parse_sip_message;
 
@@ -129,6 +129,222 @@ async fn media_backend_siphon_rtp_offer_rewrites_sdp() {
     assert!(rewritten.contains("30000"));
 
     backend.delete(call_id, "alice-tag").await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket tee — wire shape
+//
+// These assert the *exact JSON* siphon puts on the control socket, not a
+// decode/re-encode round-trip: the fake server hands back the raw frame body
+// (`frame::HEADER_LEN` is a 4-byte big-endian length prefix, so the JSON is
+// `buffer[4..consumed]`). A round-trip through the same serde impls would hide
+// a field siphon failed to carry, which is precisely the class of bug the
+// exhaustive `profile_flags_from_ng` exists to catch.
+// ---------------------------------------------------------------------------
+
+/// Spawn a fake control server that records the raw JSON body of every request
+/// it receives and answers everything `Ok`. Returns the bound address plus the
+/// receiver of recorded bodies.
+async fn spawn_recording_siphon_rtp() -> (std::net::SocketAddr, mpsc::UnboundedReceiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (record_tx, record_rx) = mpsc::unbounded_channel();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => return,
+            };
+            let record_tx = record_tx.clone();
+            tokio::spawn(async move {
+                let mut buffer: Vec<u8> = Vec::new();
+                let mut chunk = [0u8; 4096];
+                loop {
+                    while let Some((request, consumed)) =
+                        frame::decode::<Request>(&buffer).expect("decode request")
+                    {
+                        // The raw JSON exactly as siphon serialised it.
+                        let body =
+                            String::from_utf8(buffer[frame::HEADER_LEN..consumed].to_vec())
+                                .expect("request body is utf-8");
+                        buffer.drain(..consumed);
+                        let _ = record_tx.send(body);
+
+                        let result = match request.command {
+                            Command::Offer { .. } | Command::Answer { .. } => CmdResult::Ok {
+                                sdp: Some(
+                                    "v=0\r\no=- 0 0 IN IP4 203.0.113.1\r\ns=-\r\nc=IN IP4 203.0.113.1\r\nt=0 0\r\nm=audio 30000 RTP/AVP 0\r\n"
+                                        .to_string(),
+                                ),
+                                duration_ms: None,
+                                to_tag: None,
+                                stats: None,
+                                play_id: None,
+                            },
+                            Command::Ping => CmdResult::Pong,
+                            _ => CmdResult::Ok {
+                                sdp: None,
+                                duration_ms: None,
+                                to_tag: None,
+                                stats: None,
+                                play_id: None,
+                            },
+                        };
+                        let response = Response {
+                            id: request.id,
+                            result,
+                        };
+                        let bytes = frame::encode(&response).expect("encode response");
+                        if stream.write_all(&bytes).await.is_err() {
+                            return;
+                        }
+                    }
+                    match stream.read(&mut chunk).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => buffer.extend_from_slice(&chunk[..n]),
+                    }
+                }
+            });
+        }
+    });
+
+    (address, record_rx)
+}
+
+/// Build a `MediaBackend::SiphonRtp` pointed at `address`.
+fn siphon_rtp_backend(address: std::net::SocketAddr) -> MediaBackend {
+    let (event_tx, _event_rx) = mpsc::channel(16);
+    let set = SiphonRtpClientSet::new(vec![(address, 2000, 1)], None, 5_000, event_tx).unwrap();
+    MediaBackend::SiphonRtp(set)
+}
+
+#[tokio::test]
+async fn attach_ws_tee_emits_the_documented_wire_shape() {
+    let (address, mut records) = spawn_recording_siphon_rtp().await;
+    let backend = siphon_rtp_backend(address);
+    backend.ping().await.unwrap();
+    records.recv().await.expect("ping recorded");
+
+    // `channels` carries skip_serializing_if and drops out when unset;
+    // `direction` does not, so the engine always receives an explicit leg
+    // selection rather than relying on its own default.
+    backend
+        .attach_ws_tee("c", "f", "ws://h/s", WsTeeDirection::Both, None)
+        .await
+        .unwrap();
+    let body = records.recv().await.expect("attach recorded");
+    assert_eq!(
+        body,
+        r#"{"id":2,"command":"attach_ws_tee","call_id":"c","from_tag":"f","ws_uri":"ws://h/s","direction":"both"}"#,
+        "attach_ws_tee wire shape drifted"
+    );
+
+    // Explicit non-default direction + channels are carried verbatim.
+    backend
+        .attach_ws_tee("c", "f", "wss://h/s", WsTeeDirection::Caller, Some(1))
+        .await
+        .unwrap();
+    let body = records.recv().await.expect("explicit attach recorded");
+    assert_eq!(
+        body,
+        r#"{"id":3,"command":"attach_ws_tee","call_id":"c","from_tag":"f","ws_uri":"wss://h/s","direction":"caller","channels":1}"#,
+        "attach_ws_tee did not carry direction/channels"
+    );
+}
+
+#[tokio::test]
+async fn detach_ws_tee_emits_the_documented_wire_shape() {
+    let (address, mut records) = spawn_recording_siphon_rtp().await;
+    let backend = siphon_rtp_backend(address);
+    backend.ping().await.unwrap();
+    records.recv().await.expect("ping recorded");
+
+    backend.detach_ws_tee("c", "f").await.unwrap();
+    let body = records.recv().await.expect("detach recorded");
+    assert_eq!(
+        body,
+        r#"{"id":2,"command":"detach_ws_tee","call_id":"c","from_tag":"f"}"#,
+        "detach_ws_tee wire shape drifted"
+    );
+}
+
+#[tokio::test]
+async fn offer_without_ws_tee_carries_no_tee_keys() {
+    // No wire drift for existing deployments: a profile that does not ask for a
+    // tee must emit exactly what it emitted before the tee fields existed.
+    let (address, mut records) = spawn_recording_siphon_rtp().await;
+    let backend = siphon_rtp_backend(address);
+    backend.ping().await.unwrap();
+    records.recv().await.expect("ping recorded");
+
+    backend
+        .offer("call-1", "tag-a", SMOKE_SDP, &NgFlags::default())
+        .await
+        .unwrap();
+    let body = records.recv().await.expect("offer recorded");
+    for key in ["ws_tee", "ws_tee_direction", "ws_tee_channels"] {
+        assert!(
+            !body.contains(key),
+            "default profile leaked {key} onto the wire: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn offer_with_ws_tee_profile_carries_it_to_the_engine() {
+    // The declarative path: a media profile carrying ws_tee reaches the engine
+    // on offer, without a second round-trip.
+    let (address, mut records) = spawn_recording_siphon_rtp().await;
+    let backend = siphon_rtp_backend(address);
+    backend.ping().await.unwrap();
+    records.recv().await.expect("ping recorded");
+
+    let flags = NgFlags {
+        ws_tee: Some("wss://asr.example/stream".to_string()),
+        ws_tee_direction: Some(WsTeeDirection::Callee),
+        ws_tee_channels: Some(1),
+        ..NgFlags::default()
+    };
+    backend.offer("call-2", "tag-a", SMOKE_SDP, &flags).await.unwrap();
+    let body = records.recv().await.expect("offer recorded");
+    assert!(
+        body.contains(r#""ws_tee":"wss://asr.example/stream""#),
+        "ws_tee missing from offer: {body}"
+    );
+    assert!(
+        body.contains(r#""ws_tee_direction":"callee""#),
+        "ws_tee_direction missing from offer: {body}"
+    );
+    assert!(
+        body.contains(r#""ws_tee_channels":1"#),
+        "ws_tee_channels missing from offer: {body}"
+    );
+}
+
+#[tokio::test]
+async fn ws_tee_is_rejected_by_backends_that_cannot_stream() {
+    // A hollow Ok here would read as "the tee is attached" while no audio ever
+    // reaches the consumer. The rtpengine backend must say so instead.
+    let ng: SocketAddr = "127.0.0.1:22239".parse().unwrap();
+    let backend =
+        MediaBackend::RtpEngine(RtpEngineSet::new(vec![(ng, 500, 1)]).await.unwrap().into());
+
+    let error = backend
+        .attach_ws_tee("c", "f", "ws://h/s", WsTeeDirection::Both, None)
+        .await
+        .expect_err("rtpengine cannot stream a websocket tee");
+    let text = error.to_string();
+    assert!(text.contains("attach_ws_tee"), "error must name the operation: {text}");
+    assert!(text.contains("rtpengine"), "error must name the backend: {text}");
+    // Never mistaken for "the call is already gone".
+    assert!(!error.is_call_not_found());
+
+    let error = backend
+        .detach_ws_tee("c", "f")
+        .await
+        .expect_err("rtpengine cannot detach a websocket tee");
+    assert!(error.to_string().contains("detach_ws_tee"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes the WP-S2 work package of the voice-AI demo spec. `siphon-rtp-proto` 0.1.5 froze the tee command surface, which was the dependency this package was waiting on.

## Why

siphon has been able to hand a leg's audio to a WebSocket media server since the `ws_uri` work landed (#131). But `ws_uri` is a **takeover**: the WS server *becomes* leg A's far side and the A↔B relay is not wired. That is right for voice-AI answering a call and wrong for everything else. Live transcription, agent-assist and compliance monitoring all want the call to keep relaying normally while a *copy* of the audio streams out, and siphon had no way to express that at all.

A tee is send-only and additive. On the engine side one decode feeds the peer, the recorder, any SIPREC fork and the tee, so attaching one does not disturb a SIPREC subscription or the relay path; a plain in-kernel relay is promoted to the userspace pipeline for the tee's lifetime and demoted again on detach.

## What

- **Profile fields** `ws_tee`, `ws_tee_direction` (`both` | `caller` | `callee`), `ws_tee_channels` (2 = caller/callee stereo, 1 = mixed mono), carried through `NgFlagsConfig` → `NgFlags` → `profile_flags_from_ng` → the wire.
- **Per-call verbs** `rtpengine.attach_ws_tee(target, ws_uri, direction="both", channels=None)` and `rtpengine.detach_ws_tee(target)`, on the same Request/Reply/Call target resolution `play_media` already uses.
- **`@rtpengine.on_ws_tee_started` / `@rtpengine.on_ws_tee_ended`.** A tee can end while the call carries on — the server closes the socket, the transport fails — and nothing about the call changes, so without this the consumer silently stops receiving audio. `ended` carries `reason` (`detached` is the only orderly one), `frames_sent` and `frames_dropped` so a slow consumer is distinguishable from a dead one; an unexpected end logs at WARN whether or not a handler is registered. `started` carries the negotiated `channels`/`sample_rate` so a consumer decodes the L16 frames rather than guessing, and `stream_id` correlates the control event with the `start` envelope on the socket.
- **No hollow successes.** rtpengine and rtpproxy reject a tee profile at config load (naming profile, direction and field) and return a typed `Unsupported` on the per-call verbs. A tee that reads as attached while streaming nothing is the exact failure the config-load rejection exists to prevent.

The pin bump to 0.1.5 broke the build in exactly the two places it was built to break — the exhaustive `profile_flags_from_ng` struct literal and the wildcard-free `convert_event` match. That guard was added in #131 precisely so a new proto field cannot be silently defaulted, and it did its job.

## Also

A malformed `ws_tee` URI reported a config error naming `ws_uri`, a field the operator never set. The validator now takes the field name.

## Testing

- Wire shape asserted **byte-for-byte** against an in-process fake control server, reading the raw frame body rather than a decode/re-encode round-trip (a round-trip through the same serde impls would hide a field siphon failed to carry).
- No wire drift: a profile without tee fields emits an offer carrying none of them.
- Config-load rejection on both rtpengine and rtpproxy, with the field named.
- Event conversion for every `WsTeeEndReason`, plus decorator registration and `call_id`/`from_tag` filtering.
- SDK mock mirrored with docstrings and `fire_ws_tee_started` / `fire_ws_tee_ended` helpers.

`cargo clippy --all-targets --all-features -- -D warnings` clean, 3647 Rust tests green, 505 SDK tests green.

Perf baseline not re-run: this adds no per-message datapath cost (control-plane commands and profile fields only).
