### PR TITLE
fix(proxy): a transport error or transaction timeout on a branch never became a response

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -281,6 +281,22 @@ jobs:
       - name: Route self-identity (in-dialog BYE must be relayed, not 404'd)
         run: scripts/route_selfid_test.sh
 
+  # ── A forwarding transport error must become a response ────────────────────
+  # RFC 3261 §16.9 makes a transport error on forwarding a 503 on that branch,
+  # and §16.7 step 6 forwards it upstream as a 500.  Without it the branch goes
+  # silent and the caller waits out its own Timer F (32 s) for an answer the
+  # proxy already had.  Deterministic: the next hop is a container that is up
+  # and listening on nothing, so the connect is refused immediately, and the
+  # caller demands the 500 within 20 s.
+  sipp-transport-error:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Transport error on forwarding must be answered, not dropped
+        run: scripts/transport_error_test.sh
+
   # ── Terminating failover across an AoR's bindings ──────────────────────────
   # An AoR with two live bindings where only one is reachable must still be
   # deliverable.  Two things have to hold, and neither is visible in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,35 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   list is currently **empty** — all 50 fixtures are handled as the RFC requires.
 
 ### Fixed
+- **A proxied request whose branch never got an answer now gets one.** Two
+  independent paths ended at a `warn!` and told nobody, so the upstream UAC sat
+  on its `100 Trying` until its own Timer F — 32 s of silence for a failure the
+  proxy already knew about. Observed as a call clearing on an application
+  server's 30 s media timeout instead of in milliseconds.
+  - **A transport error on forwarding is now a 503 on that branch (RFC 3261
+    §16.9).** `send_to_target` logged the pool failure and returned
+    `ConnectionId::default()` as a sentinel — but that value could not carry the
+    meaning: the stream transports return it on failure while UDP returns the
+    caller's `fallback_connection_id`, which several call sites legitimately
+    pass as exactly that. It now returns a `SendOutcome` that says outright
+    whether the transport refused the message.
+  - **A client transaction timeout is now a 408 on that branch (RFC 3261 §16.7
+    step 2).** The timeout arm logged and reaped without telling the server
+    transaction anything. This is the backstop for every way a branch can go
+    quiet — a black-holed route, a peer that accepts the connection and never
+    answers, a datagram lost on the wire — not just the connect failures §16.9
+    covers.
+  - Both are injected through the ordinary response path, so fork aggregation
+    behaves as it would for a real response: a parallel fork keeps waiting on
+    its live branches, a sequential fork advances to the next target, and
+    `@proxy.on_reply` / `@proxy.on_failure`, CDR finalisation and the
+    server-transaction handoff all run unchanged.
+- **A 503 is no longer forwarded upstream; the proxy sends 500 instead**
+  (RFC 3261 §16.7 step 6), and drops the `Retry-After` that described the
+  unavailable downstream. A 503 says *this next hop* is unavailable, and a UAC
+  that saw it would take the whole proxy out of service. Locally generated
+  finals (`request.reply(503)`, `reply.reject(503)`) are unaffected — they are
+  not responses the proxy is forwarding on behalf of a branch.
 - **The reg-event NOTIFY a UE receives is now a conformant in-dialog request.**
   Two independent defects made it one a strict baseband rejects; measured, a
   handset validating it de-registered itself 21–32 s after each successful

--- a/scripts/transport_error_proxy.py
+++ b/scripts/transport_error_proxy.py
@@ -1,0 +1,41 @@
+"""Test fixture proxy for the transport-error / transaction-timeout acceptance test.
+
+Relays every out-of-dialog INVITE to a fixed next hop over TCP.  The test points
+that next hop at a host which is up but has nothing listening on the SIP port, so
+the pool's connect is refused immediately.
+
+The script does nothing else on purpose: no `@proxy.on_failure`, no fork, no
+retry.  The caller must still be answered, because RFC 3261 §16.9 makes a
+transport error on forwarding equivalent to a 503 on that branch and §16.7 step 6
+turns that into a 500 upstream.  Before that was wired, the branch simply went
+quiet and the caller sat on its `100 Trying` until its own Timer F — 32 s.
+
+Run by scripts/transport_error_test.sh via sipp/docker-compose.yaml
+(`--profile transport-error`), config sipp/configs/siphon.transport-error-test.yaml.
+"""
+from siphon import proxy, log
+
+# 172.20.0.98 is up (a plain sleeping container) but listens on nothing, so a
+# TCP connect is refused at once rather than hanging until a connect timeout.
+DEAD_NEXT_HOP = "sip:bob@172.20.0.98:5060;transport=tcp"
+
+
+@proxy.on_request("INVITE")
+def handle_invite(request):
+    if request.in_dialog:
+        request.loose_route()
+        request.relay()
+        return
+    log.info(f"[transport-error] relaying to the dead next hop {DEAD_NEXT_HOP}")
+    request.relay(DEAD_NEXT_HOP)
+
+
+@proxy.on_request
+def handle_other(request):
+    if request.method == "INVITE":
+        return
+    if request.in_dialog:
+        request.loose_route()
+        request.relay()
+        return
+    request.reply(200, "OK")

--- a/scripts/transport_error_test.sh
+++ b/scripts/transport_error_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# A forwarding transport error must become a response — SIPp acceptance test.
+#
+# siphon relays an INVITE over TCP to a host that is up but listening on
+# nothing, so the connection is refused immediately.  RFC 3261 §16.9 makes that
+# a 503 on the branch, and §16.7 step 6 forwards it upstream as a 500.
+#
+# Before this was wired the branch went silent: the error was logged, the
+# transaction was reaped, and the caller sat on its `100 Trying` until its own
+# Timer F fired 32 s later.  The caller here demands a 500 within 20 s, so the
+# old behaviour fails the run.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+COMPOSE=(docker compose -f sipp/docker-compose.yaml --profile transport-error)
+
+cleanup() { "${COMPOSE[@]}" down --remove-orphans -t 3 >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+fail() {
+  echo "FAILED: $1"
+  echo "--- siphon-transport-error logs ---"
+  "${COMPOSE[@]}" logs siphon-transport-error 2>/dev/null | tail -60 || true
+  exit 1
+}
+
+echo "=== Transport error on forwarding must be answered (RFC 3261 §16.9 / §16.7) ==="
+echo "[*] Building siphon image..."
+"${COMPOSE[@]}" build siphon-transport-error
+
+echo "[*] Starting siphon and the blackhole (up, listening on nothing)..."
+"${COMPOSE[@]}" up -d transport-error-blackhole
+"${COMPOSE[@]}" up -d --wait siphon-transport-error \
+  || fail "siphon did not become healthy"
+
+echo "[*] Calling through the dead next hop..."
+rc=0
+"${COMPOSE[@]}" run --rm sipp-transport-error-uac || rc=$?
+if [[ ${rc} -ne 0 ]]; then
+  fail "the caller was never answered (exit ${rc}) — the transport error did not become a response"
+fi
+
+# The 500 must be the proxy's own §16.7 downgrade, not a relayed 503.
+if "${COMPOSE[@]}" logs siphon-transport-error 2>/dev/null | grep -q "TCP pool send failed"; then
+  echo "[*] confirmed: the pool send did fail (so the 500 came from the error path)"
+else
+  fail "the pool send never failed — the test did not exercise the transport-error path"
+fi
+
+echo "PASS: the transport error was answered upstream as 500 instead of going silent"

--- a/sipp/configs/siphon.transport-error-test.yaml
+++ b/sipp/configs/siphon.transport-error-test.yaml
@@ -1,0 +1,27 @@
+# siphon.transport-error-test.yaml — a forwarding transport error must become a
+# response, not silence (RFC 3261 §16.9 + §16.7).
+#
+# Used with: sipp/docker-compose.yaml --profile transport-error
+#            (scripts/transport_error_test.sh)
+# Script:    scripts/transport_error_proxy.py
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+  tcp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.14"
+
+advertised_address: "172.20.0.14"
+
+script:
+  path: "scripts/transport_error_proxy.py"
+  reload: auto
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -3535,6 +3535,70 @@ services:
     profiles:
       - failover
 
+  # ── A forwarding transport error must become a response ────────────────────
+  # siphon relays an INVITE over TCP to a host that is up but listening on
+  # nothing, so the pool's connect is refused immediately.  RFC 3261 §16.9 makes
+  # that a 503 on the branch and §16.7 step 6 forwards it upstream as a 500.
+  # Before that was wired the branch went silent and the caller sat on its
+  # `100 Trying` until its own Timer F (32 s).
+  #
+  # Driver: scripts/transport_error_test.sh
+
+  siphon-transport-error:
+    image: sipp-siphon
+    build:
+      context: ..
+    container_name: siphon-transport-error
+    volumes:
+      - ./configs/siphon.transport-error-test.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.14
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - transport-error
+
+  # Up, reachable, and listening on nothing — a TCP connect to :5060 is refused
+  # at once.  An unassigned address would hang until a connect timeout instead,
+  # which would test patience rather than the error path.
+  transport-error-blackhole:
+    image: alpine:3
+    command: ["sleep", "600"]
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.98
+    profiles:
+      - transport-error
+
+  sipp-transport-error-uac:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.99
+    entrypoint:
+      - sipp
+      - "172.20.0.14:5060"
+      - -sf
+      - /sipp/scenarios/transport_error_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "20"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - transport-error
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:

--- a/sipp/transport_error_uac.xml
+++ b/sipp/transport_error_uac.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Caller for the transport-error acceptance test.
+
+  siphon relays this INVITE over TCP to a host that refuses the connection.  The
+  caller must be ANSWERED — RFC 3261 §16.9 makes the transport error a 503 on
+  that branch and §16.7 step 6 forwards it upstream as a 500.
+
+  The assertion is the `recv response="500"` with a tight timeout: before the
+  fix the branch went silent and this scenario timed out, which is exactly what
+  the caller experienced (32 s of nothing, then its own Timer F).
+
+  A 100 Trying may or may not arrive first depending on timing, so it is
+  optional; the 500 is not.
+
+  Run: sipp <proxy>:5060 -sf transport_error_uac.xml -m 1
+-->
+<scenario name="Transport error UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/siphon-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <!-- The whole point: an answer, and a 500 rather than the downstream's 503. -->
+  <recv response="500" rtd="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+[last_To:]
+[last_Call-ID:]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1560,8 +1560,30 @@ fn process_timer_actions_with_followups(
                 state.timer_wheel.remove(&timer_id);
             }
             Action::Timeout => {
+                // RFC 3261 §16.7 step 2: when a client transaction times out
+                // (Timer B for INVITE, Timer F otherwise), the proxy MUST
+                // behave as if a 408 had been received on that branch.  Logging
+                // and reaping left the upstream UAC waiting on its `100 Trying`
+                // until its own Timer F — the proxy knew the branch was dead 32
+                // seconds earlier and said nothing.
+                //
+                // This is the backstop for *every* way a branch can go quiet,
+                // not just the connect failures §16.9 covers: a black-holed
+                // route, a peer that accepts the TCP connection and never
+                // answers, a datagram lost on the wire.
+                //
+                // Server transactions reach this arm too (Timer H waiting for
+                // an ACK); `fail_branch_locally` no-ops for anything that is
+                // not a client branch of a live proxy session.
                 warn!(key = %key, "transaction timeout");
-                // Session cleanup happens via sweep_stale_entries
+                fail_branch_locally(
+                    key,
+                    408,
+                    "Request Timeout",
+                    "client transaction timed out (RFC 3261 §16.7)",
+                    state,
+                );
+                // Remaining session cleanup happens via sweep_stale_entries.
             }
             Action::ProtocolError(message) => {
                 warn!(key = %key, "transaction protocol error: {message}");
@@ -3836,7 +3858,7 @@ fn relay_request(
     //     to the live accepted-connection write half registered in
     //     `connection_map`.  No DNS, no pool lookup.
     //   - URI-relay: the legacy path through `send_to_target`.
-    let connection_id = if let Some(local) = flow_local_addr {
+    let outcome = if let Some(local) = flow_local_addr {
         let outbound_message = OutboundMessage {
             followups: None,
             connection_id: ConnectionId(flow.map(|f| f.connection_id).unwrap_or(0)),
@@ -3853,6 +3875,7 @@ fn relay_request(
                 transport = %outbound_transport,
                 "flow-relay outbound send failed: {error}"
             );
+            SendOutcome::failed()
         } else {
             debug!(
                 destination = %destination,
@@ -3860,8 +3883,8 @@ fn relay_request(
                 connection_id = ?cid,
                 "relayed via captured flow"
             );
+            SendOutcome::sent(cid)
         }
-        cid
     } else {
         // Build the legacy RelayTarget for the URI path.
         let target = RelayTarget {
@@ -3878,6 +3901,26 @@ fn relay_request(
             state,
         )
     };
+    let connection_id = outcome.connection_id;
+
+    // RFC 3261 §16.9: a transport error on forwarding MUST be handled as if a
+    // 503 had been received on that branch.  Without this the branch simply
+    // goes quiet — the upstream UAC sits on the 100 Trying until its own
+    // Timer F, which is 32 s of nothing where the caller should have been
+    // told in milliseconds.
+    if outcome.delivery_failed {
+        if let Some(ref client_key) = client_key_opt {
+            fail_branch_locally(
+                client_key,
+                503,
+                "Service Unavailable",
+                "transport error on forwarding (RFC 3261 §16.9)",
+                state,
+            );
+            return;
+        }
+    }
+
     // Patch the session's ClientBranch via the locally-held `Arc` we got
     // back from `session_store.insert(...)` rather than re-looking up
     // through the store: at high CPS on TCP loopback the UAS 200 OK can
@@ -4300,7 +4343,7 @@ fn relay_fork_branch(
     // Send: over the captured flow (direct OutboundMessage, bypassing DNS/pool
     // — mirrors the relay(flow=...) path) when one is attached, else via the
     // normal resolver/pool path.
-    let connection_id = if let Some(flow) = flow {
+    let outcome = if let Some(flow) = flow {
         // This branch bypasses `send_to_target`, so it has to do that helper's
         // HEP capture itself — otherwise a flow-pinned relay is the one request
         // that never reaches Homer.
@@ -4324,12 +4367,32 @@ fn relay_fork_branch(
         let cid = outbound_message.connection_id;
         if let Err(error) = state.outbound.send(outbound_message) {
             error!(branch = %branch, destination = %destination, transport = %outbound_transport, "fork: flow send failed: {error}");
+            SendOutcome::failed()
+        } else {
+            SendOutcome::sent(cid)
         }
-        cid
     } else {
         let relay_target = RelayTarget { address: destination, transport: Some(outbound_transport), server_name: None };
         send_to_target(data, &relay_target, inbound.transport, inbound.connection_id, send_socket.map(|pin| pin.addr), state)
     };
+    let connection_id = outcome.connection_id;
+
+    // RFC 3261 §16.9 — a transport error on this branch is a 503 on this
+    // branch.  Feeding it to the aggregator is what lets a parallel fork carry
+    // on with its other branches and a sequential fork move to the next one,
+    // instead of the whole fork stalling on a branch that never left the box.
+    if outcome.delivery_failed {
+        if let Some(ref client_key) = client_key_opt {
+            fail_branch_locally(
+                client_key,
+                503,
+                "Service Unavailable",
+                "transport error on forwarding (RFC 3261 §16.9)",
+                state,
+            );
+            return;
+        }
+    }
 
     debug!(
         branch = %branch,
@@ -4638,6 +4701,139 @@ fn execute_failure_retarget(
         "on_failure: re-targeted the request"
     );
     true
+}
+
+/// Rewrite a 503 the proxy is about to forward upstream into a 500
+/// (RFC 3261 §16.7 step 6), returning the status code actually forwarded.
+///
+/// A 503 means *this* next hop is unavailable. Passing it to the UAC would
+/// invite it to treat the proxy itself as out of service (RFC 3261 §20.33
+/// Retry-After semantics), which is both wrong and self-inflicted: the proxy is
+/// fine, one downstream target is not.
+///
+/// Any other status is returned unchanged.
+fn downgrade_503_for_upstream(
+    message: &mut SipMessage,
+    status_code: u16,
+    server_key: &TransactionKey,
+) -> u16 {
+    if status_code != 503 {
+        return status_code;
+    }
+    if let StartLine::Response(ref mut status_line) = message.start_line {
+        status_line.status_code = 500;
+        status_line.reason_phrase = "Server Internal Error".to_string();
+    }
+    // Retry-After on a 503 is about the unavailable downstream, not about us.
+    message.headers.remove("Retry-After");
+    debug!(
+        key = %server_key,
+        "forwarding 503 upstream as 500 (RFC 3261 §16.7)"
+    );
+    500
+}
+
+/// Answer a proxy client branch that will never be answered from the network,
+/// by injecting the response RFC 3261 says the proxy must behave as if it had
+/// received.
+///
+/// Two callers, one rule each:
+///
+/// * **§16.9** — a transport error on forwarding is a **503** on that branch.
+/// * **§16.7 step 2** — a client transaction that times out (Timer B / Timer F)
+///   is a **408** on that branch.
+///
+/// Both used to end at a `warn!` and nothing else, so the upstream UAC was left
+/// holding a `100 Trying` until its own Timer F fired: 32 s of silence where
+/// the proxy already knew the answer.
+///
+/// The response is routed through the ordinary [`handle_response`] path rather
+/// than being forwarded directly, because everything that has to happen next is
+/// already implemented there and only there — fork aggregation (so a parallel
+/// fork keeps waiting on its live branches and a sequential fork advances to
+/// the next target), `@proxy.on_reply` / `@proxy.on_failure`, CDR finalisation,
+/// and the handoff to the server transaction. A direct forward would need its
+/// own copy of all of it and would drift.
+///
+/// No-ops when the branch has no proxy session: a B2BUA leg registers no client
+/// transaction, and a session already torn down by a winning branch has nothing
+/// left to answer.
+fn fail_branch_locally(
+    client_key: &TransactionKey,
+    status_code: u16,
+    reason: &str,
+    cause: &str,
+    state: &DispatcherState,
+) {
+    let Some(session_arc) = state.session_store.get_by_client_key(client_key) else {
+        debug!(
+            key = %client_key,
+            status = status_code,
+            "no proxy session for branch — nothing to answer ({cause})"
+        );
+        return;
+    };
+
+    let (original_request, inbound_local_addr, branch) = {
+        let Ok(session) = session_arc.read() else {
+            error!("proxy session lock poisoned while failing a branch");
+            return;
+        };
+        (
+            session.original_request.clone(),
+            session.inbound_local_addr,
+            session.client_branches.get(client_key).cloned(),
+        )
+    };
+
+    // RFC 3261 §17.1.4: on a transport failure the client transaction goes
+    // straight to Terminated. Dropping it here also stops the synthetic
+    // response below from being fed back into it — which for an INVITE would
+    // otherwise emit an ACK to a peer that never sent anything.
+    state.transaction_manager.remove(client_key);
+
+    let mut response = build_response(
+        &original_request,
+        status_code,
+        reason,
+        state.server_header.as_deref(),
+        &[],
+    );
+
+    // `build_response` copies the request's Via stack, whose top is the UAC's.
+    // The response path keys the branch off the *topmost* Via and strips it, so
+    // put back the Via this proxy stamped on the outbound request — the one the
+    // transaction key was built from — or the injected response matches no
+    // branch and is dropped as an orphan.
+    let branch_transport = branch.as_ref().map(|b| b.transport).unwrap_or(Transport::Udp);
+    let via_value = format!(
+        "SIP/2.0/{} {};branch={}",
+        branch_transport, client_key.sent_by, client_key.branch,
+    );
+    let mut vias = vec![via_value];
+    vias.extend(response.headers.get_all("Via").cloned().unwrap_or_default());
+    response.headers.set_all("Via", vias);
+
+    warn!(
+        key = %client_key,
+        status = status_code,
+        "answering branch locally: {cause}"
+    );
+
+    let inbound = InboundMessage {
+        remote_addr: branch
+            .as_ref()
+            .map(|b| b.destination)
+            .unwrap_or(inbound_local_addr),
+        local_addr: inbound_local_addr,
+        connection_id: branch
+            .as_ref()
+            .map(|b| b.connection_id)
+            .unwrap_or_default(),
+        transport: branch_transport,
+        data: Bytes::new(),
+    };
+    handle_response(inbound, response, status_code, state);
 }
 
 /// Handle an inbound SIP response — route back to the original sender.
@@ -5406,6 +5602,18 @@ fn handle_response(
                     }
                     crate::proxy::fork::ForkAction::ForwardBestError(best_code) => {
                         debug!(best_code = best_code, "fork: all branches failed");
+                        // RFC 3261 §16.7 step 6 — the proxy does not pass a 503
+                        // upstream even when it is the best error it has (which
+                        // it will be whenever every branch hit a transport
+                        // error, §16.9).  This arm builds and sends its own
+                        // response, so it needs the rule applied at the source
+                        // rather than at the shared forward path below.
+                        let best_code = if best_code == 503 {
+                            debug!("fork: best error is 503 — forwarding 500 (RFC 3261 §16.7)");
+                            500
+                        } else {
+                            best_code
+                        };
                         let reason = best_error_reason(best_code);
                         let Ok(session) = session_arc.read() else {
                             error!("session_arc read lock poisoned");
@@ -5546,6 +5754,19 @@ fn handle_response(
                 // (cdr.auto_emit). Forked failures finalize at ForwardBestError.
                 cdr_finalize_proxy_fail(state, &original_request, status_code);
             }
+
+            // RFC 3261 §16.7 step 6: a proxy does not pass a 503 upstream — a
+            // downstream element being unavailable is not the caller's
+            // business, and a UAC that saw it would take the whole proxy out of
+            // service. It forwards 500 instead. This covers a 503 the proxy
+            // synthesized for a transport error (§16.9) as well as one a
+            // downstream server actually sent.
+            //
+            // Script-generated finals (`request.reply(503)`,
+            // `reply.reject(503)`) never reach here — they are not responses
+            // this proxy is forwarding on behalf of a branch — so the IMS
+            // P-CSCF media-authorization 503 is unaffected.
+            let status_code = downgrade_503_for_upstream(&mut message, status_code, &server_key);
 
             // Feed the response into the server transaction for caching
             let server_event = if status_code < 200 {
@@ -6108,6 +6329,44 @@ fn contact_fallback_target(
 /// TCP/TLS when no existing inbound connection is available.
 ///
 /// Returns the `ConnectionId` used (new pool connection or the existing one).
+/// What a downstream send did.
+///
+/// The connection id alone cannot carry this: on failure the stream transports
+/// return `ConnectionId::default()` as a sentinel, but UDP returns the caller's
+/// `fallback_connection_id` — which several call sites legitimately pass as
+/// `ConnectionId::default()`. A caller cannot tell the two apart, which is why
+/// a transport failure used to reach nobody.
+#[derive(Debug, Clone, Copy)]
+struct SendOutcome {
+    /// Connection the message went out on, or `ConnectionId::default()` when it
+    /// did not go out at all.
+    connection_id: ConnectionId,
+    /// The transport refused the message outright — a pool connect failed, a
+    /// WebSocket peer has no live connection, the outbound channel is gone.
+    ///
+    /// RFC 3261 §16.9 makes this equivalent to having received a 503 on that
+    /// branch, so a caller that owns a client transaction must answer upstream
+    /// rather than fall silent.
+    ///
+    /// `false` is **not** a delivery guarantee: a UDP datagram that is enqueued
+    /// and then lost reports success here, and only the client transaction's
+    /// timeout (§16.7 step 2) covers that.
+    delivery_failed: bool,
+}
+
+impl SendOutcome {
+    fn sent(connection_id: ConnectionId) -> Self {
+        Self { connection_id, delivery_failed: false }
+    }
+
+    fn failed() -> Self {
+        Self {
+            connection_id: ConnectionId::default(),
+            delivery_failed: true,
+        }
+    }
+}
+
 fn send_to_target(
     data: Bytes,
     target: &RelayTarget,
@@ -6115,7 +6374,7 @@ fn send_to_target(
     fallback_connection_id: ConnectionId,
     send_source: Option<SocketAddr>,
     state: &DispatcherState,
-) -> ConnectionId {
+) -> SendOutcome {
     let transport = target.transport.unwrap_or(fallback_transport);
     let destination = target.address;
     // A script `send_socket=` egress pin translated to a bind address:
@@ -6160,7 +6419,7 @@ fn send_to_target(
                         connection_id = ?connection_id,
                         "relayed via TCP pool"
                     );
-                    connection_id
+                    SendOutcome::sent(connection_id)
                 }
                 Err(error) => {
                     // Pool send failed (connect refused, broken pipe, etc.).
@@ -6176,7 +6435,7 @@ fn send_to_target(
                         destination = %destination,
                         "TCP pool send failed: {error}"
                     );
-                    ConnectionId::default()
+                    SendOutcome::failed()
                 }
             }
         }
@@ -6206,11 +6465,11 @@ fn send_to_target(
                             bind = %bind,
                             "relayed via source-bound TLS pool (send_socket)"
                         );
-                        connection_id
+                        SendOutcome::sent(connection_id)
                     }
                     Err(error) => {
                         error!(destination = %destination, "source-bound TLS pool send failed: {error}");
-                        ConnectionId::default()
+                        SendOutcome::failed()
                     }
                 };
             }
@@ -6242,7 +6501,7 @@ fn send_to_target(
                         "relayed via TLS connection reuse"
                     );
                 }
-                connection_id
+                SendOutcome::sent(connection_id)
             } else {
                 // No inbound connection to reuse — create outbound TLS via pool
                 let pool = Arc::clone(&state.connection_pool);
@@ -6258,13 +6517,13 @@ fn send_to_target(
                             connection_id = ?connection_id,
                             "relayed via TLS pool"
                         );
-                        connection_id
+                        SendOutcome::sent(connection_id)
                     }
                     Err(error) => {
                         // Same rationale as the TCP arm above — never echo to
                         // the inbound connection on outbound failure.
                         error!(destination = %destination, "TLS pool send failed: {error}");
-                        ConnectionId::default()
+                        SendOutcome::failed()
                     }
                 }
             }
@@ -6306,7 +6565,7 @@ fn send_to_target(
                             "relayed via WS/WSS connection reuse"
                         );
                     }
-                    connection_id
+                    SendOutcome::sent(connection_id)
                 }
                 None => {
                     warn!(
@@ -6314,7 +6573,7 @@ fn send_to_target(
                         %transport,
                         "no live WS/WSS connection to reuse — dropping (client-initiated transport cannot be dialed; use relay(flow=...) for MT routing)"
                     );
-                    ConnectionId::default()
+                    SendOutcome::failed()
                 }
             }
         }
@@ -6346,9 +6605,13 @@ fn send_to_target(
                 server_name: None,
             };
             if let Err(error) = state.outbound.send(outbound_message) {
+                // The outbound router is gone (shutdown, or the task died).
+                // Nothing will ever carry this message, so report it as a
+                // transport failure rather than a delivered send.
                 error!("failed to enqueue relayed request: {error}");
+                return SendOutcome::failed();
             }
-            fallback_connection_id
+            SendOutcome::sent(fallback_connection_id)
         }
     }
 }
@@ -19123,6 +19386,81 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    // -----------------------------------------------------------------------
+    // Transport failure / timeout must become a response (RFC 3261 §16.7, §16.9)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn send_outcome_distinguishes_failure_from_a_zero_connection_id() {
+        // The bug that hid every transport error: the stream transports
+        // returned `ConnectionId::default()` as a failure sentinel, but UDP
+        // returns the caller's `fallback_connection_id` — which several call
+        // sites pass as exactly that value. A caller could not tell "the pool
+        // refused it" from "UDP sent it with no connection id".
+        let udp_success = SendOutcome::sent(ConnectionId::default());
+        assert!(!udp_success.delivery_failed);
+        assert_eq!(udp_success.connection_id, ConnectionId::default());
+
+        let refused = SendOutcome::failed();
+        assert!(refused.delivery_failed);
+        assert_eq!(refused.connection_id, ConnectionId::default());
+
+        // Same connection id, opposite meaning — which is the whole point.
+        assert_eq!(udp_success.connection_id, refused.connection_id);
+        assert_ne!(udp_success.delivery_failed, refused.delivery_failed);
+    }
+
+    fn response_for_downgrade(status_code: u16, reason: &str) -> SipMessage {
+        SipMessageBuilder::new()
+            .response(status_code, reason.to_string())
+            .via("SIP/2.0/UDP proxy.example.com;branch=z9hG4bK-1".to_string())
+            .to("<sip:bob@example.com>;tag=b".to_string())
+            .from("<sip:alice@example.com>;tag=a".to_string())
+            .call_id("downgrade-test".to_string())
+            .cseq("1 INVITE".to_string())
+            .header("Retry-After", "120".to_string())
+            .content_length(0)
+            .build()
+            .unwrap()
+    }
+
+    fn downgrade_key() -> TransactionKey {
+        TransactionKey::new(
+            "z9hG4bK-server".to_string(),
+            Method::Invite,
+            "192.0.2.1:5060".to_string(),
+        )
+    }
+
+    #[test]
+    fn a_503_is_forwarded_upstream_as_500() {
+        // RFC 3261 §16.7 step 6. A downstream element being unavailable is not
+        // the caller's business, and a UAC that saw the 503 would take the
+        // whole proxy out of service.
+        let mut response = response_for_downgrade(503, "Service Unavailable");
+        let forwarded = downgrade_503_for_upstream(&mut response, 503, &downgrade_key());
+
+        assert_eq!(forwarded, 500);
+        assert_eq!(response.status_code(), Some(500));
+        let wire = String::from_utf8(response.to_bytes()).unwrap();
+        assert!(wire.starts_with("SIP/2.0 500 Server Internal Error"));
+        // Retry-After described the unavailable downstream, not this proxy.
+        assert!(!wire.contains("Retry-After"));
+    }
+
+    #[test]
+    fn other_status_codes_are_forwarded_untouched() {
+        for (code, reason) in [(404, "Not Found"), (408, "Request Timeout"), (200, "OK"), (500, "Server Internal Error")] {
+            let mut response = response_for_downgrade(code, reason);
+            let forwarded = downgrade_503_for_upstream(&mut response, code, &downgrade_key());
+            assert_eq!(forwarded, code, "{code} must be forwarded unchanged");
+            assert_eq!(response.status_code(), Some(code));
+            // Only the 503 path strips Retry-After.
+            let wire = String::from_utf8(response.to_bytes()).unwrap();
+            assert!(wire.contains("Retry-After"), "{code} must keep Retry-After");
+        }
+    }
 
     // -----------------------------------------------------------------------
     // Media CDR from an end-of-call summary (media.backend: siphon-rtp)


### PR DESCRIPTION
A proxied request whose branch never got an answer never produced one either. Two independent paths ended at a `warn!` and told nobody, so the upstream UAC sat on its `100 Trying` until its own Timer F — 32 s of silence for a failure the proxy already knew about. Observed as a call clearing on an application server's 30 s media timeout instead of in milliseconds.

## Layer 1 — a transport error never became a response

`send_to_target` logged the pool failure and returned `ConnectionId::default()` as a sentinel. The comment there reasons correctly about connection bookkeeping (don't fall back to the inbound connection or you echo the request back at the sender), but nothing downstream turned the failure into a response. RFC 3261 §16.9 is explicit: a transport error on forwarding MUST be treated as if a 503 had been received.

**The sentinel could not have worked.** The stream transports return `ConnectionId::default()` on failure, but the UDP arm returns the caller's `fallback_connection_id` — which several call sites legitimately pass as exactly that value. Same value, opposite meaning, so no caller could act on it. `send_to_target` now returns a `SendOutcome { connection_id, delivery_failed }` that says outright whether the transport refused the message. Of the nine call sites, seven discard the value; the two that own a client transaction are the two relay paths, and those now act on it.

`delivery_failed: false` is deliberately not a delivery guarantee — a UDP datagram that is enqueued and then lost reports success, which is what Layer 2 is for.

## Layer 2 — the client transaction timed out and still said nothing

The only `Action::Timeout` arm logged and reaped. RFC 3261 §16.7 step 2 requires a timeout on the branch to become a 408 forwarded upstream; the server transaction was never told. As you said, this is the better fix and the one that matters most: it is the backstop for *every* way a branch goes quiet — a black-holed route, a peer that accepts the TCP connection and never answers, a datagram lost on the wire — not just the connect failures §16.9 covers.

Server transactions reach that arm too (Timer H waiting for an ACK), so the helper no-ops for anything that is not a client branch of a live proxy session.

## Both go through the normal response path

Rather than forwarding directly, both inject the synthetic response into `handle_response`. Everything that has to happen next is already implemented there and only there: fork aggregation (a parallel fork keeps waiting on its live branches, a sequential fork advances to the next target), `@proxy.on_reply` / `@proxy.on_failure`, CDR finalisation, and the handoff to the server transaction. A direct forward would need its own copy of all of it and would drift out of step.

Two details that make the injection behave like a real response:

- The response carries the Via **this proxy stamped on the outbound request** — the one the transaction key was built from — because the response path keys the branch off the topmost Via and strips it. Without that the injected response matches no branch and is dropped as an orphan.
- The client transaction is removed first (RFC 3261 §17.1.4 sends it straight to Terminated on a transport failure). That also stops the synthetic response being fed back into it, which for an INVITE would otherwise emit an ACK to a peer that never sent anything.

## §16.7 step 6 — a 503 is never forwarded upstream

A 503 says *this next hop* is unavailable. A UAC that saw it would take the whole proxy out of service. It is forwarded as 500, and the `Retry-After` that described the unavailable downstream is dropped. Applied both at the fork aggregator's best-error arm (which builds and sends its own response) and at the shared forward path.

Script-generated finals — `request.reply(503)`, `reply.reject(503)` — do not go through either, so the IMS P-CSCF media-authorization 503 that `sipp/reject_uac.xml` asserts is unaffected. I checked that scenario specifically.

## Testing

New `sipp-transport-error` acceptance test (CI job of the same name): siphon relays an INVITE over TCP to a container that is up and listening on nothing, so the connect is refused immediately. The caller demands a **500 within 20 s** — the old behaviour times out — and the run additionally asserts the pool send really did fail, so it cannot pass without exercising the error path.

Unit tests for the two pure decisions: that `SendOutcome` distinguishes a refused send from a zero connection id (the bug that hid this), and that 503 → 500 + `Retry-After` stripped while every other status is forwarded untouched.

`cargo test` 3307 lib + 301 integration passing, clippy `--all-targets --all-features -D warnings` clean, acceptance test green.

## Note on reading the logs

Worth stating because it sent the first investigation the wrong way. `TransactionKey`'s `Display` is `branch:method:sent_by`, and `sent_by` is the **topmost Via** (RFC 3261 §17.2.3) — the sender's own address, not the destination. A `transaction timeout key=…:BYE:<addr>` line therefore names *us*, not where the request was going.

## Not verified here

The 16-row perf baseline and the memory-leak pair have not been run — held for the hardware matching the README table. The added work is on the failure path only (a refused send now builds one response; the timeout arm does a session lookup that returns `None` for every non-proxy transaction), and the 0-failure baseline rows never take it.
