### PR TITLE
ci(control-sdk): publishable control-plane SDKs + release workflow (official interop path)

### DIFF
--- a/.github/workflows/release-control-sdk.yaml
+++ b/.github/workflows/release-control-sdk.yaml
@@ -1,0 +1,196 @@
+# .github/workflows/release-control-sdk.yaml — Build + publish the external
+# control-plane SDKs on their OWN tag train, independent of siphon core.
+#
+# The SDKs live in the standalone excluded workspace `siphon-control-sdk/`
+# (crates siphon-control-proto + siphon-control-client, and the PyO3
+# `siphon-control` Python package). They version independently of the siphon
+# server — tied to the `siphon-control.v1` protocol — so they release on a
+# `control-sdk-vX.Y.Z` tag rather than the core `vX.Y.Z` tag that
+# release.yaml watches.
+#
+# Publishing uses the same OIDC Trusted Publishing as release.yaml: no stored
+# tokens — `pypa/gh-action-pypi-publish` mints PyPI's, `rust-lang/crates-io-auth-action`
+# mints crates.io's. `siphon-control` is a NATIVE extension (PyO3), so wheels
+# are built with maturin, per-interpreter: cp314 (GIL) AND cp314t
+# (free-threaded) are separate ABIs — the SIPhon runtime is free-threaded, so
+# both ship. There is no abi3 for free-threaded builds, hence version-tagged
+# wheels, one per interpreter.
+name: Release control SDK
+
+on:
+  push:
+    tags: ["control-sdk-v*"]
+  # Manual dry-run: builds every wheel + the sdist so cp314t coverage can be
+  # confirmed off a branch. The publish jobs are tag-gated and stay skipped.
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  # Native extension: build the wheel against the crate's own manifest.
+  MANIFEST: siphon-control-sdk/siphon-control/Cargo.toml
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Version gate ───────────────────────────────────────────────────────
+  # The tag is the single source of truth. The three crates share the
+  # siphon-control-sdk workspace version; the wheel derives its version from
+  # that crate (maturin, `dynamic = ["version"]`). Refuse to publish if the
+  # in-tree version disagrees with the tag. Skipped on workflow_dispatch, which
+  # gates the publish jobs off too (a dry-run never publishes).
+  verify-version:
+    if: startsWith(github.ref, 'refs/tags/control-sdk-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: siphon-control-sdk version must equal the tag
+        run: |
+          tag_version="${GITHUB_REF_NAME#control-sdk-v}"
+          cargo_version="$(grep -m1 '^version = ' siphon-control-sdk/Cargo.toml | sed -E 's/^version = "(.*)"/\1/')"
+          echo "tag=$tag_version cargo=$cargo_version"
+          if [ "$tag_version" != "$cargo_version" ]; then
+            echo "::error::siphon-control-sdk/Cargo.toml version ($cargo_version) does not match tag ($tag_version) — bump [workspace.package] version in the release commit."
+            exit 1
+          fi
+
+  # ── Build manylinux wheels (cp314 + cp314t) ────────────────────────────
+  # maturin-action runs these inside the pyo3/maturin manylinux container, so
+  # the interpreters come from the container's /opt/python, NOT from the host.
+  # The free-threaded build (cp314t) is a distinct ABI → a distinct wheel,
+  # built against the `python3.14t` interpreter.
+  wheels-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest,    target: x86_64,  pyver: "3.14",  abi: cp314,  interpreter: /opt/python/cp314-cp314/bin/python3.14 }
+          - { os: ubuntu-latest,    target: x86_64,  pyver: "3.14t", abi: cp314t, interpreter: /opt/python/cp314-cp314t/bin/python3.14t }
+          - { os: ubuntu-24.04-arm, target: aarch64, pyver: "3.14",  abi: cp314,  interpreter: /opt/python/cp314-cp314/bin/python3.14 }
+          - { os: ubuntu-24.04-arm, target: aarch64, pyver: "3.14t", abi: cp314t, interpreter: /opt/python/cp314-cp314t/bin/python3.14t }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build wheel (${{ matrix.target }} / ${{ matrix.abi }})
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: >-
+            --release
+            --out dist
+            --manifest-path ${{ env.MANIFEST }}
+            --interpreter ${{ matrix.interpreter }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-linux-${{ matrix.target }}-${{ matrix.abi }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  # ── Build macOS + Windows wheels (cp314 + cp314t) ──────────────────────
+  # No manylinux container here — the interpreter comes from setup-python,
+  # which installs the free-threaded build for a `3.14t` request and exposes
+  # its absolute path. Feeding that exact path to maturin keeps the GIL and
+  # free-threaded rows building against the right interpreter.
+  wheels-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-14,       target: aarch64, pyver: "3.14",  abi: cp314 }
+          - { os: macos-14,       target: aarch64, pyver: "3.14t", abi: cp314t }
+          - { os: macos-13,       target: x86_64,  pyver: "3.14",  abi: cp314 }
+          - { os: macos-13,       target: x86_64,  pyver: "3.14t", abi: cp314t }
+          - { os: windows-latest, target: x64,     pyver: "3.14",  abi: cp314 }
+          - { os: windows-latest, target: x64,     pyver: "3.14t", abi: cp314t }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        id: py
+        with:
+          python-version: ${{ matrix.pyver }}
+      - name: Build wheel (${{ matrix.os }} / ${{ matrix.target }} / ${{ matrix.abi }})
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: >-
+            --release
+            --out dist
+            --manifest-path ${{ env.MANIFEST }}
+            --interpreter ${{ steps.py.outputs.python-path }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.abi }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  # ── Source distribution ────────────────────────────────────────────────
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: >-
+            --out dist
+            --manifest-path ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  # ── Publish siphon-control to PyPI (Trusted Publishing — OIDC, no token) ─
+  # Tag-gated: never runs on a workflow_dispatch dry-run (verify-version is
+  # skipped there, which skips this job too).
+  pypi:
+    if: startsWith(github.ref, 'refs/tags/control-sdk-v')
+    needs: [verify-version, wheels-linux, wheels-native, sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC for PyPI Trusted Publishing
+    steps:
+      - name: Gather every wheel + the sdist
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: wheels-*
+          merge-multiple: true
+      - name: Publish to PyPI (Trusted Publishing — OIDC, no token)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+
+  # ── Publish crates to crates.io (Trusted Publishing — OIDC, no token) ───
+  # Dependency order: siphon-control-proto first, then siphon-control-client
+  # (which depends on it). cargo publish (>=1.66) blocks until the crate is in
+  # the index, so the client's verification build can resolve proto from the
+  # registry with no manual sleep. The Python `siphon-control` crate is a
+  # cdylib extension module and is NOT published to crates.io — it ships as a
+  # wheel to PyPI.
+  crates-io:
+    if: startsWith(github.ref, 'refs/tags/control-sdk-v')
+    needs: [verify-version, wheels-linux, wheels-native, sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # mint a short-lived crates.io token via GitHub OIDC
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: siphon-control-sdk
+      - name: Authenticate to crates.io (OIDC Trusted Publishing)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Publish siphon-control-proto
+        run: cargo publish -p siphon-control-proto --manifest-path siphon-control-sdk/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - name: Publish siphon-control-client
+        run: cargo publish -p siphon-control-client --manifest-path siphon-control-sdk/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `siphon_control_commands_total`, `siphon_control_events_dropped_total`,
   `siphon_control_auth_failures_total` and `siphon_control_handoff_timeouts_total`.
   SDK: `call.handover(app, on_lost=, deadline_ms=, vars=)`.
+- **Control-plane client SDKs are the official interop path**, now installable:
+  `pip install siphon-control` (Python) and `cargo add siphon-control-client`
+  (Rust) hide the `siphon-control.v1` wire so a controller is written with
+  `@client.on_call` / `await call.answer()` instead of hand-rolled JSON. They
+  version independently of siphon core against the protocol and ship on their own
+  `control-sdk-v*` release train (PyPI + crates.io via OIDC Trusted Publishing).
+  The raw JSON protocol is now framed as the under-the-hood reference for
+  building a client in another language. See the
+  [control-plane reference](https://siphon-sip.org/reference/control-plane/).
 - **Media profiles can drive the `siphon-rtp` WebSocket audio bridge and its DSP
   chain.** The engine has supported handing a leg's audio to an external
   WebSocket media server (decode → L16 uplink, L16 downlink → encode, the WS

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -1,0 +1,197 @@
+# Control plane (remote SDKs)
+
+SIPhon's B2BUA can hand a live call to an **out-of-process application** over a
+WebSocket, the model Asterisk gives you with ARI and FreeSWITCH with ESL. A
+script hands a call over with `call.handover("app")`; siphon holds the INVITE
+un-dialed, emits a `StasisStart` carrying the full SIP context, and your
+application answers, progresses, rejects, hangs up, refers, or reads and writes
+per-call variables over the socket.
+
+The **client SDKs are the supported way to build that application.** They hide
+the wire — no hand-rolled JSON, no request-id bookkeeping, no reconnect loop —
+and they are versioned against the `siphon-control.v1` protocol independently of
+the siphon server, so a controller you write today keeps working across siphon
+upgrades. Reach for the raw protocol only when you need a client in a language
+the SDKs don't cover.
+
+| You want to… | Use |
+| --- | --- |
+| Build a controller in **Python** | `pip install siphon-control` |
+| Build a controller in **Rust** | `cargo add siphon-control-client` |
+| Build a controller in **another language** | the [raw `siphon-control.v1` protocol](#under-the-hood-the-raw-protocol) |
+
+## Python — `siphon-control`
+
+```bash
+pip install siphon-control
+```
+
+A native (PyO3) extension over the async Rust client. The wheel is published
+for both GIL and free-threaded CPython 3.14, so it drops into a plain
+interpreter or the free-threaded runtime siphon itself uses.
+
+```python
+import asyncio
+from siphon_control import ControlClient, ControlError
+
+client = ControlClient(app="ivr-app", token="s3cr3t",
+                       url="ws://siphon:9090/control/ws")
+
+@client.on_call
+async def handle(call):
+    await call.answer()                       # UAS 2xx to the parked A-leg
+    try:
+        await call.transfer("sip:agent@pbx")  # REFER; awaits the correlated reply
+    except ControlError as error:
+        print("transfer rejected:", error.code)  # stable code: not_found, forbidden, …
+    await call.hangup()
+
+asyncio.run(client.run())                     # connect, dispatch, reconnect + resync
+```
+
+`Call` verbs: `answer()` / `answer_with(code, …)`, `progress()`,
+`reject(code, reason)`, `hangup(reason=None)`, `refer(to)` / `transfer(to)`,
+`set_header(name, value)` / `get_header(name)`, `set_var(key, value)` /
+`get_var(key)`, plus the generic `command(verb, args=None)` escape hatch and
+`next_event()`. A rejected command raises `ControlError` carrying a stable
+`.code`. Media verbs (`play_file` / `dtmf`) raise with `code ==
+"unsupported_verb"` until the server implements them.
+
+## Rust — `siphon-control-client`
+
+```bash
+cargo add siphon-control-client
+```
+
+```rust
+use siphon_control_client::{ClientConfig, sip::SipClient};
+
+# async fn demo() -> Result<(), siphon_control_client::ControlError> {
+let client = SipClient::connect(
+    ClientConfig::new("ws://siphon:9090/control/ws", "ivr-app", "s3cr3t"),
+)
+.await?;
+
+client
+    .on_call(|call| async move {
+        call.answer().await?;
+        call.transfer("sip:agent@pbx").await
+    })
+    .await?;
+# Ok(())
+# }
+```
+
+The client splits into a protocol-agnostic core (`ControlClient` /
+`ControlServer` — transport, `hello`, request-id correlation, reconnect +
+`resync`, and a generic `command(module, verb, target, args)` primitive that
+works for any adapter) and a typed `sip` facade (`sip::Call`) layered on top. A
+rejected command maps to `ControlError::Command` carrying the stable
+`ControlErrorCode`.
+
+## Connection modes
+
+Both SDKs support the two modes, over the same JSON-over-WebSocket protocol.
+
+- **Outbound per-call-connect (the multi-pod default).** Your app runs a
+  WebSocket server; siphon dials it once per handed-over call and the accepting
+  socket owns that call (the FreeSWITCH-outbound model). Siphon always dials
+  *out*, so the "which pod owns the call" affinity problem never arises. There
+  is no `hello` — the first frame is `StasisStart`.
+- **Inbound persistent.** Your app connects in to `control.listen` and owns
+  calls assigned to it (round-robin across the app's connections). It sends a
+  first `hello` and can `resync` to re-attach its calls after a reconnect.
+
+## Handing a call over
+
+Handover happens in the in-process B2BUA script (the
+[`call.handover`](call.md) verb), not in the controller:
+
+```python
+from siphon import b2bua
+
+@b2bua.on_invite
+async def route(call):
+    if call.to_uri.endswith("@ivr.example.com"):
+        call.handover("ivr-app")                 # park + hand to the controller
+    elif call.to_uri.endswith("@ai.example.com"):
+        call.handover("ivr-app", answer=True,    # answer-first (AI-park):
+                      ws_uri="wss://ai.example/stream/{call_id}")
+    else:
+        call.dial(call.ruri)                     # ordinary B2BUA
+```
+
+`answer=True` (answer-first / AI-park) answers the call and anchors its media to
+a WebSocket bridge before handing over, so the controller drives an
+already-connected channel; it requires the `siphon-rtp` media backend.
+
+## siphon configuration
+
+```yaml
+control:
+  # outbound per-call-connect (default) — siphon dials the app per call:
+  apps:
+    - name: "ivr-app"
+      token: "${IVR_APP_TOKEN}"
+      per_call_connect: true
+      connect_url: "ws://127.0.0.1:8443/siphon"
+  # inbound persistent — the app connects in here instead:
+  # listen: "127.0.0.1:9092"
+  limits:
+    event_queue_depth: 1024
+    reattach_grace_secs: 10
+```
+
+Per-app bearer tokens are constant-time compared and feed the existing auto-ban
+store. Dispatch is exactly-one-owner with per-tenant scoping: a command against
+another app's call returns `forbidden`, and a command against a dead or unknown
+call returns `not_found` — neither ever hangs.
+
+## Under the hood: the raw protocol
+
+The SDKs speak `siphon-control.v1`: a single WebSocket per connection, JSON text
+frames, request-id correlated. You only need this layer to build a client in a
+language the SDKs don't cover — otherwise the SDKs handle all of it.
+
+```
+command  (client → siphon)  { "id":"c-1", "type":"command", "module":"sip",
+                              "verb":"answer", "target":{"channel":"<id>"},
+                              "args":{"code":200} }
+reply    (siphon → client)  { "id":"c-1", "type":"reply", "status":"ok",
+                              "result":{...} }   // or "status":"error", "error":{code,message}
+event    (siphon → client)  { "type":"event", "event":"StasisStart",
+                              "channel":"<id>", "call_id":"<uuid>",
+                              "sip_call_id":"<cid>", "payload":{...} }
+```
+
+Every event carries the stable id triple `{channel, call_id, sip_call_id}` —
+`sip_call_id` is byte-identical to the CDR `call_id` and the HEP correlation
+chunk, so logs join Homer and billing with no mapping table.
+
+### Phase-1 verb set
+
+| verb | module | args | notes |
+|---|---|---|---|
+| `answer` | sip | `{code, reason?, body?, content_type?}` | UAS 2xx to the parked A-leg |
+| `progress` | sip | `{code, reason?, body?, content_type?}` | 1xx / early media |
+| `reject` | sip | `{code, reason?}` | final non-2xx + tear down |
+| `hangup` | sip | `{reason?}` | BYE an answered call, or reject an unanswered one |
+| `refer` | sip | `{to, replaces?}` | in-dialog REFER on the A-leg |
+| `set_header` / `get_header` | sip | `{name, value?}` | on the stored A-leg INVITE |
+| `set_var` / `get_var` | — | `{key, value?}` | per-call variables (drain with the call) |
+| `resync` | — | — | re-attach + enumerate this app's owned calls |
+| `describe` | — | — | list the registered adapters + their verb/event schema |
+
+`play` / `dtmf` / `bridge` / `originate` / media-stream verbs arrive in later
+phases over the same envelope.
+
+The complete wire reference, both connection modes end to end, and two
+low-level example clients (one Python, one TypeScript) that drive calls with no
+SDK live in the repository:
+
+- Protocol + example clients:
+  [`examples/remote_control/`](https://github.com/siphon-project/siphon-sip/tree/main/examples/remote_control)
+- SDK sources:
+  [`siphon-control-sdk/`](https://github.com/siphon-project/siphon-sip/tree/main/siphon-control-sdk)
+  (`siphon-control-proto` is the shared DTO crate — the single source of truth
+  for the frames above)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -50,6 +50,7 @@ from siphon import timer, metrics, sdp, sbi, ipsec, rtpengine, isc
 | [Diameter](diameter.md) | Cx / Rx / Sh / Rf interfaces and inbound-request handling |
 | [IMS control](ims.md) | iFC evaluation, SBI/N5, presence, lawful intercept, SRS |
 | [Observability](observability.md) | Logging, cache, CDR, custom metrics, timers |
+| [Control plane (remote SDKs)](control-plane.md) | Driving handed-over calls from an out-of-process app (`pip install siphon-control`, `cargo add siphon-control-client`) |
 | [Testing harness](testing.md) | The pytest harness and its result objects |
 
 !!! note "Extension namespaces"

--- a/examples/remote_control/README.md
+++ b/examples/remote_control/README.md
@@ -1,10 +1,22 @@
-# Remote-control client examples
+# Remote-control client examples (low-level protocol reference)
+
+> **Building a real controller? Use the SDKs, not this.** The supported way to
+> drive handed-over calls is the client SDKs, which hide the wire (no manual
+> JSON, no request-id bookkeeping, no reconnect loop):
+>
+> - Python: `pip install siphon-control`
+> - Rust: `cargo add siphon-control-client`
+>
+> See the [control-plane reference](https://siphon-sip.org/reference/control-plane/)
+> and [`siphon-control-sdk/`](../../siphon-control-sdk/). The two clients below
+> are a **hand-rolled `siphon-control.v1` reference** — read them to build a
+> client in a language the SDKs don't cover, or to understand the wire.
 
 Two small external applications — one Python, one TypeScript — that drive live
-calls over siphon's control WebSocket (ARI/ESL-class). A B2BUA script hands a
-call over with `call.handover("ivr-app")` (the ARI *Stasis* model); the
-out-of-process app then answers, sets a per-call variable, holds briefly, and
-hangs up. Calls that are not handed over are unaffected.
+calls over siphon's control WebSocket (ARI/ESL-class) **without an SDK**. A
+B2BUA script hands a call over with `call.handover("ivr-app")` (the ARI *Stasis*
+model); the out-of-process app then answers, sets a per-call variable, holds
+briefly, and hangs up. Calls that are not handed over are unaffected.
 
 Both clients support **both connection modes** and default to
 **outbound per-call-connect**.

--- a/examples/remote_control/README.md
+++ b/examples/remote_control/README.md
@@ -1,22 +1,10 @@
-# Remote-control client examples (low-level protocol reference)
-
-> **Building a real controller? Use the SDKs, not this.** The supported way to
-> drive handed-over calls is the client SDKs, which hide the wire (no manual
-> JSON, no request-id bookkeeping, no reconnect loop):
->
-> - Python: `pip install siphon-control`
-> - Rust: `cargo add siphon-control-client`
->
-> See the [control-plane reference](https://siphon-sip.org/reference/control-plane/)
-> and [`siphon-control-sdk/`](../../siphon-control-sdk/). The two clients below
-> are a **hand-rolled `siphon-control.v1` reference** — read them to build a
-> client in a language the SDKs don't cover, or to understand the wire.
+# Remote-control client examples
 
 Two small external applications — one Python, one TypeScript — that drive live
-calls over siphon's control WebSocket (ARI/ESL-class) **without an SDK**. A
-B2BUA script hands a call over with `call.handover("ivr-app")` (the ARI *Stasis*
-model); the out-of-process app then answers, sets a per-call variable, holds
-briefly, and hangs up. Calls that are not handed over are unaffected.
+calls over siphon's control WebSocket (ARI/ESL-class). A B2BUA script hands a
+call over with `call.handover("ivr-app")` (the ARI *Stasis* model); the
+out-of-process app then answers, sets a per-call variable, holds briefly, and
+hangs up. Calls that are not handed over are unaffected.
 
 Both clients support **both connection modes** and default to
 **outbound per-call-connect**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Diameter: reference/diameter.md
       - IMS control: reference/ims.md
       - Observability: reference/observability.md
+      - Control plane (remote SDKs): reference/control-plane.md
       - Testing harness: reference/testing.md
   - Running in production:
       - Transports & networking: transports.md

--- a/siphon-control-sdk/README.md
+++ b/siphon-control-sdk/README.md
@@ -1,0 +1,77 @@
+# SIPhon control-plane SDKs
+
+Client SDKs for the [SIPhon](https://github.com/siphon-project/siphon-sip)
+external control plane (`siphon-control.v1`) — an ARI/ESL-class rail for driving
+handed-over B2BUA calls out of process.
+
+**These SDKs are the supported way to build a SIPhon controller.** They hide the
+wire — no hand-rolled JSON, no request-id bookkeeping, no reconnect loop — and
+version against the `siphon-control.v1` protocol independently of the siphon
+server, so a controller you write today keeps working across siphon upgrades.
+Build against the [raw protocol](#the-raw-protocol) only when you need a client
+in a language the SDKs don't cover.
+
+## Install
+
+| Language | Install | Crate / package |
+| --- | --- | --- |
+| Python | `pip install siphon-control` | `siphon-control` (PyPI) |
+| Rust | `cargo add siphon-control-client` | `siphon-control-client` (crates.io) |
+
+```python
+import asyncio
+from siphon_control import ControlClient, ControlError
+
+client = ControlClient(app="ivr-app", token="s3cr3t",
+                       url="ws://siphon:9090/control/ws")
+
+@client.on_call
+async def handle(call):
+    await call.answer()
+    try:
+        await call.transfer("sip:agent@pbx")
+    except ControlError as error:
+        print("transfer rejected:", error.code)
+
+asyncio.run(client.run())
+```
+
+## The crates
+
+| Crate | Publishes to | Role |
+| --- | --- | --- |
+| [`siphon-control-proto`](siphon-control-proto/) | crates.io | Dependency-light wire DTOs (`CommandFrame` / `ReplyFrame` / `EventFrame`, error codes, handshake) — the single source of truth for the frames, shared by the server and every SDK. |
+| [`siphon-control-client`](siphon-control-client/) | crates.io | Async Rust client: protocol-agnostic core (`command(module, verb, target, args)`, request-id correlation, reconnect + `resync`) plus a typed `sip::Call` facade. |
+| [`siphon-control`](siphon-control/) | PyPI (wheel) | PyO3 bindings over the Rust client — `ControlClient` + `Call` as asyncio awaitables, `@client.on_call` dispatch. |
+
+`siphon-control` is a **native** extension, not pure Python. There is no abi3
+for free-threaded CPython, so wheels are built per interpreter: **cp314 (GIL)
+and cp314t (free-threaded)** ship as separate wheels, since the SIPhon runtime
+is free-threaded.
+
+## Versioning & release
+
+The three crates share one version (`0.1.0`), independent of the siphon server
+and tied to the `siphon-control.v1` protocol. They release on their own tag
+train — `control-sdk-vX.Y.Z` — driving
+[`.github/workflows/release-control-sdk.yaml`](../.github/workflows/release-control-sdk.yaml),
+which builds the wheels (maturin) and publishes to PyPI and crates.io via OIDC
+Trusted Publishing (no stored tokens). This is a **standalone excluded
+workspace** with its own `Cargo.lock`: a root `cargo build` of siphon-sip never
+sweeps it, and nothing here publishes on its own — only a `control-sdk-v*` tag
+does.
+
+## The raw protocol
+
+The SDKs speak `siphon-control.v1`: one WebSocket per connection, request-id
+correlated JSON text frames. The complete wire reference, both connection modes,
+and two low-level example clients (Python + TypeScript) that drive calls with no
+SDK live under
+[`examples/remote_control/`](../examples/remote_control/). Reach for that layer
+only to build a client in a language the SDKs don't cover.
+
+Full documentation: <https://siphon-sip.org/reference/control-plane/>
+
+## License
+
+MIT


### PR DESCRIPTION
## What

Makes the external control-plane SDKs **publishable** and establishes them as the official interop path for building a SIPhon controller. Follow-up to the SDK merge (#137) — no runtime change to siphon itself.

Three pieces:

1. **`.github/workflows/release-control-sdk.yaml`** — an independent release train for the SDKs on a `control-sdk-v*` tag, separate from siphon core's `v*` tag. Same OIDC Trusted Publishing as `release.yaml` (no stored tokens: `pypa/gh-action-pypi-publish` for PyPI, `rust-lang/crates-io-auth-action` for crates.io).
2. **Publish-readiness** of the three crates (metadata + version deps).
3. **Docs positioning** — a control-plane reference that leads with the SDKs and frames the raw JSON protocol as the under-the-hood reference.

## Release workflow

`siphon-control` is a **native** PyO3 extension, so wheels are built with maturin per interpreter. There is no abi3 for free-threaded CPython, so GIL and free-threaded are separate ABIs → separate version-tagged wheels. The runtime is free-threaded, so **both `cp314` and `cp314t` ship**.

Wheel matrix (10 wheels + an sdist):

| Platform | Runner | Target | `cp314` (GIL) | `cp314t` (free-threaded) |
| --- | --- | --- | --- | --- |
| Linux x86_64 | `ubuntu-latest` | `x86_64` | ✅ | ✅ |
| Linux aarch64 | `ubuntu-24.04-arm` | `aarch64` | ✅ | ✅ |
| macOS arm64 | `macos-14` | `aarch64` | ✅ | ✅ |
| macOS x86_64 | `macos-13` | `x86_64` | ✅ | ✅ |
| Windows x86_64 | `windows-latest` | `x64` | ✅ | ✅ |

- Linux wheels build in the manylinux container against its bundled interpreters (`/opt/python/cp314-cp314{,t}/bin/...`); macOS/Windows use `actions/setup-python` (which installs the free-threaded build for a `3.14t` request) and feed maturin the exact `python-path`.
- Manifest path: `siphon-control-sdk/siphon-control/Cargo.toml`.
- Publish jobs are **tag-gated** (`if: startsWith(github.ref, 'refs/tags/control-sdk-v')`) and gated behind a version-vs-tag check. `workflow_dispatch` builds every wheel + the sdist as a dry-run but publishes nothing.
- PyPI: all wheels + sdist → `siphon-control` via OIDC.
- crates.io: `siphon-control-proto` **then** `siphon-control-client` (dependency order) via OIDC. `cargo publish` (≥1.66) blocks until the crate is in the index, so the client's verify build resolves proto from the registry with no manual sleep. The PyO3 `siphon-control` crate is a cdylib extension and is **not** published to crates.io — it ships as a wheel.

## Publish-readiness

- `siphon-control-client`'s dep on `siphon-control-proto` already carries `version = "0.1.0"` alongside `path` (path for local dev, version for publish); same on the PyO3 crate. `cargo publish --dry-run` confirms it resolves against the crates.io index.
- All three crates already have the crates.io-required metadata (`description`, `license`, `repository`, `readme`). `cargo publish -p siphon-control-proto --dry-run` packages + verifies clean.
- Versions: all three at `0.1.0` (shared workspace version, independent of siphon core, tied to the `siphon-control.v1` protocol). The wheel version is `dynamic` from the crate → `0.1.0`.

## License

The project is **MIT** (root `LICENSE`, `Cargo.toml`, and the SDK workspace/crates via `license.workspace = true`, and the `pyproject.toml`). All three crates + the pyproject already declare MIT — consistent, nothing to change.

## Docs

- New `docs/reference/control-plane.md` leads with `pip install siphon-control` / `cargo add siphon-control-client` and the `@client.on_call` / `await call.answer()` snippet as the recommended way to build a controller; the raw `siphon-control.v1` protocol is the "under the hood" section for building your own client. Added to the mkdocs nav and the reference index.
- `siphon-control-sdk/README.md` (new) and `examples/remote_control/README.md` now point at the SDKs as primary; the raw example clients are kept as the low-level reference.
- One-line CHANGELOG note under `[Unreleased]`.

## Manual steps for the maintainer (account-side, before the first `control-sdk-v*` tag will publish)

These are OIDC / package-name settings that live on the package registries, not in this repo:

- [ ] Reserve/create the **`siphon-control`** project on **PyPI** and register the **trusted publisher** (owner `siphon-project`, repo `siphon-sip`, workflow `release-control-sdk.yaml`, environment left blank unless one is added).
- [ ] Reserve **`siphon-control-proto`** and **`siphon-control-client`** on **crates.io** and confirm the crates.io trusted-publishing/OIDC config matches what `release.yaml` already uses (same `rust-lang/crates-io-auth-action` flow).
- [ ] Confirm the **`control-sdk-vX.Y.Z`** tag scheme (independent of siphon core `vX.Y.Z` tags); the version gate reads `siphon-control-sdk/Cargo.toml`.
- [ ] Confirm the free-threaded **`cp314t`** wheels build green in CI (run the workflow via `workflow_dispatch` for a no-publish dry-run — this is the one part that can't be certified locally).

## Validation

- `cargo build -p siphon-control-proto -p siphon-control-client --manifest-path siphon-control-sdk/Cargo.toml` — clean.
- `cargo clippy --manifest-path siphon-control-sdk/Cargo.toml --all-targets -- -D warnings` — clean.
- `cargo publish -p siphon-control-proto --dry-run` — packages + verifies clean (metadata complete).
- Workflow YAML validated well-formed; publish steps mirror `release.yaml`'s proven OIDC shape.

This PR does **not** publish anything — the workflow fires only on a future `control-sdk-v*` tag.
