### PR TITLE
fix(proxy): terminating requests could not fail over between the bindings of one AoR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -281,6 +281,25 @@ jobs:
       - name: Route self-identity (in-dialog BYE must be relayed, not 404'd)
         run: scripts/route_selfid_test.sh
 
+  # ── Terminating failover across an AoR's bindings ──────────────────────────
+  # An AoR with two live bindings where only one is reachable must still be
+  # deliverable.  Two things have to hold, and neither is visible in the
+  # standard functional stack (one binding, no Path, no failure path):
+  #   1. Each fork branch is routed by its OWN binding's RFC 3327 Path, so the
+  #      failover branch reaches a different edge than the branch before it.
+  #   2. @proxy.on_failure fires for a single-destination relay and its
+  #      request.relay() actually re-sends.
+  # Deterministic: both callers demand a 200, and the run additionally asserts
+  # which downstream actually received each INVITE.
+  sipp-failover:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Terminating failover (per-binding Path + on_failure retarget)
+        run: scripts/failover_test.sh
+
   # IPv6 leg — manual dispatch only.  A user-defined compose network with
   # enable_ipv6 + a private ULA subnet keeps all traffic inside the bridge (no
   # host IPv6 egress needed), but docker's IPv6 bridge is not reliable on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`Contact.age_secs`** — seconds since a binding was created or last
+  refreshed, for scripts that need their own recency rule (`[c for c in
+  registrar.lookup(uri) if c.age_secs < 3600]`). Monotonic, and preserved
+  across a restart for bindings restored from a persistence backend; a stored
+  record written before age tracking reports `0`.
 - **Media profiles can drive the `siphon-rtp` WebSocket audio bridge and its DSP
   chain.** The engine has supported handing a leg's audio to an external
   WebSocket media server (decode → L16 uplink, L16 downlink → encode, the WS
@@ -92,6 +97,68 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   list is currently **empty** — all 50 fixtures are handled as the RFC requires.
 
 ### Fixed
+- **A terminating request can now fail over between the bindings of one AoR.**
+  An AoR with more than one live binding where only one was reachable was
+  undeliverable for the full lifetime of the dead binding — observed as a
+  79-minute total loss of terminating MESSAGE to a subscriber who was
+  registered, reachable and successfully sending throughout; the same shape
+  applied to terminating INVITE. Four separate defects sat between a script and
+  "try the next contact":
+  - `request.fork()` sent every branch with the **first** contact's route set.
+    Two bindings of one AoR normally have *different* RFC 3327 Path vectors —
+    different edge proxies, or the same edge proxy with a different
+    per-registration token — so downstream resolved every branch back to
+    binding 0. With `strategy="sequential"` that made failover retry the dead
+    contact N times and answer the same error. A `Contact` passed to `fork()`
+    now gets its own Route header set built from its Path (in order, RFC 3327
+    §5.3), and that route set decides the branch's next hop (RFC 3261 §16.6
+    step 6); the Request-URI stays the Contact URI. Bare-string targets keep
+    pure Request-URI routing, which is also the way to opt a target out.
+  - **`@proxy.on_failure` never fired for a single-destination
+    `request.relay()`** — it was dispatched only from the fork aggregator's
+    all-branches-failed arm, so a proxy's global failure policy was invisible
+    for the commonest case in a proxy and a registered handler simply never
+    ran. It now fires for any non-2xx final on a plain relay. `487 Request
+    Terminated` is excluded: the transaction was cancelled by the UAC, and
+    re-targeting there would resurrect an abandoned call (`@proxy.on_cancel`
+    is the hook for that teardown).
+  - **Neither failure hook could re-target the request.** Both handed the
+    script a `Request` with its inbound flow deliberately replayed for exactly
+    that purpose, then dropped it — the action a handler set with
+    `request.relay()` / `request.fork()` was never executed, and because the
+    reply had not been relayed the error was suppressed too. A retrying
+    handler therefore sent nothing at all and the UAC waited for its own timer.
+    Both `@proxy.on_failure` and the per-relay `on_failure=` callback now start
+    the re-targeted request on the same server transaction, bounded at 8
+    retargets per transaction (a chain of fresh client transactions has no
+    protocol timer to bound it). This is what the shipped
+    [`examples/ims_icscf.py`](examples/ims_icscf.py) S-CSCF failover and the
+    cookbook's failure-route snippet always claimed to do.
+  - **`Contact` exposed no registration time,** so bindings could not be
+    ordered by recency; remaining `expires` is not a substitute, since a UE
+    that asked for 600 s and registered a second ago has less time left than
+    one that asked for 3600 s an hour ago.
+- **The 2xx ACK was relayed once per fork branch,** all resolving to the one UAS
+  that answered, because the ACK path iterated the session's client branches
+  (a comment there assumed "typically just one"). A 2xx ACK is a new request
+  routed by the dialog route set (RFC 3261 §13.2.2.4) and belongs to exactly one
+  remote target; a strict UAS treats the duplicate as an out-of-sequence request
+  on a dialog it has already confirmed. Now sent once per distinct resolved hop.
+- **`registrar.lookup()` did not sort,** despite its own documentation and both
+  sibling lookups promising q-value order — it returned backend insertion order
+  (oldest first). It now returns highest q first (RFC 3261 §20.10), and within
+  one q value the most recently registered binding first. Since almost no UE
+  sends q, recency is what actually orders a real AoR's bindings, which is the
+  right default when a subscriber's SIM has moved to a new handset and the
+  previous binding is still inside its granted expiry.
+- **A binding's Path now outranks its captured inbound flow when routing a fork
+  branch.** A binding registered *through* a proxy is reached via its Path
+  vector; the captured flow answers the narrower "the Contact URI is
+  unreachable, write back on the connection the REGISTER arrived on" question,
+  and using it here sent the branch to the REGISTER's source while dropping the
+  token that identifies which binding the request is for. With no Path the flow
+  is unchanged — still the only way back to a WebSocket UE (RFC 5626 §5.3 /
+  RFC 7118 §5).
 - **B2BUA-originated requests are now retransmitted per RFC 3261 §17.1 on
   unreliable transports.** The proxy datapath relays through the transaction
   layer and so has always had Timer A (INVITE, §17.1.1.2) and Timer E

--- a/docs/cookbook/proxy.md
+++ b/docs/cookbook/proxy.md
@@ -77,6 +77,21 @@ def failure_route(request, reply):
     reply.relay()
 ```
 
+`@proxy.on_failure` also fires for a plain single-destination `request.relay()`
+— there is nothing to aggregate, so every non-2xx final response is "it failed".
+The one exclusion is `487 Request Terminated`: the caller cancelled, and
+re-targeting there would resurrect a call they have already abandoned (use
+`@proxy.on_cancel` for that teardown).
+
+The handler has three ways out. `reply.relay()` forwards the failure; a
+`request.reply(code, reason)` answers with something else; and
+`request.relay(...)` / `request.fork(...)` **re-targets** — a fresh attempt on
+the same server transaction, so the caller keeps waiting on its original request
+instead of seeing the error. Returning without any of them drops silently.
+Re-targeting is bounded at 8 attempts per transaction (nothing in the protocol
+bounds a chain of fresh client transactions), after which the failure is
+forwarded.
+
 And to touch responses on the way back (rewrite headers, strip internal info):
 
 ```python

--- a/docs/cookbook/registrar.md
+++ b/docs/cookbook/registrar.md
@@ -74,10 +74,21 @@ A few things worth knowing:
 
 - **`registrar.save(request)` sends the 200 OK for you** (with the granted Expires,
   clamped by `max_expires`). You don't reply yourself.
-- **`request.fork(contacts)`** passes the `Contact` objects (not just `.uri`). For a
-  binding this node accepted, that routes over the captured inbound flow — the only
-  way to reach a WebSocket UE (RFC 5626 §5.3 connection reuse). Non-local contacts
-  fall back to URI routing.
+- **`request.fork(contacts)`** passes the `Contact` objects (not just `.uri`). That
+  matters for two reasons. A binding this node accepted routes over the captured
+  inbound flow — the only way to reach a WebSocket UE (RFC 5626 §5.3 connection
+  reuse). And a binding registered *through* an edge proxy gets its own Route
+  header set built from its RFC 3327 Path, so each branch goes out through the
+  proxy chain (and the per-registration Path token) that binding was registered
+  with. Without that, every branch would carry the first binding's route set and a
+  Path-token edge proxy would deliver them all back to the same contact, which is
+  the difference between real failover and retrying one dead binding N times.
+  Pass `[c.uri for c in contacts]` to opt out and route purely by Request-URI.
+- **Bindings come back in the order to try them**: highest q first (RFC 3261
+  §20.10), then most recently registered. Most UEs send no q, so recency is
+  usually what orders them — the right default when a SIM has moved to a new
+  handset and the previous binding is still inside its granted expiry. Use
+  `Contact.age_secs` if you need your own rule.
 - **`request.fix_nated_register()`** rewrites the Contact with the source the packet
   actually came from, so NAT'd clients are reachable. Pair it with `nat:` config.
 

--- a/docs/cookbook/snippets.md
+++ b/docs/cookbook/snippets.md
@@ -92,7 +92,10 @@ def screen(request):
 
 ## Send to voicemail when everything fails
 
-`@proxy.on_failure` fires once all branches of a relay/fork have failed.
+`@proxy.on_failure` fires once all branches of a relay/fork have failed — for a
+single-destination relay that means any non-2xx final. `request.relay(...)` from
+the handler re-targets on the same server transaction, so the caller keeps
+waiting rather than seeing the failure.
 
 ```python
 @proxy.on_failure

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,47 +4,29 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,15 +39,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -91,12 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,22 +80,39 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
+name = "arcstr"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -130,15 +123,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -146,21 +139,22 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -209,28 +203,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "base64"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -258,22 +264,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -289,45 +310,45 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -335,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -347,36 +368,90 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.4"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -404,43 +479,73 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -452,9 +557,50 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -462,19 +608,33 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -484,21 +644,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "ecdsa"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki 0.7.3",
+]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
+name = "either"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468 0.7.0",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -518,12 +700,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
+name = "event-listener"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "getrandom 0.2.17",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+dependencies = [
+ "getrandom 0.4.3",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -531,6 +749,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flume"
@@ -549,12 +773,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -588,70 +806,74 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -663,7 +885,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -674,25 +896,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -700,25 +931,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -739,24 +957,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "thiserror 2.0.18",
+ "jni",
+ "rand 0.10.2",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -764,31 +981,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.18",
+ "system-configuration",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "http"
-version = "1.4.0"
+name = "hmac"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -796,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -806,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -830,10 +1090,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -845,7 +1114,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -853,15 +1121,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -874,7 +1141,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -885,7 +1152,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -893,12 +1160,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -906,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -919,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -933,15 +1201,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -953,15 +1221,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -971,12 +1239,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -991,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1001,70 +1263,64 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -1085,35 +1341,85 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1121,11 +1427,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
 ]
 
@@ -1136,35 +1442,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
+name = "libredox"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
- "anyhow",
- "version_check",
+ "libc",
 ]
 
 [[package]]
@@ -1175,9 +1474,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1190,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1216,22 +1515,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1241,21 +1560,21 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -1266,6 +1585,23 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
 ]
 
 [[package]]
@@ -1293,7 +1629,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1311,7 +1647,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1325,13 +1661,19 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1362,10 +1704,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -1376,6 +1736,24 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1401,10 +1779,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1413,25 +1834,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "pkcs8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac 0.13.0",
+ "md-5",
+ "memchr",
+ "rand 0.10.2",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1443,52 +1909,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "prefix-trie"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
- "proc-macro2",
- "syn",
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hex",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -1498,20 +1973,34 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -1523,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1537,18 +2026,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1556,34 +2045,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -1591,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1602,8 +2090,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
- "thiserror 2.0.18",
+ "socket2",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -1611,20 +2099,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1632,23 +2121,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1673,9 +2162,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1683,13 +2172,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1704,6 +2193,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -1713,22 +2211,31 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rasn"
-version = "0.22.2"
+version = "0.28.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d1ed06b066a36d0492d65daaa5f40b7101c24a1228e0af2709712ef1a86e1"
+checksum = "88235e585f2f3fc26ad809c79a84dd77e6a7203eb7d12e5bcaab89fc036d3d90"
 dependencies = [
  "bitvec",
  "bitvec-nom2",
  "bytes",
+ "cfg-if",
  "chrono",
  "either",
- "hashbrown 0.14.5",
  "nom 7.1.3",
  "num-bigint",
  "num-integer",
@@ -1737,31 +2244,57 @@ dependencies = [
  "rasn-derive",
  "serde_json",
  "snafu",
+ "xml-no-std",
 ]
 
 [[package]]
 name = "rasn-derive"
-version = "0.22.2"
+version = "0.28.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f35fecd68ee4d5850baa37ee4520456bbae761fdd42a7fcb95701c268500a93"
+checksum = "11dcd4dab09ceadedb3e2bedf340deb583f0e25bba9ad966b5655c2fb62b1392"
 dependencies = [
  "proc-macro2",
  "rasn-derive-impl",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "rasn-derive-impl"
-version = "0.22.2"
+version = "0.28.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355eedbab62312d9474e1c2e7963ce5fad99bded7e9abd42ae4f040762a2c5f6"
+checksum = "f121c276d3f2fba8caabc870288de3f81abdb0bb94d5510651e58e1e00a7b9e7"
 dependencies = [
  "either",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "uuid",
+]
+
+[[package]]
+name = "redis"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
+dependencies = [
+ "arcstr",
+ "async-lock",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -1770,14 +2303,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1787,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1798,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1808,9 +2341,10 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1819,6 +2353,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1830,12 +2365,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1845,6 +2382,16 @@ name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
 
 [[package]]
 name = "ring"
@@ -1862,9 +2409,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1872,7 +2428,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1881,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1896,19 +2452,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1916,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1928,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1954,46 +2501,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "sec1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
+name = "serde_bytes"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2026,29 +2597,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2062,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2077,6 +2674,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "siphon-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -2085,49 +2714,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphon-rtp-proto"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226aef8325e781c170039a9a580312c28aa52aa6dac5c5f797a0df9a513f1309"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "siphon-sip"
-version = "0.1.3"
+version = "1.5.1"
 dependencies = [
  "aes",
  "arc-swap",
  "axum",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "clap",
  "dashmap",
  "flume",
  "futures-util",
+ "getrandom 0.4.3",
  "hickory-resolver",
  "http",
  "indexmap",
  "ipnet",
+ "libc",
  "md5",
+ "netlink-sys",
  "nom 8.0.0",
  "notify",
  "num_cpus",
+ "p256",
  "prometheus",
  "pyo3",
  "pyo3-async-runtimes",
  "quick-xml",
  "rasn",
  "rasn-derive",
+ "redis",
  "regex",
  "reqwest",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "serde_yml",
- "socket2 0.6.3",
- "thiserror 2.0.18",
+ "serde_yaml_ng",
+ "sha2 0.11.0",
+ "siphon-rtp-proto",
+ "socket2",
+ "thiserror 2.0.19",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
+ "tokio-postgres",
  "tokio-rustls",
- "tokio-sctp",
  "tokio-tungstenite",
  "tower",
+ "tower-http 0.7.0",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "webpki-roots",
+ "x509-cert",
 ]
 
 [[package]]
@@ -2138,9 +2792,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snafu"
@@ -2160,34 +2814,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2195,11 +2829,31 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -2207,6 +2861,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2221,10 +2886,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "syn"
-version = "2.0.117"
+name = "symlink"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2248,7 +2930,28 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2280,11 +2983,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2295,34 +2998,95 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2330,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2344,10 +3108,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.50.0"
+name = "tls_codec"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2355,20 +3140,46 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -2382,28 +3193,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-sctp"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9937103e605c84ae728ac305a3765bb80b8d006078b3e20d5cd12b4d4e0046d6"
-dependencies = [
- "bitflags 1.3.2",
- "bytes",
- "libc",
- "socket2 0.4.10",
- "tokio",
-]
-
-[[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2424,18 +3236,33 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]
@@ -2465,6 +3292,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.19",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,7 +3312,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2497,21 +3337,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.22"
+name = "tracing-serde"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2522,26 +3375,37 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "sha1",
- "thiserror 2.0.18",
- "utf-8",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
@@ -2550,10 +3414,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
+name = "unicode-normalization"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2574,12 +3453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,13 +3466,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.2",
  "wasm-bindgen",
 ]
 
@@ -2641,28 +3514,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+name = "wasite"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
 dependencies = [
- "wit-bindgen",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2673,23 +3555,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2697,65 +3575,44 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
+name = "wasm-streams"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2773,11 +3630,24 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]
@@ -2785,22 +3655,6 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -2812,24 +3666,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2870,21 +3738,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -2918,12 +3771,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2936,12 +3783,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2951,12 +3792,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2984,12 +3819,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2999,12 +3828,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3020,12 +3843,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3035,12 +3852,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3055,108 +3866,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -3168,10 +3887,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.1"
+name = "x509-cert"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
+dependencies = [
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
+ "tls_codec",
+]
+
+[[package]]
+name = "xml-no-std"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3180,68 +3923,82 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.41"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.41"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3250,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3261,17 +4018,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/scripts/failover_proxy.py
+++ b/scripts/failover_proxy.py
@@ -1,0 +1,90 @@
+"""Test fixture proxy for terminating failover across an AoR's bindings.
+
+Two acceptance scenarios share this script.
+
+1. **Per-binding Path routing** (`sip:bob@…`).  Two bindings for one AoR, each
+   registered through a different edge proxy (the REGISTERs carry different RFC
+   3327 Path headers).  The script does nothing but `request.fork(contacts,
+   strategy="sequential")` — it never touches Route.  Each branch must go out
+   through *its own* binding's Path, so when the first edge answers 404 the
+   second branch reaches a different edge and the call completes.
+
+2. **Failure re-targeting** (`sip:carol@…`).  A single-destination
+   `request.relay()` to a primary backend that rejects the call, with
+   `@proxy.on_failure` sending it to a backup.  The handler has to fire at all
+   (there is no fork here, so nothing aggregates) and its `request.relay()` has
+   to actually re-send, or the caller never gets an answer.
+
+Run by scripts/failover_test.sh via sipp/docker-compose.yaml
+(`--profile failover`), config sipp/configs/siphon.failover-test.yaml.
+"""
+from siphon import proxy, registrar, log
+
+# Scenario 2's two backends: the primary rejects, the backup answers.
+CAROL_PRIMARY = "sip:carol@172.20.0.95:5060"
+CAROL_BACKUP = "sip:carol@172.20.0.97:5060"
+
+
+@proxy.on_request("REGISTER")
+def handle_register(request):
+    # No auth: the fixture is about routing, and each UE registers exactly once.
+    # registrar.save() stores the REGISTER's Path vector with the binding, which
+    # is the whole input to scenario 1.
+    registrar.save(request)
+
+
+@proxy.on_request("INVITE")
+def handle_invite(request):
+    if request.in_dialog:
+        request.loose_route()
+        request.relay()
+        return
+
+    # Stay in the path so the caller's in-dialog ACK/BYE come back through us.
+    request.record_route()
+
+    user = request.ruri.user
+
+    if user == "carol":
+        # Scenario 2: one destination, no fork, no aggregator.
+        request.relay(CAROL_PRIMARY)
+        return
+
+    contacts = registrar.lookup(request.ruri)
+    if not contacts:
+        request.reply(404, "Not Found")
+        return
+
+    for contact in contacts:
+        log.info(f"[failover] binding {contact.uri} path={contact.path} q={contact.q}")
+
+    # Scenario 1: the script deliberately sets no Route.  Each branch's route
+    # set has to come from its own binding's Path.
+    request.fork(contacts, strategy="sequential")
+
+
+@proxy.on_request
+def handle_other(request):
+    # An unfiltered handler runs for EVERY method, including the ones handled
+    # above — so it has to bow out for those or its action would overwrite
+    # theirs (the fork/relay decision is the last one written before dispatch).
+    if request.method in ("REGISTER", "INVITE"):
+        return
+    if request.in_dialog:
+        request.loose_route()
+        request.relay()
+        return
+    request.reply(200, "OK")
+
+
+@proxy.on_failure
+def failure_route(request, reply):
+    # Scenario 2: re-target to the backup instead of answering the failure
+    # upstream.  Bounded by the framework (MAX_FAILURE_RETARGETS) — and since
+    # the backup answers, the chain ends after one retarget anyway.
+    if request.method == "INVITE" and request.ruri.user == "carol":
+        log.info(f"[failover] on_failure {reply.status_code} — retrying {CAROL_BACKUP}")
+        request.relay(CAROL_BACKUP)
+        return
+
+    reply.relay()

--- a/scripts/failover_test.sh
+++ b/scripts/failover_test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Terminating failover across an AoR's bindings — SIPp acceptance test.
+#
+# Two scenarios, one fixture proxy (scripts/failover_proxy.py):
+#
+#   1. Per-binding Path routing.  bob has two live bindings registered through
+#      different edge proxies (different RFC 3327 Path tokens).  The first
+#      edge answers 404 — its binding is gone.  The sequential fork's second
+#      branch must be routed by the *second* binding's Path and reach the other
+#      edge.  If every branch inherits branch 0's route set, the second branch
+#      is delivered back to the same dead edge and the caller gets the 404.
+#
+#   2. Failure re-targeting.  carol's primary backend rejects; the backup is
+#      only reachable from @proxy.on_failure.  The first attempt is a
+#      single-destination request.relay() — no fork, no aggregator — so the
+#      call completes only if the handler runs for a plain relay AND its
+#      request.relay() actually re-sends.
+#
+# Both callers demand a 200; anything else fails the run.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+COMPOSE=(docker compose -f sipp/docker-compose.yaml --profile failover)
+
+cleanup() { "${COMPOSE[@]}" down --remove-orphans -t 3 >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+fail() {
+  echo "FAILED: $1"
+  echo "--- siphon-failover logs ---"
+  "${COMPOSE[@]}" logs siphon-failover 2>/dev/null | tail -80 || true
+  exit 1
+}
+
+echo "=== Terminating failover across an AoR's bindings ==="
+echo "[*] Building siphon image..."
+"${COMPOSE[@]}" build siphon-failover
+
+echo "[*] Starting siphon..."
+"${COMPOSE[@]}" up -d --wait siphon-failover || fail "siphon did not become healthy"
+
+# ── Scenario 1: per-binding Path routing ────────────────────────────────────
+echo
+echo "--- 1/2: per-binding Path routing (RFC 3327 §5.3) ---"
+
+echo "[*] Registering bob's two bindings (Path token-a q=1.0, token-b q=0.5)..."
+"${COMPOSE[@]}" run --rm sipp-failover-register-a >/dev/null \
+  || fail "binding A did not register"
+"${COMPOSE[@]}" run --rm sipp-failover-register-b >/dev/null \
+  || fail "binding B did not register"
+
+echo "[*] Starting both edges (.90 answers 404, .91 answers 200)..."
+"${COMPOSE[@]}" up -d sipp-failover-reject sipp-failover-answer
+sleep 2
+
+echo "[*] Calling bob..."
+rc=0
+"${COMPOSE[@]}" run --rm sipp-failover-uac || rc=$?
+if [[ ${rc} -ne 0 ]]; then
+  echo "--- dead edge (.90) logs ---"
+  "${COMPOSE[@]}" logs sipp-failover-reject 2>/dev/null | tail -30 || true
+  echo "--- live edge (.91) logs ---"
+  "${COMPOSE[@]}" logs sipp-failover-answer 2>/dev/null | tail -30 || true
+  fail "the call was not answered (exit ${rc}) — the failover branch did not reach binding B's edge"
+fi
+
+# The live edge must actually have been rung, and the dead one must have been
+# tried first.  Without both, the test would also pass if siphon had answered
+# the call itself or had only ever contacted one edge.
+edge_received_invite() {
+  "${COMPOSE[@]}" logs "$1" 2>/dev/null | grep -a "> INVITE" | grep -qE "INVITE +[1-9]"
+}
+edge_received_invite sipp-failover-reject \
+  || fail "binding A's edge never received the INVITE — branch 0 was not routed by its Path"
+edge_received_invite sipp-failover-answer \
+  || fail "binding B's edge never received the INVITE — the failover branch reused binding A's route set"
+
+"${COMPOSE[@]}" rm -sf sipp-failover-reject sipp-failover-answer >/dev/null 2>&1 || true
+echo "PASS: each fork branch was routed through its own binding's Path"
+
+# ── Scenario 2: failure re-targeting on a single relay ──────────────────────
+echo
+echo "--- 2/2: @proxy.on_failure re-target on a single-destination relay ---"
+
+echo "[*] Starting carol's primary (rejects) and backup (answers) backends..."
+"${COMPOSE[@]}" up -d sipp-failover-backend-primary sipp-failover-backend-backup
+sleep 2
+
+echo "[*] Calling carol..."
+rc=0
+"${COMPOSE[@]}" run --rm sipp-failover-retarget-uac || rc=$?
+if [[ ${rc} -ne 0 ]]; then
+  echo "--- primary backend logs ---"
+  "${COMPOSE[@]}" logs sipp-failover-backend-primary 2>/dev/null | tail -30 || true
+  echo "--- backup backend logs ---"
+  "${COMPOSE[@]}" logs sipp-failover-backend-backup 2>/dev/null | tail -30 || true
+  fail "the call was not answered (exit ${rc}) — on_failure did not re-target the relay"
+fi
+
+edge_received_invite sipp-failover-backend-primary \
+  || fail "the primary backend never received the INVITE"
+edge_received_invite sipp-failover-backend-backup \
+  || fail "the backup backend never received the INVITE — on_failure's request.relay() did not re-send"
+
+echo "PASS: on_failure fired for a single-destination relay and its retry reached the backup"
+echo
+echo "ALL PASS"

--- a/sdk/siphon_sdk/types.py
+++ b/sdk/siphon_sdk/types.py
@@ -122,6 +122,7 @@ class Contact:
         uri: The contact URI string (e.g. ``"sip:alice@192.168.1.5:5060"``).
         q: Quality value between 0.0 and 1.0 (higher = preferred).
         expires: Seconds remaining until this binding expires.
+        age_secs: Seconds since the binding was created or last refreshed.
     """
 
     uri: str
@@ -134,9 +135,33 @@ class Contact:
     expires: int = 3600
     """Seconds remaining until this contact binding expires."""
 
+    age_secs: int = 0
+    """Seconds since this binding was created or last refreshed.
+
+    Use for recency rules — :attr:`expires` cannot answer that question,
+    because it is time *remaining* and every UE asks for a different
+    lifetime: a handset that requested 600 s and registered a second ago
+    sorts below one that requested 3600 s an hour ago.
+
+    ``registrar.lookup()`` already returns bindings most-recent-first
+    within one q-value; this is for scripts that need a different rule::
+
+        fresh = [c for c in registrar.lookup(uri) if c.age_secs < 3600]
+
+    Monotonic (immune to wall-clock steps) and preserved across a restart
+    for bindings restored from a persistence backend.  A binding whose
+    stored record pre-dates age tracking reports ``0``."""
+
     path: list = field(default_factory=list)
     """RFC 3327 Path headers stored with this binding.
-    Use as Route headers when routing terminating requests to this contact."""
+
+    Passing the ``Contact`` itself to ``request.fork()`` makes the proxy
+    build this branch's Route header set from the Path automatically (in
+    order, per RFC 3327 §5.3) and route the branch by its topmost entry —
+    which is what lets the bindings of one AoR fail over independently,
+    since two bindings usually carry different Path tokens.  Read it
+    directly only when routing by hand with
+    ``request.set_header("Route", ...)``."""
 
     instance_id: Optional[str] = None
     """Stable identity of the siphon instance that originally accepted the

--- a/sipp/configs/siphon.failover-test.yaml
+++ b/sipp/configs/siphon.failover-test.yaml
@@ -1,0 +1,31 @@
+# siphon.failover-test.yaml — terminating failover across an AoR's bindings.
+#
+# Used with: sipp/docker-compose.yaml --profile failover (scripts/failover_test.sh)
+# Script:    scripts/failover_proxy.py
+#
+# No auth: both acceptance scenarios are about routing, and the fixture
+# registers each UE exactly once.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.13"
+
+advertised_address: "172.20.0.13"
+
+script:
+  path: "scripts/failover_proxy.py"
+  reload: auto
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -3297,6 +3297,244 @@ services:
     profiles:
       - routing
 
+  # ── Terminating failover across an AoR's bindings ───────────────────────────
+  # Two acceptance scenarios on one fixture (scripts/failover_proxy.py):
+  #
+  #  1. Per-binding Path routing.  bob registers twice with different RFC 3327
+  #     Path tokens (edge .90 and edge .91).  Edge .90 answers 404 (its binding
+  #     is gone); the sequential fork's second branch must be routed by binding
+  #     B's OWN Path and reach edge .91, which answers 200.  If branches share
+  #     branch 0's route set, .91 is never reached and the caller gets the 404.
+  #
+  #  2. Failure re-targeting on a single-destination relay.  carol's backend
+  #     (.95) answers 503, then 486, then 200.  There is no fork, so this only
+  #     works if @proxy.on_failure fires for a plain relay AND its
+  #     request.relay() actually re-sends.
+  #
+  # Driver: scripts/failover_test.sh
+
+  siphon-failover:
+    image: sipp-siphon
+    build:
+      context: ..
+    container_name: siphon-failover
+    volumes:
+      - ./configs/siphon.failover-test.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.13
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - failover
+
+  # bob's first binding — Path token resolves to edge .90, q=1.0 so the
+  # sequential fork tries it first.
+  sipp-failover-register-a:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-failover:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.92
+    entrypoint:
+      - sipp
+      - "172.20.0.13:5060"
+      - -sf
+      - /sipp/scenarios/failover_register_path.xml
+      - -s
+      - bob
+      - -key
+      - regpath
+      - "<sip:token-a@172.20.0.90:5060;lr>"
+      - -key
+      - regq
+      - "1.0"
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+      - -trace_err
+    profiles:
+      - failover
+
+  # bob's second binding — Path token resolves to edge .91, q=0.5 so it is the
+  # failover branch, not the first one tried.
+  sipp-failover-register-b:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-failover:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.93
+    entrypoint:
+      - sipp
+      - "172.20.0.13:5060"
+      - -sf
+      - /sipp/scenarios/failover_register_path.xml
+      - -s
+      - bob
+      - -key
+      - regpath
+      - "<sip:token-b@172.20.0.91:5060;lr>"
+      - -key
+      - regq
+      - "0.5"
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+      - -trace_err
+    profiles:
+      - failover
+
+  sipp-failover-reject:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.90
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/failover_reject_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - failover
+
+  sipp-failover-answer:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.91
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/failover_answer_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - failover
+
+  # carol's primary backend — rejects, so on_failure has to re-target.
+  sipp-failover-backend-primary:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.95
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/failover_reject_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - failover
+
+  # carol's backup backend — only reachable via the on_failure retarget.
+  sipp-failover-backend-backup:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.97
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/failover_answer_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - failover
+
+  sipp-failover-uac:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.94
+    entrypoint:
+      - sipp
+      - "172.20.0.13:5060"
+      - -sf
+      - /sipp/scenarios/failover_uac.xml
+      - -s
+      - bob
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "40"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - failover
+
+  sipp-failover-retarget-uac:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.96
+    entrypoint:
+      - sipp
+      - "172.20.0.13:5060"
+      - -sf
+      - /sipp/scenarios/failover_uac.xml
+      - -s
+      - carol
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "40"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - failover
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:

--- a/sipp/failover_answer_uas.xml
+++ b/sipp/failover_answer_uas.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  The destination that must be failed over TO: answers 180 + 200, then handles
+  the ACK and the BYE.  Used twice by the failover acceptance test:
+
+    - as the edge proxy holding the live binding.  It can only be reached if
+      branch 1 of the sequential fork was routed by that binding's OWN Path
+      token; if every branch inherits branch 0's route set, this scenario never
+      receives an INVITE and the caller gets the 404 instead.
+    - as the backup backend of the @proxy.on_failure re-target scenario, where
+      it can only be reached if the handler's request.relay() actually re-sent.
+
+  Run: sipp -sf failover_answer_uas.xml -p 5060
+-->
+<scenario name="Failover answer">
+
+  <recv request="INVITE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag91[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag91[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=live 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv request="ACK" rtd="true" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="1000" />
+
+</scenario>

--- a/sipp/failover_register_path.xml
+++ b/sipp/failover_register_path.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  REGISTER carrying an RFC 3327 Path header, as an edge proxy would insert it.
+
+  The Path URI's userpart is a per-registration token: the edge proxy resolves
+  it back to *this* binding when a terminating request comes back through it.
+  Two UEs of the same AoR register with different tokens through different
+  edges, which is what makes each binding independently routable — and what a
+  fork has to preserve per branch.
+
+  -key regpath  the full Path header value, e.g. "<sip:token-a@172.20.0.90:5060;lr>"
+  -key regq     the Contact q-value that orders the bindings, e.g. "1.0"
+
+  Run: sipp <proxy>:5060 -sf failover_register_path.xml -s bob \
+            -key regpath '<sip:token-a@172.20.0.90:5060;lr>' -key regq 1.0 -m 1
+-->
+<scenario name="REGISTER with Path">
+
+  <send retrans="500">
+    <![CDATA[
+REGISTER sip:[remote_ip] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:[service]@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 REGISTER
+Contact: <sip:[service]@[local_ip]:[local_port];transport=[transport]>;q=[regq];expires=3600
+Path: [regpath]
+Max-Forwards: 70
+User-Agent: SIPp/siphon-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/failover_reject_uas.xml
+++ b/sipp/failover_reject_uas.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  The destination that must be failed over FROM.  Answers 404 to one INVITE and
+  exits.  Used twice by the failover acceptance test:
+
+    - as the edge proxy holding a binding that is gone (the SIM moved, the
+      security association was replaced).  Receiving the INVITE here at all
+      proves branch 0 was routed by that binding's own Path.
+    - as the primary backend of the @proxy.on_failure re-target scenario.
+
+  Either way the call is only rescued if the *next* attempt goes somewhere
+  else, which is the behaviour under test.
+
+  Run: sipp -sf failover_reject_uas.xml -p 5060
+-->
+<scenario name="Failover reject">
+
+  <recv request="INVITE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 404 Not Found
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag90[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Mandatory: siphon's INVITE client transaction ACKs a non-2xx hop-by-hop
+       (RFC 3261 §17.1.1.3), so this always arrives. -->
+  <recv request="ACK" rtd="true" />
+
+</scenario>

--- a/sipp/failover_uac.xml
+++ b/sipp/failover_uac.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Caller for both failover acceptance scenarios.  It expects the call to be
+  ANSWERED — a 404/503 arriving instead is the failure signal, so no error
+  response is tolerated anywhere in the flow.
+
+  -s bob    -> per-binding Path routing: the first binding's edge answers 404,
+               the second binding's edge must be reached and answer 200.
+  -s carol  -> failure re-targeting: the single backend answers 503, then 486,
+               then 200; only an on_failure handler that can actually re-send
+               gets us to that 200.
+
+  Run: sipp <proxy>:5060 -sf failover_uac.xml -s bob -m 1
+-->
+<scenario name="Failover UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:[service]@[remote_ip] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/siphon-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="180" optional="true" />
+
+  <!-- The whole point: a 200, not the first branch's / first attempt's error.
+       rrs="true" captures the proxy's Record-Route for the in-dialog leg. -->
+  <recv response="200" rtd="true" rrs="true" />
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+[last_To:]
+[last_Call-ID:]
+CSeq: 1 ACK
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+[last_To:]
+[last_Call-ID:]
+CSeq: 2 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" />
+
+</scenario>

--- a/sipp/failure_route_uas.xml
+++ b/sipp/failure_route_uas.xml
@@ -29,7 +29,7 @@ Content-Length: 0
 ]]>
   </send>
 
-  <recv request="ACK" optional="true" />
+  <recv request="ACK" />
 
   <pause milliseconds="100" />
 
@@ -49,7 +49,7 @@ Content-Length: 0
 ]]>
   </send>
 
-  <recv request="ACK" optional="true" />
+  <recv request="ACK" />
 
   <pause milliseconds="100" />
 
@@ -94,7 +94,7 @@ a=rtpmap:0 PCMU/8000
 ]]>
   </send>
 
-  <recv request="ACK" optional="true" />
+  <recv request="ACK" />
 
   <!-- Wait for BYE -->
   <recv request="BYE" />

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -3381,7 +3381,7 @@ fn handle_request(
                 send_socket.as_ref(),
             );
         }
-        RequestAction::Fork { targets, flows, strategy, send_socket } => {
+        RequestAction::Fork { targets, flows, routes, strategy, send_socket } => {
             if targets.is_empty() {
                 warn!("fork with empty targets list");
                 let response = build_response(&message_guard, 500, "No Targets", state.server_header.as_deref(), &[]);
@@ -3400,12 +3400,15 @@ fn handle_request(
                     &message_guard,
                     targets,
                     flows,
+                    routes,
                     fork_strategy,
                     record_routed,
                     &inbound,
                     server_key.as_ref(),
                     state,
                     send_socket.as_ref(),
+                    on_reply_cb,
+                    on_failure_cb,
                 );
             }
         }
@@ -3902,16 +3905,20 @@ fn relay_request(
 ///
 /// Creates a ProxySession with a ForkAggregator and sends to all targets
 /// (parallel) or just the first (sequential, rest tried on failure).
+#[allow(clippy::too_many_arguments)]
 fn relay_fork_request(
     message: &SipMessage,
     targets: &[String],
     flows: &[Option<crate::script::api::registrar::PyFlow>],
+    routes: &[Vec<String>],
     strategy: crate::proxy::fork::ForkStrategy,
     record_routed: bool,
     inbound: &InboundMessage,
     server_key: Option<&TransactionKey>,
     state: &DispatcherState,
     send_socket: Option<&crate::transport::SendSocket>,
+    on_reply_callback: Option<Py<PyAny>>,
+    on_failure_callback: Option<Py<PyAny>>,
 ) {
     use crate::proxy::fork::ForkAggregator;
 
@@ -3937,8 +3944,59 @@ fn relay_fork_request(
         Some(key) => key.clone(),
         None => {
             // Fall back to single-target relay if no server transaction —
-            // carry the first branch's flow so a single WS contact still routes.
-            relay_request(message, targets.first().map(|s| s.as_str()), record_routed, inbound, None, state, None, None, None, None, flows.first().and_then(|f| f.as_ref()), send_socket);
+            // carry the first branch's flow so a single WS contact still
+            // routes, its Path route set so it still reaches the right
+            // binding, and the per-relay callbacks the script attached (this
+            // path is a plain relay in everything but name, so silently
+            // dropping them would make `relay(on_failure=…)` a no-op).
+            let first_target = targets.first().map(|s| s.as_str()).unwrap_or("");
+            let first_path = routes.first().map(Vec::as_slice).unwrap_or(&[]);
+            let Some(routing) = core::branch_routing(first_path, first_target) else {
+                warn!(
+                    target = %first_target,
+                    path = ?first_path,
+                    "fork: single target has an unusable Path route set — dropping"
+                );
+                return;
+            };
+            // A branch with a Path route set is routed by its top Route
+            // (RFC 3261 §16.6 step 6), not by the Contact URI — passing no
+            // next-hop lets relay_request pick that Route up itself.
+            let has_route_set = routing.route_set.is_some();
+            let next_hop = if has_route_set {
+                None
+            } else {
+                targets.first().map(|s| s.as_str())
+            };
+            let single_message;
+            let relay_message = match routing.route_set {
+                Some(route_value) => {
+                    let mut cloned = message.clone();
+                    cloned.headers.set("Route", route_value);
+                    single_message = cloned;
+                    &single_message
+                }
+                None => message,
+            };
+            relay_request(
+                relay_message,
+                next_hop,
+                record_routed,
+                inbound,
+                None,
+                state,
+                on_reply_callback,
+                on_failure_callback,
+                None,
+                None,
+                // Same precedence as a real fork branch: a Path route set
+                // outranks the captured flow (see `relay_fork_branch`).
+                flows
+                    .first()
+                    .and_then(|f| f.as_ref())
+                    .filter(|_| !has_route_set),
+                send_socket,
+            );
             return;
         }
     };
@@ -3954,6 +4012,7 @@ fn relay_fork_request(
     );
     session.fork_aggregator = Some(Arc::clone(&aggregator));
     session.fork_flows = flows.to_vec();
+    session.fork_routes = routes.to_vec();
     session.fork_send_socket = send_socket.cloned();
 
     // Determine which branches to start now
@@ -3982,6 +4041,7 @@ fn relay_fork_request(
             &session_arc,
             &aggregator,
             flows.get(branch_index).and_then(|f| f.as_ref()),
+            routes.get(branch_index).map(Vec::as_slice).unwrap_or(&[]),
             send_socket,
             state,
         );
@@ -3992,6 +4052,13 @@ fn relay_fork_request(
 ///
 /// Resolves the target, adds Via, sends the request, creates a client transaction,
 /// and registers the branch in the ProxySession.
+///
+/// `branch_path` is this branch's RFC 3327 Path vector (empty for a bare-URI
+/// target).  When non-empty it becomes the branch's Route header set, replacing
+/// whatever Route the request carried, and the top Route becomes the branch's
+/// next hop (RFC 3327 §5.3 + RFC 3261 §16.6 step 6).  The Request-URI stays the
+/// branch target either way.
+#[allow(clippy::too_many_arguments)]
 fn relay_fork_branch(
     message: &SipMessage,
     target: &str,
@@ -4002,12 +4069,45 @@ fn relay_fork_branch(
     session_arc: &Arc<RwLock<ProxySession>>,
     aggregator: &Arc<std::sync::Mutex<crate::proxy::fork::ForkAggregator>>,
     flow: Option<&crate::script::api::registrar::PyFlow>,
+    branch_path: &[String],
     send_socket: Option<&crate::transport::SendSocket>,
     state: &DispatcherState,
 ) {
+    // This branch's own route set, from the Path stored with its registration
+    // binding.  Two bindings of one AoR usually traverse different proxy chains
+    // (or the same edge proxy with a different per-registration token), so
+    // without this every branch inherits branch 0's Route and a Path-token
+    // proxy resolves them all back to the *first* binding — the second branch
+    // is then a retry of the first, not a second contact.
+    let routing = match core::branch_routing(branch_path, target) {
+        Some(routing) => routing,
+        None => {
+            warn!(
+                target = %target,
+                branch = branch_index,
+                path = ?branch_path,
+                "fork: branch has an unusable Path route set — dropping the branch"
+            );
+            return;
+        }
+    };
+    let branch_route_set = routing.route_set;
+
+    // A Path route set outranks the captured inbound flow.  A binding with a
+    // Path was registered *through* an intermediate proxy, and RFC 3327 §5.3
+    // makes that vector the route set for reaching it — the per-registration
+    // token in the Path URI is the only thing that tells the edge proxy which
+    // of its bindings this request is for.  The captured flow answers a
+    // narrower question ("the Contact URI is unreachable, write back on the
+    // connection the REGISTER came in on"), and using it here would send the
+    // branch to the REGISTER's source while dropping the token that identifies
+    // the binding.  With no Path, the flow is still the only way back to a
+    // WebSocket UE (RFC 5626 §5.3 / RFC 7118 §5), so nothing changes there.
+    let flow = flow.filter(|_| branch_route_set.is_none());
+
     // Resolve the branch destination + transport: over the captured inbound flow
-    // (RFC 5626 §5.3 connection reuse — the only way back to a WebSocket UE,
-    // RFC 7118 §5) when one is attached, else by DNS-resolving the target URI.
+    // when one applies, else by DNS-resolving the branch's top Route (RFC 3261
+    // §16.6 step 6) or, with no route set, the target URI.
     let (mut destination, mut outbound_transport) = if let Some(flow) = flow {
         let transport = match flow.transport.as_str() {
             "udp" => Transport::Udp,
@@ -4022,10 +4122,13 @@ fn relay_fork_branch(
         };
         (flow.source_addr, transport)
     } else {
-        let relay_target = match resolve_target(target, &state.dns_resolver) {
+        // Route set present → the next hop is its topmost entry, not the
+        // Contact URI (RFC 3261 §16.6 step 6).  This is what actually sends
+        // branch N through binding N's own edge proxy.
+        let relay_target = match resolve_target(&routing.next_hop, &state.dns_resolver) {
             Some(t) => t,
             None => {
-                warn!(target = %target, branch = branch_index, "fork: cannot resolve target");
+                warn!(target = %routing.next_hop, branch = branch_index, "fork: cannot resolve target");
                 return;
             }
         };
@@ -4040,6 +4143,14 @@ fn relay_fork_branch(
 
     // Clone and modify message
     let mut relayed = message.clone();
+
+    // Give the branch its own route set (RFC 3327 §5.3).  This *replaces* any
+    // Route on the request: the Path vector is the complete route set for
+    // reaching this binding, and leaving an inherited entry in front of it
+    // would send the branch through the previous binding's proxy chain.
+    if let Some(ref route_value) = branch_route_set {
+        relayed.headers.set("Route", route_value.clone());
+    }
 
     if core::decrement_max_forwards(&mut relayed.headers).is_err() {
         return; // caller handles the error for the whole fork
@@ -4255,6 +4366,278 @@ fn relay_fork_branch(
             }
         }
     }
+}
+
+/// Upper bound on how many times `@proxy.on_failure` may re-target one server
+/// transaction.  A retarget is a fresh client transaction on the same server
+/// transaction, so no protocol timer bounds the chain — a script that always
+/// retries would loop until the UAC gave up.  Eight is far above any real
+/// failover depth (an AoR's bindings, a gateway list) and low enough that a
+/// runaway script fails fast and loudly.
+const MAX_FAILURE_RETARGETS: u8 = 8;
+
+/// A retarget requested by an `@proxy.on_failure` handler (or by a per-relay
+/// `on_failure=` callback) — the script called `request.relay()` /
+/// `request.fork()` instead of forwarding the error.
+struct FailureRetarget {
+    /// The Relay/Fork action the handler set.
+    action: RequestAction,
+    /// The request as the handler left it — Route, Request-URI and headers may
+    /// all have been rewritten to point at the next candidate.
+    request: SipMessage,
+    on_reply_callback: Option<Py<PyAny>>,
+    on_failure_callback: Option<Py<PyAny>>,
+    send_via_transport: Option<String>,
+    send_via_target: Option<String>,
+}
+
+/// What the `@proxy.on_failure` handlers decided.
+struct FailureHandlerOutcome {
+    /// The error response, as the handlers left it.
+    response: SipMessage,
+    /// Whether a handler called `reply.relay()` — false means "suppress".
+    forwarded: bool,
+    /// Set when a handler re-targeted the request instead.
+    retarget: Option<FailureRetarget>,
+}
+
+/// Run the `@proxy.on_failure` handlers for a failed relay or fork.
+///
+/// The handlers get the original request (with its inbound flow replayed, so
+/// Path-token MT routing works on the retry) and the error response.  They may
+/// forward the error (`reply.relay()`), replace it (`request.reply()`), drop it
+/// silently, or re-target the request (`request.relay()` / `request.fork()`) —
+/// the last of which is returned as a [`FailureRetarget`] for the caller to
+/// execute.
+fn run_proxy_failure_handlers(
+    response: SipMessage,
+    original_request: SipMessage,
+    transport: Transport,
+    source_addr: SocketAddr,
+    inbound_local_addr: SocketAddr,
+    connection_id: ConnectionId,
+    state: &DispatcherState,
+) -> FailureHandlerOutcome {
+    let engine_state = state.engine.state();
+    let failure_handlers = engine_state.handlers_for(&HandlerKind::ProxyFailure);
+    if failure_handlers.is_empty() {
+        return FailureHandlerOutcome {
+            response,
+            forwarded: true,
+            retarget: None,
+        };
+    }
+
+    let response_arc = Arc::new(std::sync::Mutex::new(response));
+    let request_arc = Arc::new(std::sync::Mutex::new(original_request));
+    let reply = PyReply::new(Arc::clone(&response_arc));
+    let mut py_request = PyRequest::with_local_domains(
+        Arc::clone(&request_arc),
+        transport.to_string(),
+        source_addr.ip().to_string(),
+        source_addr.port(),
+        Arc::clone(&state.local_domains),
+    )
+    .with_self_identity(Arc::clone(&state.self_identity));
+    // Replay the inbound flow capture so the failure handler can do Path-token
+    // MT routing (`registrar.lookup_by_token` + `request.relay(flow=…)`) on the
+    // retry — the same context the on_request handler saw.
+    py_request.set_local_port(inbound_local_addr.port());
+    py_request.set_inbound_flow(inbound_local_addr, connection_id.0);
+
+    let (forwarded, action, on_reply_callback, on_failure_callback, send_via_transport, send_via_target) =
+        Python::attach(|python| {
+            let py_reply = match Py::new(python, reply) {
+                Ok(obj) => obj,
+                Err(error) => {
+                    error!("failed to create PyReply for on_failure: {error}");
+                    return (true, RequestAction::None, None, None, None, None);
+                }
+            };
+            let py_req = match Py::new(python, py_request) {
+                Ok(obj) => obj,
+                Err(error) => {
+                    error!("failed to create PyRequest for on_failure: {error}");
+                    return (true, RequestAction::None, None, None, None, None);
+                }
+            };
+
+            for handler in &failure_handlers {
+                let callable = handler.callable.bind(python);
+                match callable.call1((py_req.bind(python), py_reply.bind(python))) {
+                    Ok(ret) => {
+                        if handler.is_async {
+                            if let Err(error) = run_coroutine(python, &ret) {
+                                error!("async on_failure handler error: {error}");
+                                return (true, RequestAction::None, None, None, None, None);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        error!("on_failure handler error: {error}");
+                        return (true, RequestAction::None, None, None, None, None);
+                    }
+                }
+            }
+
+            let forwarded = py_reply.borrow(python).was_forwarded();
+            let mut borrowed = py_req.borrow_mut(python);
+            (
+                forwarded,
+                borrowed.action().clone(),
+                borrowed.take_on_reply_callback(),
+                borrowed.take_on_failure_callback(),
+                borrowed.via_transport_override().map(|s| s.to_string()),
+                borrowed.via_target_override().map(|s| s.to_string()),
+            )
+        });
+
+    let response = match Arc::try_unwrap(response_arc) {
+        Ok(mutex) => mutex.into_inner().unwrap_or_else(|e| e.into_inner()),
+        Err(arc) => arc.lock().unwrap_or_else(|e| e.into_inner()).clone(),
+    };
+
+    // Only Relay/Fork is a retarget.  `RequestAction::Reply` is the script
+    // answering the UAC itself — that lands on the normal reply path below via
+    // the response the handler mutated; `None` is the documented silent drop.
+    let retarget = match action {
+        RequestAction::Relay { .. } | RequestAction::Fork { .. } => {
+            let request = match Arc::try_unwrap(request_arc) {
+                Ok(mutex) => mutex.into_inner().unwrap_or_else(|e| e.into_inner()),
+                Err(arc) => arc.lock().unwrap_or_else(|e| e.into_inner()).clone(),
+            };
+            Some(FailureRetarget {
+                action,
+                request,
+                on_reply_callback,
+                on_failure_callback,
+                send_via_transport,
+                send_via_target,
+            })
+        }
+        _ => None,
+    };
+
+    FailureHandlerOutcome {
+        response,
+        forwarded,
+        retarget,
+    }
+}
+
+/// Execute a retarget an `@proxy.on_failure` handler asked for: start a fresh
+/// client transaction (or fork) on the *same* server transaction, so the UAC
+/// keeps waiting on its original request instead of seeing the failure.
+///
+/// Returns `false` when the retarget was refused (retry budget exhausted); the
+/// caller then forwards the error response as if no retarget had been asked
+/// for, which is the only outcome that still answers the UAC.
+#[allow(clippy::too_many_arguments)]
+fn execute_failure_retarget(
+    retarget: FailureRetarget,
+    server_key: &TransactionKey,
+    record_routed: bool,
+    transport: Transport,
+    source_addr: SocketAddr,
+    inbound_local_addr: SocketAddr,
+    connection_id: ConnectionId,
+    previous_retargets: u8,
+    state: &DispatcherState,
+) -> bool {
+    if previous_retargets >= MAX_FAILURE_RETARGETS {
+        warn!(
+            server_key = %server_key,
+            retargets = previous_retargets,
+            "on_failure: retarget budget exhausted — forwarding the failure instead"
+        );
+        return false;
+    }
+
+    // Drop the exhausted session (and its client-key indices) before the new
+    // one is inserted for the same server key — otherwise the retry's response
+    // would find the old, completed session.
+    state.session_store.remove_by_server_key(server_key);
+
+    let inbound = InboundMessage {
+        remote_addr: source_addr,
+        local_addr: inbound_local_addr,
+        connection_id,
+        transport,
+        data: Bytes::new(),
+    };
+
+    match retarget.action {
+        RequestAction::Relay {
+            ref next_hop,
+            ref flow,
+            ref send_socket,
+        } => {
+            let send_socket = state.resolve_send_socket(send_socket.as_deref());
+            relay_request(
+                &retarget.request,
+                next_hop.as_deref(),
+                record_routed,
+                &inbound,
+                Some(server_key),
+                state,
+                retarget.on_reply_callback,
+                retarget.on_failure_callback,
+                retarget.send_via_transport.as_deref(),
+                retarget.send_via_target.as_deref(),
+                flow.as_ref(),
+                send_socket.as_ref(),
+            );
+        }
+        RequestAction::Fork {
+            ref targets,
+            ref flows,
+            ref routes,
+            ref strategy,
+            ref send_socket,
+        } => {
+            if targets.is_empty() {
+                warn!(server_key = %server_key, "on_failure: fork with no targets — forwarding the failure");
+                return false;
+            }
+            let fork_strategy = match strategy.as_str() {
+                "sequential" => crate::proxy::fork::ForkStrategy::Sequential,
+                _ => crate::proxy::fork::ForkStrategy::Parallel,
+            };
+            let send_socket = state.resolve_send_socket(send_socket.as_deref());
+            relay_fork_request(
+                &retarget.request,
+                targets,
+                flows,
+                routes,
+                fork_strategy,
+                record_routed,
+                &inbound,
+                Some(server_key),
+                state,
+                send_socket.as_ref(),
+                retarget.on_reply_callback,
+                retarget.on_failure_callback,
+            );
+        }
+        _ => return false,
+    }
+
+    // Carry the retry count onto the session the relay just created so the
+    // chain stays bounded.  Looked up rather than threaded through the relay
+    // signatures; a response that beats this write only costs one extra
+    // permitted retarget, which the budget still bounds.
+    if let Some(session_arc) = state.session_store.get_by_server_key(server_key) {
+        if let Ok(mut session) = session_arc.write() {
+            session.failure_retargets = previous_retargets.saturating_add(1);
+        }
+    }
+
+    debug!(
+        server_key = %server_key,
+        retarget = previous_retargets + 1,
+        "on_failure: re-targeted the request"
+    );
+    true
 }
 
 /// Handle an inbound SIP response — route back to the original sender.
@@ -4624,7 +5007,7 @@ fn handle_response(
 
     if let Some(ref client_key) = client_txn_key {
         if let Some(session_arc) = state.session_store.get_by_client_key(client_key) {
-            let (source_addr, inbound_local_addr, connection_id, transport, server_key, fork_agg, branch_index, original_request, relay_on_reply, relay_on_failure, client_branch, final_response_sent) = {
+            let (source_addr, inbound_local_addr, connection_id, transport, server_key, fork_agg, branch_index, original_request, relay_on_reply, relay_on_failure, client_branch, final_response_sent, record_routed, failure_retargets) = {
                 let session = match session_arc.read() {
                     Ok(s) => s,
                     Err(error) => {
@@ -4651,6 +5034,8 @@ fn handle_response(
                     relay_on_failure,
                     session.client_branches.get(client_key).cloned(),
                     session.final_response_sent,
+                    session.record_routed,
+                    session.failure_retargets,
                 )
             };
 
@@ -4762,7 +5147,16 @@ fn handle_response(
             if relay_on_reply.is_some() || (relay_on_failure.is_some() && status_code >= 400) {
                 let msg_arc = Arc::new(std::sync::Mutex::new(message));
                 let req_arc = Arc::new(std::sync::Mutex::new(original_request.clone()));
-                let (updated_msg, cb_forward, cb_reject): (Option<SipMessage>, bool, Option<(u16, String)>) = Python::attach(|python| {
+                type RelayCallbackOutcome = (
+                    bool,
+                    Option<(u16, String)>,
+                    // Set only when the on_failure callback ran and re-targeted
+                    // the request: (action, on_reply, on_failure, via transport,
+                    // via target).  Scoped to that callback so an on_reply
+                    // callback calling relay() can never be mistaken for one.
+                    Option<(RequestAction, Option<Py<PyAny>>, Option<Py<PyAny>>, Option<String>, Option<String>)>,
+                );
+                let (cb_forward, cb_reject, cb_retarget): RelayCallbackOutcome = Python::attach(|python| {
                     let py_reply_obj = PyReply::new(Arc::clone(&msg_arc))
                         .with_response_source(
                             inbound.remote_addr.ip().to_string(),
@@ -4772,7 +5166,7 @@ fn handle_response(
                         Ok(obj) => obj,
                         Err(error) => {
                             error!("failed to create PyReply for relay callback: {error}");
-                            return (None, true, None);
+                            return (true, None, None);
                         }
                     };
                     let py_req = {
@@ -4797,10 +5191,11 @@ fn handle_response(
                             Ok(obj) => obj,
                             Err(error) => {
                                 error!("failed to create PyRequest for relay callback: {error}");
-                                return (None, true, None);
+                                return (true, None, None);
                             }
                         }
                     };
+                    let mut retarget = None;
 
                     // on_reply callback: (request, reply)
                     if let Some(ref on_reply) = relay_on_reply {
@@ -4836,13 +5231,31 @@ fn handle_response(
                                     error!("relay on_failure callback error: {error}");
                                 }
                             }
+                            // A per-relay on_failure callback may re-target the
+                            // request too, on the same terms as the global
+                            // `@proxy.on_failure` handler.  Read the action here
+                            // — inside the on_failure arm — so an on_reply
+                            // callback that calls relay() is never mistaken for
+                            // a failure retarget.
+                            let mut borrowed = py_req.borrow_mut(python);
+                            if matches!(
+                                borrowed.action(),
+                                RequestAction::Relay { .. } | RequestAction::Fork { .. }
+                            ) {
+                                retarget = Some((
+                                    borrowed.action().clone(),
+                                    borrowed.take_on_reply_callback(),
+                                    borrowed.take_on_failure_callback(),
+                                    borrowed.via_transport_override().map(|s| s.to_string()),
+                                    borrowed.via_target_override().map(|s| s.to_string()),
+                                ));
+                            }
                         }
                     }
 
                     let reply_ref = py_reply.borrow(python);
-                    (None, reply_ref.was_forwarded(), reply_ref.reject_action())
+                    (reply_ref.was_forwarded(), reply_ref.reject_action(), retarget)
                 });
-                let _ = updated_msg; // unused — message stays in msg_arc
                 // A per-relay on_reply callback can reject too (same contract as
                 // the global `@proxy.on_reply` handler) — fail the in-progress
                 // INVITE upstream + CANCEL downstream.  Reached only when the
@@ -4862,6 +5275,36 @@ fn handle_response(
                     );
                     return;
                 }
+                // The per-relay on_failure callback re-targeted the request —
+                // start it on the same server transaction instead of answering
+                // the UAC with this failure.
+                if let Some((action, on_reply_cb, on_failure_cb, via_transport, via_target)) = cb_retarget {
+                    let retargeted_request = match Arc::try_unwrap(req_arc) {
+                        Ok(mutex) => mutex.into_inner().unwrap_or_else(|e| e.into_inner()),
+                        Err(arc) => arc.lock().unwrap_or_else(|e| e.into_inner()).clone(),
+                    };
+                    if execute_failure_retarget(
+                        FailureRetarget {
+                            action,
+                            request: retargeted_request,
+                            on_reply_callback: on_reply_cb,
+                            on_failure_callback: on_failure_cb,
+                            send_via_transport: via_transport,
+                            send_via_target: via_target,
+                        },
+                        &server_key,
+                        record_routed,
+                        transport,
+                        source_addr,
+                        inbound_local_addr,
+                        connection_id,
+                        failure_retargets,
+                        state,
+                    ) {
+                        return;
+                    }
+                    // Budget exhausted — fall through and answer the UAC.
+                }
                 if !cb_forward {
                     state.session_store.remove_client_key(client_key);
                     return;
@@ -4871,6 +5314,64 @@ fn handle_response(
                     Ok(mutex) => mutex.into_inner().unwrap_or_else(|e| e.into_inner()),
                     Err(arc) => arc.lock().unwrap_or_else(|e| e.into_inner()).clone(),
                 };
+            }
+
+            // --- Global @proxy.on_failure for a single-target relay ---
+            //
+            // A fork reaches the handlers through the aggregator's
+            // ForwardBestError arm below.  A plain `request.relay()` has no
+            // aggregator at all, so before this the global failure policy was
+            // simply never invoked for the commonest case in a proxy — a script
+            // could register `@proxy.on_failure`, see it never fire, and have
+            // no way to express failover (the shipped I-CSCF S-CSCF failover
+            // example depended on exactly this).  With one branch there is
+            // nothing to aggregate: every non-2xx final response *is* "all
+            // branches failed".
+            //
+            // 487 is excluded: the transaction was cancelled by the UAC, so a
+            // retarget would resurrect a call the caller has already abandoned.
+            // `@proxy.on_cancel` is the hook for that teardown.
+            if fork_agg.is_none()
+                && (300..700).contains(&status_code)
+                && status_code != 487
+                && !final_response_sent
+            {
+                let outcome = run_proxy_failure_handlers(
+                    message,
+                    original_request.clone(),
+                    transport,
+                    source_addr,
+                    inbound_local_addr,
+                    connection_id,
+                    state,
+                );
+
+                if let Some(retarget) = outcome.retarget {
+                    if execute_failure_retarget(
+                        retarget,
+                        &server_key,
+                        record_routed,
+                        transport,
+                        source_addr,
+                        inbound_local_addr,
+                        connection_id,
+                        failure_retargets,
+                        state,
+                    ) {
+                        return;
+                    }
+                    // Budget exhausted — fall through and answer the UAC.
+                }
+
+                if !outcome.forwarded {
+                    debug!(
+                        status = status_code,
+                        "on_failure handler suppressed error response (single relay)"
+                    );
+                    state.session_store.remove_client_key(client_key);
+                    return;
+                }
+                message = outcome.response;
             }
 
             // --- Fork aggregator decision ---
@@ -4944,85 +5445,50 @@ fn handle_response(
                         };
 
                         // Invoke @proxy.on_failure handlers before forwarding
-                        let engine_state = state.engine.state();
-                        let failure_handlers = engine_state.handlers_for(&HandlerKind::ProxyFailure);
-                        if !failure_handlers.is_empty() {
-                            let response_arc = Arc::new(std::sync::Mutex::new(best_response));
-                            let reply = PyReply::new(Arc::clone(&response_arc));
-                            let request_arc = Arc::new(std::sync::Mutex::new(original_request));
-                            let mut py_request = PyRequest::with_local_domains(
-                                request_arc,
-                                transport.to_string(),
-                                source_addr.ip().to_string(),
-                                source_addr.port(),
-                                Arc::clone(&state.local_domains),
-                            )
-                            .with_self_identity(Arc::clone(&state.self_identity));
-                            // Replay the inbound flow capture so the
-                            // failure handler can do Path-token MT
-                            // routing (`registrar.lookup_by_token` +
-                            // `request.relay(flow=…)`) on retry.
-                            py_request.set_local_port(inbound_local_addr.port());
-                            py_request.set_inbound_flow(inbound_local_addr, connection_id.0);
+                        let outcome = run_proxy_failure_handlers(
+                            best_response,
+                            original_request,
+                            transport,
+                            source_addr,
+                            inbound_local_addr,
+                            connection_id,
+                            state,
+                        );
 
-                            let forwarded = Python::attach(|python| {
-                                let py_reply = match Py::new(python, reply) {
-                                    Ok(obj) => obj,
-                                    Err(e) => {
-                                        error!("failed to create PyReply for on_failure: {e}");
-                                        return true;
-                                    }
-                                };
-                                let py_req = match Py::new(python, py_request) {
-                                    Ok(obj) => obj,
-                                    Err(e) => {
-                                        error!("failed to create PyRequest for on_failure: {e}");
-                                        return true;
-                                    }
-                                };
-
-                                for handler in &failure_handlers {
-                                    let callable = handler.callable.bind(python);
-                                    let result = callable.call1((py_req.bind(python), py_reply.bind(python),));
-                                    match result {
-                                        Ok(ret) => {
-                                            if handler.is_async {
-                                                if let Err(e) = run_coroutine(python, &ret) {
-                                                    error!("async on_failure handler error: {e}");
-                                                    return true;
-                                                }
-                                            }
-                                        }
-                                        Err(e) => {
-                                            error!("on_failure handler error: {e}");
-                                            return true;
-                                        }
-                                    }
-                                }
-
-                                let result = py_reply.borrow(python).was_forwarded();
-                                result
-                            });
-
-                            if !forwarded {
-                                debug!("on_failure handler suppressed error response");
-                                state.session_store.remove_by_server_key(&server_key);
+                        // The handler re-targeted the request (`request.relay()`
+                        // / `request.fork()`) — start it on the same server
+                        // transaction and leave the UAC waiting rather than
+                        // answering the failure.  Nothing else may run: no
+                        // response upstream, no failed CDR.
+                        if let Some(retarget) = outcome.retarget {
+                            if execute_failure_retarget(
+                                retarget,
+                                &server_key,
+                                record_routed,
+                                transport,
+                                source_addr,
+                                inbound_local_addr,
+                                connection_id,
+                                failure_retargets,
+                                state,
+                            ) {
                                 return;
                             }
-
-                            let final_response = match Arc::try_unwrap(response_arc) {
-                                Ok(mutex) => mutex.into_inner().unwrap_or_else(|e| e.into_inner()),
-                                Err(arc) => arc.lock().unwrap_or_else(|e| e.into_inner()).clone(),
-                            };
-                            // 3GPP TS 33.203 §7.4: the relayed-back response
-                            // must egress on the same SA's local endpoint
-                            // that the request arrived on.  Pass the session's
-                            // captured inbound_local_addr so the OutboundRouter
-                            // hits the right per-listener UDP channel.
-                            send_message_from(final_response, transport, source_addr, connection_id, Some(inbound_local_addr), state);
-                        } else {
-                            send_message_from(best_response, transport, source_addr, connection_id, Some(inbound_local_addr), state);
+                            // Budget exhausted — fall through and answer the UAC.
                         }
+
+                        if !outcome.forwarded {
+                            debug!("on_failure handler suppressed error response");
+                            state.session_store.remove_by_server_key(&server_key);
+                            return;
+                        }
+
+                        // 3GPP TS 33.203 §7.4: the relayed-back response must
+                        // egress on the same SA's local endpoint that the
+                        // request arrived on.  Pass the session's captured
+                        // inbound_local_addr so the OutboundRouter hits the
+                        // right per-listener UDP channel.
+                        send_message_from(outcome.response, transport, source_addr, connection_id, Some(inbound_local_addr), state);
 
                         // CDR: both forwarded paths converge here (a retrying /
                         // suppressing on_failure handler already returned above),
@@ -9350,7 +9816,7 @@ fn start_next_fork_branch(
     server_key: &TransactionKey,
     state: &DispatcherState,
 ) {
-    let (original_request, record_routed, source_addr, connection_id, transport, agg, branch_flow, send_socket) = {
+    let (original_request, record_routed, source_addr, connection_id, transport, agg, branch_flow, branch_path, send_socket) = {
         let session = match session_arc.read() {
             Ok(s) => s,
             Err(_) => return,
@@ -9363,6 +9829,9 @@ fn start_next_fork_branch(
             session.transport,
             session.fork_aggregator.clone(),
             session.fork_flows.get(next_index).cloned().flatten(),
+            // The failover branch's own Path route set — the whole reason
+            // sequential forking across an AoR's bindings can work at all.
+            session.fork_routes.get(next_index).cloned().unwrap_or_default(),
             session.fork_send_socket.clone(),
         )
     };
@@ -9398,6 +9867,7 @@ fn start_next_fork_branch(
             session_arc,
             &agg,
             branch_flow.as_ref(),
+            &branch_path,
             send_socket.as_ref(),
             state,
         );
@@ -9513,7 +9983,21 @@ fn handle_ack_via_session(
         }
     };
 
-    // Forward ACK to each client branch (typically just one for a completed call)
+    // Forward the ACK once per distinct downstream destination.
+    //
+    // A 2xx ACK is a new request routed by the *dialog route set* (RFC 3261
+    // §13.2.2.4), so every branch of a fork resolves it to the same place: the
+    // one UAS that answered.  Iterating the branches without this guard sent
+    // the UAS one ACK per branch — harmless on the wire only if the UAS is
+    // forgiving, but a strict one treats the duplicate as an out-of-sequence
+    // request on a dialog it has already confirmed.  The dedupe key is the
+    // resolved hop, not the branch, so a session that genuinely has two remote
+    // targets still gets one ACK each.
+    // Keyed on the resolved hop only — NOT on the connection id, which is
+    // derived per branch (for UDP it is a hash of the branch's own remote
+    // address) and would make two branches that resolve to the same UAS look
+    // like different hops.
+    let mut sent_destinations: Vec<(SocketAddr, Transport)> = Vec::new();
     for client_key in &session.client_keys {
         if let Some(client_branch) = session.get_client_branch(client_key) {
             let mut ack_downstream = message.clone();
@@ -9594,6 +10078,17 @@ fn handle_ack_via_session(
                 &state.via_host(&out_transport),
                 Some(state.via_port(&out_transport)),
             );
+
+            let hop = (destination, out_transport);
+            if sent_destinations.contains(&hop) {
+                debug!(
+                    client_key = %client_key,
+                    %destination,
+                    "2xx ACK already relayed to this hop by another fork branch — skipping"
+                );
+                continue;
+            }
+            sent_destinations.push(hop);
 
             let data = Bytes::from(ack_downstream.to_bytes());
             debug!(

--- a/src/proxy/core.rs
+++ b/src/proxy/core.rs
@@ -366,6 +366,89 @@ pub fn next_hop_from_route(headers: &SipHeaders) -> Option<String> {
     entries.first().map(|entry| entry.uri.to_string())
 }
 
+/// Build the Route header value for a target from the Path vector stored with
+/// its registration binding (RFC 3327 §5.3).
+///
+/// The Path vector is preserved in order — Path\[0\] is the proxy nearest the
+/// registrar, so it becomes the first Route entry and therefore this branch's
+/// next hop.  Each stored value is normalized to a single `<uri;lr>` entry; a
+/// stored value that itself holds several comma-separated entries (legal, one
+/// Path header can carry a list) expands to that many Route entries, and any
+/// header-level parameters after the `>` are preserved.
+///
+/// Returns `None` for an empty Path vector — the caller then leaves the
+/// request's existing Route set alone.
+///
+/// This is what makes two bindings of one AoR independently routable: they
+/// commonly traverse different edge proxies, or the same edge proxy with a
+/// different per-registration Path token (RFC 3327 §5 / TS 24.229 §5.2.7.2),
+/// so every fork branch needs *its own* route set rather than the one the
+/// script happened to leave on the request.
+pub fn route_set_from_path(path: &[String]) -> Option<String> {
+    let mut entries: Vec<String> = Vec::new();
+    for raw in path {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match RouteEntry::parse_multi(trimmed) {
+            Ok(parsed) if !parsed.is_empty() => {
+                // `RouteEntry`'s Display re-emits `<uri>;header-params`, so URI
+                // parameters (`;lr`, `;ob`) and header parameters both survive.
+                entries.extend(parsed.iter().map(|entry| entry.to_string()));
+            }
+            // Unparseable as a name-addr (e.g. a bare `sip:host;lr` addr-spec,
+            // which RFC 3327's grammar allows when there are no header params).
+            // Wrap it verbatim rather than dropping the hop — losing a Path
+            // entry silently would route the branch to the wrong place.
+            _ => entries.push(format!("<{}>", trimmed.trim_matches(['<', '>']).trim())),
+        }
+    }
+    if entries.is_empty() {
+        None
+    } else {
+        Some(entries.join(", "))
+    }
+}
+
+/// How one fork branch is routed: its own Route header set (from the
+/// registration binding's Path vector) and the URI to actually send it to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchRouting {
+    /// Route header value to set on this branch, replacing any Route the
+    /// request carried.  `None` when the binding has no Path — the branch then
+    /// keeps the request's existing Route set (today's bare-URI behaviour).
+    pub route_set: Option<String>,
+    /// URI to resolve for this branch's next hop: the topmost Route when a
+    /// route set applies (RFC 3261 §16.6 step 6), else the branch target.
+    pub next_hop: String,
+}
+
+/// Decide how to route one fork branch, given the branch target (the Contact
+/// URI, which stays the Request-URI) and the Path vector stored with that
+/// binding.
+///
+/// Returns `None` when the binding has a Path that cannot be turned into a
+/// usable route set.  The caller must drop that branch rather than fall back
+/// to the target URI: a binding whose Path is unusable is not reachable by
+/// Request-URI either, and silently sending it anyway is how a branch ends up
+/// delivered to the *wrong* binding.
+pub fn branch_routing(branch_path: &[String], target: &str) -> Option<BranchRouting> {
+    let Some(route_set) = route_set_from_path(branch_path) else {
+        return Some(BranchRouting {
+            route_set: None,
+            next_hop: target.to_string(),
+        });
+    };
+    let mut headers = SipHeaders::new();
+    headers.set("Route", route_set.clone());
+    let next_hop = next_hop_from_route(&headers)?;
+    Some(BranchRouting {
+        route_set: Some(route_set),
+        next_hop,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -778,6 +861,150 @@ mod tests {
     fn next_hop_from_route_none_when_no_route() {
         let headers = SipHeaders::new();
         assert!(super::next_hop_from_route(&headers).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // route_set_from_path (RFC 3327 §5.3)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn route_set_from_path_preserves_order() {
+        // Path[0] is the hop nearest the registrar, so it must stay first —
+        // it is the branch's next hop.
+        let path = vec![
+            "<sip:icscf.ims.example.com;lr>".to_string(),
+            "<sip:pcscf.ims.example.com;lr>".to_string(),
+        ];
+        let route = super::route_set_from_path(&path).unwrap();
+        assert_eq!(
+            route,
+            "<sip:icscf.ims.example.com;lr>, <sip:pcscf.ims.example.com;lr>"
+        );
+    }
+
+    #[test]
+    fn route_set_from_path_keeps_token_userpart() {
+        // The whole point of per-branch route sets: the opaque per-registration
+        // token in the Path userpart is what the edge proxy resolves back to a
+        // binding (RFC 3327 §5 / TS 24.229 §5.2.7.2).
+        let path = vec!["<sip:TOKEN-B@edge.example.com;lr>".to_string()];
+        let route = super::route_set_from_path(&path).unwrap();
+        assert!(route.contains("TOKEN-B@edge.example.com"));
+    }
+
+    #[test]
+    fn route_set_from_path_expands_comma_separated_value() {
+        // One Path header may carry a list; each entry becomes its own Route.
+        let path = vec!["<sip:a.example.com;lr>, <sip:b.example.com;lr>".to_string()];
+        let route = super::route_set_from_path(&path).unwrap();
+        assert_eq!(route, "<sip:a.example.com;lr>, <sip:b.example.com;lr>");
+        let entries = RouteEntry::parse_multi(&route).unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn route_set_from_path_preserves_header_params() {
+        let path = vec!["<sip:edge.example.com;lr>;ob".to_string()];
+        let route = super::route_set_from_path(&path).unwrap();
+        assert_eq!(route, "<sip:edge.example.com;lr>;ob");
+    }
+
+    #[test]
+    fn route_set_from_path_wraps_bare_addr_spec() {
+        // RFC 3327's path-value allows a bare addr-spec; it must not be dropped.
+        let path = vec!["sip:edge.example.com;lr".to_string()];
+        let route = super::route_set_from_path(&path).unwrap();
+        assert_eq!(route, "<sip:edge.example.com;lr>");
+        assert!(super::next_hop_from_route(&route_headers(&route)).is_some());
+    }
+
+    #[test]
+    fn route_set_from_path_empty_is_none() {
+        assert!(super::route_set_from_path(&[]).is_none());
+        assert!(super::route_set_from_path(&["   ".to_string()]).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // branch_routing — the per-branch decision the proxy fork path makes
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn branch_routing_sends_each_branch_through_its_own_path() {
+        // The reported bug, at the decision that causes it: two bindings of one
+        // AoR behind the same Path-token edge proxy.  Each branch must resolve
+        // to its OWN token, otherwise branch 1 is just a retry of binding 0.
+        let branch_a = super::branch_routing(
+            &["<sip:TOKEN-A@edge.example.com;lr>".to_string()],
+            "sip:alice@10.0.0.1:5060",
+        )
+        .unwrap();
+        let branch_b = super::branch_routing(
+            &["<sip:TOKEN-B@edge.example.com;lr>".to_string()],
+            "sip:alice@10.0.0.2:5060",
+        )
+        .unwrap();
+
+        assert_eq!(
+            branch_a.route_set.as_deref(),
+            Some("<sip:TOKEN-A@edge.example.com;lr>")
+        );
+        assert_eq!(
+            branch_b.route_set.as_deref(),
+            Some("<sip:TOKEN-B@edge.example.com;lr>")
+        );
+        assert_ne!(
+            branch_a.route_set, branch_b.route_set,
+            "the two branches must not share a route set"
+        );
+        // Both go to the same edge proxy host — the token in the Route is what
+        // distinguishes the bindings, so the next hop being equal is correct.
+        assert!(branch_a.next_hop.contains("TOKEN-A@edge.example.com"));
+        assert!(branch_b.next_hop.contains("TOKEN-B@edge.example.com"));
+    }
+
+    #[test]
+    fn branch_routing_without_path_keeps_target_routing() {
+        let routing = super::branch_routing(&[], "sip:alice@10.0.0.1:5060").unwrap();
+        assert!(
+            routing.route_set.is_none(),
+            "no Path must leave the request's Route set untouched"
+        );
+        assert_eq!(routing.next_hop, "sip:alice@10.0.0.1:5060");
+    }
+
+    #[test]
+    fn branch_routing_next_hop_is_top_route_not_the_contact() {
+        // RFC 3261 §16.6 step 6 — with a route set, the branch goes to the top
+        // Route.  The Contact URI stays the Request-URI (applied by the caller).
+        let routing = super::branch_routing(
+            &[
+                "<sip:icscf.ims.example.com;lr>".to_string(),
+                "<sip:pcscf.ims.example.com;lr>".to_string(),
+            ],
+            "sip:alice@10.0.0.1:5060",
+        )
+        .unwrap();
+        assert!(routing.next_hop.contains("icscf.ims.example.com"));
+        assert!(!routing.next_hop.contains("10.0.0.1"));
+    }
+
+    #[test]
+    fn branch_routing_drops_branch_with_unusable_path() {
+        // A binding whose Path cannot be parsed into a route set is not
+        // reachable by Request-URI either — falling back to the target would
+        // deliver the branch to the wrong binding, which is the bug being fixed.
+        assert!(super::branch_routing(&["not a uri at all".to_string()], "sip:a@b").is_none());
+    }
+
+    #[test]
+    fn route_set_from_path_next_hop_is_first_entry() {
+        let path = vec![
+            "<sip:first.example.com;lr>".to_string(),
+            "<sip:second.example.com;lr>".to_string(),
+        ];
+        let route = super::route_set_from_path(&path).unwrap();
+        let hop = super::next_hop_from_route(&route_headers(&route)).unwrap();
+        assert!(hop.contains("first.example.com"));
     }
 
     #[test]

--- a/src/proxy/session.rs
+++ b/src/proxy/session.rs
@@ -76,6 +76,16 @@ pub struct ProxySession {
     /// branches started after the first.  `PyFlow` is plain data (no
     /// `Py<PyAny>`), so cloning it off the dispatcher thread is sound.
     pub fork_flows: Vec<Option<crate::script::api::registrar::PyFlow>>,
+    /// Per-fork-branch Route header set, parallel to the aggregator's branches.
+    /// Built from the RFC 3327 Path vector stored with that branch's
+    /// registration binding (`Contact.path`), so each branch is routed through
+    /// *its own* proxy chain / per-registration Path token rather than through
+    /// whatever Route the script left on the request.  Empty means "leave the
+    /// request's Route set alone" (a bare-URI target).  Stored on the session
+    /// so sequential forking (`start_next_fork_branch`) can recover the route
+    /// set for branches started after the first — the branch that actually
+    /// matters for failover.
+    pub fork_routes: Vec<Vec<String>>,
     /// Script `send_socket=` egress pin for the whole fork, stored so sequential
     /// forking (`start_next_fork_branch`) applies the same source-socket pin to
     /// branches started after the first.  `SendSocket` is plain data (no
@@ -101,6 +111,14 @@ pub struct ProxySession {
     /// ACKed by the client transaction) instead of forwarding a second final
     /// response upstream.
     pub final_response_sent: bool,
+    /// How many times an `@proxy.on_failure` handler has already re-targeted
+    /// this server transaction via `request.relay()` / `request.fork()`.
+    ///
+    /// A retarget starts a fresh client transaction on the *same* server
+    /// transaction, so nothing in the protocol bounds the chain — Max-Forwards
+    /// is decremented from the original request each time, exactly as it is for
+    /// the branches of one fork.  This counter is that bound.
+    pub failure_retargets: u8,
 }
 
 impl ProxySession {
@@ -120,6 +138,7 @@ impl ProxySession {
             client_branches: HashMap::new(),
             fork_aggregator: None,
             fork_flows: Vec::new(),
+            fork_routes: Vec::new(),
             fork_send_socket: None,
             branch_index_map: HashMap::new(),
             source_addr,
@@ -132,6 +151,7 @@ impl ProxySession {
             on_reply_callback: None,
             on_failure_callback: None,
             final_response_sent: false,
+            failure_retargets: 0,
         }
     }
 

--- a/src/registrar/backend.rs
+++ b/src/registrar/backend.rs
@@ -27,6 +27,15 @@ pub struct StoredContact {
     /// this field fall back to treating `expires_secs` as remaining.
     #[serde(default)]
     pub expires_at: Option<u64>,
+    /// When the binding was created/refreshed, as Unix epoch seconds.
+    ///
+    /// `Contact::registered_at` is a monotonic `Instant`, which cannot cross a
+    /// process boundary — without this the age of every binding restored from a
+    /// backend would reset to zero on restart, and "prefer the most recently
+    /// registered binding" would silently become "prefer an arbitrary one"
+    /// after a restart.  `None` for entries written before this field existed.
+    #[serde(default)]
+    pub registered_at_epoch: Option<u64>,
     /// Call-ID that created this binding.
     pub call_id: String,
     /// CSeq sequence number.
@@ -101,6 +110,9 @@ impl StoredContact {
             q: contact.q,
             expires_secs: remaining,
             expires_at: Some(now_epoch + remaining),
+            registered_at_epoch: Some(
+                now_epoch.saturating_sub(contact.registered_at.elapsed().as_secs()),
+            ),
             call_id: contact.call_id.clone(),
             cseq: contact.cseq,
             source_addr: contact.source_addr.map(|a| a.to_string()),
@@ -138,6 +150,27 @@ impl StoredContact {
         self.remaining_secs() == 0
     }
 
+    /// Rebuild the monotonic `registered_at` for a restored binding so its age
+    /// survives the restart (see [`registered_at_epoch`](Self::registered_at_epoch)).
+    ///
+    /// Falls back to "now" when the stored epoch is missing (legacy entry) or
+    /// lies in the future (clock stepped backwards on a shared backend) —
+    /// treating an unknown age as zero only ever makes a binding look *newer*,
+    /// which is the safe direction: a fresh binding is never preferred less
+    /// than it should be, and expiry is governed by `expires_at`, not this.
+    fn restored_registered_at(&self) -> std::time::Instant {
+        let now = std::time::Instant::now();
+        let Some(registered_at_epoch) = self.registered_at_epoch else {
+            return now;
+        };
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let age = Duration::from_secs(now_epoch.saturating_sub(registered_at_epoch));
+        now.checked_sub(age).unwrap_or(now)
+    }
+
     /// Convert to an in-memory Contact type.
     /// Returns `None` if the URI is unparseable or the contact has expired.
     pub fn to_contact(&self) -> Option<super::Contact> {
@@ -162,7 +195,7 @@ impl StoredContact {
         Some(super::Contact {
             uri,
             q: self.q,
-            registered_at: std::time::Instant::now(),
+            registered_at: self.restored_registered_at(),
             expires: Duration::from_secs(remaining),
             call_id: self.call_id.clone(),
             cseq: self.cseq,
@@ -1423,6 +1456,7 @@ mod tests {
             q: 1.0,
             expires_secs: 3600,
             expires_at: Some(now_epoch + 3600),
+            registered_at_epoch: None,
             call_id: "call-1".to_string(),
             cseq: 1,
             source_addr: None,
@@ -1452,6 +1486,58 @@ mod tests {
         assert_eq!(back.uri, stored.uri);
         assert_eq!(back.q, stored.q);
         assert_eq!(back.call_id, stored.call_id);
+    }
+
+    #[test]
+    fn stored_contact_preserves_registration_age_across_restart() {
+        // `Contact::registered_at` is a monotonic Instant and cannot cross a
+        // process boundary.  Without the epoch, every binding restored from
+        // Redis/Postgres would come back looking brand new and
+        // "prefer the most recently registered binding" would degrade to
+        // "prefer an arbitrary one" after a restart.
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let mut stored = sample_stored_contact();
+        stored.registered_at_epoch = Some(now_epoch - 900);
+
+        let contact = stored.to_contact().unwrap();
+        assert!(
+            (899..=901).contains(&contact.age_seconds()),
+            "restored binding must keep its age, got {}",
+            contact.age_seconds()
+        );
+
+        // And it survives the trip back out to the backend.
+        let back = StoredContact::from_contact(&contact);
+        let round_tripped = back.registered_at_epoch.expect("epoch must be written");
+        assert!(round_tripped.abs_diff(now_epoch - 900) <= 1);
+    }
+
+    #[test]
+    fn stored_contact_without_epoch_reports_zero_age() {
+        // Legacy entry written before age tracking: report a zero age rather
+        // than a nonsense one.  Zero only ever makes a binding look newer,
+        // which is the safe direction — expiry is governed by `expires_at`.
+        let stored = sample_stored_contact();
+        assert!(stored.registered_at_epoch.is_none());
+        let contact = stored.to_contact().unwrap();
+        assert_eq!(contact.age_seconds(), 0);
+    }
+
+    #[test]
+    fn stored_contact_with_future_epoch_reports_zero_age() {
+        // Clock stepped backwards on a shared backend — must not panic or
+        // produce a wrapped age.
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let mut stored = sample_stored_contact();
+        stored.registered_at_epoch = Some(now_epoch + 10_000);
+        let contact = stored.to_contact().unwrap();
+        assert_eq!(contact.age_seconds(), 0);
     }
 
     #[test]
@@ -1583,6 +1669,7 @@ mod tests {
             q: 1.0,
             expires_secs: 3600,
             expires_at: Some(now_epoch + 3600),
+            registered_at_epoch: None,
             call_id: "c1".to_string(),
             cseq: 1,
             source_addr: Some("10.0.0.1:50000".into()),
@@ -1674,6 +1761,7 @@ mod tests {
         let stored = StoredContact {
             expires_secs: 0,
             expires_at: Some(1), // epoch second 1 — long expired
+            registered_at_epoch: None,
             ..sample_stored_contact()
         };
         assert!(stored.is_expired());
@@ -1689,6 +1777,7 @@ mod tests {
         let stored = StoredContact {
             expires_secs: 9999, // stale value — should be ignored
             expires_at: Some(now_epoch + 100),
+            registered_at_epoch: None,
             ..sample_stored_contact()
         };
         let remaining = stored.remaining_secs();
@@ -1701,6 +1790,7 @@ mod tests {
         let stored = StoredContact {
             expires_secs: 500,
             expires_at: None,
+            registered_at_epoch: None,
             ..sample_stored_contact()
         };
         assert_eq!(stored.remaining_secs(), 500);
@@ -1781,6 +1871,7 @@ mod tests {
                 q: 1.0,
                 expires_secs: 3600,
                 expires_at: Some(now_epoch + 3600),
+                registered_at_epoch: None,
                 call_id: "c1".to_string(),
                 cseq: 1,
                 source_addr: None,
@@ -1805,6 +1896,7 @@ mod tests {
                     q: 1.0,
                     expires_secs: 3600,
                     expires_at: Some(now_epoch + 3600),
+                    registered_at_epoch: None,
                     call_id: "c2".to_string(),
                     cseq: 1,
                     source_addr: None,
@@ -1825,6 +1917,7 @@ mod tests {
                     q: 0.5,
                     expires_secs: 1800,
                     expires_at: Some(now_epoch + 1800),
+                    registered_at_epoch: None,
                     call_id: "c3".to_string(),
                     cseq: 2,
                     source_addr: None,
@@ -1865,6 +1958,7 @@ mod tests {
                 q: 1.0,
                 expires_secs: 0,
                 expires_at: Some(1), // long expired
+                registered_at_epoch: None,
                 call_id: "c1".to_string(),
                 cseq: 1,
                 source_addr: None,
@@ -1906,6 +2000,7 @@ mod tests {
                 q: 1.0,
                 expires_secs: 3600,
                 expires_at: Some(now_epoch + 3600),
+                registered_at_epoch: None,
                 call_id: "c1".to_string(),
                 cseq: 1,
                 source_addr: None,

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -186,6 +186,21 @@ pub struct Contact {
     pub kind: ContactKind,
 }
 
+/// Order routable bindings the way a terminating request should try them:
+/// highest q first (RFC 3261 §20.10 — the caller's declared preference), and
+/// within one q value the most recently registered binding first.
+///
+/// Recency is the tiebreak rather than the primary key because q is an explicit
+/// instruction from the registering UA; but since almost no UE sends q, recency
+/// is what actually orders a real AoR's bindings.
+fn sort_by_preference(contacts: &mut [Contact]) {
+    contacts.sort_by(|a, b| {
+        b.q.partial_cmp(&a.q)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.age_seconds().cmp(&b.age_seconds()))
+    });
+}
+
 impl Contact {
     /// Seconds remaining until this contact expires.
     pub fn remaining_seconds(&self) -> u64 {
@@ -196,6 +211,18 @@ impl Contact {
     /// Whether this contact has expired.
     pub fn is_expired(&self) -> bool {
         self.registered_at.elapsed() >= self.expires
+    }
+
+    /// Seconds since this binding was created or last refreshed.
+    ///
+    /// The ordering signal for "prefer the most recently registered binding",
+    /// which is what a terminating request wants when a subscriber's SIM has
+    /// moved to a new handset and the old binding is still inside its granted
+    /// expiry.  Remaining `expires` cannot answer that: a UE that asked for
+    /// 600 s and registered a second ago has less time left than one that asked
+    /// for 3600 s an hour ago.
+    pub fn age_seconds(&self) -> u64 {
+        self.registered_at.elapsed().as_secs()
     }
 }
 
@@ -966,7 +993,16 @@ impl Registrar {
     }
 
     /// Look up routable contacts for an AoR. Returns non-expired UE-side
-    /// contacts sorted by q descending.
+    /// contacts sorted by q descending, most recently registered first within
+    /// one q value.
+    ///
+    /// The q-value is the caller's declared preference (RFC 3261 §20.10) and so
+    /// dominates.  Most UEs send no q at all, which leaves every binding at the
+    /// same value and makes recency the effective order — the right default for
+    /// a terminating request when a subscriber's SIM has moved to a new handset
+    /// and the previous binding is still inside its granted expiry.  (Before
+    /// this the list came back in backend insertion order, i.e. oldest first,
+    /// while this doc already claimed q ordering.)
     ///
     /// If `aor` is an alias of an IMS implicit registration set's primary,
     /// returns the primary's contacts (so terminating routing on a non-primary
@@ -978,7 +1014,7 @@ impl Registrar {
     /// merged view that reg-event NOTIFY emission uses.
     pub fn lookup(&self, aor: &str) -> Vec<Contact> {
         let primary = self.resolve_alias(aor);
-        match self.bindings.get(primary.as_str()) {
+        let mut out: Vec<Contact> = match self.bindings.get(primary.as_str()) {
             Some(entry) => entry
                 .value()
                 .iter()
@@ -986,7 +1022,9 @@ impl Registrar {
                 .cloned()
                 .collect(),
             None => Vec::new(),
-        }
+        };
+        sort_by_preference(&mut out);
+        out
     }
 
     /// Look up every non-expired contact for an AoR, including AS-side
@@ -1064,7 +1102,7 @@ impl Registrar {
                 }
             }
         }
-        out.sort_by(|a, b| b.q.partial_cmp(&a.q).unwrap_or(std::cmp::Ordering::Equal));
+        sort_by_preference(&mut out);
         out
     }
 
@@ -2841,6 +2879,117 @@ mod tests {
         let contacts = registrar.lookup("sip:alice@example.com");
         assert_eq!(contacts.len(), 1);
         assert_eq!(contacts[0].path, path);
+    }
+
+    #[test]
+    fn lookup_returns_most_recently_registered_first() {
+        // A subscriber's SIM moved to a new handset and the old binding is
+        // still inside its granted expiry.  A terminating request should try
+        // the new one first; before this, lookup() handed back backend
+        // insertion order (oldest first) while claiming to sort.
+        let registrar = Registrar::default();
+        registrar
+            .save_full(
+                "sip:alice@example.com",
+                contact_uri("alice", "10.0.0.1"),
+                3600, 1.0, "old-handset".into(), 1,
+                None, None, None, None,
+                Vec::new(),
+                FlowCapture::default(),
+                Vec::new(),
+            )
+            .unwrap();
+        registrar
+            .save_full(
+                "sip:alice@example.com",
+                contact_uri("alice", "10.0.0.2"),
+                3600, 1.0, "new-handset".into(), 1,
+                None, None, None, None,
+                Vec::new(),
+                FlowCapture::default(),
+                Vec::new(),
+            )
+            .unwrap();
+
+        // Age the first binding so recency is unambiguous.
+        if let Some(mut entry) = registrar.bindings.get_mut("sip:alice@example.com") {
+            for contact in entry.value_mut().iter_mut() {
+                if contact.call_id == "old-handset" {
+                    contact.registered_at = Instant::now() - Duration::from_secs(600);
+                }
+            }
+        }
+
+        let contacts = registrar.lookup("sip:alice@example.com");
+        assert_eq!(contacts.len(), 2);
+        assert_eq!(contacts[0].call_id, "new-handset");
+        assert_eq!(contacts[1].call_id, "old-handset");
+    }
+
+    #[test]
+    fn lookup_q_value_beats_recency() {
+        // q is the registering UA's explicit preference (RFC 3261 §20.10), so
+        // it must dominate; recency only breaks ties.
+        let registrar = Registrar::default();
+        registrar
+            .save_full(
+                "sip:alice@example.com",
+                contact_uri("alice", "10.0.0.1"),
+                3600, 1.0, "preferred-but-old".into(), 1,
+                None, None, None, None,
+                Vec::new(),
+                FlowCapture::default(),
+                Vec::new(),
+            )
+            .unwrap();
+        registrar
+            .save_full(
+                "sip:alice@example.com",
+                contact_uri("alice", "10.0.0.2"),
+                3600, 0.3, "recent-but-deprioritised".into(), 1,
+                None, None, None, None,
+                Vec::new(),
+                FlowCapture::default(),
+                Vec::new(),
+            )
+            .unwrap();
+        if let Some(mut entry) = registrar.bindings.get_mut("sip:alice@example.com") {
+            for contact in entry.value_mut().iter_mut() {
+                if contact.call_id == "preferred-but-old" {
+                    contact.registered_at = Instant::now() - Duration::from_secs(3000);
+                }
+            }
+        }
+
+        let contacts = registrar.lookup("sip:alice@example.com");
+        assert_eq!(contacts[0].call_id, "preferred-but-old");
+    }
+
+    #[test]
+    fn contact_age_seconds_tracks_registration_time() {
+        let registrar = Registrar::default();
+        registrar
+            .save_full(
+                "sip:alice@example.com",
+                contact_uri("alice", "10.0.0.1"),
+                3600, 1.0, "c1".into(), 1,
+                None, None, None, None,
+                Vec::new(),
+                FlowCapture::default(),
+                Vec::new(),
+            )
+            .unwrap();
+        if let Some(mut entry) = registrar.bindings.get_mut("sip:alice@example.com") {
+            for contact in entry.value_mut().iter_mut() {
+                contact.registered_at = Instant::now() - Duration::from_secs(120);
+            }
+        }
+
+        let contacts = registrar.lookup("sip:alice@example.com");
+        assert!((119..=121).contains(&contacts[0].age_seconds()));
+        // Remaining expiry cannot stand in for age — this binding still has
+        // most of its hour left despite being two minutes old.
+        assert!(contacts[0].remaining_seconds() > 3000);
     }
 
     #[test]

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -1345,7 +1345,11 @@ impl PyCall {
         let mut flows: Vec<Option<super::registrar::PyFlow>> = Vec::with_capacity(targets.len());
         for item in targets {
             if let Ok(contact) = item.extract::<PyRef<super::registrar::PyContact>>() {
-                let (uri, flow) = contact.fork_target();
+                // The binding's Path vector is deliberately not consumed here:
+                // the B2BUA builds a fresh B-leg INVITE with its own route set,
+                // so a per-branch Path route set needs separate plumbing to the
+                // dial path (the proxy path consumes it via RequestAction::Fork).
+                let (uri, flow, _path) = contact.fork_target();
                 target_uris.push(uri);
                 flows.push(flow);
             } else {

--- a/src/script/api/registrar.rs
+++ b/src/script/api/registrar.rs
@@ -141,6 +141,8 @@ pub struct PyContact {
     q_value: f32,
     /// Seconds remaining until this contact expires.
     expires_remaining: u64,
+    /// Seconds since the binding was created or last refreshed.
+    age_seconds: u64,
     /// Source address of the REGISTER (for NAT traversal routing).
     /// Format: "sip:ip:port;transport=proto" — like OpenSIPS received_avp.
     received_string: Option<String>,
@@ -195,6 +197,29 @@ impl PyContact {
     #[getter]
     fn expires(&self) -> u64 {
         self.expires_remaining
+    }
+
+    /// Seconds since this binding was created or last refreshed.
+    ///
+    /// Use this to order bindings by recency — ``expires`` cannot answer that
+    /// question, because it is time *remaining* and every UE asks for a
+    /// different lifetime: a handset that requested 600 s and registered a
+    /// second ago sorts below one that requested 3600 s an hour ago.
+    ///
+    /// ``registrar.lookup()`` already returns bindings most-recent-first within
+    /// one q-value, so this is for scripts that need a different rule — e.g.
+    /// "ignore anything older than an hour":
+    ///
+    /// ```text
+    /// fresh = [c for c in registrar.lookup(uri) if c.age_secs < 3600]
+    /// ```
+    ///
+    /// Monotonic, so it is immune to wall-clock steps.  It survives a restart
+    /// for bindings restored from a persistence backend; a binding whose stored
+    /// record pre-dates age tracking reports ``0``.
+    #[getter]
+    fn age_secs(&self) -> u64 {
+        self.age_seconds
     }
 
     /// The received address (source IP:port of the REGISTER).
@@ -319,19 +344,25 @@ impl PyContact {
         Self::from_rust_contact_with_registrar(contact, None)
     }
 
-    /// `(uri, flow)` for flow-aware `request.fork()` / `call.fork()`.
+    /// `(uri, flow, path)` for flow-aware `request.fork()` / `call.fork()`.
     ///
     /// The captured flow is only surfaced when this binding was accepted by the
     /// **local** process (`is_local`); a binding restored from a shared backend
     /// on another instance carries a `connection_id` that is meaningless here,
     /// so it falls back to URI routing.  The URI is always the Contact URI.
-    pub fn fork_target(&self) -> (String, Option<PyFlow>) {
+    ///
+    /// `path` is this binding's RFC 3327 Path vector.  Two bindings of one AoR
+    /// generally have *different* Path vectors — different edge proxies, or the
+    /// same edge proxy with a different per-registration token — so the proxy
+    /// turns it into a per-branch Route set rather than sending every branch
+    /// with whatever Route the script left on the request.
+    pub fn fork_target(&self) -> (String, Option<PyFlow>, Vec<String>) {
         let flow = if self.is_local_value {
             self.flow_value.clone()
         } else {
             None
         };
-        (self.uri_string.clone(), flow)
+        (self.uri_string.clone(), flow, self.path_headers.clone())
     }
 
     /// Same as [`from_rust_contact`] but resolves `is_local` against the
@@ -378,6 +409,7 @@ impl PyContact {
                         uri_string: contact.uri.to_string(),
                         q_value: contact.q,
                         expires_remaining: contact.remaining_seconds(),
+                        age_seconds: contact.age_seconds(),
                         received_string,
                         path_headers: contact.path.clone(),
                         instance_id_value: contact.instance_id.clone(),
@@ -402,6 +434,7 @@ impl PyContact {
             uri_string: contact.uri.to_string(),
             q_value: contact.q,
             expires_remaining: contact.remaining_seconds(),
+            age_seconds: contact.age_seconds(),
             received_string,
             path_headers: contact.path.clone(),
             instance_id_value: contact.instance_id.clone(),
@@ -1893,6 +1926,7 @@ mod tests {
             uri_string: "sip:alice@10.0.0.1".to_string(),
             q_value: 1.0,
             expires_remaining: 3600,
+            age_seconds: 0,
             received_string: None,
             path_headers: vec![],
             instance_id_value: None,
@@ -2383,16 +2417,57 @@ mod tests {
 
         // Non-local → flow withheld, URI carried for DNS routing.
         py.is_local_value = false;
-        let (uri, flow) = py.fork_target();
+        let (uri, flow, _path) = py.fork_target();
         assert!(flow.is_none(), "non-local binding must not surface its flow");
         assert!(uri.contains("bob@df7jal23ls0d.invalid"));
 
         // Local → flow surfaced for connection reuse.
         py.is_local_value = true;
-        let (_, flow) = py.fork_target();
+        let (_, flow, _path) = py.fork_target();
         let flow = flow.expect("local binding must surface its captured flow");
         assert_eq!(flow.transport, "wss");
         assert_eq!(flow.connection_id, 0xc0ffee);
+    }
+
+    #[test]
+    fn fork_target_carries_the_bindings_own_path() {
+        // Per-branch route sets are the whole failover story: two bindings of
+        // one AoR carry different Path tokens, and the fork branch must be
+        // routed by *its own* one.  A cross-instance binding still surfaces
+        // its Path (unlike the flow) — Path is routable from anywhere, a
+        // captured connection_id is not.
+        let path = vec!["<sip:TOKEN-B@edge.example.com;lr>".to_string()];
+        let contact = Contact {
+            uri: SipUri::new("10.0.0.2".to_string()).with_user("bob".into()),
+            q: 1.0,
+            registered_at: std::time::Instant::now(),
+            expires: std::time::Duration::from_secs(3600),
+            call_id: "c2".into(),
+            cseq: 1,
+            source_addr: Some("10.0.0.2:50000".parse().unwrap()),
+            source_transport: Some("udp".into()),
+            sip_instance: None,
+            reg_id: None,
+            path: path.clone(),
+            pending: false,
+            instance_id: None,
+            instance_epoch: None,
+            flow_token: Some("TOKEN-B".into()),
+            inbound_local_addr: Some("127.0.0.1:5060".parse().unwrap()),
+            inbound_connection_id: Some(7),
+            params: Vec::new(),
+            kind: crate::registrar::ContactKind::Ue,
+        };
+        let mut py = PyContact::from_rust_contact(&contact);
+
+        py.is_local_value = false;
+        let (_, flow, carried) = py.fork_target();
+        assert!(flow.is_none());
+        assert_eq!(carried, path, "Path must survive a non-local binding");
+
+        py.is_local_value = true;
+        let (_, _, carried) = py.fork_target();
+        assert_eq!(carried, path);
     }
 
     #[test]

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -112,9 +112,18 @@ pub enum RequestAction {
     /// the only way to reach a WebSocket UE) instead of DNS-resolving the URI.
     /// A flow is only attached for a `Contact` the local process accepted
     /// (`Contact.is_local`); bare-string targets always carry `None`.
+    ///
+    /// `routes` is also parallel to `targets`: it holds the RFC 3327 Path
+    /// vector stored with that binding.  A non-empty entry becomes that
+    /// branch's Route header set (and therefore its next hop), replacing any
+    /// Route the script left on the request — without this every branch would
+    /// inherit branch 0's route set and a Path-token edge proxy would resolve
+    /// them all back to the *same* binding.  Bare-string targets carry an
+    /// empty vector and keep pure Request-URI routing.
     Fork {
         targets: Vec<String>,
         flows: Vec<Option<super::registrar::PyFlow>>,
+        routes: Vec<Vec<String>>,
         strategy: String,
         /// Force-send-socket egress pin applied to every branch (see
         /// [`RequestAction::Relay::send_socket`]).  A per-branch flow (`flows[i]`)
@@ -919,6 +928,19 @@ impl PyRequest {
     /// captured inbound flow — RFC 5626 §5.3 connection reuse, mandatory for
     /// WebSocket UEs (RFC 7118 §5).  Bare strings (and non-local contacts) are
     /// DNS-resolved as before.
+    ///
+    /// A `Contact` that carries an RFC 3327 Path vector additionally gets its
+    /// **own** Route header set on that branch, built from the Path in order
+    /// (RFC 3327 §5.3), and that route set decides the branch's next hop.  This
+    /// is what makes failover between the bindings of one AoR work: two
+    /// bindings usually have different Path vectors (different edge proxies, or
+    /// the same edge proxy with a different per-registration token), so without
+    /// it every branch would go out with branch 0's route set and a Path-token
+    /// proxy would deliver them all back to the first binding.  The branch's
+    /// Request-URI is still the Contact URI.
+    ///
+    /// Pass a bare URI string (`request.fork([c.uri for c in contacts])`) to
+    /// opt a target out of Path routing and route purely by Request-URI.
     #[pyo3(signature = (targets, strategy="parallel", send_socket=None))]
     fn fork(
         &mut self,
@@ -929,20 +951,24 @@ impl PyRequest {
         validate_send_socket(send_socket.as_deref())?;
         let mut target_uris: Vec<String> = Vec::with_capacity(targets.len());
         let mut flows: Vec<Option<super::registrar::PyFlow>> = Vec::with_capacity(targets.len());
+        let mut routes: Vec<Vec<String>> = Vec::with_capacity(targets.len());
         for item in targets {
             if let Ok(contact) = item.extract::<PyRef<super::registrar::PyContact>>() {
-                let (uri, flow) = contact.fork_target();
+                let (uri, flow, path) = contact.fork_target();
                 target_uris.push(uri);
                 flows.push(flow);
+                routes.push(path);
             } else {
                 // Bare URI string (or anything string-coercible).
                 target_uris.push(item.extract::<String>()?);
                 flows.push(None);
+                routes.push(Vec::new());
             }
         }
         self.action = RequestAction::Fork {
             targets: target_uris,
             flows,
+            routes,
             strategy: strategy.to_string(),
             send_socket,
         };
@@ -1772,6 +1798,33 @@ mod tests {
         PyRequest::new(message, "udp".to_string(), "10.0.0.1".to_string(), 5060)
     }
 
+    /// A registered binding with an RFC 3327 Path vector, as `registrar.lookup()`
+    /// hands it to a script.
+    fn contact_with_path(uri: &str, path: Vec<String>) -> super::super::registrar::PyContact {
+        let contact = crate::registrar::Contact {
+            uri: crate::sip::parser::parse_uri_standalone(uri).unwrap(),
+            q: 1.0,
+            registered_at: std::time::Instant::now(),
+            expires: std::time::Duration::from_secs(3600),
+            call_id: "reg-call-id".into(),
+            cseq: 1,
+            source_addr: None,
+            source_transport: Some("udp".into()),
+            sip_instance: None,
+            reg_id: None,
+            path,
+            pending: false,
+            instance_id: None,
+            instance_epoch: None,
+            flow_token: None,
+            inbound_local_addr: None,
+            inbound_connection_id: None,
+            params: Vec::new(),
+            kind: crate::registrar::ContactKind::Ue,
+        };
+        super::super::registrar::PyContact::from_rust_contact(&contact)
+    }
+
     #[test]
     fn method_returns_invite() {
         let request = make_request();
@@ -2092,10 +2145,48 @@ mod tests {
                 RequestAction::Fork {
                     targets: vec!["sip:a@host".to_string(), "sip:b@host".to_string()],
                     flows: vec![None, None],
+                    routes: vec![vec![], vec![]],
                     strategy: "sequential".to_string(),
                     send_socket: None,
                 }
             );
+        });
+    }
+
+    #[test]
+    fn fork_carries_each_contacts_own_path() {
+        // The bug this guards: every branch used to go out with whatever Route
+        // the script left on the request (branch 0's Path in practice), so a
+        // Path-token edge proxy resolved every branch back to the *first*
+        // binding — sequential forking retried the dead contact N times.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let mut request = make_request();
+            let contact_a = contact_with_path(
+                "sip:alice@10.0.0.1:5060",
+                vec!["<sip:TOKEN-A@edge.example.com;lr>".to_string()],
+            );
+            let contact_b = contact_with_path(
+                "sip:alice@10.0.0.2:5060",
+                vec!["<sip:TOKEN-B@edge.example.com;lr>".to_string()],
+            );
+            let targets: Vec<Bound<'_, PyAny>> = vec![
+                Py::new(py, contact_a).unwrap().into_bound(py).into_any(),
+                Py::new(py, contact_b).unwrap().into_bound(py).into_any(),
+                // A bare string opts out of Path routing entirely.
+                pyo3::types::PyString::new(py, "sip:carol@10.0.0.3").into_any(),
+            ];
+            request.fork(targets, "sequential", None).unwrap();
+            match request.action() {
+                RequestAction::Fork { targets, routes, .. } => {
+                    assert_eq!(targets.len(), 3);
+                    assert_eq!(routes.len(), 3, "routes must stay parallel to targets");
+                    assert_eq!(routes[0], vec!["<sip:TOKEN-A@edge.example.com;lr>".to_string()]);
+                    assert_eq!(routes[1], vec!["<sip:TOKEN-B@edge.example.com;lr>".to_string()]);
+                    assert!(routes[2].is_empty(), "bare string target carries no Path");
+                }
+                other => panic!("expected Fork, got {other:?}"),
+            }
         });
     }
 

--- a/tests/integration/proxy_tests.rs
+++ b/tests/integration/proxy_tests.rs
@@ -713,3 +713,120 @@ fn concurrent_registrar_access() {
         assert_eq!(contacts[0].uri.host, format!("10.0.0.{}", i + 1));
     }
 }
+fn binding_with_path(host: &str, path: Vec<String>) -> siphon::registrar::Contact {
+    siphon::registrar::Contact {
+        uri: SipUri::new(host.to_string()).with_user("alice".to_string()).with_port(5060),
+        q: 1.0,
+        registered_at: std::time::Instant::now(),
+        expires: std::time::Duration::from_secs(3600),
+        call_id: format!("reg-{host}"),
+        cseq: 1,
+        source_addr: None,
+        source_transport: Some("udp".to_string()),
+        sip_instance: None,
+        reg_id: None,
+        path,
+        pending: false,
+        instance_id: None,
+        instance_epoch: None,
+        flow_token: None,
+        inbound_local_addr: None,
+        inbound_connection_id: None,
+        params: Vec::new(),
+        kind: siphon::registrar::ContactKind::Ue,
+    }
+}
+
+#[test]
+fn two_bindings_of_one_aor_get_independent_route_sets() {
+    use siphon::proxy::core::branch_routing;
+    use siphon::script::api::registrar::PyContact;
+
+    let binding_a = binding_with_path("10.0.0.1", vec!["<sip:TOKEN-A@edge.example.com;lr>".to_string()]);
+    let binding_b = binding_with_path("10.0.0.2", vec!["<sip:TOKEN-B@edge.example.com;lr>".to_string()]);
+
+    let (uri_a, _flow_a, path_a) = PyContact::from_rust_contact(&binding_a).fork_target();
+    let (uri_b, _flow_b, path_b) = PyContact::from_rust_contact(&binding_b).fork_target();
+
+    let branch_a = branch_routing(&path_a, &uri_a).expect("binding A must be routable");
+    let branch_b = branch_routing(&path_b, &uri_b).expect("binding B must be routable");
+
+    assert_eq!(branch_a.route_set.as_deref(), Some("<sip:TOKEN-A@edge.example.com;lr>"));
+    assert_eq!(branch_b.route_set.as_deref(), Some("<sip:TOKEN-B@edge.example.com;lr>"));
+    assert!(branch_a.next_hop.contains("TOKEN-A"));
+    assert!(branch_b.next_hop.contains("TOKEN-B"));
+
+    assert!(uri_a.contains("10.0.0.1"));
+    assert!(uri_b.contains("10.0.0.2"));
+}
+
+#[test]
+fn binding_without_path_still_routes_by_contact_uri() {
+    use siphon::proxy::core::branch_routing;
+    use siphon::script::api::registrar::PyContact;
+
+    let binding = binding_with_path("10.0.0.7", Vec::new());
+    let (uri, _flow, path) = PyContact::from_rust_contact(&binding).fork_target();
+    let routing = branch_routing(&path, &uri).expect("routable");
+    assert!(routing.route_set.is_none());
+    assert_eq!(routing.next_hop, uri);
+}
+
+#[test]
+fn multi_hop_path_becomes_the_full_route_set_in_order() {
+    use siphon::proxy::core::branch_routing;
+    use siphon::script::api::registrar::PyContact;
+
+    let binding = binding_with_path(
+        "10.0.0.3",
+        vec![
+            "<sip:icscf.ims.example.com;lr>".to_string(),
+            "<sip:pcscf.ims.example.com;lr>".to_string(),
+        ],
+    );
+    let (uri, _flow, path) = PyContact::from_rust_contact(&binding).fork_target();
+    let routing = branch_routing(&path, &uri).expect("routable");
+
+    assert_eq!(
+        routing.route_set.as_deref(),
+        Some("<sip:icscf.ims.example.com;lr>, <sip:pcscf.ims.example.com;lr>")
+    );
+    assert!(routing.next_hop.contains("icscf.ims.example.com"));
+}
+
+#[test]
+fn registrar_lookup_orders_bindings_newest_first() {
+    let registrar = Registrar::new(RegistrarConfig::default());
+
+    registrar
+        .save_with_source(
+            "sip:alice@example.com",
+            SipUri::new("10.0.0.1".to_string()).with_user("alice".to_string()).with_port(5060),
+            3600,
+            1.0,
+            "old-handset".to_string(),
+            1,
+            None,
+            Some("udp".to_string()),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    registrar
+        .save_with_source(
+            "sip:alice@example.com",
+            SipUri::new("10.0.0.2".to_string()).with_user("alice".to_string()).with_port(5060),
+            3600,
+            1.0,
+            "new-handset".to_string(),
+            1,
+            None,
+            Some("udp".to_string()),
+        )
+        .unwrap();
+
+    let contacts = registrar.lookup("sip:alice@example.com");
+    assert_eq!(contacts.len(), 2);
+    assert_eq!(contacts[0].call_id, "new-handset");
+    assert_eq!(contacts[1].call_id, "old-handset");
+    assert!(contacts[1].age_seconds() >= contacts[0].age_seconds());
+}


### PR DESCRIPTION
An AoR with more than one live binding where only one is reachable was undeliverable for the full lifetime of the dead binding. There was no way to express "try the next contact" in a script — a script that tried dropped the transaction instead. Observed as a 79-minute total loss of terminating MESSAGE to a subscriber who was registered, reachable and successfully sending throughout; the same shape applies to terminating INVITE.

Four separate defects sat between a script and a working failover. Any one of them alone breaks it.

## 1. `request.fork()` ignored `Contact.path` — every branch inherited branch 0's Route

`relay_fork_branch` rewrote the Request-URI per branch but never touched the `Route` header set, so every branch went out carrying whatever Route the script had left on the request — in practice branch 0's Path, since that is the only way a script can express "route this binding through its stored Path".

Two bindings of one AoR normally have **different** Path vectors: different edge proxies, or the same edge proxy with a different per-registration token (RFC 3327 §5 / TS 24.229 §5.2.7.2 — the standard answer to userless Contacts, NAT, IPsec port asymmetry and foreign-realm IMPUs). A Path-token edge proxy therefore resolved every branch back to binding 0. With `strategy="sequential"` that made failover retry the dead contact N times and answer the same error.

A `Contact` passed to `fork()` now gets its own Route header set, built from its Path in order (RFC 3327 §5.3), and that route set decides the branch's next hop (RFC 3261 §16.6 step 6). The Request-URI stays the Contact URI. Bare-string targets keep pure Request-URI routing, which is also how you opt a target out. `README.md` already mapped `request.fork(targets)` onto Kamailio's `t_load_contacts()` / `t_next_contacts()` pair; this is the missing half of that equivalence.

Related, and found by the acceptance test: **a binding's Path now outranks its captured inbound flow.** The flow answers the narrower "the Contact URI is unreachable, write back on the connection the REGISTER arrived on" question. Using it for a Path-carrying binding sent the branch to the REGISTER's source *and dropped the token that says which binding the request is for*. With no Path the flow is unchanged — still the only way back to a WebSocket UE (RFC 5626 §5.3 / RFC 7118 §5).

## 2. Neither failure hook could re-target; `request.relay()` there was a silent no-op

Both `@proxy.on_failure` and the per-relay `on_failure=` callback built a `Request` and deliberately replayed the inbound flow onto it, with a comment saying why (so a retry could do Path-token MT routing). Then the `Request` was dropped — its `RequestAction` was read nowhere. A script that followed the comment got the worst of both: the retry never left the box, the error response was suppressed, the session was removed, and the UAC received **nothing at all** until its own timer fired.

Both now execute a `Relay` / `Fork` action as a fresh client transaction on the same server transaction — no response upstream, no failed CDR — bounded at 8 retargets per transaction, since a chain of fresh client transactions has no protocol timer to bound it. Past the budget the failure is forwarded, which is the only outcome that still answers the UAC.

The per-relay callback reads the action strictly inside its own `on_failure` arm, so an `on_reply` callback that happens to call `relay()` can never be mistaken for a failure retarget.

## 3. `@proxy.on_failure` never fired for a single-target `request.relay()`

`HandlerKind::ProxyFailure` was dispatched from exactly one place: the `ForwardBestError` arm of the fork aggregator. A plain relay creates no aggregator, so a script's global failure policy was invisible for the commonest case in a proxy — a registered handler looked wired, logged nothing, and never ran. The shipped [`examples/ims_icscf.py`](examples/ims_icscf.py) S-CSCF failover depends on exactly this (it relays to one S-CSCF and retries from `@proxy.on_failure`), as does the cookbook's failure-route snippet; both were decorative.

It now fires for any non-2xx final on a single-destination relay. **`487 Request Terminated` is excluded** — the transaction was cancelled by the UAC, so a retarget would resurrect a call the caller has already abandoned; `@proxy.on_cancel` is the hook for that teardown. The single-target fork degradation also no longer drops the `on_reply` / `on_failure` callbacks.

## 4. No registration time on `Contact`

Bindings could not be ordered by recency. Remaining `expires` is not a substitute: a UE that asked for 600 s and registered a second ago has less time left than one that asked for 3600 s an hour ago. `Contact.age_secs` is monotonic (no clock-skew questions across a shared backend) and survives a restart via a new `registered_at_epoch` on the stored record — without that, every binding restored from Redis/Postgres would come back looking brand new.

While there: `registrar.lookup()` **did not sort at all**, despite its own doc comment and both sibling lookups promising q order — it returned backend insertion order, oldest first. It now returns highest q first (RFC 3261 §20.10), most recently registered first within one q value. Almost no UE sends q, so recency is what actually orders a real AoR's bindings, which is the right default when a SIM has moved to a new handset and the previous binding is still inside its granted expiry.

## Also fixed

**The 2xx ACK was relayed once per fork branch.** The ACK path iterated the session's client branches (a comment there assumed "typically just one"), and every branch resolves to the same place because a 2xx ACK is routed by the dialog route set (RFC 3261 §13.2.2.4). The answering UAS got one ACK per branch; a strict UAS treats the duplicate as an out-of-sequence request on a dialog it has already confirmed — which is exactly how the acceptance test surfaced it. Now sent once per distinct resolved hop.

## Testing

New SIPp acceptance test, `scripts/failover_test.sh` (CI job `sipp-failover`), covering both shapes end to end against one fixture proxy:

1. **Per-binding Path routing** — bob registers twice with different Path tokens (edge `.90`, edge `.91`) at different q values. Edge `.90` answers 404; the sequential fork's second branch must be routed by binding B's own Path and reach edge `.91`, which answers. The run additionally asserts *which* downstream received each INVITE, so it cannot pass on a proxy that answered the call itself or only ever contacted one edge.
2. **Failure re-targeting** — carol's primary backend rejects and the backup is only reachable from `@proxy.on_failure`, on a single-destination relay with no fork and no aggregator.

Verified to exit 255 against a pre-fix binary and 0 after. Pre-fix, the logs show branch 1 going to binding A's destination; post-fix they show `destination=172.20.0.90` then `destination=172.20.0.91`, and `on_failure: re-targeted the request retarget=1`.

Also fixes `sipp/failure_route_uas.xml`, an orphan scenario that could not load at all (`<recv> before <pause> ... without a mandatory message` — the ACKs were marked optional; siphon always ACKs a non-2xx hop-by-hop per RFC 3261 §17.1.1.3).

Unit + integration coverage for the pure decisions: `route_set_from_path` / `branch_routing` in `proxy::core`, per-branch routes on `RequestAction::Fork`, `fork_target` carrying the Path, lookup ordering, and the stored-epoch age round-trip (including the legacy-record and clock-stepped-backwards cases).

`cargo test` 3665 passed / 0 failed, SDK 495 passed, clippy `--all-targets --all-features -D warnings` clean.

## Not in scope

`call.fork()` in the B2BUA has the same class of gap — it builds a fresh B-leg INVITE with its own route set, so consuming a per-branch Path there needs separate plumbing into the dial path. The call site is marked; the proxy path consumes it via `RequestAction::Fork`.

The 16-row perf baseline and the memory-leak pair have **not** been run — held for the hardware that matches the README table. The changed code is on the fork and failure paths (a failed relay now runs Python handlers where it previously did not); the 0-failure baseline rows never take it.
