### PR TITLE
feat(control-sdk): add ControlServer per-call-connect mode to the python sdk

### DIFF
--- a/siphon-control-sdk/siphon-control/README.md
+++ b/siphon-control-sdk/siphon-control/README.md
@@ -6,6 +6,23 @@ handed-over calls out of process. Built with [PyO3](https://pyo3.rs) over the
 async Rust client, so the wire is hidden: no manual JSON, no request-id
 bookkeeping.
 
+## Two connection modes
+
+The plane runs in one of two modes; both are exposed here and share the SAME
+`@on_call` decorator and the SAME `Call` handle — only the transport differs.
+
+- **Inbound-persistent** (`ControlClient`) — the app dials siphon and holds one
+  long-lived socket (does the `hello` handshake). Simplest to reason about; use
+  it for development and single-process controllers.
+- **Per-call-connect** (`ControlServer`) — *siphon dials the app* per handed-over
+  call, so the app is a WebSocket server. Each accepted connection owns exactly
+  one call and the first frame is a pushed `StasisStart` (no `hello`). This is
+  the documented production default for multi-pod controllers: because the
+  accepting socket *is* the call, "the audio lands on the wrong pod" can't
+  happen.
+
+### Inbound-persistent
+
 ```python
 import asyncio
 from siphon_control import ControlClient, ControlError
@@ -24,7 +41,28 @@ async def handle(call):
 asyncio.run(client.run())
 ```
 
+### Per-call-connect
+
+```python
+import asyncio
+from siphon_control import ControlServer, ControlError
+
+server = ControlServer(app="ivr-app", token="s3cr3t", bind="0.0.0.0:8790")
+
+@server.on_call
+async def handle(call):
+    await call.answer()
+    try:
+        await call.transfer("sip:agent@pbx")
+    except ControlError as error:
+        print("transfer rejected:", error.code)
+
+asyncio.run(server.serve())
+```
+
 ## API
+
+### `ControlClient` (inbound-persistent)
 
 - `ControlClient(app, token, url=…, protocol=1, reply_timeout_ms=…, reconnect_backoff_ms=…)`
 - `@client.on_call` — register an async (or sync) per-call handler.
@@ -32,6 +70,22 @@ asyncio.run(client.run())
 - `await client.command(verb, module=None, target=None, args=None)` — the generic
   `{module, verb, target, args}` primitive for any adapter (SIP today; SMPP/SS7 later).
 - `await client.describe()` — adapter schema.
+- `client.shutdown()` — stop the client and unblock `run()`.
+
+### `ControlServer` (per-call-connect)
+
+- `ControlServer(app, token, bind="0.0.0.0:8790", reply_timeout_ms=…)` — `bind` is
+  the address the app listens on for siphon to dial; the token is validated on the
+  incoming upgrade.
+- `@server.on_call` — the SAME decorator + `Call` handle as `ControlClient`.
+- `await server.bind()` — bind the listener; resolves to the bound address string
+  (bind to `…:0` to learn the ephemeral port before siphon dials in).
+- `server.local_addr` — the bound address once `bind()` / `serve()` has run, else `None`.
+- `await server.serve()` / `await server.run()` — accept siphon's per-call dials
+  forever (stop by cancelling the task).
+
+### `Call` (shared by both modes)
+
 - `Call` verbs: `answer()`, `answer_with(code, …)`, `progress()`, `reject(code, reason)`,
   `hangup(reason=None)`, `refer(to)` / `transfer(to)`, `set_header(name, value)`,
   `get_header(name)`, `set_var(key, value)`, `get_var(key)`, `command(verb, args=None)`,

--- a/siphon-control-sdk/siphon-control/src/lib.rs
+++ b/siphon-control-sdk/siphon-control/src/lib.rs
@@ -1,26 +1,56 @@
 //! Python bindings (PyO3) for the SIPhon external control plane.
 //!
 //! Wraps [`siphon_control_client`]. Async methods return Python awaitables via
-//! `pyo3-async-runtimes`, so a control app reads like idiomatic asyncio:
+//! `pyo3-async-runtimes`, so a control app reads like idiomatic asyncio.
 //!
-//! ```python
-//! from siphon_control import ControlClient
+//! # Two connection modes (both exposed here)
 //!
-//! client = ControlClient(app="ivr-app", token="s3cr3t",
-//!                        url="ws://siphon:9090/control/ws")
+//! - **Inbound-persistent** — [`ControlClient`]. The app dials siphon's
+//!   `/control/ws` and keeps one long-lived socket (does the `hello`
+//!   handshake). Simplest to reason about; ideal for development and
+//!   single-process controllers.
 //!
-//! @client.on_call
-//! async def handle(call):
-//!     await call.answer()
-//!     await call.transfer("sip:agent@pbx")   # raises ControlError on a typed error
+//!   ```python
+//!   from siphon_control import ControlClient
 //!
-//! await client.run()
-//! ```
+//!   client = ControlClient(app="ivr-app", token="s3cr3t",
+//!                          url="ws://siphon:9090/control/ws")
 //!
-//! The layering mirrors the Rust crate: `ControlClient.command(...)` is the
-//! generic `{module, verb, target, args}` primitive for any adapter, and the
-//! `on_call` decorator + `Call` verbs are the SIP facade on top.
+//!   @client.on_call
+//!   async def handle(call):
+//!       await call.answer()
+//!       await call.transfer("sip:agent@pbx")   # raises ControlError on a typed error
+//!
+//!   await client.run()
+//!   ```
+//!
+//! - **Per-call-connect** — [`ControlServer`]. *siphon dials the app* at
+//!   handover, so the app is a WebSocket server; each accepted connection owns
+//!   exactly one call and the first frame is a pushed `StasisStart` (no `hello`
+//!   from the app side). This is the documented production default for
+//!   multi-pod controllers — "the audio lands on the wrong pod" is structurally
+//!   impossible when the accepting socket *is* the call.
+//!
+//!   ```python
+//!   from siphon_control import ControlServer
+//!
+//!   server = ControlServer(app="ivr-app", token="s3cr3t", bind="0.0.0.0:8790")
+//!
+//!   @server.on_call
+//!   async def handle(call):
+//!       await call.answer()
+//!       await call.transfer("sip:agent@pbx")
+//!
+//!   await server.serve()
+//!   ```
+//!
+//! Both modes reuse the SAME `@on_call` decorator and the SAME [`Call`] handle;
+//! only the transport differs (dial-out vs. be-dialed). The layering mirrors the
+//! Rust crate: `ControlClient.command(...)` is the generic `{module, verb,
+//! target, args}` primitive for any adapter, and the `on_call` decorator +
+//! `Call` verbs are the SIP facade on top.
 
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -30,8 +60,8 @@ use pyo3::types::PyList;
 use pyo3_async_runtimes::TaskLocals;
 
 use siphon_control_client::proto::ControlErrorCode;
-use siphon_control_client::sip::{Call as RustCall, SipClient};
-use siphon_control_client::{ClientConfig, ControlError as ClientError};
+use siphon_control_client::sip::{Call as RustCall, SipClient, SipServer};
+use siphon_control_client::{ClientConfig, ControlError as ClientError, ServerConfig};
 
 pyo3::create_exception!(
     siphon_control,
@@ -464,6 +494,129 @@ async fn dispatch_to_python(handler: Py<PyAny>, locals: TaskLocals, call: RustCa
 }
 
 // ---------------------------------------------------------------------------
+// ControlServer pyclass (per-call-connect mode — siphon dials the app)
+// ---------------------------------------------------------------------------
+
+struct ServerInner {
+    config: ServerConfig,
+    server: tokio::sync::Mutex<Option<Arc<SipServer>>>,
+    handler: Mutex<Option<Py<PyAny>>>,
+    local_addr: Mutex<Option<String>>,
+}
+
+/// The per-call-connect control server: **siphon dials the app**, so this is a
+/// WebSocket server. Construct it, register a handler with `@server.on_call`,
+/// then `await server.serve()`. Each accepted connection owns exactly one call;
+/// the first frame is a pushed `StasisStart` (no `hello`).
+#[pyclass(module = "siphon_control", name = "ControlServer")]
+struct ControlServer {
+    inner: Arc<ServerInner>,
+}
+
+#[pymethods]
+impl ControlServer {
+    #[new]
+    #[pyo3(signature = (app, token, bind=None, reply_timeout_ms=10_000))]
+    fn new(app: String, token: String, bind: Option<String>, reply_timeout_ms: u64) -> PyResult<Self> {
+        let bind = bind.unwrap_or_else(|| "0.0.0.0:8790".to_string());
+        let listen: SocketAddr = bind
+            .parse()
+            .map_err(|error| PyValueError::new_err(format!("invalid bind address {bind:?}: {error}")))?;
+        let mut config = ServerConfig::new(listen, app, token);
+        config.reply_timeout = Duration::from_millis(reply_timeout_ms);
+        Ok(Self {
+            inner: Arc::new(ServerInner {
+                config,
+                server: tokio::sync::Mutex::new(None),
+                handler: Mutex::new(None),
+                local_addr: Mutex::new(None),
+            }),
+        })
+    }
+
+    /// Register the per-call handler. Usable as a decorator: `@server.on_call`.
+    /// Reuses the SAME `Call` handle + dispatch as `ControlClient.on_call`.
+    fn on_call(&self, py: Python<'_>, handler: Py<PyAny>) -> Py<PyAny> {
+        *lock(&self.inner.handler) = Some(handler.clone_ref(py));
+        handler
+    }
+
+    /// Bind the listener (idempotent). Returns an awaitable resolving to the
+    /// bound address string, e.g. `"127.0.0.1:54321"` — useful when binding to
+    /// port `0` to learn the ephemeral port before siphon dials in.
+    fn bind<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            ensure_server(&inner).await?;
+            Ok(lock(&inner.local_addr).clone())
+        })
+    }
+
+    /// The bound address once [`ControlServer::bind`] (or `serve`) has run, else
+    /// `None`. When constructed with a port-`0` bind, this is where siphon dials.
+    #[getter]
+    fn local_addr(&self) -> Option<String> {
+        lock(&self.inner.local_addr).clone()
+    }
+
+    /// Bind (if needed), register the handler bridge, then run the accept loop
+    /// forever — accepting each per-call dial siphon makes. Runs until the
+    /// awaitable is cancelled or the listener fails.
+    fn serve<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.serve_impl(py)
+    }
+
+    /// Alias for [`ControlServer::serve`].
+    fn run<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.serve_impl(py)
+    }
+}
+
+impl ControlServer {
+    fn serve_impl<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        // Capture the running loop's task locals *now* (on the Python thread) so
+        // the handler bridge can drive Python coroutines from Rust.
+        let locals = pyo3_async_runtimes::tokio::get_current_locals(py)?;
+        let handler = lock(&self.inner.handler).as_ref().map(|h| h.clone_ref(py));
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let server = ensure_server(&inner).await?;
+            if let Some(handler) = handler {
+                install_server_handler_bridge(&server, handler, locals);
+            }
+            server.run().await.map_err(to_pyerr)?;
+            Ok(())
+        })
+    }
+}
+
+/// Bind the underlying [`SipServer`] once, caching it + its bound address.
+async fn ensure_server(inner: &Arc<ServerInner>) -> PyResult<Arc<SipServer>> {
+    let mut guard = inner.server.lock().await;
+    if let Some(server) = guard.as_ref() {
+        return Ok(Arc::clone(server));
+    }
+    let server = Arc::new(SipServer::bind(inner.config.clone()).await.map_err(to_pyerr)?);
+    let bound = server.local_addr().map_err(to_pyerr)?;
+    *lock(&inner.local_addr) = Some(bound.to_string());
+    *guard = Some(Arc::clone(&server));
+    Ok(server)
+}
+
+/// Bridge the stored Python handler to the SIP server, reusing the same
+/// per-call dispatch as the inbound client (identical `Call` + coroutine drive).
+fn install_server_handler_bridge(server: &SipServer, handler: Py<PyAny>, locals: TaskLocals) {
+    server.set_call_handler(move |call: RustCall| {
+        let handler = Python::attach(|py| handler.clone_ref(py));
+        let locals = locals.clone();
+        async move {
+            dispatch_to_python(handler, locals, call).await;
+            Ok(())
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Module init
 // ---------------------------------------------------------------------------
 
@@ -471,11 +624,15 @@ async fn dispatch_to_python(handler: Py<PyAny>, locals: TaskLocals, call: RustCa
 #[pyo3(name = "siphon_control")]
 fn siphon_control(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<ControlClient>()?;
+    module.add_class::<ControlServer>()?;
     module.add_class::<Call>()?;
     module.add("ControlError", module.py().get_type::<ControlError>())?;
     module.add(
         "__all__",
-        PyList::new(module.py(), ["ControlClient", "Call", "ControlError"])?,
+        PyList::new(
+            module.py(),
+            ["ControlClient", "ControlServer", "Call", "ControlError"],
+        )?,
     )?;
     Ok(())
 }

--- a/siphon-control-sdk/siphon-control/tests/test_smoke.py
+++ b/siphon-control-sdk/siphon-control/tests/test_smoke.py
@@ -2,9 +2,14 @@
 
 Drives the real extension module against an in-process ``websockets`` stub that
 speaks the ``siphon-control.v1`` handshake, echoes correlated replies, and can
-push events. Covers: build a client, connect + hello, a command round-trip, a
-typed ``ControlError`` on an error reply, and the ``@client.on_call`` async
-dispatch.
+push events. Covers BOTH connection modes:
+
+* **Inbound-persistent** (``ControlClient``) — the app dials the stub: build a
+  client, connect + hello, a command round-trip, a typed ``ControlError`` on an
+  error reply, and the ``@client.on_call`` async dispatch.
+* **Per-call-connect** (``ControlServer``) — the stub (playing siphon) dials the
+  app: the app listens, siphon connects and pushes ``StasisStart``, the
+  ``@server.on_call`` handler fires and a ``Call`` verb round-trips.
 
 Run: ``python -m pytest tests/`` (needs ``websockets`` installed).
 """
@@ -16,7 +21,7 @@ import json
 import pytest
 import websockets
 
-from siphon_control import Call, ControlClient, ControlError
+from siphon_control import Call, ControlClient, ControlError, ControlServer
 
 APP = "ivr-app"
 TOKEN = "s3cr3t"
@@ -109,6 +114,9 @@ async def _serve_stub():
 
 def test_module_surface():
     assert hasattr(ControlClient, "on_call")
+    assert hasattr(ControlServer, "on_call")
+    assert hasattr(ControlServer, "serve")
+    assert hasattr(ControlServer, "run")
     assert hasattr(Call, "answer")
     assert issubclass(ControlError, Exception)
 
@@ -158,5 +166,109 @@ def test_on_call_async_dispatch():
             client.shutdown()
             with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
                 await asyncio.wait_for(run_task, timeout=5)
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# Per-call-connect mode (ControlServer) — siphon dials the app.
+# ---------------------------------------------------------------------------
+
+
+async def _push_stasis(siphon):
+    """Push the ownership-conferring StasisStart as siphon's first frame."""
+    await siphon.send(
+        json.dumps(
+            {
+                "type": "event",
+                "event": "StasisStart",
+                "channel": "ch-out",
+                "app": APP,
+                "call_id": "call-uuid",
+                "sip_call_id": "sipcid@out",
+                "payload": {"from": "sip:alice@example.com"},
+            }
+        )
+    )
+
+
+def test_server_mode_on_call_dispatch_and_verb_roundtrip():
+    async def scenario():
+        server = ControlServer(app=APP, token=TOKEN, bind="127.0.0.1:0")
+        # Bind first so the ephemeral port is known before siphon dials in.
+        addr = await server.bind()
+        assert addr == server.local_addr
+        assert addr.startswith("127.0.0.1:")
+
+        fired = asyncio.get_event_loop().create_future()
+
+        @server.on_call
+        async def handle(call):
+            await call.answer()  # sends a command; resolves on the stub's reply
+            if not fired.done():
+                fired.set_result((call.channel_id, call.sip_call_id, call.is_reattached))
+
+        serve_task = asyncio.ensure_future(server.serve())
+        # Let serve() install the handler bridge and reach the accept loop.
+        await asyncio.sleep(0.3)
+
+        # The stub plays siphon: dial the app, present the token + subprotocol.
+        uri = f"ws://{addr}/siphon"
+        async with websockets.connect(
+            uri,
+            additional_headers={"Authorization": f"Bearer {TOKEN}"},
+            subprotocols=[SUBPROTOCOL],
+        ) as siphon:
+            await _push_stasis(siphon)
+
+            # The handler's call.answer() sends a command over THIS connection.
+            command = json.loads(await asyncio.wait_for(siphon.recv(), timeout=5))
+            assert command["type"] == "command"
+            assert command["verb"] == "answer"
+            assert command["module"] == "sip"
+            assert command["target"]["channel"] == "ch-out"
+            await siphon.send(
+                json.dumps(
+                    {
+                        "id": command["id"],
+                        "type": "reply",
+                        "status": "ok",
+                        "result": {"state": "answered"},
+                    }
+                )
+            )
+
+            channel, sip_call_id, reattached = await asyncio.wait_for(fired, timeout=5)
+            assert channel == "ch-out"
+            assert sip_call_id == "sipcid@out"
+            assert reattached is False
+
+        serve_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+            await asyncio.wait_for(serve_task, timeout=5)
+
+    asyncio.run(scenario())
+
+
+def test_server_mode_rejects_bad_token():
+    async def scenario():
+        server = ControlServer(app=APP, token=TOKEN, bind="127.0.0.1:0")
+        addr = await server.bind()
+        serve_task = asyncio.ensure_future(server.serve())
+        await asyncio.sleep(0.3)
+
+        uri = f"ws://{addr}/siphon"
+        with pytest.raises(websockets.exceptions.InvalidStatus) as excinfo:
+            async with websockets.connect(
+                uri,
+                additional_headers={"Authorization": "Bearer wrong"},
+                subprotocols=[SUBPROTOCOL],
+            ):
+                pass
+        assert excinfo.value.response.status_code == 401
+
+        serve_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+            await asyncio.wait_for(serve_task, timeout=5)
 
     asyncio.run(scenario())


### PR DESCRIPTION
## What

The PyO3 Python SDK for the control plane (`siphon-control-sdk/siphon-control/`)
only exposed the **inbound-persistent** mode (`ControlClient` — the app dials
siphon's `/control/ws` and holds one long-lived socket, `hello` handshake). It
was missing the **per-call-connect** mode, where *siphon dials the app*: the app
runs a WebSocket server, each accepted connection owns exactly one call, and the
first frame is a pushed `StasisStart` (no `hello`). That mode is the documented
production default for multi-pod controllers, and both the Rust client
(`sip::SipServer`) and the TS client already have it.

This adds a `ControlServer` pyclass so the Python SDK supports **both** modes.

## API surface

```python
from siphon_control import ControlServer

server = ControlServer(app="ivr-app", token="s3cr3t", bind="0.0.0.0:8790")

@server.on_call
async def handle(call):
    await call.answer()
    await call.transfer("sip:agent@pbx")

await server.serve()
```

- `ControlServer(app, token, bind="0.0.0.0:8790", reply_timeout_ms=10_000)` —
  `bind` is the address the app listens on for siphon to dial; the token is
  validated on the incoming upgrade (401 on mismatch, before the socket opens).
- `@server.on_call` — the **same** decorator as `ControlClient`.
- `await server.bind()` — bind the listener (idempotent); resolves to the bound
  address string, so a `…:0` bind can learn its ephemeral port before siphon
  dials in.
- `server.local_addr` — the bound address once `bind()`/`serve()` has run, else
  `None`.
- `await server.serve()` / `await server.run()` — accept siphon's per-call dials
  forever (stop by cancelling the task).

`ControlServer` **reuses the same `Call` handle and the same `on_call` dispatch**
as `ControlClient` — it wraps `siphon_control_client::sip::SipServer` and shares
the async bridge (`future_into_py` + `TaskLocals` capture + `dispatch_to_python`).
The only difference is the transport: it listens and is dialed, instead of
dialing. `ControlClient` is unchanged; both are exported from the module and
`__all__`.

The module docstring and the crate README now document both modes and when to
use each (inbound = simple/dev/single-process; per-call-connect = multi-pod
production default).

## Tests

Two pytest smoke tests alongside the existing ones, driven with `maturin
develop` + pytest against a stub "siphon" (a `websockets` client that dials the
server):

- `test_server_mode_on_call_dispatch_and_verb_roundtrip` — start a
  `ControlServer` on an ephemeral loopback port, dial in as siphon, push
  `StasisStart`, assert `@server.on_call` fires and a `Call.answer()` command
  round-trips against the stub.
- `test_server_mode_rejects_bad_token` — a dial with the wrong token is rejected
  401 before the upgrade.

All 5 tests pass; `cargo clippy --all-targets --all-features -- -D warnings` is
clean on the SDK workspace.

## Scope

Touches only `siphon-control-sdk/siphon-control/` (`src/lib.rs`, `README.md`,
`tests/test_smoke.py`). No Rust-client-crate change was needed — `SipServer` /
`ServerConfig` are already public and re-exported.
