### PR TITLE
feat(control-sdk): TypeScript client SDK (@siphon/control) for the external control plane

### DIFF
--- a/.github/workflows/release-control-sdk-ts.yaml
+++ b/.github/workflows/release-control-sdk-ts.yaml
@@ -1,0 +1,52 @@
+name: release-control-sdk-ts
+
+# Publishes the TypeScript control-plane SDK (@siphon/control) to npm.
+#
+# The TS SDK is versioned independently of the siphon-sip crate (tied to the
+# control protocol, matching the Rust/Python SDKs), so it has its own tag prefix
+# `control-sdk-v*` and its own workflow. A `workflow_dispatch` run builds + tests
+# without publishing (dry run); only a `control-sdk-v*` tag publishes.
+
+on:
+  push:
+    tags:
+      - "control-sdk-v*"
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: siphon-control-sdk/typescript
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC for npm Trusted Publishing (no stored NPM_TOKEN)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # npm OIDC Trusted Publishing needs npm >= 11.5.1 (newer than the version
+      # bundled with the runner); provenance is minted from the id-token below.
+      - name: Upgrade npm (Trusted Publishing support)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      # Publish only on a real tag — a manual workflow_dispatch run stops after
+      # the build + test dry run above.
+      - name: Publish to npm (Trusted Publishing — OIDC, no token)
+        if: startsWith(github.ref, 'refs/tags/control-sdk-v')
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-control-sdk-ts.yaml
+++ b/.github/workflows/release-control-sdk-ts.yaml
@@ -1,6 +1,6 @@
 name: release-control-sdk-ts
 
-# Publishes the TypeScript control-plane SDK (@siphon/control) to npm.
+# Publishes the TypeScript control-plane SDK (@siphon-project/control) to npm.
 #
 # The TS SDK is versioned independently of the siphon-sip crate (tied to the
 # control protocol, matching the Rust/Python SDKs), so it has its own tag prefix

--- a/examples/remote_control/.gitignore
+++ b/examples/remote_control/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/examples/remote_control/README.md
+++ b/examples/remote_control/README.md
@@ -15,7 +15,7 @@ would.
 
 - **Python** (`control_client.py`) uses [`siphon-control`](../../siphon-control-sdk/siphon-control),
   which ships the **inbound-persistent** client.
-- **TypeScript** (`control_client.ts`) uses [`@siphon/control`](../../siphon-control-sdk/typescript),
+- **TypeScript** (`control_client.ts`) uses [`@siphon-project/control`](../../siphon-control-sdk/typescript),
   which ships **both** connection modes.
 
 The raw `siphon-control.v1` JSON protocol these SDKs speak (the command / reply /
@@ -95,7 +95,7 @@ IVR_APP_TOKEN=changeme-dev-token python control_client.py
 
 ## Run the TypeScript client
 
-The example depends on `@siphon/control` via a `file:` path to the sibling
+The example depends on `@siphon-project/control` via a `file:` path to the sibling
 package, so it is runnable before the SDK is published. **Build the SDK first**
 (its `dist/` is what the `file:` dependency resolves):
 
@@ -106,7 +106,7 @@ npm --prefix ../../siphon-control-sdk/typescript run build
 
 # then this example:
 npm install                           # wires up the file: dependency
-# ...once published, this is simply `npm i @siphon/control`.
+# ...once published, this is simply `npm i @siphon-project/control`.
 
 # outbound (default): this app is the server siphon dials
 SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token npm start

--- a/examples/remote_control/README.md
+++ b/examples/remote_control/README.md
@@ -1,74 +1,47 @@
 # Remote-control client examples
 
 Two small external applications — one Python, one TypeScript — that drive live
-calls over siphon's control WebSocket (ARI/ESL-class). A B2BUA script hands a
-call over with `call.handover("ivr-app")` (the ARI *Stasis* model); the
-out-of-process app then answers, sets a per-call variable, holds briefly, and
-hangs up. Calls that are not handed over are unaffected.
+calls over siphon's control WebSocket (ARI/ESL-class) using the official client
+**SDKs**. A B2BUA script hands a call over with `call.handover("ivr-app")` (the
+ARI *Stasis* model); the out-of-process app then answers, sets a per-call
+variable, holds briefly, and hangs up. Calls that are not handed over are
+unaffected.
 
-Both clients support **both connection modes** and default to
-**outbound per-call-connect**.
+Both examples use the SDK — the official interop path. There is **no manual
+frame construction**: the SDK owns the transport, the `hello` handshake,
+request-id correlation, and reconnect + `resync`. You write `call.answer()` /
+`call.transfer(...)` / `call.hangup()`, exactly as an in-process siphon script
+would.
+
+- **Python** (`control_client.py`) uses [`siphon-control`](../../siphon-control-sdk/siphon-control),
+  which ships the **inbound-persistent** client.
+- **TypeScript** (`control_client.ts`) uses [`@siphon/control`](../../siphon-control-sdk/typescript),
+  which ships **both** connection modes.
+
+The raw `siphon-control.v1` JSON protocol these SDKs speak (the command / reply /
+event envelope, the verb set, the error codes) is documented under the hood in
+the control-plane reference at <https://siphon-sip.org/reference/control-plane/>
+— you do not need it to use the examples.
 
 ## Connection modes
-
-Same JSON-over-WebSocket protocol (subprotocol `siphon-control.v1`) on the
-socket in either mode.
 
 - **Outbound per-call-connect (the documented default).** The app runs a
   WebSocket **server**; siphon dials it once per handed-over call and the
   accepting socket owns that call (the FreeSWITCH-outbound model). There is **no
   `hello`** — the first frame the app receives is `StasisStart`. Use this for
   multi-pod / autoscaled controllers: siphon always dials *out*, so the "which
-  pod owns the call" affinity problem cannot arise. The app must echo the
-  `siphon-control.v1` subprotocol on accept (both example servers do).
+  pod owns the call" affinity problem cannot arise. In the TypeScript SDK this is
+  `SipServer`.
 
 - **Inbound persistent.** The app is a WebSocket **client** that connects in to
   `control.listen` and owns calls assigned to it (round-robin across the app's
   connections). It sends a first `hello` (whose `app` must match the token's
-  configured application) and can `resync` to re-attach its calls after a
-  reconnect.
+  configured application) and `resync`s to re-attach its calls after a reconnect.
+  This is `SipClient` (TypeScript) / `ControlClient` (Python).
 
-Select the mode with `SIPHON_CONTROL_MODE` (`outbound` | `inbound`).
-
-## Wire protocol
-
-Single WebSocket per connection, JSON text frames, request-id correlated.
-Adapter commands carry `module` (`"sip"`); substrate commands (`hello`,
-`resync`, `describe`, `set_var`, `get_var`) omit it.
-
-```
-command  (client → siphon)  { "id":"c-1", "type":"command", "module":"sip",
-                              "verb":"answer", "target":{"channel":"<id>"},
-                              "args":{"code":200} }
-reply    (siphon → client)  { "id":"c-1", "type":"reply", "status":"ok",
-                              "result":{...} }   // or "status":"error", "error":{code,message}
-event    (siphon → client)  { "type":"event", "event":"StasisStart",
-                              "channel":"<id>", "call_id":"<uuid>",
-                              "sip_call_id":"<cid>", "payload":{...} }
-```
-
-Every event carries the stable id triple `{channel, call_id, sip_call_id}` —
-`sip_call_id` is byte-identical to the CDR `call_id` and the HEP correlation
-chunk, so your logs join Homer + billing with no mapping table.
-
-## Phase-1 verb set
-
-| verb | module | args | notes |
-|---|---|---|---|
-| `answer` | sip | `{code, reason?, body?, content_type?}` | send a UAS 2xx to the parked A-leg |
-| `progress` | sip | `{code, reason?, body?, content_type?}` | send a 1xx / early media |
-| `reject` | sip | `{code, reason?}` | final non-2xx + tear down |
-| `hangup` | sip | `{reason?}` | BYE an answered call, or reject an unanswered one |
-| `refer` | sip | `{to, replaces?}` | in-dialog REFER on the A-leg |
-| `set_header` / `get_header` | sip | `{name, value?}` | on the stored A-leg INVITE |
-| `set_var` / `get_var` | — | `{key, value?}` | per-call variables (drain with the call) |
-| `resync` | — | — | re-attach + enumerate this app's owned calls |
-| `describe` | — | — | list the registered adapters + their verb/event schema |
-
-A command against a dead/unknown call returns a typed `not_found`; a command
-targeting another app's call returns `forbidden` — neither ever hangs.
-(`play` / `dtmf` / `bridge` / `originate` / media-stream verbs arrive in later
-phases over the same protocol and envelope.)
+The TypeScript example selects the mode with `SIPHON_CONTROL_MODE`
+(`outbound` | `inbound`). The Python SDK ships the inbound-persistent client, so
+the Python example is inbound.
 
 ## siphon configuration
 
@@ -106,30 +79,39 @@ async def route(call):
 ```
 
 `answer=True` (answer-first / AI-park) answers the call and anchors its media to
-the `voice_ai` WebSocket bridge before handing over, so the app drives an
-already-connected channel; it requires the `siphon-rtp` media backend.
+the WebSocket bridge before handing over, so the app drives an already-connected
+channel; it requires the `siphon-rtp` media backend.
 
 ## Run the Python client
 
 ```bash
-pip install "websockets>=14"
+# install the SDK:
+pip install siphon-control            # once published
+# ...or from this repo, into the active venv:
+#   cd ../../siphon-control-sdk/siphon-control && maturin develop
 
-# outbound (default): this app is the server siphon dials
-SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token python control_client.py
-
-# inbound: this app dials siphon's control.listen
-SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token python control_client.py
+IVR_APP_TOKEN=changeme-dev-token python control_client.py
 ```
 
 ## Run the TypeScript client
 
-```bash
-npm install
+The example depends on `@siphon/control` via a `file:` path to the sibling
+package, so it is runnable before the SDK is published. **Build the SDK first**
+(its `dist/` is what the `file:` dependency resolves):
 
-# outbound (default)
+```bash
+# build the sibling SDK once:
+npm --prefix ../../siphon-control-sdk/typescript install
+npm --prefix ../../siphon-control-sdk/typescript run build
+
+# then this example:
+npm install                           # wires up the file: dependency
+# ...once published, this is simply `npm i @siphon/control`.
+
+# outbound (default): this app is the server siphon dials
 SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token npm start
 
-# inbound
+# inbound: this app dials siphon's control.listen
 SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token npm start
 
 # type-check only
@@ -140,8 +122,8 @@ npm run typecheck
 
 | var | default | applies to | meaning |
 |---|---|---|---|
-| `SIPHON_CONTROL_MODE` | `outbound` | both | `outbound` (server) or `inbound` (client) |
+| `SIPHON_CONTROL_MODE` | `outbound` | TypeScript | `outbound` (server) or `inbound` (client) |
 | `IVR_APP_TOKEN` | `changeme-dev-token` | both | bearer token (must match `control.apps[].token`) |
-| `SIPHON_CONTROL_APP` | `ivr-app` | inbound | app name asserted in `hello` |
-| `SIPHON_CONTROL_BIND` | `127.0.0.1:8443` | outbound | `host:port` this app listens on for siphon's dials |
+| `SIPHON_CONTROL_APP` | `ivr-app` | both | app name asserted in `hello` (inbound) |
+| `SIPHON_CONTROL_BIND` | `127.0.0.1:8443` | TypeScript outbound | `host:port` this app listens on for siphon's dials |
 | `SIPHON_CONTROL_URL` | `ws://127.0.0.1:9092/control/ws` | inbound | siphon's control listener URL |

--- a/examples/remote_control/control_client.py
+++ b/examples/remote_control/control_client.py
@@ -1,199 +1,75 @@
 #!/usr/bin/env python3
-"""Example external control application for the siphon control plane.
+"""Example external control application for the siphon control plane — Python SDK.
 
-Drives live B2BUA calls a script hands over with ``call.handover("<app>")`` (the
-ARI *Stasis* model) over siphon's control WebSocket. Calls that are not handed
-over are unaffected.
+Drives live B2BUA calls a script hands over with ``call.handover("ivr-app")`` (the
+ARI *Stasis* model) over siphon's control WebSocket, using the ``siphon-control``
+Python SDK. The SDK owns the wire completely: no manual JSON, no ``rpc()`` helper,
+no request-id bookkeeping — you get a ``Call`` whose verbs read like an in-process
+siphon script (``call.answer()`` / ``call.transfer(...)`` / ``call.hangup()``).
 
-Two connection modes, same wire protocol (subprotocol ``siphon-control.v1``):
+Inbound-persistent mode: this app is a WebSocket *client* that connects in to
+``control.listen``, sends a ``hello``, and owns the calls assigned to it. On a
+reconnect the SDK ``resync``s and re-dispatches the calls it still owns. (The
+Python SDK ships the inbound-persistent client; for the per-call-connect model
+where siphon dials the app, see the TypeScript example.)
 
-  * **outbound per-call-connect (the default)** — this app runs a WebSocket
-    *server*; siphon dials it once per handed-over call and the accepting socket
-    owns that call. No ``hello`` — the first frame is ``StasisStart``. This is
-    the model to use for multi-pod / autoscaled controllers (siphon always dials
-    *out*, so the "which pod owns the call" affinity problem cannot arise).
+The demo answers each handed-over call, stamps a per-call variable, holds
+briefly, then hangs up. Calls that are not handed over are unaffected.
 
-  * **inbound persistent** — this app is a WebSocket *client* that connects in to
-    ``control.listen`` and owns calls assigned to it (round-robin). It sends a
-    ``hello`` and can ``resync`` to re-attach its calls after a reconnect.
+Install the SDK::
 
-Select the mode with ``SIPHON_CONTROL_MODE`` (``outbound`` | ``inbound``).
+    pip install siphon-control            # once published
+    # ...or from this repo, into the active venv:
+    #   cd siphon-control-sdk/siphon-control && maturin develop
 
-The demo call flow answers each handed-over call, stamps a per-call variable,
-holds briefly, then hangs up. The Phase-1 verb set is
-``answer`` / ``progress`` / ``reject`` / ``hangup`` / ``refer`` /
-``set_header`` / ``get_header`` (SIP adapter, ``module: "sip"``) plus the
-substrate verbs ``resync`` / ``describe`` / ``set_var`` / ``get_var``.
+Run::
 
-Usage::
-
-    pip install "websockets>=14"
-    # outbound (default): siphon dials this server
-    SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token \\
-        python control_client.py
-    # inbound: this app dials siphon
-    SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token \\
-        python control_client.py
+    IVR_APP_TOKEN=changeme-dev-token python control_client.py
 
 See README.md for the matching siphon ``control:`` config and handover script.
 """
 from __future__ import annotations
 
 import asyncio
-import itertools
-import json
 import os
 
-import websockets
+from siphon_control import Call, ControlClient, ControlError
 
-SUBPROTOCOL = "siphon-control.v1"
-
-MODE = os.environ.get("SIPHON_CONTROL_MODE", "outbound").lower()
 APP_NAME = os.environ.get("SIPHON_CONTROL_APP", "ivr-app")
 TOKEN = os.environ.get("IVR_APP_TOKEN", "changeme-dev-token")
-
-# inbound: where to dial siphon.
 CONTROL_URL = os.environ.get("SIPHON_CONTROL_URL", "ws://127.0.0.1:9092/control/ws")
-# outbound: where this app listens for siphon's per-call dials.
-BIND = os.environ.get("SIPHON_CONTROL_BIND", "127.0.0.1:8443")
 
 ANSWER_HOLD_SECONDS = 5.0
 
-# Verbs the SIP adapter serves (routed with module="sip"); everything else is a
-# substrate verb (hello/resync/describe/set_var/get_var) and omits the module.
-_SIP_VERBS = {
-    "answer", "progress", "reject", "hangup", "refer", "set_header", "get_header",
-}
+client = ControlClient(app=APP_NAME, token=TOKEN, url=CONTROL_URL)
 
 
-class ControlSession:
-    """One control connection with request/reply correlation + event dispatch."""
-
-    def __init__(self, connection) -> None:
-        self._connection = connection
-        self._ids = itertools.count(1)
-        self._pending: dict[str, asyncio.Future] = {}
-        self._tasks: set[asyncio.Task] = set()
-
-    async def rpc(self, verb: str, *, target: dict | None = None,
-                  args: dict | None = None) -> dict:
-        """Send a command and await its correlated reply frame."""
-        request_id = f"c-{next(self._ids)}"
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-        self._pending[request_id] = future
-        command: dict = {
-            "id": request_id,
-            "type": "command",
-            "verb": verb,
-            "target": target or {},
-            "args": args or {},
-        }
-        if verb in _SIP_VERBS:
-            command["module"] = "sip"
-        await self._connection.send(json.dumps(command))
-        return await future
-
-    async def read_loop(self) -> None:
-        """Dispatch replies + events until the socket closes."""
-        async for raw in self._connection:
-            frame = json.loads(raw)
-            kind = frame.get("type")
-            if kind == "reply":
-                future = self._pending.pop(frame.get("id", ""), None)
-                if future is not None and not future.done():
-                    future.set_result(frame)
-            elif kind == "event":
-                # Handle each event concurrently so a long call flow never blocks
-                # the read loop (and thus never stalls another call).
-                self._spawn(self._on_event(frame))
-
-    def _spawn(self, coro) -> None:
-        task = asyncio.ensure_future(coro)
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
-
-    async def _on_event(self, event: dict) -> None:
-        name = event.get("event")
-        channel = event.get("channel")
-        if name == "StasisStart":
-            # payload carries the full SIP context; sip_call_id joins CDR / HEP.
-            print(f"[event] StasisStart {channel} sip_call_id={event.get('sip_call_id')}")
-            await self._handle_call(channel)
-        elif name == "StasisEnd":
-            print(f"[event] StasisEnd {channel} reason={event.get('payload', {}).get('reason')}")
-        else:
-            print(f"[event] {name} {channel}")
-
-    async def _handle_call(self, channel: str) -> None:
-        target = {"channel": channel}
-        answered = await self.rpc("answer", target=target, args={"code": 200})
-        if answered.get("status") != "ok":
-            print(f"[call] answer rejected: {answered.get('error')}")
-            return
+@client.on_call
+async def handle_call(call: Call) -> None:
+    """Answer, stamp a per-call variable, hold, then hang up."""
+    print(f"[call] StasisStart {call.channel_id} sip_call_id={call.sip_call_id}")
+    try:
+        await call.answer()
         # Per-call variables live on the control channel (drain with the call).
-        await self.rpc("set_var", target=target, args={"key": "demo", "value": "1"})
-        got = await self.rpc("get_var", target=target, args={"key": "demo"})
-        print(f"[call] answered {channel}; demo={got.get('result', {}).get('value')}; "
+        await call.set_var("demo", "1")
+        demo = await call.get_var("demo")
+        print(f"[call] answered {call.channel_id}; demo={demo}; "
               f"holding {ANSWER_HOLD_SECONDS}s")
         await asyncio.sleep(ANSWER_HOLD_SECONDS)
-        hung = await self.rpc("hangup", target=target)
-        print(f"[call] hangup {channel}: {hung.get('status')}")
-
-
-async def run_inbound() -> None:
-    """Client mode: dial siphon, hello, resync, then drive assigned calls."""
-    headers = {"Authorization": f"Bearer {TOKEN}"}
-    async with websockets.connect(
-        CONTROL_URL, additional_headers=headers, subprotocols=[SUBPROTOCOL]
-    ) as connection:
-        print(f"[control] connected (inbound) to {CONTROL_URL}")
-        session = ControlSession(connection)
-        reader = asyncio.ensure_future(session.read_loop())
-        hello = await session.rpc("hello", args={"app": APP_NAME, "protocol": 1})
-        if hello.get("status") != "ok":
-            reader.cancel()
-            raise RuntimeError(f"hello rejected: {hello.get('error')}")
-        print(f"[control] registered as {APP_NAME!r}")
-        # Re-attach any calls we still own from a previous connection.
-        resync = await session.rpc("resync")
-        owned = resync.get("result", {}).get("channels", [])
-        print(f"[control] resync re-attached {len(owned)} call(s)")
-        for channel in owned:
-            session._spawn(session._handle_call(channel["channel"]))
-        await reader
-
-
-async def _outbound_handler(connection) -> None:
-    """Server mode: siphon dialed us for one call — we already own it."""
-    # Verify the bearer token siphon presents (the app's own policy).
-    presented = connection.request.headers.get("Authorization", "")
-    if presented != f"Bearer {TOKEN}":
-        print("[control] rejected outbound dial: bad/missing token")
-        await connection.close(code=1008, reason="unauthorized")
-        return
-    print("[control] siphon dialed in (outbound per-call-connect) — we own this call")
-    # No hello in outbound mode: the first frame is StasisStart. The websockets
-    # server has already echoed the `siphon-control.v1` subprotocol on accept.
-    await ControlSession(connection).read_loop()
-
-
-async def run_outbound() -> None:
-    """Server mode: listen for siphon's per-call dials."""
-    host, _, port = BIND.partition(":")
-    async with websockets.serve(
-        _outbound_handler, host, int(port), subprotocols=[SUBPROTOCOL]
-    ):
-        print(f"[control] listening (outbound per-call-connect) on ws://{BIND}")
-        await asyncio.Future()  # run forever
+        # Blind transfer instead of hanging up? -> await call.transfer("sip:agent@pbx")
+        await call.hangup()
+        print(f"[call] hung up {call.channel_id}")
+    except ControlError as error:
+        # A dead/unknown call is a typed `not_found`; a verb the server does not
+        # implement yet is `unsupported_verb`. Never fatal to the other calls.
+        print(f"[call] {call.channel_id} rejected: {error.code}")
 
 
 async def main() -> None:
-    if MODE == "inbound":
-        await run_inbound()
-    elif MODE == "outbound":
-        await run_outbound()
-    else:
-        raise SystemExit(f"SIPHON_CONTROL_MODE must be 'outbound' or 'inbound' (got {MODE!r})")
+    print(f"[control] connecting to {CONTROL_URL} as {APP_NAME!r}")
+    # run() connects + hello, then drives the supervised reconnect + resync loop,
+    # dispatching each handed-over call to @client.on_call.
+    await client.run()
 
 
 if __name__ == "__main__":

--- a/examples/remote_control/control_client.ts
+++ b/examples/remote_control/control_client.ts
@@ -1,26 +1,33 @@
 /**
- * Example external control application for the siphon control plane.
+ * Example external control application for the siphon control plane — TypeScript SDK.
  *
- * Drives live B2BUA calls a script hands over with `call.handover("<app>")` (the
- * ARI *Stasis* model) over siphon's control WebSocket. Calls that are not handed
- * over are unaffected.
+ * Drives live B2BUA calls a script hands over with `call.handover("ivr-app")` (the
+ * ARI *Stasis* model) over siphon's control WebSocket, using the `@siphon/control`
+ * SDK. The SDK owns the wire completely: no `ws`, no manual JSON, no request-id
+ * bookkeeping — you get a `Call` whose verbs read like an in-process siphon script
+ * (`call.answer()` / `call.transfer(...)` / `call.hangup()`).
  *
- * Two connection modes, same wire protocol (subprotocol `siphon-control.v1`):
+ * Two connection modes, same wire (subprotocol `siphon-control.v1`):
  *
- *   - **outbound per-call-connect (the default)** — this app runs a WebSocket
- *     *server*; siphon dials it once per handed-over call and the accepting
- *     socket owns that call. No `hello` — the first frame is `StasisStart`. Use
- *     this for multi-pod / autoscaled controllers (siphon always dials *out*, so
- *     the "which pod owns the call" affinity problem cannot arise).
- *   - **inbound persistent** — this app is a WebSocket *client* that connects in
- *     to `control.listen` and owns calls assigned to it (round-robin). It sends a
- *     `hello` and can `resync` to re-attach its calls after a reconnect.
+ *   - **outbound per-call-connect (the default)** — this app is a WebSocket
+ *     *server* (`SipServer`); siphon dials it once per handed-over call and the
+ *     accepting socket owns that call. No `hello` — the first frame is
+ *     `StasisStart`. Use this for multi-pod / autoscaled controllers (siphon
+ *     always dials *out*, so the "which pod owns the call" affinity problem
+ *     cannot arise).
+ *   - **inbound persistent** — this app is a WebSocket *client* (`SipClient`)
+ *     that connects in to `control.listen` and owns calls assigned to it. It
+ *     sends a `hello` and `resync`s to re-attach its calls after a reconnect.
+ *
+ * `SipClient` / `SipServer` are the SIP facade over the generic `ControlClient` /
+ * `ControlServer` core; both expose the same `onCall(handler)` + `Call` verbs.
  *
  * Select the mode with `SIPHON_CONTROL_MODE` (`outbound` | `inbound`).
  *
- * The Phase-1 verb set is `answer` / `progress` / `reject` / `hangup` / `refer` /
- * `set_header` / `get_header` (SIP adapter, `module: "sip"`) plus the substrate
- * verbs `resync` / `describe` / `set_var` / `get_var`.
+ * Install the SDK:
+ *   npm i @siphon/control            # once published
+ *   # this example already depends on it via a file: path to the sibling package,
+ *   # so `npm install` here wires it up (build the SDK first — see README.md).
  *
  * Usage:
  *   npm install
@@ -31,9 +38,8 @@
  *
  * See README.md for the matching siphon `control:` config and handover script.
  */
-import WebSocket, { WebSocketServer } from "ws";
-
-const SUBPROTOCOL = "siphon-control.v1";
+import { SipClient, SipServer, ControlError } from "@siphon/control";
+import type { Call } from "@siphon/control";
 
 const MODE = (process.env.SIPHON_CONTROL_MODE ?? "outbound").toLowerCase();
 const APP_NAME = process.env.SIPHON_CONTROL_APP ?? "ivr-app";
@@ -42,150 +48,61 @@ const CONTROL_URL = process.env.SIPHON_CONTROL_URL ?? "ws://127.0.0.1:9092/contr
 const BIND = process.env.SIPHON_CONTROL_BIND ?? "127.0.0.1:8443";
 const ANSWER_HOLD_MS = 5000;
 
-// Verbs the SIP adapter serves (routed with module="sip"); everything else is a
-// substrate verb (hello/resync/describe/set_var/get_var) and omits the module.
-const SIP_VERBS = new Set([
-  "answer", "progress", "reject", "hangup", "refer", "set_header", "get_header",
-]);
-
-interface ReplyFrame {
-  id: string;
-  type: "reply";
-  status: "ok" | "error";
-  result?: any;
-  error?: { code: string; message: string };
-}
-
-interface EventFrame {
-  type: "event";
-  event: string;
-  channel?: string;
-  call_id?: string;
-  sip_call_id?: string;
-  payload?: any;
-}
-
-type InboundFrame = ReplyFrame | EventFrame;
-
-/** One control connection with request/reply correlation + event dispatch. */
-class ControlSession {
-  private nextId = 1;
-  private readonly pending = new Map<string, (reply: ReplyFrame) => void>();
-
-  constructor(private readonly socket: WebSocket) {
-    socket.on("message", (data) => this.onMessage(data.toString()));
-  }
-
-  /** Send a command and resolve with its correlated reply frame. */
-  rpc(verb: string, target: unknown = {}, args: unknown = {}): Promise<ReplyFrame> {
-    const id = `c-${this.nextId++}`;
-    const command: Record<string, unknown> = { id, type: "command", verb, target, args };
-    if (SIP_VERBS.has(verb)) command.module = "sip";
-    return new Promise((resolve) => {
-      this.pending.set(id, resolve);
-      this.socket.send(JSON.stringify(command));
-    });
-  }
-
-  private onMessage(raw: string): void {
-    const frame = JSON.parse(raw) as InboundFrame;
-    if (frame.type === "reply") {
-      const resolve = this.pending.get(frame.id);
-      if (resolve) {
-        this.pending.delete(frame.id);
-        resolve(frame);
-      }
-    } else if (frame.type === "event") {
-      // Handle each event concurrently so a long call flow never blocks the read
-      // loop (and thus never stalls another call).
-      void this.onEvent(frame);
-    }
-  }
-
-  private async onEvent(event: EventFrame): Promise<void> {
-    if (event.event === "StasisStart" && event.channel) {
-      console.log(`[event] StasisStart ${event.channel} sip_call_id=${event.sip_call_id}`);
-      await this.handleCall(event.channel);
-    } else if (event.event === "StasisEnd") {
-      console.log(`[event] StasisEnd ${event.channel} reason=${event.payload?.reason}`);
-    } else {
-      console.log(`[event] ${event.event} ${event.channel ?? ""}`);
-    }
-  }
-
-  async handleCall(channel: string): Promise<void> {
-    const target = { channel };
-    const answered = await this.rpc("answer", target, { code: 200 });
-    if (answered.status !== "ok") {
-      console.log("[call] answer rejected:", answered.error);
-      return;
-    }
+/** The demo call flow: answer, stamp a per-call variable, hold, then hang up. */
+async function handleCall(call: Call): Promise<void> {
+  console.log(`[call] StasisStart ${call.channelId} sip_call_id=${call.sipCallId}`);
+  try {
+    await call.answer();
     // Per-call variables live on the control channel (drain with the call).
-    await this.rpc("set_var", target, { key: "demo", value: "1" });
-    const got = await this.rpc("get_var", target, { key: "demo" });
-    console.log(`[call] answered ${channel}; demo=${got.result?.value}; holding ${ANSWER_HOLD_MS}ms`);
+    await call.setVar("demo", "1");
+    const demo = await call.getVar("demo");
+    console.log(`[call] answered ${call.channelId}; demo=${demo}; holding ${ANSWER_HOLD_MS}ms`);
     await new Promise((resolve) => setTimeout(resolve, ANSWER_HOLD_MS));
-    const hung = await this.rpc("hangup", target);
-    console.log(`[call] hangup ${channel}: ${hung.status}`);
-  }
-
-  /** Register this connection (inbound mode hello handshake) + resync. */
-  async register(): Promise<void> {
-    const hello = await this.rpc("hello", {}, { app: APP_NAME, protocol: 1 });
-    if (hello.status !== "ok") {
-      throw new Error(`hello rejected: ${JSON.stringify(hello.error)}`);
+    // Blind transfer instead of hanging up? -> await call.transfer("sip:agent@pbx")
+    await call.hangup(); // alias for call.terminate()
+    console.log(`[call] hung up ${call.channelId}`);
+  } catch (error) {
+    if (error instanceof ControlError) {
+      // A dead/unknown call is a typed `not_found`; a verb the server does not
+      // implement yet is `unsupported_verb`. Never fatal to the other calls.
+      console.log(`[call] ${call.channelId} rejected: ${error.code}`);
+    } else {
+      throw error;
     }
-    console.log(`[control] registered as ${APP_NAME}`);
-    const resync = await this.rpc("resync");
-    const owned = (resync.result?.channels ?? []) as Array<{ channel: string }>;
-    console.log(`[control] resync re-attached ${owned.length} call(s)`);
-    for (const call of owned) void this.handleCall(call.channel);
   }
 }
 
-/** Client mode: dial siphon, hello, resync, then drive assigned calls. */
-function runInbound(): void {
-  const socket = new WebSocket(CONTROL_URL, [SUBPROTOCOL], {
-    headers: { Authorization: `Bearer ${TOKEN}` },
-  });
-  const session = new ControlSession(socket);
-  socket.on("open", () => {
-    console.log(`[control] connected (inbound) to ${CONTROL_URL}`);
-    session.register().catch((error) => {
-      console.error(error);
-      socket.close();
-    });
-  });
-  socket.on("error", (error) => console.error("[control] socket error:", error));
-  socket.on("close", () => console.log("[control] connection closed"));
+/** Inbound persistent: dial siphon, hello, resync, then drive assigned calls. */
+async function runInbound(): Promise<void> {
+  const client = await SipClient.connect({ url: CONTROL_URL, app: APP_NAME, token: TOKEN });
+  console.log(`[control] connected (inbound) to ${CONTROL_URL} as ${APP_NAME}`);
+  await client.onCall(handleCall); // drives reconnect + resync to completion
 }
 
-/** Server mode: siphon dials us per call — we already own it (no hello). */
-function runOutbound(): void {
+/** Outbound per-call-connect: siphon dials this server once per handed-over call. */
+async function runOutbound(): Promise<void> {
   const [host, port] = BIND.split(":");
-  const server = new WebSocketServer({
-    host,
-    port: Number(port),
-    // Echo the subprotocol siphon offers on the dial (required — the client
-    // rejects the handshake otherwise).
-    handleProtocols: (protocols) => (protocols.has(SUBPROTOCOL) ? SUBPROTOCOL : false),
-    // Verify the bearer token siphon presents (the app's own policy).
-    verifyClient: ({ req }, done) => {
-      const ok = req.headers["authorization"] === `Bearer ${TOKEN}`;
-      done(ok, 401, "unauthorized");
-    },
-  });
-  server.on("connection", (socket) => {
-    console.log("[control] siphon dialed in (outbound per-call-connect) — we own this call");
-    new ControlSession(socket); // the first frame is StasisStart
+  const server = await SipServer.bind({
+    host: host ?? "127.0.0.1",
+    port: Number(port ?? 8443),
+    app: APP_NAME,
+    token: TOKEN,
   });
   console.log(`[control] listening (outbound per-call-connect) on ws://${BIND}`);
+  await server.onCall(handleCall);
 }
 
-function main(): void {
-  if (MODE === "inbound") runInbound();
-  else if (MODE === "outbound") runOutbound();
-  else throw new Error(`SIPHON_CONTROL_MODE must be 'outbound' or 'inbound' (got ${MODE})`);
+async function main(): Promise<void> {
+  if (MODE === "inbound") {
+    await runInbound();
+  } else if (MODE === "outbound") {
+    await runOutbound();
+  } else {
+    throw new Error(`SIPHON_CONTROL_MODE must be 'outbound' or 'inbound' (got ${MODE})`);
+  }
 }
 
-main();
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/remote_control/control_client.ts
+++ b/examples/remote_control/control_client.ts
@@ -2,7 +2,7 @@
  * Example external control application for the siphon control plane — TypeScript SDK.
  *
  * Drives live B2BUA calls a script hands over with `call.handover("ivr-app")` (the
- * ARI *Stasis* model) over siphon's control WebSocket, using the `@siphon/control`
+ * ARI *Stasis* model) over siphon's control WebSocket, using the `@siphon-project/control`
  * SDK. The SDK owns the wire completely: no `ws`, no manual JSON, no request-id
  * bookkeeping — you get a `Call` whose verbs read like an in-process siphon script
  * (`call.answer()` / `call.transfer(...)` / `call.hangup()`).
@@ -25,7 +25,7 @@
  * Select the mode with `SIPHON_CONTROL_MODE` (`outbound` | `inbound`).
  *
  * Install the SDK:
- *   npm i @siphon/control            # once published
+ *   npm i @siphon-project/control            # once published
  *   # this example already depends on it via a file: path to the sibling package,
  *   # so `npm install` here wires it up (build the SDK first — see README.md).
  *
@@ -38,8 +38,8 @@
  *
  * See README.md for the matching siphon `control:` config and handover script.
  */
-import { SipClient, SipServer, ControlError } from "@siphon/control";
-import type { Call } from "@siphon/control";
+import { SipClient, SipServer, ControlError } from "@siphon-project/control";
+import type { Call } from "@siphon-project/control";
 
 const MODE = (process.env.SIPHON_CONTROL_MODE ?? "outbound").toLowerCase();
 const APP_NAME = process.env.SIPHON_CONTROL_APP ?? "ivr-app";

--- a/examples/remote_control/package.json
+++ b/examples/remote_control/package.json
@@ -4,13 +4,13 @@
   "private": true,
   "type": "module",
   "license": "MIT",
-  "description": "Example external control application for the siphon control plane (uses the @siphon/control SDK)",
+  "description": "Example external control application for the siphon control plane (uses the @siphon-project/control SDK)",
   "scripts": {
     "start": "tsx control_client.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@siphon/control": "file:../../siphon-control-sdk/typescript"
+    "@siphon-project/control": "file:../../siphon-control-sdk/typescript"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/examples/remote_control/package.json
+++ b/examples/remote_control/package.json
@@ -3,17 +3,16 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Example external control application for the siphon control plane",
+  "description": "Example external control application for the siphon control plane (uses the @siphon/control SDK)",
   "scripts": {
     "start": "tsx control_client.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "ws": "^8.18.0"
+    "@siphon/control": "file:../../siphon-control-sdk/typescript"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "@types/ws": "^8.5.12",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
   }

--- a/examples/remote_control/package.json
+++ b/examples/remote_control/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "description": "Example external control application for the siphon control plane (uses the @siphon/control SDK)",
   "scripts": {
     "start": "tsx control_client.ts",

--- a/siphon-control-sdk/typescript/.gitignore
+++ b/siphon-control-sdk/typescript/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.tsbuildinfo
+coverage/
+.npm/
+npm-debug.log*

--- a/siphon-control-sdk/typescript/LICENSE
+++ b/siphon-control-sdk/typescript/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SIPhon Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/siphon-control-sdk/typescript/README.md
+++ b/siphon-control-sdk/typescript/README.md
@@ -1,4 +1,4 @@
-# @siphon/control (TypeScript)
+# @siphon-project/control (TypeScript)
 
 TypeScript / Node client for the [SIPhon](https://github.com/siphon-project/siphon-sip)
 external control plane (`siphon-control.v1`) — an ARI/ESL-class rail for driving
@@ -11,14 +11,13 @@ The wire is hidden: no manual JSON, no request-id bookkeeping, no hand-rolled
 scripting API (`call.answer()`, `call.terminate()`, `call.transfer()`, …), so an
 out-of-process controller reads like an in-process script.
 
-> **Package name.** Published as the scoped `@siphon/control`. If the `@siphon`
-> npm organization is unavailable at publish time, the fallback is the unscoped
-> `siphon-control` — the import surface is identical either way.
+> **Package name.** Published as `@siphon-project/control` (scoped to the
+> `siphon-project` npm org).
 
 ## Install
 
 ```sh
-npm install @siphon/control ws
+npm install @siphon-project/control ws
 ```
 
 `ws` is a peer runtime dependency (the Node WebSocket implementation).
@@ -26,7 +25,7 @@ npm install @siphon/control ws
 ## Quick start
 
 ```ts
-import { SipClient, ControlError } from "@siphon/control";
+import { SipClient, ControlError } from "@siphon-project/control";
 
 const client = await SipClient.connect({
   url: "ws://siphon:9090/control/ws",
@@ -60,7 +59,7 @@ Same wire protocol (subprotocol `siphon-control.v1`), two ways to connect:
   impossible.
 
 ```ts
-import { SipServer } from "@siphon/control";
+import { SipServer } from "@siphon-project/control";
 
 const server = await SipServer.bind({
   host: "0.0.0.0",

--- a/siphon-control-sdk/typescript/README.md
+++ b/siphon-control-sdk/typescript/README.md
@@ -1,0 +1,156 @@
+# @siphon/control (TypeScript)
+
+TypeScript / Node client for the [SIPhon](https://github.com/siphon-project/siphon-sip)
+external control plane (`siphon-control.v1`) — an ARI/ESL-class rail for driving
+handed-over calls out of process. The third client language alongside the Rust
+(`siphon-control-client`) and Python (`siphon-control`) SDKs, over the
+byte-identical wire.
+
+The wire is hidden: no manual JSON, no request-id bookkeeping, no hand-rolled
+`rpc()`. You get a `Call` handle whose verbs mirror the in-process siphon
+scripting API (`call.answer()`, `call.terminate()`, `call.transfer()`, …), so an
+out-of-process controller reads like an in-process script.
+
+> **Package name.** Published as the scoped `@siphon/control`. If the `@siphon`
+> npm organization is unavailable at publish time, the fallback is the unscoped
+> `siphon-control` — the import surface is identical either way.
+
+## Install
+
+```sh
+npm install @siphon/control ws
+```
+
+`ws` is a peer runtime dependency (the Node WebSocket implementation).
+
+## Quick start
+
+```ts
+import { SipClient, ControlError } from "@siphon/control";
+
+const client = await SipClient.connect({
+  url: "ws://siphon:9090/control/ws",
+  app: "ivr-app",
+  token: "s3cr3t",
+});
+
+await client.onCall(async (call) => {
+  await call.answer();
+  try {
+    await call.transfer("sip:agent@pbx"); // REFER; awaits the correlated reply
+  } catch (error) {
+    if (error instanceof ControlError) {
+      console.log("transfer rejected:", error.code);
+    }
+  }
+});
+```
+
+## Two connection modes
+
+Same wire protocol (subprotocol `siphon-control.v1`), two ways to connect:
+
+- **Inbound-persistent** (`SipClient`): the app is a WebSocket *client* that
+  dials into siphon's `control.listen`, sends a `hello`, and owns the calls
+  assigned to it. It can `resync` to re-attach its calls after a reconnect.
+- **Per-call-connect** (`SipServer`, the documented multi-pod default): siphon
+  *dials the app* once per handed-over call, so the app is a WebSocket *server*.
+  No `hello` — the first frame is `StasisStart`, and the accepting socket owns
+  exactly that one call, so "the audio lands on the wrong pod" is structurally
+  impossible.
+
+```ts
+import { SipServer } from "@siphon/control";
+
+const server = await SipServer.bind({
+  host: "0.0.0.0",
+  port: 8443,
+  app: "ivr-app",
+  token: "changeme-dev-token",
+});
+await server.onCall(async (call) => {
+  await call.answer();
+});
+```
+
+## Layering: protocol-agnostic core + typed facade
+
+- `ControlClient` / `ControlServer` are the **generic core**: transport, `hello`,
+  request-id correlation, reconnect + `resync`, and a generic event stream.
+  Their headline primitive is `command(module, verb, target, args)`, which works
+  for any adapter (`sip` today; `smpp`/`ss7` later) with zero changes.
+- `SipClient` / `SipServer` are the **typed SIP facade** on top: a `Call`'s
+  verbs are thin wrappers over `command("sip", …)`, and `StasisStart`→`Call`
+  dispatch lives there. A future `smpp` / `ss7` facade is an additive sibling
+  over the same core.
+
+```ts
+// The generic escape hatch (any module / verb):
+const schema = await client.controlClient.describe();
+await client.command("sip", "answer", { channel: "ch1" }, { code: 200 });
+```
+
+## `Call` verbs (mirror the in-process scripting API)
+
+| Method | Wire verb (`module`) | Notes |
+| --- | --- | --- |
+| `answer(options?)` | `answer` (`sip`) | UAS 2xx (default `200 OK`) |
+| `progress(options?)` | `progress` (`sip`) | UAS 1xx / early media (default `183`) |
+| `reject(code, reason?)` | `reject` (`sip`) | final non-2xx + teardown |
+| `terminate(reason?)` | `hangup` (`sip`) | primary teardown name |
+| `hangup(reason?)` | `hangup` (`sip`) | alias for `terminate` |
+| `refer(to)` | `refer` (`sip`) | in-dialog REFER (blind transfer) |
+| `transfer(to)` | `refer` (`sip`) | alias for `refer` |
+| `referReplaces(to, replaces)` | `refer` (`sip`) | attended transfer (RFC 3891) |
+| `setHeader(name, value)` | `set_header` (`sip`) | on the stored A-leg INVITE |
+| `getHeader(name)` | `get_header` (`sip`) | returns `string \| null` |
+| `setVar(key, value)` | `set_var` (substrate) | per-call variable |
+| `getVar(key)` | `get_var` (substrate) | returns `string \| null` |
+| `removeHeader(name)` | `remove_header` (`sip`) | ‡ |
+| `acceptRefer(options?)` | `accept_refer` (`sip`) | ‡ |
+| `rejectRefer(code, reason?)` | `reject_refer` (`sip`) | ‡ |
+| `playFile(file)` | `play` (`sip`) | ‡ media |
+| `dtmf(digits)` | `dtmf` (`sip`) | ‡ media |
+| `command(verb, args?)` | (`sip`) | arbitrary SIP-adapter verb |
+| `nextEvent()` / `events()` | — | per-call event stream |
+
+Identity/context getters: `channelId`, `callId`, `sipCallId`, `app`, `payload`,
+`reattached`.
+
+‡ Accepted verb names the Phase-1 server answers with a `ControlError` whose
+`.code === "unsupported_verb"` (`error.isUnsupportedVerb()`) until it implements
+them. They send a real command — nothing is stubbed client-side.
+
+## Errors
+
+A `status:"error"` reply throws a `ControlError` carrying the stable wire code in
+`.code` (`not_found`, `forbidden`, `unsupported_verb`, `unauthorized`, …).
+Transport / handshake / timeout failures throw a `ControlError` with a `.kind`
+(`unauthorized`, `handshake`, `closed`, `timeout`, `websocket`, `config`) and no
+`.code`.
+
+```ts
+try {
+  await call.playFile("/prompts/welcome.wav");
+} catch (error) {
+  if (error instanceof ControlError && error.isUnsupportedVerb()) {
+    // media isn't wired server-side yet — fall back gracefully
+  }
+}
+```
+
+## Build & test
+
+```sh
+npm install
+npm run build      # dual ESM + CJS + .d.ts (tsup)
+npm run typecheck  # tsc --noEmit
+npm test           # vitest
+```
+
+The package ships ESM and CommonJS with type declarations for both. The
+`wire.test.ts` suite pins the exact command bytes against the server contract.
+
+## License
+
+MIT

--- a/siphon-control-sdk/typescript/package-lock.json
+++ b/siphon-control-sdk/typescript/package-lock.json
@@ -1,0 +1,2331 @@
+{
+  "name": "@siphon/control",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@siphon/control",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.9.0",
+        "@types/ws": "^8.5.13",
+        "tsup": "^8.3.5",
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/siphon-control-sdk/typescript/package-lock.json
+++ b/siphon-control-sdk/typescript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@siphon/control",
+  "name": "@siphon-project/control",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@siphon/control",
+      "name": "@siphon-project/control",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/siphon-control-sdk/typescript/package.json
+++ b/siphon-control-sdk/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@siphon/control",
+  "name": "@siphon-project/control",
   "version": "0.1.0",
   "description": "TypeScript client for the SIPhon external control plane (siphon-control.v1) — an ARI/ESL-class rail for driving handed-over calls out of process.",
   "type": "module",

--- a/siphon-control-sdk/typescript/package.json
+++ b/siphon-control-sdk/typescript/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@siphon/control",
+  "version": "0.1.0",
+  "description": "TypeScript client for the SIPhon external control plane (siphon-control.v1) — an ARI/ESL-class rail for driving handed-over calls out of process.",
+  "type": "module",
+  "license": "MIT",
+  "author": "The SIPhon authors",
+  "homepage": "https://github.com/siphon-project/siphon-sip",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/siphon-project/siphon-sip.git",
+    "directory": "siphon-control-sdk/typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/siphon-project/siphon-sip/issues"
+  },
+  "keywords": [
+    "sip",
+    "voip",
+    "b2bua",
+    "control",
+    "ari",
+    "esl",
+    "telephony",
+    "websocket"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "@types/ws": "^8.5.13",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.5"
+  }
+}

--- a/siphon-control-sdk/typescript/src/client.ts
+++ b/siphon-control-sdk/typescript/src/client.ts
@@ -1,0 +1,294 @@
+/**
+ * The protocol-agnostic inbound-persistent control client.
+ *
+ * Knows nothing about SIP: it owns the transport, the `hello` handshake,
+ * request-id correlation, reconnect + `resync`, and a generic event stream. Its
+ * headline primitive is {@link ControlClient.command} over `{module, verb,
+ * target, args}`, which works for any adapter with zero changes. Typed
+ * per-protocol facades (see {@link SipClient}) are built on top. Mirrors the
+ * Rust `ControlClient`.
+ */
+
+import WebSocket from "ws";
+
+import { ControlError } from "./errors";
+import type { IdCounter } from "./internal";
+import { AsyncQueue, sleep } from "./internal";
+import {
+  DESCRIBE,
+  HELLO,
+  PROTOCOL_VERSION,
+  RESYNC,
+  SUBPROTOCOL,
+} from "./protocol";
+import type {
+  ChannelSnapshot,
+  EventFrame,
+  HelloResult,
+  ResyncResult,
+} from "./protocol";
+import type { CommandTransport } from "./session";
+import { Session } from "./session";
+
+/** How a {@link ControlClient} connects and behaves. */
+export interface ClientConfig {
+  /** The control-plane URL, e.g. `ws://siphon:9090/control/ws` (or `wss://…`). */
+  url: string;
+  /** The application name — must equal the token's configured app. */
+  app: string;
+  /** The bearer token presented on the upgrade. */
+  token: string;
+  /** Protocol version to advertise in `hello` (defaults to {@link PROTOCOL_VERSION}). */
+  protocol?: number;
+  /** How long a command waits for its reply before a timeout (default 10 000 ms). */
+  replyTimeoutMs?: number;
+  /** Backoff between reconnect attempts in {@link ControlClient.run} (default 1 000 ms). */
+  reconnectBackoffMs?: number;
+}
+
+type ResolvedConfig = Required<ClientConfig>;
+
+function resolveConfig(config: ClientConfig): ResolvedConfig {
+  return {
+    url: config.url,
+    app: config.app,
+    token: config.token,
+    protocol: config.protocol ?? PROTOCOL_VERSION,
+    replyTimeoutMs: config.replyTimeoutMs ?? 10_000,
+    reconnectBackoffMs: config.reconnectBackoffMs ?? 1_000,
+  };
+}
+
+/** An item on the client's generic event stream. */
+export type ClientEvent =
+  | { type: "event"; frame: EventFrame }
+  | { type: "reattach"; snapshot: ChannelSnapshot };
+
+type EventCallback = (event: ClientEvent) => void;
+
+/** A generic subscription to the client's event stream (see {@link ControlClient.events}). */
+export class EventStream {
+  constructor(private readonly queue: AsyncQueue<ClientEvent>) {}
+
+  /** Await the next event. `null` once the client shuts down. */
+  next(): Promise<ClientEvent | null> {
+    return this.queue.next();
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<ClientEvent> {
+    return this.queue[Symbol.asyncIterator]();
+  }
+}
+
+/**
+ * The protocol-agnostic inbound-persistent control client.
+ *
+ * Use {@link ControlClient.command} directly for any module, or wrap it in a
+ * typed facade such as {@link SipClient}.
+ */
+export class ControlClient {
+  private readonly config: ResolvedConfig;
+  private readonly nextId: IdCounter = { value: 1 };
+  private current: Session | null = null;
+  private eventCallback: EventCallback | null = null;
+  private shutdownRequested = false;
+  private readonly shutdownWaiters: Array<() => void> = [];
+
+  private constructor(config: ClientConfig) {
+    this.config = resolveConfig(config);
+  }
+
+  /**
+   * Connect + `hello`. A bad token surfaces as a {@link ControlError} of kind
+   * `unauthorized` (the upgrade is rejected 401 before the socket opens).
+   */
+  static async connect(config: ClientConfig): Promise<ControlClient> {
+    const client = new ControlClient(config);
+    client.current = await client.connectAndHandshake();
+    return client;
+  }
+
+  /**
+   * Register a callback for every event (pushed events + reconnect reattach).
+   * Overwrites any previous callback / stream. Facades set this internally.
+   */
+  onEvent(callback: EventCallback): void {
+    this.eventCallback = callback;
+  }
+
+  /** A pull-style stream of every event. Overwrites any previous callback. */
+  events(): EventStream {
+    const queue = new AsyncQueue<ClientEvent>();
+    this.eventCallback = (event) => queue.push(event);
+    return new EventStream(queue);
+  }
+
+  /**
+   * Send a raw command on the current session and return the reply's `result`.
+   * The generic primitive every facade is built on.
+   */
+  async command(
+    module: string | null,
+    verb: string,
+    target: unknown,
+    args: unknown,
+  ): Promise<unknown> {
+    const session = this.current;
+    if (!session || session.isClosed()) {
+      throw ControlError.closed();
+    }
+    return session.command(module, verb, target, args);
+  }
+
+  /** Fetch the registered adapters' verb/event schema (`describe`). */
+  async describe(): Promise<unknown> {
+    return this.command(null, DESCRIBE, null, null);
+  }
+
+  /** Re-enumerate the channels this connection owns (`resync`). */
+  async resync(): Promise<ChannelSnapshot[]> {
+    const value = (await this.command(null, RESYNC, null, null)) as ResyncResult | null;
+    return value?.channels ?? [];
+  }
+
+  /**
+   * A {@link CommandTransport} that routes to the client's *current* session (so
+   * a facade handle keeps working across reconnects). Used by {@link SipClient}.
+   */
+  commander(): CommandTransport {
+    return {
+      command: (module, verb, target, args) => this.command(module, verb, target, args),
+    };
+  }
+
+  /**
+   * Drive the client: keep the connection alive, reconnecting with backoff and
+   * re-attaching owned channels (`resync`, delivered as `reattach` events) after
+   * each reconnect. Resolves on {@link ControlClient.shutdown}, or rejects on a
+   * fatal error (token revoked → `unauthorized`).
+   */
+  async run(): Promise<void> {
+    for (;;) {
+      let session = this.current;
+      if (!session || session.isClosed()) {
+        if (this.shutdownRequested) {
+          return;
+        }
+        try {
+          session = await this.connectAndHandshake();
+        } catch (error) {
+          if (error instanceof ControlError && error.kind === "unauthorized") {
+            throw error;
+          }
+          await Promise.race([sleep(this.config.reconnectBackoffMs), this.shutdownSignal()]);
+          if (this.shutdownRequested) {
+            return;
+          }
+          continue;
+        }
+        this.current = session;
+        await this.resyncAndReattach(session);
+      }
+
+      await Promise.race([session.waitClosed(), this.shutdownSignal()]);
+      if (this.shutdownRequested) {
+        return;
+      }
+      this.current = null;
+    }
+  }
+
+  /** Stop the client: close the current session and unblock {@link ControlClient.run}. */
+  shutdown(): void {
+    this.shutdownRequested = true;
+    for (const waiter of this.shutdownWaiters.splice(0)) {
+      waiter();
+    }
+    if (this.current) {
+      this.current.close();
+      this.current = null;
+    }
+  }
+
+  private shutdownSignal(): Promise<void> {
+    if (this.shutdownRequested) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.shutdownWaiters.push(resolve));
+  }
+
+  private emit(event: ClientEvent): void {
+    this.eventCallback?.(event);
+  }
+
+  private async connectAndHandshake(): Promise<Session> {
+    const socket = await this.openSocket();
+    const session = new Session(
+      socket,
+      this.nextId,
+      this.config.replyTimeoutMs,
+      (frame) => this.emit({ type: "event", frame }),
+    );
+    const result = (await session.command(null, HELLO, null, {
+      app: this.config.app,
+      protocol: this.config.protocol,
+    })) as HelloResult | null;
+    if (!result || result.subprotocol !== SUBPROTOCOL) {
+      session.close();
+      throw ControlError.handshake(
+        `server negotiated subprotocol ${JSON.stringify(result?.subprotocol)}, expected ${JSON.stringify(SUBPROTOCOL)}`,
+      );
+    }
+    return session;
+  }
+
+  private openSocket(): Promise<WebSocket> {
+    return new Promise<WebSocket>((resolve, reject) => {
+      const socket = new WebSocket(this.config.url, [SUBPROTOCOL], {
+        headers: { Authorization: `Bearer ${this.config.token}` },
+      });
+      let settled = false;
+      const settle = (): void => {
+        settled = true;
+        socket.off("open", onOpen);
+        socket.off("unexpected-response", onUnexpected);
+      };
+      const onOpen = (): void => {
+        settle();
+        resolve(socket);
+      };
+      const onUnexpected = (
+        request: { destroy: () => void },
+        response: { statusCode?: number },
+      ): void => {
+        settle();
+        // Free the aborted upgrade's socket without the "closed before the
+        // connection was established" that `socket.terminate()` throws here.
+        request.destroy();
+        reject(ControlError.unauthorized(response.statusCode ?? 0));
+      };
+      const onError = (error: Error): void => {
+        if (!settled) {
+          settle();
+          reject(ControlError.websocket(error.message));
+        }
+        // Post-settle errors (e.g. the destroyed handshake socket hanging up)
+        // are swallowed here so a stray `error` never crashes the process.
+      };
+      socket.on("open", onOpen);
+      socket.on("unexpected-response", onUnexpected);
+      socket.on("error", onError);
+    });
+  }
+
+  private async resyncAndReattach(session: Session): Promise<void> {
+    try {
+      const value = (await session.command(null, RESYNC, null, null)) as ResyncResult | null;
+      for (const snapshot of value?.channels ?? []) {
+        this.emit({ type: "reattach", snapshot });
+      }
+    } catch {
+      // A failed resync is non-fatal — the connection stays up.
+    }
+  }
+}

--- a/siphon-control-sdk/typescript/src/errors.ts
+++ b/siphon-control-sdk/typescript/src/errors.ts
@@ -1,0 +1,109 @@
+/**
+ * The client error type for the SIPhon control plane.
+ *
+ * The load-bearing case is a server `status:"error"` reply, which becomes a
+ * {@link ControlError} carrying the stable {@link ControlErrorCode} in `.code`
+ * so callers can branch on the cause (e.g. treat `unsupported_verb` as "the
+ * server doesn't do media yet" rather than a hard failure). Mirrors the Rust
+ * `ControlError` enum and the Python `ControlError` exception.
+ */
+
+/** Stable machine-readable error codes returned in a reply's `error.code`. */
+export type ControlErrorCode =
+  | "unauthorized"
+  | "forbidden"
+  | "not_found"
+  | "bad_request"
+  | "rate_limited"
+  | "originate_denied"
+  | "unsupported_verb"
+  | "unsupported_version"
+  | "protocol_error"
+  | "unavailable";
+
+/**
+ * How a {@link ControlError} arose. `command` is the wire-level rejection (it
+ * carries a {@link ControlErrorCode}); the rest are transport / local failures
+ * that never had a wire code.
+ */
+export type ControlErrorKind =
+  | "command"
+  | "unauthorized"
+  | "handshake"
+  | "closed"
+  | "timeout"
+  | "websocket"
+  | "config";
+
+/** Everything that can go wrong driving the control plane. */
+export class ControlError extends Error {
+  /** The classification of this error. */
+  readonly kind: ControlErrorKind;
+  /** The stable wire code, present only for a `command` rejection. */
+  readonly code?: ControlErrorCode;
+  /** The HTTP status of a rejected upgrade, present only for `unauthorized`. */
+  readonly status?: number;
+
+  constructor(
+    kind: ControlErrorKind,
+    message: string,
+    options?: { code?: ControlErrorCode; status?: number },
+  ) {
+    super(message);
+    this.name = "ControlError";
+    this.kind = kind;
+    this.code = options?.code;
+    this.status = options?.status;
+    // Restore the prototype chain across the transpiled `extends Error`.
+    Object.setPrototypeOf(this, ControlError.prototype);
+  }
+
+  /**
+   * True when this is a server-side `unsupported_verb` rejection — the state a
+   * media verb (`playFile`/`dtmf`/…) lands in until the server implements it.
+   */
+  isUnsupportedVerb(): boolean {
+    return this.kind === "command" && this.code === "unsupported_verb";
+  }
+
+  /** A server `status:"error"` reply. */
+  static command(code: ControlErrorCode, message: string): ControlError {
+    return new ControlError("command", `control command rejected (${code}): ${message}`, {
+      code,
+    });
+  }
+
+  /** The WebSocket upgrade was rejected before it opened (bad/missing token). */
+  static unauthorized(status: number): ControlError {
+    return new ControlError(
+      "unauthorized",
+      `unauthorized: the control token was rejected (HTTP ${status})`,
+      { status },
+    );
+  }
+
+  /** The `hello` handshake (or subprotocol negotiation) failed. */
+  static handshake(detail: string): ControlError {
+    return new ControlError("handshake", `handshake failed: ${detail}`);
+  }
+
+  /** The connection is closed (or was never established). */
+  static closed(): ControlError {
+    return new ControlError("closed", "control connection is closed");
+  }
+
+  /** A command was sent but no reply arrived within the configured window. */
+  static timeout(timeoutMs: number): ControlError {
+    return new ControlError("timeout", `timed out awaiting a reply after ${timeoutMs}ms`);
+  }
+
+  /** A transport-level WebSocket error. */
+  static websocket(detail: string): ControlError {
+    return new ControlError("websocket", `websocket error: ${detail}`);
+  }
+
+  /** A configuration value was invalid (bad URL, bad listen address, …). */
+  static config(detail: string): ControlError {
+    return new ControlError("config", `configuration error: ${detail}`);
+  }
+}

--- a/siphon-control-sdk/typescript/src/index.ts
+++ b/siphon-control-sdk/typescript/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@siphon/control` — the TypeScript client SDK for the SIPhon external control
+ * `@siphon-project/control` — the TypeScript client SDK for the SIPhon external control
  * plane (`siphon-control.v1`), an ARI/ESL-class rail for driving handed-over
  * calls out of process. The third client language alongside the Rust and Python
  * SDKs, over the byte-identical wire.
@@ -16,7 +16,7 @@
  *   over `command("sip", …)`, and `StasisStart`→`Call` dispatch lives there.
  *
  * ```ts
- * import { SipClient } from "@siphon/control";
+ * import { SipClient } from "@siphon-project/control";
  *
  * const client = await SipClient.connect({
  *   url: "ws://siphon:9090/control/ws",

--- a/siphon-control-sdk/typescript/src/index.ts
+++ b/siphon-control-sdk/typescript/src/index.ts
@@ -1,0 +1,95 @@
+/**
+ * `@siphon/control` — the TypeScript client SDK for the SIPhon external control
+ * plane (`siphon-control.v1`), an ARI/ESL-class rail for driving handed-over
+ * calls out of process. The third client language alongside the Rust and Python
+ * SDKs, over the byte-identical wire.
+ *
+ * ## Layering (protocol-agnostic core + typed facades)
+ *
+ * - {@link ControlClient} / {@link ControlServer} are the **generic core**:
+ *   transport, `hello`, request-id correlation, reconnect + `resync`, and a
+ *   generic event stream. Their headline primitive is
+ *   {@link ControlClient.command}`(module, verb, target, args)`, which works for
+ *   any adapter (`sip`, and future `smpp`/`ss7`) with zero changes.
+ * - {@link SipClient} / {@link SipServer} are the **typed SIP facade**: a
+ *   {@link Call}'s verbs (`answer`/`terminate`/`transfer`/…) are thin wrappers
+ *   over `command("sip", …)`, and `StasisStart`→`Call` dispatch lives there.
+ *
+ * ```ts
+ * import { SipClient } from "@siphon/control";
+ *
+ * const client = await SipClient.connect({
+ *   url: "ws://siphon:9090/control/ws",
+ *   app: "ivr-app",
+ *   token: "s3cr3t",
+ * });
+ * await client.onCall(async (call) => {
+ *   await call.answer();
+ *   await call.transfer("sip:agent@pbx"); // REFER; awaits the correlated reply
+ * });
+ * ```
+ *
+ * ## Two connection modes
+ *
+ * - **Inbound-persistent** ({@link SipClient}): the app connects to siphon and
+ *   keeps one long-lived socket (does `hello`).
+ * - **Per-call-connect** ({@link SipServer}): siphon dials the app per
+ *   handed-over call (the app is a WS server; no `hello`).
+ *
+ * ## Errors
+ *
+ * A `status:"error"` reply throws a {@link ControlError} carrying the stable
+ * {@link ControlErrorCode} in `.code`. Media verbs ({@link Call.playFile} /
+ * {@link Call.dtmf}) throw `code === "unsupported_verb"` until the server
+ * implements them (`error.isUnsupportedVerb()`).
+ */
+
+export { ControlError } from "./errors";
+export type { ControlErrorCode, ControlErrorKind } from "./errors";
+
+export {
+  SUBPROTOCOL,
+  PROTOCOL_VERSION,
+  MODULE_SIP,
+  MODULE_SMPP,
+  MODULE_SS7,
+  HELLO,
+  RESYNC,
+  DESCRIBE,
+  SET_VAR,
+  GET_VAR,
+  SipVerb,
+  sipEventKind,
+  encodeCommand,
+  parseInboundFrame,
+} from "./protocol";
+export type {
+  FrameType,
+  ReplyStatus,
+  ReplyError,
+  ReplyFrame,
+  EventFrame,
+  HelloArgs,
+  HelloResult,
+  ChannelSnapshot,
+  ResyncResult,
+  SipVerbToken,
+  SipEventKind,
+} from "./protocol";
+
+export { ControlClient, EventStream } from "./client";
+export type { ClientConfig, ClientEvent } from "./client";
+
+export { ControlServer } from "./server";
+export type { ServerConfig, ConnectionEventSink } from "./server";
+
+export type { CommandTransport, EventSink } from "./session";
+
+export { Call, CallStream, SipClient, SipServer } from "./sip";
+export type {
+  CallEvent,
+  CallHandler,
+  ResponseOptions,
+  ReferReplaces,
+  AcceptReferOptions,
+} from "./sip";

--- a/siphon-control-sdk/typescript/src/internal.ts
+++ b/siphon-control-sdk/typescript/src/internal.ts
@@ -1,0 +1,68 @@
+/** Small internal utilities shared by the client, server, and SIP facade. */
+
+/**
+ * An unbounded, single-consumer async queue (the TypeScript analogue of Rust's
+ * `tokio::sync::mpsc::unbounded_channel`). `push` never blocks; `next` resolves
+ * with the next item, or `null` once the queue is closed and drained.
+ */
+export class AsyncQueue<T> {
+  private readonly items: T[] = [];
+  private readonly waiters: Array<(value: T | null) => void> = [];
+  private closed = false;
+
+  /** Enqueue an item (or hand it directly to a waiting consumer). */
+  push(item: T): void {
+    if (this.closed) {
+      return;
+    }
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(item);
+    } else {
+      this.items.push(item);
+    }
+  }
+
+  /** Await the next item, or `null` once the queue is closed and drained. */
+  next(): Promise<T | null> {
+    if (this.items.length > 0) {
+      return Promise.resolve(this.items.shift() as T);
+    }
+    if (this.closed) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  /** Close the queue: pending and future `next()` calls resolve with `null`. */
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter(null);
+    }
+  }
+
+  /** Async-iterate the queue until it closes. */
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
+    for (;;) {
+      const item = await this.next();
+      if (item === null) {
+        return;
+      }
+      yield item;
+    }
+  }
+}
+
+/** A shared, mutable request-id counter (Rust's `Arc<AtomicU64>`). */
+export interface IdCounter {
+  value: number;
+}
+
+/** Resolve after `ms` milliseconds. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/siphon-control-sdk/typescript/src/protocol.ts
+++ b/siphon-control-sdk/typescript/src/protocol.ts
@@ -1,0 +1,203 @@
+/**
+ * Wire protocol for the SIPhon external control plane (`siphon-control.v1`).
+ *
+ * This module is the TypeScript mirror of the Rust `siphon-control-proto` crate
+ * and the server's inline `src/control/protocol.rs`. The frame shapes here are
+ * **byte-identical** to what the server emits and parses:
+ *
+ * - **command** (client → siphon): `{id, type:"command", module?, verb, target, args}`
+ * - **reply** (siphon → client, `id` echoed): `{id, type:"reply", status, result|error}`
+ * - **event** (siphon → client, un-id'd, pushed): `{type:"event", event, channel?, app?, call_id?, sip_call_id?, payload?}`
+ *
+ * `module` routes a command to the registered adapter (`sip`|`smpp`|`ss7`);
+ * substrate verbs (`hello`, `resync`, `describe`, `set_var`, `get_var`) omit it.
+ */
+
+/** The WebSocket subprotocol token this rail speaks. */
+export const SUBPROTOCOL = "siphon-control.v1";
+
+/** The protocol version this build implements. */
+export const PROTOCOL_VERSION = 1;
+
+/** Adapter routing key for the built-in SIP adapter. */
+export const MODULE_SIP = "sip";
+/** Adapter routing key for an SMPP adapter (registered by a host binary). */
+export const MODULE_SMPP = "smpp";
+/** Adapter routing key for an SS7 adapter (registered by a host binary). */
+export const MODULE_SS7 = "ss7";
+
+/** The mandatory first-frame handshake verb. */
+export const HELLO = "hello";
+/** Substrate verb: re-enumerate the channels this connection owns. */
+export const RESYNC = "resync";
+/** Substrate verb: fetch the registered adapters' schema. */
+export const DESCRIBE = "describe";
+/** Substrate verb: set a per-channel variable. */
+export const SET_VAR = "set_var";
+/** Substrate verb: read a per-channel variable. */
+export const GET_VAR = "get_var";
+
+/** The `type` discriminator on every frame. */
+export type FrameType = "command" | "reply" | "event";
+
+/** The status of a reply. */
+export type ReplyStatus = "ok" | "error";
+
+import type { ControlErrorCode } from "./errors";
+
+/** The error body of a failed reply. */
+export interface ReplyError {
+  code: ControlErrorCode;
+  message: string;
+}
+
+/** A reply frame (siphon → client, `id` echoed). */
+export interface ReplyFrame {
+  id: string;
+  type: "reply";
+  status: ReplyStatus;
+  /** Present on success. */
+  result?: unknown;
+  /** Present on failure. */
+  error?: ReplyError;
+}
+
+/**
+ * A pushed event frame (siphon → client, un-id'd).
+ *
+ * Carries the stable id triple `{channel, call_id, sip_call_id}` so a controller
+ * joins CDR + HEP with no mapping table: `sip_call_id` is byte-identical to the
+ * CDR `call_id` and the HEP correlation chunk.
+ */
+export interface EventFrame {
+  type: "event";
+  /** Event name (e.g. `"StasisStart"`, `"StasisEnd"`). */
+  event: string;
+  /** The channel this event concerns (leg-scoped id), when applicable. */
+  channel?: string;
+  /** The application the channel was handed to. */
+  app?: string;
+  /** The internal call UUID (`CallActor.id`) — the grouping key across legs. */
+  call_id?: string;
+  /** The per-leg SIP Call-ID — the CDR / HEP join key. */
+  sip_call_id?: string;
+  /** Event-specific payload. */
+  payload?: unknown;
+}
+
+/** Arguments of the `hello` handshake command. */
+export interface HelloArgs {
+  app: string;
+  protocol?: number;
+}
+
+/** The `result` of a successful `hello` reply. */
+export interface HelloResult {
+  app: string;
+  protocol: number;
+  subprotocol: string;
+}
+
+/** One channel in a `resync` reply — the id triple plus its state + vars. */
+export interface ChannelSnapshot {
+  channel: string;
+  call_id: string;
+  sip_call_id: string;
+  state: string;
+  vars: Record<string, string>;
+}
+
+/** The `result` of a successful `resync` reply. */
+export interface ResyncResult {
+  channels: ChannelSnapshot[];
+}
+
+/**
+ * Serialize a command frame to the exact JSON bytes the server parses.
+ *
+ * Field order follows the server's struct declaration order — `id`, `type`,
+ * `module` (omitted when absent), `verb`, `target`, `args` — so the bytes are
+ * identical to the Rust `CommandFrame` serialization. `target`/`args` are always
+ * emitted (defaulting to JSON `null`); `module` is dropped when null/undefined.
+ */
+export function encodeCommand(
+  id: string,
+  module: string | null | undefined,
+  verb: string,
+  target: unknown,
+  args: unknown,
+): string {
+  const frame: Record<string, unknown> = { id, type: "command" };
+  if (module != null) {
+    frame.module = module;
+  }
+  frame.verb = verb;
+  frame.target = target ?? null;
+  frame.args = args ?? null;
+  return JSON.stringify(frame);
+}
+
+/** Parse an inbound text frame into a {@link ReplyFrame} or {@link EventFrame}. */
+export function parseInboundFrame(text: string): ReplyFrame | EventFrame | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const frameType = (value as { type?: unknown }).type;
+  if (frameType === "reply") {
+    return value as ReplyFrame;
+  }
+  if (frameType === "event") {
+    return value as EventFrame;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// SIP adapter (`module = "sip"`) verb + event helper names.
+// ---------------------------------------------------------------------------
+
+/**
+ * The verbs the built-in SIP adapter accepts (`module = "sip"`).
+ *
+ * These are the exact wire tokens. The Phase-1 server implements
+ * `answer`/`progress`/`reject`/`hangup`/`refer`/`set_header`/`get_header`;
+ * the rest (`remove_header`, `accept_refer`, `reject_refer`, `play`, `dtmf`)
+ * are accepted names the server answers `unsupported_verb` until it implements
+ * them.
+ */
+export const SipVerb = {
+  Answer: "answer",
+  Progress: "progress",
+  Reject: "reject",
+  Hangup: "hangup",
+  Refer: "refer",
+  SetHeader: "set_header",
+  GetHeader: "get_header",
+  RemoveHeader: "remove_header",
+  AcceptRefer: "accept_refer",
+  RejectRefer: "reject_refer",
+  Play: "play",
+  Dtmf: "dtmf",
+} as const;
+
+/** A value of {@link SipVerb}. */
+export type SipVerbToken = (typeof SipVerb)[keyof typeof SipVerb];
+
+/** The well-known SIP-adapter event names (the ARI *Stasis* model). */
+export type SipEventKind =
+  | "StasisStart"
+  | "StasisEnd"
+  | "ChannelStateChange"
+  | "ChannelHangupRequest"
+  | (string & {});
+
+/** Parse a wire event name; unknown names pass through verbatim (forward-compatible). */
+export function sipEventKind(name: string): SipEventKind {
+  return name as SipEventKind;
+}

--- a/siphon-control-sdk/typescript/src/server.ts
+++ b/siphon-control-sdk/typescript/src/server.ts
@@ -1,0 +1,146 @@
+/**
+ * Outbound per-call-connect mode: siphon *dials the application* at handover,
+ * so the app is a WebSocket **server**. This is the documented default for
+ * multi-pod controllers — the accepting socket owns exactly that one call, so
+ * "the audio lands on the wrong pod" is structurally impossible.
+ *
+ * No `hello` is exchanged: siphon presents the token in the dial headers, and
+ * the first frame the app receives is a pushed event (`StasisStart` for SIP).
+ * Mirrors the Rust `ControlServer`.
+ */
+
+import type { AddressInfo } from "node:net";
+
+import WebSocket, { WebSocketServer } from "ws";
+
+import { ControlError } from "./errors";
+import type { IdCounter } from "./internal";
+import { SUBPROTOCOL } from "./protocol";
+import type { EventFrame } from "./protocol";
+import type { CommandTransport, EventSink } from "./session";
+import { Session } from "./session";
+
+/** How a {@link ControlServer} listens for siphon's per-call dials. */
+export interface ServerConfig {
+  /** The host to bind (e.g. `0.0.0.0`). */
+  host: string;
+  /** The port to bind (`0` picks a free port — read it back via `localAddr`). */
+  port: number;
+  /** The application name (context / logging). */
+  app: string;
+  /** The bearer token siphon must present on the dial. */
+  token: string;
+  /** How long a command waits for its reply before a timeout (default 10 000 ms). */
+  replyTimeoutMs?: number;
+}
+
+/** A sink the server calls for each event, carrying the {@link CommandTransport}
+ * of the connection that produced it (so a facade commands back on the right one). */
+export type ConnectionEventSink = (frame: EventFrame, transport: CommandTransport) => void;
+
+/** The protocol-agnostic per-call-connect control server. */
+export class ControlServer {
+  private readonly nextId: IdCounter = { value: 1 };
+  private eventSink: ConnectionEventSink | null = null;
+  private readonly closeWaiters: Array<() => void> = [];
+  private readonly sockets = new Set<WebSocket>();
+  private closed = false;
+
+  private constructor(
+    private readonly config: ServerConfig,
+    private readonly wss: WebSocketServer,
+  ) {
+    wss.on("connection", (socket, request) => this.onConnection(socket, request));
+    wss.on("close", () => this.markClosed());
+  }
+
+  /** Bind the listener (so the assigned port is known before accepting). */
+  static bind(config: ServerConfig): Promise<ControlServer> {
+    const token = config.token;
+    return new Promise<ControlServer>((resolve, reject) => {
+      const wss = new WebSocketServer({
+        host: config.host,
+        port: config.port,
+        // Echo the subprotocol siphon offers on the dial (required — the client
+        // rejects the handshake otherwise).
+        handleProtocols: (protocols) => (protocols.has(SUBPROTOCOL) ? SUBPROTOCOL : false),
+        // Verify the bearer token siphon presents (the app's own policy).
+        verifyClient: ({ req }, done) => {
+          const ok = req.headers["authorization"] === `Bearer ${token}`;
+          done(ok, 401, "unauthorized");
+        },
+      });
+      const onError = (error: Error): void => {
+        wss.off("listening", onListening);
+        reject(ControlError.config(`bind ${config.host}:${config.port}: ${error.message}`));
+      };
+      const onListening = (): void => {
+        wss.off("error", onError);
+        resolve(new ControlServer(config, wss));
+      };
+      wss.once("listening", onListening);
+      wss.once("error", onError);
+    });
+  }
+
+  /** The actual bound address (useful when binding to port 0 in tests). */
+  localAddr(): AddressInfo {
+    const address = this.wss.address();
+    if (typeof address === "string" || address === null) {
+      throw ControlError.config("server is not bound to a TCP address");
+    }
+    return address;
+  }
+
+  /** Register the sink for `(event, connection-commander)` pairs. Facades set this internally. */
+  onConnectionEvent(sink: ConnectionEventSink): void {
+    this.eventSink = sink;
+  }
+
+  /** Resolve once the server has been closed (`run` resolves at the same time). */
+  run(): Promise<void> {
+    if (this.closed) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.closeWaiters.push(resolve));
+  }
+
+  /** Stop accepting dials, drop live connections, and close the listener. */
+  close(): Promise<void> {
+    // Terminate live connections first: the underlying HTTP server's `close`
+    // does not fire until every connection has ended.
+    for (const socket of this.sockets) {
+      socket.terminate();
+    }
+    this.sockets.clear();
+    return new Promise((resolve) => {
+      this.wss.close(() => {
+        this.markClosed();
+        resolve();
+      });
+    });
+  }
+
+  private markClosed(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    for (const waiter of this.closeWaiters.splice(0)) {
+      waiter();
+    }
+  }
+
+  private onConnection(socket: WebSocket, _request: unknown): void {
+    this.sockets.add(socket);
+    socket.on("close", () => this.sockets.delete(socket));
+    // The event sink needs this connection's commander, which is the session
+    // itself. `session` is assigned synchronously here, before any inbound
+    // message can be delivered (those arrive on later ticks).
+    let session: Session;
+    const sink: EventSink = (frame) => {
+      this.eventSink?.(frame, session);
+    };
+    session = new Session(socket, this.nextId, this.config.replyTimeoutMs ?? 10_000, sink);
+  }
+}

--- a/siphon-control-sdk/typescript/src/session.ts
+++ b/siphon-control-sdk/typescript/src/session.ts
@@ -1,0 +1,151 @@
+/**
+ * One live WebSocket connection: request-id correlation, the read path, and
+ * generic event fan-out. Knows nothing about SIP — it moves opaque `{module,
+ * verb, target, args}` frames and hands every event to a sink.
+ *
+ * Shared verbatim by the inbound client and the per-call-connect server; only
+ * how the socket is *acquired* differs. Mirrors the Rust `SessionCore`.
+ */
+
+import type { RawData, WebSocket } from "ws";
+
+import { ControlError } from "./errors";
+import type { IdCounter } from "./internal";
+import { encodeCommand, parseInboundFrame } from "./protocol";
+import type { EventFrame } from "./protocol";
+
+/** A sink the read path calls for every inbound event frame (any module). */
+export type EventSink = (frame: EventFrame) => void;
+
+/**
+ * Anything that can send a control command and await its correlated reply.
+ *
+ * Implemented by {@link Session} (bound to one connection — the per-call-connect
+ * server) and by the client's commander (routes to the current session,
+ * surviving reconnects — the inbound client). Lets a facade's handle command its
+ * call without caring which mode it runs in.
+ */
+export interface CommandTransport {
+  command(
+    module: string | null,
+    verb: string,
+    target: unknown,
+    args: unknown,
+  ): Promise<unknown>;
+}
+
+interface Pending {
+  resolve: (result: unknown) => void;
+  reject: (error: ControlError) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** The shared, transport-agnostic state of one connection. */
+export class Session implements CommandTransport {
+  private readonly pending = new Map<string, Pending>();
+  private closed = false;
+  private readonly closeWaiters: Array<() => void> = [];
+
+  constructor(
+    private readonly socket: WebSocket,
+    private readonly nextId: IdCounter,
+    private readonly replyTimeoutMs: number,
+    private readonly eventSink: EventSink,
+  ) {
+    socket.on("message", (data: RawData) => this.onMessage(data.toString()));
+    socket.on("close", () => this.markClosed());
+    socket.on("error", () => this.markClosed());
+  }
+
+  /**
+   * Send a command and await its correlated reply. Maps a `status:"error"`
+   * reply to a rejected {@link ControlError} carrying the wire code.
+   */
+  command(
+    module: string | null,
+    verb: string,
+    target: unknown,
+    args: unknown,
+  ): Promise<unknown> {
+    if (this.closed) {
+      return Promise.reject(ControlError.closed());
+    }
+    const id = `c-${this.nextId.value++}`;
+    const text = encodeCommand(id, module, verb, target, args);
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(ControlError.timeout(this.replyTimeoutMs));
+      }, this.replyTimeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        this.socket.send(text);
+      } catch (error) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(ControlError.websocket(String(error)));
+      }
+    });
+  }
+
+  private onMessage(text: string): void {
+    const frame = parseInboundFrame(text);
+    if (frame === null) {
+      return;
+    }
+    if (frame.type === "reply") {
+      const pending = this.pending.get(frame.id);
+      if (!pending) {
+        return; // reply for an unknown / expired id — drop.
+      }
+      this.pending.delete(frame.id);
+      clearTimeout(pending.timer);
+      if (frame.status === "ok") {
+        pending.resolve(frame.result ?? null);
+      } else {
+        const code = frame.error?.code ?? "protocol_error";
+        const message = frame.error?.message ?? "error reply without an error body";
+        pending.reject(ControlError.command(code, message));
+      }
+    } else {
+      this.eventSink(frame);
+    }
+  }
+
+  /** Explicitly close the connection. */
+  close(): void {
+    try {
+      this.socket.close();
+    } catch {
+      // ignore — already closing / closed.
+    }
+    this.markClosed();
+  }
+
+  private markClosed(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(ControlError.closed());
+    }
+    this.pending.clear();
+    for (const waiter of this.closeWaiters.splice(0)) {
+      waiter();
+    }
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  /** Resolve once the connection is closed. */
+  waitClosed(): Promise<void> {
+    if (this.closed) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.closeWaiters.push(resolve));
+  }
+}

--- a/siphon-control-sdk/typescript/src/sip.ts
+++ b/siphon-control-sdk/typescript/src/sip.ts
@@ -1,0 +1,547 @@
+/**
+ * The **SIP facade** over the protocol-agnostic core.
+ *
+ * {@link Call} is a typed handle whose verbs (`answer`/`progress`/`reject`/
+ * `terminate`/`refer`/…) are thin wrappers that send `command("sip", …)` on the
+ * underlying core and await the correlated reply. The method names mirror the
+ * in-process siphon scripting API (`call.answer()`, `call.terminate()`,
+ * `call.transfer()`, `call.setHeader()`, …), so an out-of-process controller
+ * reads like an in-process script. The `StasisStart`→{@link Call} dispatch and
+ * the `onCall` handler live here (they are SIP/ARI concepts) on top of the
+ * core's generic event stream, so a future `smpp` / `ss7` facade is an additive
+ * sibling over the same core.
+ */
+
+import type { ControlClient, ClientConfig, ClientEvent } from "./client";
+import { ControlClient as ControlClientImpl } from "./client";
+import { AsyncQueue } from "./internal";
+import {
+  MODULE_SIP,
+  SET_VAR,
+  GET_VAR,
+  SipVerb,
+  sipEventKind,
+} from "./protocol";
+import type {
+  ChannelSnapshot,
+  EventFrame,
+  SipEventKind,
+} from "./protocol";
+import type { ControlServer, ServerConfig } from "./server";
+import { ControlServer as ControlServerImpl } from "./server";
+import type { CommandTransport } from "./session";
+
+// ---------------------------------------------------------------------------
+// Call handle
+// ---------------------------------------------------------------------------
+
+/** One event delivered to a call's stream (`ChannelStateChange`,
+ * `ChannelHangupRequest`, `StasisEnd`, …). */
+export interface CallEvent {
+  /** The parsed event kind. */
+  kind: SipEventKind;
+  /** The event-specific payload. */
+  payload: unknown;
+  /** The raw frame (for fields not surfaced above). */
+  frame: EventFrame;
+}
+
+function callEventFromFrame(frame: EventFrame): CallEvent {
+  return { kind: sipEventKind(frame.event), payload: frame.payload ?? null, frame };
+}
+
+/** Options for a UAS provisional / final response (`answer` / `progress`). */
+export interface ResponseOptions {
+  code?: number;
+  reason?: string;
+  body?: string;
+  contentType?: string;
+}
+
+function responseArgs(options: ResponseOptions): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  if (options.code !== undefined) {
+    args.code = options.code;
+  }
+  if (options.reason !== undefined) {
+    args.reason = options.reason;
+  }
+  if (options.body !== undefined) {
+    args.body = options.body;
+  }
+  if (options.contentType !== undefined) {
+    args.content_type = options.contentType;
+  }
+  return args;
+}
+
+/** The RFC 3891 `Replaces` triple for an attended transfer. */
+export interface ReferReplaces {
+  callId: string;
+  fromTag: string;
+  toTag: string;
+  earlyOnly?: boolean;
+}
+
+/** Options for {@link Call.acceptRefer}. */
+export interface AcceptReferOptions {
+  target?: string;
+  nextHop?: string;
+  mode?: "terminate" | "transparent";
+}
+
+function stringValue(result: unknown): string | null {
+  if (typeof result === "object" && result !== null) {
+    const value = (result as { value?: unknown }).value;
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * A handed-over SIP call. Cheap to hold (shares one connection + event stream).
+ * Verb names mirror the in-process `call.*` scripting API.
+ */
+export class Call {
+  constructor(
+    private readonly transport: CommandTransport,
+    /** The leg-scoped channel id — the address for every verb on this call. */
+    readonly channelId: string,
+    /** The internal `CallActor` id (the grouping key across legs), if known. */
+    readonly callId: string | null,
+    /** The per-leg SIP `Call-ID` — byte-identical to the CDR / HEP join key. */
+    readonly sipCallId: string | null,
+    /** The application this call was handed to. */
+    readonly app: string | null,
+    /** The `StasisStart` payload (full SIP context), or the `resync` snapshot. */
+    readonly payload: unknown,
+    /** True when this call came from a `resync` re-attach after a reconnect. */
+    readonly reattached: boolean,
+    private readonly eventQueue: AsyncQueue<CallEvent>,
+  ) {}
+
+  private target(): { channel: string } {
+    return { channel: this.channelId };
+  }
+
+  private sip(verb: string, args: unknown): Promise<unknown> {
+    return this.transport.command(MODULE_SIP, verb, this.target(), args);
+  }
+
+  private substrate(verb: string, args: unknown): Promise<unknown> {
+    return this.transport.command(null, verb, this.target(), args);
+  }
+
+  // --- SIP verbs (mirror the in-process scripting API) -------------------
+
+  /** Send a UAS 2xx to the parked A-leg (default `200 OK`). */
+  async answer(options?: ResponseOptions): Promise<void> {
+    await this.sip(SipVerb.Answer, options ? responseArgs(options) : {});
+  }
+
+  /** Send a UAS 1xx / early media (default `183 Session Progress`). */
+  async progress(options?: ResponseOptions): Promise<void> {
+    await this.sip(SipVerb.Progress, options ? responseArgs(options) : {});
+  }
+
+  /** Send a final non-2xx and tear the call down. */
+  async reject(code: number, reason?: string): Promise<void> {
+    const args: Record<string, unknown> = { code };
+    if (reason !== undefined) {
+      args.reason = reason;
+    }
+    await this.sip(SipVerb.Reject, args);
+  }
+
+  /**
+   * Tear the call down: BYE an answered call (full teardown funnel), or reject
+   * an unanswered one. Mirrors the in-process `call.terminate()`.
+   */
+  async terminate(reason?: string): Promise<void> {
+    await this.sip(SipVerb.Hangup, reason !== undefined ? { reason } : {});
+  }
+
+  /** Alias for {@link Call.terminate}. */
+  async hangup(reason?: string): Promise<void> {
+    await this.terminate(reason);
+  }
+
+  /** Send an in-dialog REFER on the A-leg (blind transfer). */
+  async refer(to: string): Promise<void> {
+    await this.sip(SipVerb.Refer, { to });
+  }
+
+  /** Blind-transfer alias for {@link Call.refer}. */
+  async transfer(to: string): Promise<void> {
+    await this.refer(to);
+  }
+
+  /** Attended transfer — REFER with a `Replaces` triple (RFC 3891). */
+  async referReplaces(to: string, replaces: ReferReplaces): Promise<void> {
+    await this.sip(SipVerb.Refer, {
+      to,
+      replaces: {
+        call_id: replaces.callId,
+        from_tag: replaces.fromTag,
+        to_tag: replaces.toTag,
+        early_only: replaces.earlyOnly ?? false,
+      },
+    });
+  }
+
+  /**
+   * Accept an inbound REFER on this tracked call. **Not implemented server-side
+   * in Phase 1** — resolves to a {@link ControlError} with `code ===
+   * "unsupported_verb"` until the server adds it.
+   */
+  async acceptRefer(options?: AcceptReferOptions): Promise<void> {
+    const args: Record<string, unknown> = {};
+    if (options?.target !== undefined) {
+      args.target = options.target;
+    }
+    if (options?.nextHop !== undefined) {
+      args.next_hop = options.nextHop;
+    }
+    if (options?.mode !== undefined) {
+      args.mode = options.mode;
+    }
+    await this.sip(SipVerb.AcceptRefer, args);
+  }
+
+  /**
+   * Reject an inbound REFER on this tracked call. **Not implemented server-side
+   * in Phase 1** — see {@link Call.acceptRefer}.
+   */
+  async rejectRefer(code: number, reason?: string): Promise<void> {
+    const args: Record<string, unknown> = { code };
+    if (reason !== undefined) {
+      args.reason = reason;
+    }
+    await this.sip(SipVerb.RejectRefer, args);
+  }
+
+  /** Set a header on the stored A-leg INVITE. */
+  async setHeader(name: string, value: string): Promise<void> {
+    await this.sip(SipVerb.SetHeader, { name, value });
+  }
+
+  /** Read a header from the stored A-leg INVITE (`null` when absent). */
+  async getHeader(name: string): Promise<string | null> {
+    const result = await this.sip(SipVerb.GetHeader, { name });
+    return stringValue(result);
+  }
+
+  /**
+   * Remove a header from the stored A-leg INVITE. **Not implemented server-side
+   * in Phase 1** — resolves to a {@link ControlError} with `code ===
+   * "unsupported_verb"` until the server adds it.
+   */
+  async removeHeader(name: string): Promise<void> {
+    await this.sip(SipVerb.RemoveHeader, { name });
+  }
+
+  // --- per-call variables (substrate verbs, no module) -------------------
+
+  /** Set a per-call variable (survives a reconnect via `resync`). */
+  async setVar(key: string, value: string): Promise<void> {
+    await this.substrate(SET_VAR, { key, value });
+  }
+
+  /** Read a per-call variable (`null` when unset). */
+  async getVar(key: string): Promise<string | null> {
+    const result = await this.substrate(GET_VAR, { key });
+    return stringValue(result);
+  }
+
+  // --- media (server answers `unsupported_verb` today) -------------------
+
+  /**
+   * Play an announcement. **Not yet implemented server-side** — resolves to a
+   * {@link ControlError} with `code === "unsupported_verb"` until the media
+   * backend lands.
+   */
+  async playFile(file: string): Promise<void> {
+    await this.sip(SipVerb.Play, { file });
+  }
+
+  /** Send DTMF. **Not yet implemented server-side** — see {@link Call.playFile}. */
+  async dtmf(digits: string): Promise<void> {
+    await this.sip(SipVerb.Dtmf, { digits });
+  }
+
+  // --- escape hatch + events --------------------------------------------
+
+  /** Send an arbitrary SIP-adapter verb + args and return the raw result. */
+  async command(verb: string, args?: unknown): Promise<unknown> {
+    return this.sip(verb, args ?? {});
+  }
+
+  /**
+   * Await the next event for this call (`ChannelStateChange`,
+   * `ChannelHangupRequest`, `StasisEnd`). `null` once the stream closes.
+   */
+  nextEvent(): Promise<CallEvent | null> {
+    return this.eventQueue.next();
+  }
+
+  /** Async-iterate this call's events until the stream closes. */
+  events(): AsyncIterableIterator<CallEvent> {
+    return this.eventQueue[Symbol.asyncIterator]();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Call dispatch (handler or pull stream) + per-channel event routing
+// ---------------------------------------------------------------------------
+
+/** A per-call handler. Both sync (`void`) and async (`Promise<void>`) supported. */
+export type CallHandler = (call: Call) => void | Promise<void>;
+
+/** A pull-style stream of handed-over calls (alternative to a handler). */
+export class CallStream {
+  constructor(private readonly queue: AsyncQueue<Call>) {}
+
+  /** Await the next handed-over call. `null` once the client/server shuts down. */
+  next(): Promise<Call | null> {
+    return this.queue.next();
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<Call> {
+    return this.queue[Symbol.asyncIterator]();
+  }
+}
+
+/**
+ * The SIP facade's event router: builds `Call`s from `StasisStart`/reattach,
+ * routes channel-scoped events to the owning call, and dispatches new calls to a
+ * handler or pull stream. Mirrors the Rust `SipFacade`.
+ */
+class SipFacade {
+  private handler: CallHandler | null = null;
+  private callQueue: AsyncQueue<Call> | null = null;
+  private readonly channels = new Map<string, AsyncQueue<CallEvent>>();
+
+  setHandler(handler: CallHandler): void {
+    this.handler = handler;
+  }
+
+  setStream(): CallStream {
+    const queue = new AsyncQueue<Call>();
+    this.callQueue = queue;
+    return new CallStream(queue);
+  }
+
+  handleClientEvent(event: ClientEvent, transport: CommandTransport): void {
+    if (event.type === "event") {
+      this.handleEvent(event.frame, transport);
+    } else {
+      this.reattach(event.snapshot, transport);
+    }
+  }
+
+  handleEvent(frame: EventFrame, transport: CommandTransport): void {
+    const kind = sipEventKind(frame.event);
+    if (kind === "StasisStart") {
+      if (!frame.channel) {
+        return; // StasisStart without a channel — drop.
+      }
+      const queue = new AsyncQueue<CallEvent>();
+      this.channels.set(frame.channel, queue);
+      const call = new Call(
+        transport,
+        frame.channel,
+        frame.call_id ?? null,
+        frame.sip_call_id ?? null,
+        frame.app ?? null,
+        frame.payload ?? null,
+        false,
+        queue,
+      );
+      this.dispatch(call);
+    } else if (kind === "StasisEnd") {
+      if (frame.channel) {
+        this.route(frame.channel, callEventFromFrame(frame));
+        const queue = this.channels.get(frame.channel);
+        queue?.close();
+        this.channels.delete(frame.channel);
+      }
+    } else if (frame.channel) {
+      this.route(frame.channel, callEventFromFrame(frame));
+    }
+  }
+
+  private reattach(snapshot: ChannelSnapshot, transport: CommandTransport): void {
+    const queue = new AsyncQueue<CallEvent>();
+    this.channels.set(snapshot.channel, queue);
+    const call = new Call(
+      transport,
+      snapshot.channel,
+      snapshot.call_id,
+      snapshot.sip_call_id,
+      null,
+      snapshot,
+      true,
+      queue,
+    );
+    this.dispatch(call);
+  }
+
+  private route(channel: string, event: CallEvent): void {
+    this.channels.get(channel)?.push(event);
+  }
+
+  private dispatch(call: Call): void {
+    if (this.handler) {
+      const handler = this.handler;
+      void Promise.resolve()
+        .then(() => handler(call))
+        .catch((error: unknown) => {
+          // A handler error must never take down the router.
+          void error;
+        });
+    } else if (this.callQueue) {
+      this.callQueue.push(call);
+    }
+    // No handler / stream → the call is dropped (nothing owns it).
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inbound-persistent SIP facade
+// ---------------------------------------------------------------------------
+
+/**
+ * The SIP facade over an inbound-persistent {@link ControlClient}.
+ *
+ * ```ts
+ * const client = await SipClient.connect({
+ *   url: "ws://siphon:9090/control/ws",
+ *   app: "ivr-app",
+ *   token: "s3cr3t",
+ * });
+ * await client.onCall(async (call) => {
+ *   await call.answer();
+ *   await call.transfer("sip:agent@pbx");
+ * });
+ * ```
+ */
+export class SipClient {
+  private readonly facade = new SipFacade();
+
+  private constructor(private readonly client: ControlClient) {
+    const commander = client.commander();
+    client.onEvent((event) => this.facade.handleClientEvent(event, commander));
+  }
+
+  /** Connect + `hello`, then install the SIP event router. */
+  static async connect(config: ClientConfig): Promise<SipClient> {
+    const client = await ControlClientImpl.connect(config);
+    return new SipClient(client);
+  }
+
+  /** Wrap an already-connected generic client with the SIP facade. */
+  static wrap(client: ControlClient): SipClient {
+    return new SipClient(client);
+  }
+
+  /** The underlying generic client (for raw `command` on any module). */
+  get controlClient(): ControlClient {
+    return this.client;
+  }
+
+  /** Register a call handler (does not block). */
+  setCallHandler(handler: CallHandler): void {
+    this.facade.setHandler(handler);
+  }
+
+  /**
+   * Register a call handler **and drive the client to completion** (the
+   * supervised reconnect + resync loop).
+   */
+  onCall(handler: CallHandler): Promise<void> {
+    this.setCallHandler(handler);
+    return this.client.run();
+  }
+
+  /** A pull-style stream of handed-over calls (alternative to a handler). */
+  calls(): CallStream {
+    return this.facade.setStream();
+  }
+
+  /** Drive the supervised connection loop (reconnect + resync). */
+  run(): Promise<void> {
+    return this.client.run();
+  }
+
+  /** Fetch the registered adapters' schema (`describe`). */
+  describe(): Promise<unknown> {
+    return this.client.describe();
+  }
+
+  /** Send a raw command on any module (the generic escape hatch). */
+  command(
+    module: string | null,
+    verb: string,
+    target: unknown,
+    args: unknown,
+  ): Promise<unknown> {
+    return this.client.command(module, verb, target, args);
+  }
+
+  /** Stop the client. */
+  shutdown(): void {
+    this.client.shutdown();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-call-connect SIP facade
+// ---------------------------------------------------------------------------
+
+/** The SIP facade over a per-call-connect {@link ControlServer}. */
+export class SipServer {
+  private readonly facade = new SipFacade();
+
+  private constructor(private readonly server: ControlServer) {
+    server.onConnectionEvent((frame, transport) => this.facade.handleEvent(frame, transport));
+  }
+
+  /** Bind the listener and install the SIP event router. */
+  static async bind(config: ServerConfig): Promise<SipServer> {
+    const server = await ControlServerImpl.bind(config);
+    return new SipServer(server);
+  }
+
+  /** The actual bound address (useful when binding to port 0 in tests). */
+  localAddr(): import("node:net").AddressInfo {
+    return this.server.localAddr();
+  }
+
+  /** Register a call handler (does not block). */
+  setCallHandler(handler: CallHandler): void {
+    this.facade.setHandler(handler);
+  }
+
+  /** A pull-style stream of dialed-in calls (alternative to a handler). */
+  calls(): CallStream {
+    return this.facade.setStream();
+  }
+
+  /** Register a call handler **and run the accept loop** to completion. */
+  onCall(handler: CallHandler): Promise<void> {
+    this.setCallHandler(handler);
+    return this.server.run();
+  }
+
+  /** Accept siphon's per-call dials until the server is closed. */
+  run(): Promise<void> {
+    return this.server.run();
+  }
+
+  /** Stop accepting dials and close the listener. */
+  close(): Promise<void> {
+    return this.server.close();
+  }
+}

--- a/siphon-control-sdk/typescript/test/correlation.test.ts
+++ b/siphon-control-sdk/typescript/test/correlation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Correlation: a command sent over a live socket resolves with the matching
+ * reply's `result`, a `status:"error"` reply throws a typed `ControlError` with
+ * the wire `.code` (asserting `unsupported_verb`), and a dropped reply times out.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import { ControlClient, ControlError } from "../src/index";
+import { ControlStub } from "./helpers";
+
+let stub: ControlStub | undefined;
+
+afterEach(async () => {
+  await stub?.stop();
+  stub = undefined;
+});
+
+describe("request/reply correlation over a live socket", () => {
+  it("resolves a command with the reply result and rejects unsupported_verb", async () => {
+    stub = await ControlStub.start({
+      onCommand: (frame) => {
+        if (frame.verb === "answer") {
+          return { status: "ok", result: { state: "answered", code: 200 } };
+        }
+        if (frame.verb === "play") {
+          return { status: "error", error: { code: "unsupported_verb", message: "no media backend" } };
+        }
+        return { status: "ok", result: {} };
+      },
+    });
+
+    const client = await ControlClient.connect({ url: stub.url(), app: "ivr-app", token: "t" });
+
+    const ok = await client.command("sip", "answer", { channel: "ch1" }, {});
+    expect(ok).toEqual({ state: "answered", code: 200 });
+
+    let caught: unknown;
+    try {
+      await client.command("sip", "play", { channel: "ch1" }, { file: "x.wav" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ControlError);
+    const controlError = caught as ControlError;
+    expect(controlError.code).toBe("unsupported_verb");
+    expect(controlError.kind).toBe("command");
+    expect(controlError.isUnsupportedVerb()).toBe(true);
+
+    client.shutdown();
+  });
+
+  it("times out when no reply arrives within the window", async () => {
+    stub = await ControlStub.start({
+      onCommand: (frame) => (frame.verb === "slow" ? undefined : { status: "ok", result: {} }),
+    });
+
+    const client = await ControlClient.connect({
+      url: stub.url(),
+      app: "ivr-app",
+      token: "t",
+      replyTimeoutMs: 120,
+    });
+
+    await expect(
+      client.command("sip", "slow", { channel: "ch1" }, {}),
+    ).rejects.toMatchObject({ kind: "timeout" });
+
+    client.shutdown();
+  });
+
+  it("surfaces a rejected upgrade as an unauthorized error", async () => {
+    stub = await ControlStub.start({ token: "right-token" });
+    await expect(
+      ControlClient.connect({ url: stub.url(), app: "ivr-app", token: "wrong-token" }),
+    ).rejects.toMatchObject({ kind: "unauthorized" });
+  });
+});

--- a/siphon-control-sdk/typescript/test/dispatch.test.ts
+++ b/siphon-control-sdk/typescript/test/dispatch.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Dispatch: a `StasisStart` event builds a `Call` and drives the registered
+ * handler, in both connection modes — the inbound-persistent `SipClient.onCall`
+ * and the per-call-connect `SipServer` where siphon dials in.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import WebSocket from "ws";
+
+import { SipClient, SipServer, SUBPROTOCOL } from "../src/index";
+import type { Call } from "../src/index";
+import { ControlStub, waitFor } from "./helpers";
+
+interface ReplyLike {
+  id: string;
+  type: string;
+  status?: string;
+  verb?: string;
+}
+interface CommandLike {
+  id: string;
+  type: string;
+  verb: string;
+  target?: { channel?: string };
+}
+
+let cleanup: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  for (const step of cleanup.splice(0)) {
+    await step();
+  }
+});
+
+describe("inbound-persistent SipClient.onCall dispatch", () => {
+  it("hands a StasisStart to the handler and drives call.answer()", async () => {
+    const stub = await ControlStub.start({
+      onCommand: (frame) =>
+        frame.verb === "answer"
+          ? { status: "ok", result: { state: "answered" } }
+          : { status: "ok", result: {} },
+    });
+    cleanup.push(() => stub.stop());
+
+    const sip = await SipClient.connect({ url: stub.url(), app: "ivr-app", token: "t" });
+
+    let received: Call | undefined;
+    const runPromise = sip.onCall(async (call) => {
+      received = call;
+      await call.answer();
+    });
+
+    await waitFor(() => stub.connectionCount() === 1);
+    stub.pushEvent({
+      event: "StasisStart",
+      channel: "ch1",
+      call_id: "call-uuid",
+      sip_call_id: "sipcid@host",
+      app: "ivr-app",
+      payload: { source_ip: "203.0.113.7" },
+    });
+
+    await waitFor(() => received !== undefined);
+    expect(received?.channelId).toBe("ch1");
+    expect(received?.sipCallId).toBe("sipcid@host");
+    expect(received?.callId).toBe("call-uuid");
+
+    await waitFor(() =>
+      stub.received.some((f) => f.verb === "answer" && f.target?.channel === "ch1"),
+    );
+
+    sip.shutdown();
+    await runPromise;
+  });
+});
+
+describe("per-call-connect SipServer dispatch (siphon dials in)", () => {
+  it("accepts a dial, hands the StasisStart to the handler, and commands back", async () => {
+    const server = await SipServer.bind({
+      host: "127.0.0.1",
+      port: 0,
+      app: "ivr-app",
+      token: "sekret",
+    });
+    cleanup.push(() => server.close());
+    const port = server.localAddr().port;
+
+    let received: Call | undefined;
+    server.setCallHandler(async (call) => {
+      received = call;
+      await call.answer();
+    });
+
+    const dial = new WebSocket(`ws://127.0.0.1:${port}/`, [SUBPROTOCOL], {
+      headers: { Authorization: "Bearer sekret" },
+    });
+    cleanup.push(() => dial.close());
+    const inbound: ReplyLike[] = [];
+    dial.on("message", (data) => inbound.push(JSON.parse(data.toString()) as CommandLike));
+
+    await new Promise<void>((resolve, reject) => {
+      dial.on("open", () => resolve());
+      dial.on("error", reject);
+    });
+
+    // The first frame siphon sends on a per-call dial is StasisStart (no hello).
+    dial.send(
+      JSON.stringify({
+        type: "event",
+        event: "StasisStart",
+        channel: "ch7",
+        call_id: "cu-7",
+        sip_call_id: "sc7@host",
+        app: "ivr-app",
+        payload: {},
+      }),
+    );
+
+    await waitFor(() => received !== undefined);
+    expect(received?.channelId).toBe("ch7");
+
+    // The server (our SipServer) should have sent an answer command back to us.
+    await waitFor(() => inbound.some((f) => f.type === "command" && (f as CommandLike).verb === "answer"));
+    const answerCommand = inbound.find((f) => (f as CommandLike).verb === "answer") as CommandLike;
+    expect(answerCommand.target?.channel).toBe("ch7");
+    dial.send(JSON.stringify({ id: answerCommand.id, type: "reply", status: "ok", result: {} }));
+  });
+});

--- a/siphon-control-sdk/typescript/test/helpers.ts
+++ b/siphon-control-sdk/typescript/test/helpers.ts
@@ -1,0 +1,151 @@
+/** A tiny in-process stub of siphon's control WebSocket, for correlation tests. */
+
+import type { AddressInfo } from "node:net";
+
+import { WebSocketServer } from "ws";
+import type { WebSocket } from "ws";
+
+import { SUBPROTOCOL } from "../src/index";
+
+/** The shape a stub sees for an inbound command frame. */
+export interface CommandFrameLike {
+  id: string;
+  type: string;
+  module?: string;
+  verb: string;
+  target?: { channel?: string } | null;
+  args?: Record<string, unknown> | null;
+}
+
+/** A reply body the stub returns for a command (`undefined` = deliberately drop). */
+export type ReplyBody =
+  | { status: "ok"; result?: unknown }
+  | { status: "error"; error: { code: string; message: string } };
+
+export interface StubOptions {
+  /** Reject the upgrade unless the bearer token matches this (per-call-connect style). */
+  token?: string;
+  /** Per-command reply logic; return `undefined` to drop (for timeout tests). */
+  onCommand?: (frame: CommandFrameLike, socket: WebSocket) => ReplyBody | undefined;
+  /** Channels returned from a `resync`. */
+  resyncChannels?: unknown[];
+  /** Auto-answer the `hello` handshake (default true). */
+  autoHello?: boolean;
+}
+
+/** A protocol-speaking WebSocket stub the SDK's client can connect to. */
+export class ControlStub {
+  /** Every command frame the stub received, in order. */
+  readonly received: CommandFrameLike[] = [];
+  private readonly sockets = new Set<WebSocket>();
+
+  private constructor(
+    private readonly wss: WebSocketServer,
+    private readonly options: StubOptions,
+  ) {}
+
+  static async start(options: StubOptions = {}): Promise<ControlStub> {
+    const wss = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      handleProtocols: (protocols) => (protocols.has(SUBPROTOCOL) ? SUBPROTOCOL : false),
+      verifyClient:
+        options.token === undefined
+          ? undefined
+          : ({ req }, done) => done(req.headers.authorization === `Bearer ${options.token}`, 401),
+    });
+    const stub = new ControlStub(wss, options);
+    wss.on("connection", (socket) => stub.onConnection(socket));
+    await new Promise<void>((resolve, reject) => {
+      wss.once("listening", () => resolve());
+      wss.once("error", reject);
+    });
+    return stub;
+  }
+
+  address(): AddressInfo {
+    const address = this.wss.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("stub is not bound to a TCP port");
+    }
+    return address;
+  }
+
+  url(): string {
+    return `ws://127.0.0.1:${this.address().port}/control/ws`;
+  }
+
+  private onConnection(socket: WebSocket): void {
+    this.sockets.add(socket);
+    socket.on("close", () => this.sockets.delete(socket));
+    socket.on("message", (data) => {
+      const frame = JSON.parse(data.toString()) as CommandFrameLike;
+      if (frame.type !== "command") {
+        return;
+      }
+      this.received.push(frame);
+      const reply = this.replyFor(frame, socket);
+      if (reply) {
+        socket.send(JSON.stringify({ id: frame.id, type: "reply", ...reply }));
+      }
+    });
+  }
+
+  private replyFor(frame: CommandFrameLike, socket: WebSocket): ReplyBody | undefined {
+    if (frame.verb === "hello" && (this.options.autoHello ?? true)) {
+      const args = frame.args ?? {};
+      return {
+        status: "ok",
+        result: {
+          app: (args.app as string) ?? "app",
+          protocol: (args.protocol as number) ?? 1,
+          subprotocol: SUBPROTOCOL,
+        },
+      };
+    }
+    if (frame.verb === "resync") {
+      return { status: "ok", result: { channels: this.options.resyncChannels ?? [] } };
+    }
+    if (this.options.onCommand) {
+      return this.options.onCommand(frame, socket);
+    }
+    return { status: "ok", result: {} };
+  }
+
+  /** Push an event frame to every connected socket (or a specific one). */
+  pushEvent(event: Record<string, unknown>, socket?: WebSocket): void {
+    const targets = socket ? [socket] : [...this.sockets];
+    for (const target of targets) {
+      target.send(JSON.stringify({ type: "event", ...event }));
+    }
+  }
+
+  connectionCount(): number {
+    return this.sockets.size;
+  }
+
+  async stop(): Promise<void> {
+    for (const socket of this.sockets) {
+      socket.terminate();
+    }
+    await new Promise<void>((resolve) => this.wss.close(() => resolve()));
+  }
+}
+
+/** Poll `predicate` until it is true, or throw after `timeoutMs`. */
+export async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+  stepMs = 5,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (predicate()) {
+      return;
+    }
+    if (Date.now() > deadline) {
+      throw new Error("waitFor: condition not met before timeout");
+    }
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+}

--- a/siphon-control-sdk/typescript/test/wire.test.ts
+++ b/siphon-control-sdk/typescript/test/wire.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Wire-parity: the exact bytes this SDK serializes must equal what the server
+ * emits and parses. The three pinned vectors below are the TypeScript twins of
+ * the Rust `siphon-control-proto` `*_exact_bytes` tests — same field order, same
+ * `module` omission for substrate verbs, same `null` target/args.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { AsyncQueue } from "../src/internal";
+import {
+  Call,
+  encodeCommand,
+  sipEventKind,
+  SipVerb,
+  MODULE_SIP,
+} from "../src/index";
+import type { CallEvent } from "../src/index";
+import type { CommandTransport } from "../src/session";
+
+describe("command wire bytes (byte-identical to the server)", () => {
+  it("serializes an answer command exactly", () => {
+    expect(
+      encodeCommand("c-1", "sip", "answer", { channel: "ch1" }, { code: 200 }),
+    ).toBe(
+      '{"id":"c-1","type":"command","module":"sip","verb":"answer","target":{"channel":"ch1"},"args":{"code":200}}',
+    );
+  });
+
+  it("serializes a substrate command with null target and args (no module)", () => {
+    expect(encodeCommand("c-2", null, "resync", null, null)).toBe(
+      '{"id":"c-2","type":"command","verb":"resync","target":null,"args":null}',
+    );
+  });
+
+  it("serializes the hello handshake exactly", () => {
+    expect(
+      encodeCommand("c-0", null, "hello", null, { app: "ivr-app", protocol: 1 }),
+    ).toBe(
+      '{"id":"c-0","type":"command","verb":"hello","target":null,"args":{"app":"ivr-app","protocol":1}}',
+    );
+  });
+});
+
+describe("SipVerb wire tokens + event names", () => {
+  it("maps verbs to the exact wire tokens", () => {
+    expect(SipVerb.Answer).toBe("answer");
+    expect(SipVerb.Hangup).toBe("hangup");
+    expect(SipVerb.SetHeader).toBe("set_header");
+    expect(SipVerb.GetHeader).toBe("get_header");
+    expect(SipVerb.RemoveHeader).toBe("remove_header");
+    expect(SipVerb.AcceptRefer).toBe("accept_refer");
+    expect(SipVerb.RejectRefer).toBe("reject_refer");
+    expect(SipVerb.Play).toBe("play");
+    expect(SipVerb.Dtmf).toBe("dtmf");
+  });
+
+  it("passes unknown event names through (forward-compatible)", () => {
+    expect(sipEventKind("StasisStart")).toBe("StasisStart");
+    expect(sipEventKind("SomethingNew")).toBe("SomethingNew");
+  });
+});
+
+// A CommandTransport that records every call and returns a canned result.
+interface Recorded {
+  module: string | null;
+  verb: string;
+  target: unknown;
+  args: unknown;
+}
+
+class RecordingTransport implements CommandTransport {
+  readonly calls: Recorded[] = [];
+  constructor(private readonly result: unknown = {}) {}
+  command(module: string | null, verb: string, target: unknown, args: unknown): Promise<unknown> {
+    this.calls.push({ module, verb, target, args });
+    return Promise.resolve(this.result);
+  }
+}
+
+function makeCall(transport: CommandTransport): Call {
+  return new Call(transport, "ch1", "call-uuid", "sip@host", "ivr-app", null, false, new AsyncQueue<CallEvent>());
+}
+
+describe("Call verbs map to the in-process-mirrored wire verbs", () => {
+  it("answer / progress / reject", async () => {
+    const transport = new RecordingTransport();
+    const call = makeCall(transport);
+    await call.answer();
+    await call.answer({ code: 200, reason: "OK" });
+    await call.progress();
+    await call.reject(486, "Busy Here");
+    expect(transport.calls).toEqual([
+      { module: MODULE_SIP, verb: "answer", target: { channel: "ch1" }, args: {} },
+      { module: MODULE_SIP, verb: "answer", target: { channel: "ch1" }, args: { code: 200, reason: "OK" } },
+      { module: MODULE_SIP, verb: "progress", target: { channel: "ch1" }, args: {} },
+      { module: MODULE_SIP, verb: "reject", target: { channel: "ch1" }, args: { code: 486, reason: "Busy Here" } },
+    ]);
+  });
+
+  it("terminate is primary, hangup is an alias — both send the hangup verb", async () => {
+    const transport = new RecordingTransport();
+    const call = makeCall(transport);
+    await call.terminate();
+    await call.hangup("Q.850;cause=16");
+    expect(transport.calls).toEqual([
+      { module: MODULE_SIP, verb: "hangup", target: { channel: "ch1" }, args: {} },
+      { module: MODULE_SIP, verb: "hangup", target: { channel: "ch1" }, args: { reason: "Q.850;cause=16" } },
+    ]);
+  });
+
+  it("refer / transfer / referReplaces", async () => {
+    const transport = new RecordingTransport();
+    const call = makeCall(transport);
+    await call.refer("sip:agent@pbx");
+    await call.transfer("sip:queue@pbx");
+    await call.referReplaces("sip:b@pbx", {
+      callId: "abc",
+      fromTag: "ft",
+      toTag: "tt",
+      earlyOnly: true,
+    });
+    expect(transport.calls).toEqual([
+      { module: MODULE_SIP, verb: "refer", target: { channel: "ch1" }, args: { to: "sip:agent@pbx" } },
+      { module: MODULE_SIP, verb: "refer", target: { channel: "ch1" }, args: { to: "sip:queue@pbx" } },
+      {
+        module: MODULE_SIP,
+        verb: "refer",
+        target: { channel: "ch1" },
+        args: {
+          to: "sip:b@pbx",
+          replaces: { call_id: "abc", from_tag: "ft", to_tag: "tt", early_only: true },
+        },
+      },
+    ]);
+  });
+
+  it("header + var verbs (snake_case wire tokens, substrate vars carry no module)", async () => {
+    const transport = new RecordingTransport({ value: "hdr-value" });
+    const call = makeCall(transport);
+    await call.setHeader("X-Tag", "1");
+    expect(await call.getHeader("X-Tag")).toBe("hdr-value");
+    await call.removeHeader("X-Tag");
+    await call.setVar("queue", "support");
+    expect(await call.getVar("queue")).toBe("hdr-value");
+    expect(transport.calls).toEqual([
+      { module: MODULE_SIP, verb: "set_header", target: { channel: "ch1" }, args: { name: "X-Tag", value: "1" } },
+      { module: MODULE_SIP, verb: "get_header", target: { channel: "ch1" }, args: { name: "X-Tag" } },
+      { module: MODULE_SIP, verb: "remove_header", target: { channel: "ch1" }, args: { name: "X-Tag" } },
+      { module: null, verb: "set_var", target: { channel: "ch1" }, args: { key: "queue", value: "support" } },
+      { module: null, verb: "get_var", target: { channel: "ch1" }, args: { key: "queue" } },
+    ]);
+  });
+
+  it("acceptRefer / rejectRefer / media verbs", async () => {
+    const transport = new RecordingTransport();
+    const call = makeCall(transport);
+    await call.acceptRefer({ target: "sip:c@pbx", nextHop: "sip:sbc", mode: "terminate" });
+    await call.rejectRefer(603, "Decline");
+    await call.playFile("/prompts/welcome.wav");
+    await call.dtmf("123#");
+    expect(transport.calls).toEqual([
+      {
+        module: MODULE_SIP,
+        verb: "accept_refer",
+        target: { channel: "ch1" },
+        args: { target: "sip:c@pbx", next_hop: "sip:sbc", mode: "terminate" },
+      },
+      { module: MODULE_SIP, verb: "reject_refer", target: { channel: "ch1" }, args: { code: 603, reason: "Decline" } },
+      { module: MODULE_SIP, verb: "play", target: { channel: "ch1" }, args: { file: "/prompts/welcome.wav" } },
+      { module: MODULE_SIP, verb: "dtmf", target: { channel: "ch1" }, args: { digits: "123#" } },
+    ]);
+  });
+});

--- a/siphon-control-sdk/typescript/tsconfig.json
+++ b/siphon-control-sdk/typescript/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src", "test"]
+}

--- a/siphon-control-sdk/typescript/tsup.config.ts
+++ b/siphon-control-sdk/typescript/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+// Dual ESM + CJS build with `.d.ts` (ESM) and `.d.cts` (CJS) type outputs, so
+// the package resolves cleanly under both `import` and `require` (see the
+// `exports` map in package.json). `ws` stays external — it is a runtime dep the
+// consumer installs, not something to bundle.
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  target: "node18",
+  external: ["ws"],
+});


### PR DESCRIPTION
## TypeScript SDK for the external control plane (`@siphon/control`)

The third client language alongside the merged Rust (`siphon-control-client`) and
PyO3 (`siphon-control`) SDKs, over the byte-identical `siphon-control.v1` wire.
Lands at `siphon-control-sdk/typescript/`.

### Design — mirrors the Rust/Python SDKs

**Protocol-agnostic core + per-module facade** (so `smpp`/`ss7` facades are
additive, not a rewrite):

- **Core** — `ControlClient` / `ControlServer`: `command(module, verb, target,
  args)`, request-id correlation, typed `ControlError` (with `.code`) on
  `status:"error"`, a generic event stream, the `hello` handshake, reconnect +
  `resync`/reattach. Both connection modes: **inbound-persistent** (the app dials
  siphon's `/control/ws`) and **per-call-connect** (the app is a WS server siphon
  dials — no hello, `StasisStart` first).
- **`sip` facade** — `SipClient.onCall(async (call) => …)` / `SipServer.onCall`
  plus a `Call` class whose methods wrap `command("sip", …)`.

### API parity — `Call` reads like an in-process siphon script

Mirrors `src/script/api/call.rs` (`PyCall`) naming. `Call` method signatures:

```ts
answer(options?: ResponseOptions): Promise<void>
progress(options?: ResponseOptions): Promise<void>
reject(code: number, reason?: string): Promise<void>
terminate(reason?: string): Promise<void>          // primary (mirrors call.terminate())
hangup(reason?: string): Promise<void>             // alias for terminate()
refer(to: string): Promise<void>
transfer(to: string): Promise<void>                // alias for refer()
referReplaces(to: string, replaces: ReferReplaces): Promise<void>
setHeader(name: string, value: string): Promise<void>
getHeader(name: string): Promise<string | null>
removeHeader(name: string): Promise<void>          // ‡ unsupported_verb today
acceptRefer(options?: AcceptReferOptions): Promise<void>   // ‡ unsupported_verb today
rejectRefer(code: number, reason?: string): Promise<void>  // ‡ unsupported_verb today
setVar(key: string, value: string): Promise<void>  // substrate verb (no module)
getVar(key: string): Promise<string | null>        // substrate verb (no module)
playFile(file: string): Promise<void>              // ‡ media — unsupported_verb today
dtmf(digits: string): Promise<void>                // ‡ media — unsupported_verb today
command(verb: string, args?: unknown): Promise<unknown>    // escape hatch
nextEvent(): Promise<CallEvent | null>
events(): AsyncIterableIterator<CallEvent>
```

`terminate` is the primary teardown name (mirrors in-process `call.terminate()`),
`hangup` an alias — both send the `hangup` wire verb. The ‡ verbs send a real
command and surface the server's typed `unsupported_verb` (`error.isUnsupportedVerb()`)
until the Phase-1 server implements them — nothing is stubbed client-side.

### Package + build

- `@siphon/control`, `type: module`, dual **ESM + CJS + `.d.ts`** via tsup, strict
  `tsconfig`. Runtime dep `ws`; MIT (matches the repo LICENSE).
- Wire-parity is **pinned**: `test/wire.test.ts` asserts the exact command bytes
  the server parses — e.g. `{"id":"c-1","type":"command","module":"sip","verb":"answer","target":{"channel":"ch1"},"args":{"code":200}}`
  — the TypeScript twin of the Rust `siphon-control-proto` `*_exact_bytes` tests.
- Tests: wire-parity + request/reply correlation against an in-process stub WS
  server (incl. `unsupported_verb` and timeout) + `onCall` dispatch in **both**
  modes. `npm test` (15/15), `npm run build`, `tsc --noEmit` all green.

### Examples — now SDK-only

`examples/remote_control/` is rewritten to use the SDKs (the official interop
path), with zero manual frame construction:

- `control_client.py` → `from siphon_control import ControlClient`, `@client.on_call`
  + `await call.answer()/set_var/hangup` (inbound — the mode the Python SDK ships).
- `control_client.ts` → `@siphon/control`'s `SipClient` / `SipServer` `.onCall`,
  both modes; depends on the sibling package via a `file:` path so it runs
  pre-publish, and the `ws` dependency is dropped (the SDK owns the transport).
- The README points at `pip install siphon-control` / `npm i @siphon/control` and
  defers the raw wire to the control-plane reference instead of duplicating it.

### npm publish (own workflow)

`.github/workflows/release-control-sdk-ts.yaml` — fires on a `control-sdk-v*` tag
(+ `workflow_dispatch` dry run), builds/tests, then `npm publish --provenance
--access public` via **npm OIDC Trusted Publishing** (`id-token: write`, no stored
`NPM_TOKEN`). Guarded to publish on the tag only. Nothing publishes from this PR.

### Scope

Only **adds** `siphon-control-sdk/typescript/` and the new workflow (plus the
in-scope `examples/remote_control/` rewrite). Does not touch `docs/`, `mkdocs.yml`,
or any existing workflow. Independent version `0.1.0` (tied to the protocol,
matching the other SDKs).

Draft — the release workflow only fires on a future `control-sdk-v*` tag.
