### PR TITLE
chore(siphon-bin): bump smpp extension to siphon-smpp v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,39 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the existing `address_family` treatment — the engines ignore an unknown value
   silently, which otherwise lands as a call quietly negotiated the wrong way.
 
+- **Bump the `siphon-bin` SMPP extension to siphon-smpp v1.4.0.** The pin was
+  still on v1.3.0: the 1.5.1 entry announcing a move to v1.3.1 never reached
+  `siphon-bin/Cargo.toml`, so the manifest and that entry disagreed and the
+  extension shipped a release behind what was documented. This moves straight to
+  v1.4.0 and picks up both releases:
+  - **Optional parameters (TLVs) are readable and writable from a script**, as a
+    dict keyed by SMPP 3.4 spec name or by raw integer tag on `submit_via`,
+    `submit_multi_via`, `data_via`, `deliver_to` and `data_to`; inbound, `Pdu`
+    gained `tlvs`, `tlv(name_or_tag)` and typed shortcuts. That is what makes
+    messages past the 254-byte `short_message` limit, `sar_*` concatenation and
+    receipts carrying `receipted_message_id` / `message_state` possible at all.
+  - **`data_sm` carried no message in either direction.** It has no
+    `short_message` field — the body exists only as the `message_payload`
+    optional parameter (§4.2.2) — so `data_via` / `data_to` took no message
+    argument and inbound `data_sm` always arrived empty. Both ends now carry it,
+    and the new `pdu.body` reads whichever of the two the peer used.
+  - **A `short_message` over 254 bytes panicked the SMPP runtime**, because
+    smpp34's constructors `assert!` on the limit and script input reached them
+    unchecked — a 255-byte body took down the tokio task instead of failing the
+    call. It now raises.
+  - **Inbound `alert_notification` reached handlers as garbage** — its decode
+    started at byte 0 while the read loop hands it a complete PDU, so every field
+    was 16 bytes off, and it did so without erroring.
+  - **`smpp34` 1.2.1's lost-response fix** (the v1.3.1 content): both writer
+    tasks registered a request's pending-response entry only *after* the socket
+    write returned, and the read loop drops any response it has no entry for, so
+    a response landing in that gap was discarded and the caller blocked until its
+    30s response timer expired — the PDU was lost, not merely slow. It hit the
+    SMSC→ESME direction too, i.e. the delivery-receipt path.
+
+  Only affects builds with `--features smpp`; the plain `siphon` binary is
+  unaffected.
+
 - **Content-Length is now validated against the octets actually received.** A
   value that is not a non-negative integer, or that claims more octets than
   arrived, leaves the message unframeable and is rejected instead of being

--- a/siphon-bin/Cargo.lock
+++ b/siphon-bin/Cargo.lock
@@ -4,13 +4,13 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -115,7 +115,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -250,6 +250,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -371,11 +377,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -410,7 +416,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -500,6 +506,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -616,21 +628,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -671,7 +694,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -692,12 +715,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -718,7 +741,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -929,7 +952,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1257,7 +1280,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1435,11 +1458,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1512,7 +1535,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1531,7 +1554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1662,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -1830,13 +1853,13 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1923,7 +1946,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2001,6 +2024,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,8 +2069,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2059,7 +2091,7 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2250,7 +2282,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2262,7 +2294,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2429,21 +2461,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "once_cell",
- "rasn-derive 0.28.13",
+ "rasn-derive",
  "serde_json",
  "snafu",
  "xml-no-std",
-]
-
-[[package]]
-name = "rasn-derive"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f35fecd68ee4d5850baa37ee4520456bbae761fdd42a7fcb95701c268500a93"
-dependencies = [
- "proc-macro2",
- "rasn-derive-impl 0.22.2",
- "syn",
 ]
 
 [[package]]
@@ -2453,22 +2474,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11dcd4dab09ceadedb3e2bedf340deb583f0e25bba9ad966b5655c2fb62b1392"
 dependencies = [
  "proc-macro2",
- "rasn-derive-impl 0.28.13",
- "syn",
-]
-
-[[package]]
-name = "rasn-derive-impl"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355eedbab62312d9474e1c2e7963ce5fad99bded7e9abd42ae4f040762a2c5f6"
-dependencies = [
- "either",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
- "uuid",
+ "rasn-derive-impl",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2481,7 +2488,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "uuid",
 ]
 
@@ -2554,7 +2561,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2581,7 +2588,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2752,7 +2759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
  "pkcs8",
  "subtle",
@@ -2825,7 +2832,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3022,15 +3029,15 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
 ]
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50101a2f08a8fc84d0e725827cdc814842beb151ed7d77253a49022f17b64477"
+checksum = "26afa6b54b21e7ba5c89a57bda3743ce2d2b829955f454e2663ba4b983f4e134"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -3040,13 +3047,13 @@ dependencies = [
 
 [[package]]
 name = "siphon-sip"
-version = "1.2.1"
-source = "git+https://github.com/siphon-project/siphon-sip?branch=main#d13e4eb144e6ad43c7196a1ce98f9c0776745eab"
+version = "1.5.1"
+source = "git+https://github.com/siphon-project/siphon-sip?branch=main#a37bc217b2ff4ae5335d1dfdaef3dffaf6805fab"
 dependencies = [
  "aes",
  "arc-swap",
  "axum",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "clap",
@@ -3070,7 +3077,7 @@ dependencies = [
  "pyo3-async-runtimes",
  "quick-xml",
  "rasn",
- "rasn-derive 0.22.2",
+ "rasn-derive",
  "redis",
  "regex",
  "reqwest",
@@ -3078,7 +3085,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "siphon-rtp-proto",
  "socket2",
  "thiserror 2.0.18",
@@ -3089,6 +3096,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite",
  "tower",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -3099,8 +3107,8 @@ dependencies = [
 
 [[package]]
 name = "siphon-smpp"
-version = "1.3.0"
-source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.3.0#482dfd8a9aada3adcb185cd619502c5a4aaff13a"
+version = "1.4.0"
+source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.4.0#0e5a0bc7c5ef7f3e766bf611f485596f51d3753b"
 dependencies = [
  "async-trait",
  "pyo3",
@@ -3128,9 +3136,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smpp34"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c8235d507333b55e847f37a59f8c3685a597852aee366b086d7e326b528f39"
+checksum = "cc2bbbf21f2c9c4c943f866103b00e9de6f4dfff1fb9bddcbf8254dd988a8a9e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3165,7 +3173,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3194,7 +3202,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -3244,6 +3262,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,7 +3289,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3341,7 +3370,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3352,7 +3381,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3468,7 +3497,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3496,7 +3525,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3608,6 +3637,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3652,7 +3696,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3928,7 +3972,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -4032,7 +4076,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4043,7 +4087,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4269,13 +4313,13 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
- "const-oid 0.9.6",
- "der",
- "spki",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
  "tls_codec",
 ]
 
@@ -4310,7 +4354,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -4331,7 +4375,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4351,7 +4395,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -4372,7 +4416,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4405,7 +4449,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -32,13 +32,13 @@ full = ["smpp", "http"]    # convenience aggregate: every extension module
 # Single-source rule: every crate here that depends on siphon-sip MUST use a
 # byte-identical git URL + ref, or cargo keys two separate `siphon-sip` sources
 # (it does NOT follow GitHub's repo-rename redirect) and the builder closures
-# fail to type-match. siphon-smpp v1.3.0 pins
+# fail to type-match. siphon-smpp v1.4.0 pins
 # `siphon-sip = { git = ".../siphon-sip", branch = "main" }`, so siphon-sip stays
 # on `branch = "main"` here too; the committed Cargo.lock pins the exact SHA for
 # reproducible builds (advance with `cargo update`). Extension crates themselves
 # are pinned to their released tags for stable, intentional bumps.
 siphon-sip = { git = "https://github.com/siphon-project/siphon-sip", branch = "main" }
-siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.3.0", optional = true }
+siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.4.0", optional = true }
 siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.1", optional = true }
 
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
Moves the `siphon-bin` SMPP extension pin from v1.3.0 to v1.4.0.

## Why it jumps two releases

The pin was still on **v1.3.0**. The `1.5.1` changelog entry announcing a bump to
v1.3.1 never reached `siphon-bin/Cargo.toml` or its lockfile, so the manifest and
the changelog disagreed and the extension shipped a release behind what was
documented. This goes straight to v1.4.0 and folds in both.

## What v1.4.0 brings

- **Optional parameters (TLVs) are readable and writable from a script** — a dict
  keyed by SMPP 3.4 spec name or by raw integer tag on `submit_via`,
  `submit_multi_via`, `data_via`, `deliver_to` and `data_to`; inbound, `Pdu` gained
  `tlvs`, `tlv(name_or_tag)` and typed shortcuts. This is what makes messages past
  the 254-byte `short_message` limit, `sar_*` concatenation, and receipts carrying
  `receipted_message_id` / `message_state` possible at all.
- **`data_sm` carried no message in either direction.** It has no `short_message`
  field — the body exists only as the `message_payload` optional parameter
  (§4.2.2) — so `data_via` / `data_to` took no message argument and inbound
  `data_sm` always arrived empty. Both ends now carry it, and the new `pdu.body`
  reads whichever of the two the peer used.
- **A `short_message` over 254 bytes panicked the SMPP runtime**, because smpp34's
  constructors `assert!` on the limit and script input reached them unchecked — a
  255-byte body took down the tokio task instead of failing the call. It now raises.
- **Inbound `alert_notification` reached handlers as garbage** — its decode started
  at byte 0 while the read loop hands it a complete PDU, so every field was 16 bytes
  off, and it did so without erroring.
- **smpp34 1.2.1's lost-response fix** (the v1.3.1 content): both writer tasks
  registered a request's pending-response entry only *after* the socket write
  returned, and the read loop drops any response it has no entry for, so a response
  landing in that gap was discarded and the caller blocked until its 30s response
  timer expired — the PDU was lost, not merely slow. It hit the SMSC→ESME direction
  too, i.e. the delivery-receipt path.

## Lockfile

The committed lock also advances to current `siphon-sip` main, which siphon-smpp
v1.4.0 requires anyway (it pins siphon-sip 1.5.0). That brings `smpp34` 1.2.0 →
1.3.0 and `siphon-rtp-proto` 0.1.4 → 0.1.5.

Worth noting on that last one: 0.1.5 added `Event::WsTeeStarted` / `WsTeeEnded` and
the `ws_tee*` `ProfileFlags` fields without `#[non_exhaustive]`, and the pin is a
caret range, so a fresh resolve took 0.1.5 and failed to compile against siphon-sip
until the engine-side handling landed on main. It has landed, so the lock takes
0.1.5 cleanly here.

## Verification

Clippy clean on all three configurations CI builds:

- `cargo clippy --all-targets -- -D warnings` (no extensions)
- `cargo clippy --all-targets --features smpp -- -D warnings`
- `cargo clippy --all-targets --features full -- -D warnings` (smpp + http)

Only affects builds with `--features smpp`; the plain `siphon` binary is unaffected.