### PR TITLE
chore(test): documentation address range in examples and test data

### DIFF
--- a/examples/diameter_server.yaml
+++ b/examples/diameter_server.yaml
@@ -44,10 +44,10 @@ diameter:
   # reaches a script.
   clients:
     - name: client-a
-      allowed_ips: ["172.16.0.150", "172.16.0.0/24"]
+      allowed_ips: ["192.0.2.150", "192.0.2.0/24"]
       expected_origin_host: "client-a.epc.mnc001.mcc001.3gppnetwork.org"
 
   # Backend(s) this server connects out to and relays toward. Referenced by
   # name from the script via diameter.peer_pool(..., "backend").
   servers:
-    - { name: backend, host: "172.16.0.61", port: 3868, transport: tcp }
+    - { name: backend, host: "192.0.2.61", port: 3868, transport: tcp }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1872,7 +1872,7 @@ fn default_dialog_backend() -> DialogBackendType {
 /// ```yaml
 /// cache:
 ///   - name: "cnam"
-///     url: "redis://172.16.0.252:6379"
+///     url: "redis://192.0.2.252:6379"
 ///     local_ttl_secs: 60
 ///     local_max_entries: 10000
 /// ```
@@ -4563,7 +4563,7 @@ script:
   path: "scripts/proxy_default.py"
 cache:
   - name: "cnam"
-    url: "redis://172.16.0.252:6379"
+    url: "redis://192.0.2.252:6379"
     local_ttl_secs: 60
     local_max_entries: 10000
 "#;
@@ -6213,10 +6213,10 @@ diameter:
         origin_realm: "epc.mnc001.mcc001.3gppnetwork.org"
       clients:
         - name: mme
-          allowed_ips: ["172.16.0.0/24"]
+          allowed_ips: ["192.0.2.0/24"]
           expected_origin_host: "mme.epc.example.org"
       servers:
-        - { name: hss, host: "172.16.0.61", port: 3868, transport: tcp }
+        - { name: hss, host: "192.0.2.61", port: 3868, transport: tcp }
 "#;
         let config = Config::from_str(yaml).expect("Diameter server config should parse");
         let diameter = config.diameter.expect("diameter section");
@@ -6229,7 +6229,7 @@ diameter:
         let tenant = diameter.tenants.get("default").expect("default tenant");
         assert_eq!(tenant.identity.origin_host, "diam.epc.mnc001.mcc001.3gppnetwork.org");
         assert_eq!(tenant.clients[0].name, "mme");
-        assert_eq!(tenant.clients[0].allowed_ips, vec!["172.16.0.0/24"]);
+        assert_eq!(tenant.clients[0].allowed_ips, vec!["192.0.2.0/24"]);
         assert_eq!(tenant.servers[0].name, "hss");
         assert_eq!(tenant.servers[0].port, 3868);
 
@@ -6256,7 +6256,7 @@ diameter:
         origin_host: "hss.epc.example.org"
         origin_realm: "epc.example.org"
       connect_to:
-        - { name: upstream, host: "172.16.0.10", port: 3868, transport: sctp }
+        - { name: upstream, host: "192.0.2.10", port: 3868, transport: sctp }
 "#;
         let config = Config::from_str(yaml).expect("HSS connect_to config should parse");
         let diameter = config.diameter.expect("diameter section");

--- a/src/diameter/auth.rs
+++ b/src/diameter/auth.rs
@@ -51,7 +51,7 @@ impl SourceIpAcl {
     }
 
     /// Add an entry from a config string — either a CIDR (`10.0.0.0/24`) or a
-    /// bare address (`172.16.0.1`, treated as a /32 or /128 host route).
+    /// bare address (`192.0.2.1`, treated as a /32 or /128 host route).
     pub fn add_str(&mut self, cidr: &str, tenant: &str, peer: &str) -> Result<(), AclParseError> {
         self.add(parse_cidr(cidr)?, tenant, peer);
         Ok(())
@@ -133,11 +133,11 @@ mod tests {
     #[test]
     fn acl_matches_bare_ip_and_cidr() {
         let mut acl = SourceIpAcl::new();
-        acl.add_str("172.16.0.150", "default", "ip-sm-gw").unwrap();
+        acl.add_str("192.0.2.150", "default", "ip-sm-gw").unwrap();
         acl.add_str("10.0.0.0/24", "default", "mme-pool").unwrap();
 
         assert_eq!(
-            acl.lookup("172.16.0.150".parse().unwrap()),
+            acl.lookup("192.0.2.150".parse().unwrap()),
             Some(AclMatch {
                 tenant: "default".into(),
                 peer: "ip-sm-gw".into()

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -21344,7 +21344,7 @@ mod tests {
             let prack = build_b2bua_prack_message(
                 &dialog(),
                 crate::transport::Transport::Udp,
-                "172.16.0.153",
+                "192.0.2.153",
                 5060,
                 &target,
                 1,
@@ -21418,11 +21418,11 @@ mod tests {
         // remains (after the proxy popped its own), that Route is the next hop —
         // NOT the Request-URI (the UE Contact) and NOT the cached INVITE branch.
         let ack = ack_request_with_route(Some(
-            "<sip:172.16.0.101:5060;transport=udp;lr>, <sip:172.16.0.101:5060;transport=tcp;lr>",
+            "<sip:192.0.2.101:5060;transport=udp;lr>, <sip:192.0.2.101:5060;transport=tcp;lr>",
         ));
         let next_hop = ack_next_hop_uri(&ack.headers, &ack.start_line).expect("ACK has a next hop");
         let parsed = parse_uri_standalone(&next_hop).unwrap();
-        assert_eq!(parsed.host, "172.16.0.101");
+        assert_eq!(parsed.host, "192.0.2.101");
         assert_eq!(parsed.port, Some(5060));
         assert_ne!(
             parsed.host, "100.65.0.2",
@@ -21459,17 +21459,17 @@ mod tests {
         // Request-URI. The cached-branch path mis-delivered the ACK so the UAS
         // never confirmed the dialog.
         let mut ack = ack_request_with_route(Some(
-            "<sip:172.16.0.121:6060;lr>, <sip:172.16.0.101:5060;transport=udp;lr>",
+            "<sip:192.0.2.121:6060;lr>, <sip:192.0.2.101:5060;transport=udp;lr>",
         ));
 
         // Mirror handle_ack_via_session: consume our own leading Route entries.
-        let identity = ack_identity(&[("172.16.0.121", &[6060])]);
+        let identity = ack_identity(&[("192.0.2.121", &[6060])]);
         core::consume_self_routes(&mut ack.headers, &identity);
 
         let next_hop = ack_next_hop_uri(&ack.headers, &ack.start_line).expect("next hop");
         let parsed = parse_uri_standalone(&next_hop).unwrap();
         assert_eq!(
-            parsed.host, "172.16.0.101",
+            parsed.host, "192.0.2.101",
             "ACK must follow the dialog route set to the P-CSCF",
         );
         assert_eq!(parsed.port, Some(5060));
@@ -21487,11 +21487,11 @@ mod tests {
         // the apparent next hop — a routing loop. The ACK must consume both
         // self-Routes (via pop_local_routes) and forward to the P-CSCF, exactly
         // as loose_route() does for the in-dialog BYE on this dialog.
-        let identity = ack_identity(&[("172.16.0.121", &[6060])]);
+        let identity = ack_identity(&[("192.0.2.121", &[6060])]);
         let mut ack = ack_request_with_route(Some(
-            "<sip:172.16.0.121:6060;transport=tcp;lr>, \
-             <sip:172.16.0.121:6060;transport=udp;lr>, \
-             <sip:172.16.0.101:5060;transport=udp;lr>",
+            "<sip:192.0.2.121:6060;transport=tcp;lr>, \
+             <sip:192.0.2.121:6060;transport=udp;lr>, \
+             <sip:192.0.2.101:5060;transport=udp;lr>",
         ));
 
         // Mirror handle_ack_via_session's route consumption.
@@ -21500,7 +21500,7 @@ mod tests {
         let next_hop = ack_next_hop_uri(&ack.headers, &ack.start_line).expect("next hop");
         let parsed = parse_uri_standalone(&next_hop).unwrap();
         assert_eq!(
-            parsed.host, "172.16.0.101",
+            parsed.host, "192.0.2.101",
             "ACK must skip our own double Record-Route and follow the route set",
         );
         assert_eq!(parsed.port, Some(5060));
@@ -21513,10 +21513,10 @@ mod tests {
         // whenever it carried `;lr`, stripping a downstream proxy's own Route
         // and sending the ACK a hop too far. It now applies the same
         // self-identity test the in-dialog BYE does.
-        let identity = ack_identity(&[("172.16.0.121", &[6060])]);
+        let identity = ack_identity(&[("192.0.2.121", &[6060])]);
         let mut ack = ack_request_with_route(Some(
-            "<sip:172.16.0.101:5060;transport=udp;lr>, \
-             <sip:172.16.0.199:5060;transport=udp;lr>",
+            "<sip:192.0.2.101:5060;transport=udp;lr>, \
+             <sip:192.0.2.199:5060;transport=udp;lr>",
         ));
 
         let popped = core::consume_self_routes(&mut ack.headers, &identity);
@@ -21525,7 +21525,7 @@ mod tests {
         let next_hop = ack_next_hop_uri(&ack.headers, &ack.start_line).expect("next hop");
         let parsed = parse_uri_standalone(&next_hop).unwrap();
         assert_eq!(
-            parsed.host, "172.16.0.101",
+            parsed.host, "192.0.2.101",
             "ACK must still go to the first Route, not past it",
         );
     }
@@ -21536,10 +21536,10 @@ mod tests {
         // carries our advertised/bind address, which `domain.local` need not
         // list. The ACK resolves self-identity from the same widened set, so
         // both in-dialog paths agree about the same dialog's route set.
-        let identity = ack_identity(&[("172.16.0.121", &[6060])]);
+        let identity = ack_identity(&[("192.0.2.121", &[6060])]);
         let mut ack = ack_request_with_route(Some(
-            "<sip:172.16.0.121:6060;transport=udp;lr>, \
-             <sip:172.16.0.101:5060;transport=udp;lr>",
+            "<sip:192.0.2.121:6060;transport=udp;lr>, \
+             <sip:192.0.2.101:5060;transport=udp;lr>",
         ));
 
         let popped = core::consume_self_routes(&mut ack.headers, &identity);
@@ -21547,7 +21547,7 @@ mod tests {
 
         let next_hop = ack_next_hop_uri(&ack.headers, &ack.start_line).expect("next hop");
         let parsed = parse_uri_standalone(&next_hop).unwrap();
-        assert_eq!(parsed.host, "172.16.0.101");
+        assert_eq!(parsed.host, "192.0.2.101");
     }
 
     // -----------------------------------------------------------------------
@@ -22973,11 +22973,11 @@ a=rtpmap:8 PCMA/8000\r\n";
         let client_key = TransactionKey::new(
             "z9hG4bK-invite-branch-B".to_string(),
             Method::Invite,
-            "172.16.0.111:4060".to_string(),
+            "192.0.2.111:4060".to_string(),
         );
         let via = cancel_via_for_client_branch(&client_key, Transport::Udp);
         assert_eq!(
-            via, "SIP/2.0/UDP 172.16.0.111:4060;branch=z9hG4bK-invite-branch-B",
+            via, "SIP/2.0/UDP 192.0.2.111:4060;branch=z9hG4bK-invite-branch-B",
             "forwarded CANCEL must reuse the INVITE's top Via branch + sent-by (RFC 3261 §9.1)",
         );
     }

--- a/src/registrant/mod.rs
+++ b/src/registrant/mod.rs
@@ -1437,7 +1437,7 @@ fn default_contact_uri(username: &str, address: SocketAddr, transport: Transport
 /// Request-URI. Uses the full SIP-URI parser so host and port are split
 /// correctly — `SipUri::new("host:port")` would put the whole thing in the
 /// host field, and the IPv6 heuristic in `format_sip_host` would then bracket
-/// it (`sip:[172.16.0.101:5060]`), which breaks the registrar's DNS/relay.
+/// it (`sip:[192.0.2.101:5060]`), which breaks the registrar's DNS/relay.
 fn registrar_request_uri(registrar_uri: &str) -> SipUri {
     crate::sip::parser::parse_uri_standalone(registrar_uri).unwrap_or_else(|_| {
         SipUri::new(
@@ -1608,11 +1608,11 @@ mod tests {
         manager.add(entry);
 
         let mut listen = HashMap::new();
-        listen.insert(Transport::Tls, "172.16.0.153:5061".parse().unwrap());
+        listen.insert(Transport::Tls, "192.0.2.153:5061".parse().unwrap());
 
         let result = manager.build_register(
             "sip:trunk@carrier.com",
-            "172.16.0.153:5060".parse().unwrap(),
+            "192.0.2.153:5060".parse().unwrap(),
             &listen,
             3600,
         );
@@ -1625,12 +1625,12 @@ mod tests {
         let raw = String::from_utf8_lossy(&bytes);
         // Contact should use TLS listen port and transport param
         assert!(
-            raw.contains("172.16.0.153:5061;transport=tls"),
+            raw.contains("192.0.2.153:5061;transport=tls"),
             "Contact should use TLS port 5061 and transport=tls: {raw}"
         );
         // Via should also use TLS port
         assert!(
-            raw.contains("SIP/2.0/TLS 172.16.0.153:5061"),
+            raw.contains("SIP/2.0/TLS 192.0.2.153:5061"),
             "Via should use TLS port 5061: {raw}"
         );
     }
@@ -2452,7 +2452,7 @@ mod tests {
     fn build_register_ip_registrar_and_impi_contact_are_well_formed() {
         let manager = make_manager();
         // 3GPP test range; IMPI username + IPv4:port registrar — the combo
-        // that produced `sip:[172.16.0.101:5060]` and `user@domain@ip`.
+        // that produced `sip:[192.0.2.101:5060]` and `user@domain@ip`.
         let credentials = aka::AkaCredentials::from_hex(
             "465b5ce8b199b49faa5f0a2ee238a6bc",
             None,
@@ -2463,8 +2463,8 @@ mod tests {
         let aor = "sip:001019999999999@ims.mnc01.mcc001.3gppnetwork.org";
         let entry = RegistrantEntry::new(
             aor.to_string(),
-            "sip:172.16.0.101:5060".to_string(),
-            "172.16.0.101:5060".parse().unwrap(),
+            "sip:192.0.2.101:5060".to_string(),
+            "192.0.2.101:5060".parse().unwrap(),
             Transport::Udp,
             RegistrantCredentials {
                 username: "001019999999999@ims.mnc01.mcc001.3gppnetwork.org".to_string(),
@@ -2485,10 +2485,10 @@ mod tests {
 
         // Request-URI: IPv4:port, no brackets.
         assert!(
-            raw.starts_with("REGISTER sip:172.16.0.101:5060 SIP/2.0"),
+            raw.starts_with("REGISTER sip:192.0.2.101:5060 SIP/2.0"),
             "R-URI must not be bracketed: {raw}"
         );
-        assert!(!raw.contains("sip:[172.16.0.101"), "{raw}");
+        assert!(!raw.contains("sip:[192.0.2.101"), "{raw}");
 
         // Via carries rport (RFC 3581) so the P-CSCF can respond to the actual
         // source port (NAT / symmetric-response robustness).

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -2210,7 +2210,7 @@ mod tests {
     #[test]
     fn loose_route_non_local_route_not_consumed() {
         // RFC 3261 §16.4: a proxy must only consume Routes that match itself.
-        // A TAS (domain 172.16.0.152) receiving a Route to scscf.example.com
+        // A TAS (domain 192.0.2.152) receiving a Route to scscf.example.com
         // must NOT consume it — relay() should follow the Route to the S-CSCF.
         let message = SipMessage {
             start_line: StartLine::Request(RequestLine {
@@ -2226,7 +2226,7 @@ mod tests {
             },
             body: vec![],
         };
-        let local_domains = Arc::new(vec!["172.16.0.152".to_string()]);
+        let local_domains = Arc::new(vec!["192.0.2.152".to_string()]);
         let mut request = PyRequest::with_local_domains(
             Arc::new(Mutex::new(message)),
             "tcp".to_string(),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1054,7 +1054,7 @@ mod tests {
         assert!(default.1.try_recv().is_ok());
 
         // Unknown source (not a registered listener) → default channel.
-        router.send(make(Some(addr("172.16.0.1:5060")))).unwrap();
+        router.send(make(Some(addr("192.0.2.1:5060")))).unwrap();
         assert!(default.1.try_recv().is_ok());
     }
 
@@ -1183,7 +1183,7 @@ mod tests {
         assert!(registry.resolve(Transport::Tls, addr("10.0.0.1:5060")).is_none());
 
         // An address siphon isn't listening on does not resolve.
-        assert!(registry.resolve(Transport::Udp, addr("172.16.0.1:5060")).is_none());
+        assert!(registry.resolve(Transport::Udp, addr("192.0.2.1:5060")).is_none());
     }
 
     #[test]

--- a/tests/integration/dns_tests.rs
+++ b/tests/integration/dns_tests.rs
@@ -148,13 +148,13 @@ async fn host_with_explicit_port_skips_srv() {
     let resolver = SipResolver::from_system().unwrap();
 
     let results = resolver
-        .resolve("172.16.0.1", Some(5070), "sip", Some("udp"))
+        .resolve("192.0.2.1", Some(5070), "sip", Some("udp"))
         .await;
 
     assert_eq!(results.len(), 1);
     assert_eq!(
         results[0].address,
-        "172.16.0.1:5070".parse::<SocketAddr>().unwrap()
+        "192.0.2.1:5070".parse::<SocketAddr>().unwrap()
     );
     assert_eq!(results[0].transport.as_deref(), Some("udp"));
 }


### PR DESCRIPTION
Host addresses in examples, rustdoc and test data now come from the RFC 5737 documentation range (192.0.2.0/24) instead of RFC 1918 space. The last octet is preserved throughout, so distinct hosts in a given test stay distinct and every assertion keeps its shape — the change is inert by construction (51 substitutions, no logic touched).

Left on RFC 1918 deliberately, because there the private range is itself the subject:

- `source_ip_in(["10.0.0.0/8", "172.16.0.0/12"])` in `sdk/siphon_sdk/request.py`, `sdk/tests/test_inline_script.py` and the `request.source_ip_in` rustdoc — the example exists to show matching against private space, and it pairs the /12 with 10/8 to say so.
- `src/transport/acl.rs`'s `allow_only_permits_matching`, whose assertions walk the /12's own boundaries (`172.31.255.255` is its top address). No documentation prefix can express a /12, so rewriting it would cost real coverage.

Also picks up two occurrences in the CANCEL Via test data that #142 changes identically; both sides make the same substitution, so they merge either way and whichever lands second simply has nothing to do there.

Gates: `cargo test` 3371 lib + 306 integration + 45 + RFC4475 + rtpengine + doc, 0 failed; SDK 514; clippy `--all-targets --all-features -D warnings` clean.