### PR TITLE
chore(control-sdk): python per-call-connect example, ts sdk in the docs, idempotent re-tag guards

### DIFF
--- a/.github/workflows/release-control-sdk-ts.yaml
+++ b/.github/workflows/release-control-sdk-ts.yaml
@@ -49,4 +49,13 @@ jobs:
       # the build + test dry run above.
       - name: Publish to npm (Trusted Publishing — OIDC, no token)
         if: startsWith(github.ref, 'refs/tags/control-sdk-v')
-        run: npm publish --provenance --access public
+        # Idempotent re-tag: skip if this version is already on npm so a re-run
+        # of a control-sdk-v* tag never fails on an existing version.
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          published="$(npm view "@siphon-project/control@${version}" version 2>/dev/null || true)"
+          if [ -n "$published" ]; then
+            echo "@siphon-project/control@${version} already published, skipping"
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/release-control-sdk.yaml
+++ b/.github/workflows/release-control-sdk.yaml
@@ -163,6 +163,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+          # Idempotent re-tag: skip any wheel/sdist already on PyPI so
+          # re-running a control-sdk-v* tag never fails on an existing version.
+          skip-existing: true
 
   # ── Publish crates to crates.io (Trusted Publishing — OIDC, no token) ───
   # Dependency order: siphon-control-proto first, then siphon-control-client
@@ -187,10 +190,25 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Publish siphon-control-proto
-        run: cargo publish -p siphon-control-proto --manifest-path siphon-control-sdk/Cargo.toml
+        # Idempotent re-tag: skip if this version is already on crates.io so a
+        # re-run of a control-sdk-v* tag never fails on an existing version.
+        # crates.io rejects requests without a User-Agent, hence -A.
+        run: |
+          version="$(grep -m1 '^version = ' siphon-control-sdk/Cargo.toml | sed -E 's/^version = "(.*)"/\1/')"
+          if curl -sf -A "siphon-control-sdk release (github.com/siphon-project/siphon-sip)" "https://crates.io/api/v1/crates/siphon-control-proto/${version}" -o /dev/null; then
+            echo "siphon-control-proto ${version} already published, skipping"
+          else
+            cargo publish -p siphon-control-proto --manifest-path siphon-control-sdk/Cargo.toml
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish siphon-control-client
-        run: cargo publish -p siphon-control-client --manifest-path siphon-control-sdk/Cargo.toml
+        run: |
+          version="$(grep -m1 '^version = ' siphon-control-sdk/Cargo.toml | sed -E 's/^version = "(.*)"/\1/')"
+          if curl -sf -A "siphon-control-sdk release (github.com/siphon-project/siphon-sip)" "https://crates.io/api/v1/crates/siphon-control-client/${version}" -o /dev/null; then
+            echo "siphon-control-client ${version} already published, skipping"
+          else
+            cargo publish -p siphon-control-client --manifest-path siphon-control-sdk/Cargo.toml
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -18,6 +18,7 @@ the SDKs don't cover.
 | --- | --- |
 | Build a controller in **Python** | `pip install siphon-control` |
 | Build a controller in **Rust** | `cargo add siphon-control-client` |
+| Build a controller in **TypeScript** | `npm i @siphon-project/control` |
 | Build a controller in **another language** | the [raw `siphon-control.v1` protocol](#under-the-hood-the-raw-protocol) |
 
 ## Python — `siphon-control`
@@ -89,9 +90,42 @@ works for any adapter) and a typed `sip` facade (`sip::Call`) layered on top. A
 rejected command maps to `ControlError::Command` carrying the stable
 `ControlErrorCode`.
 
+## TypeScript — `@siphon-project/control`
+
+```bash
+npm i @siphon-project/control
+```
+
+```typescript
+import { SipClient, ControlError } from "@siphon-project/control";
+
+const client = await SipClient.connect({
+  url: "ws://siphon:9090/control/ws",
+  app: "ivr-app",
+  token: "s3cr3t",
+});
+
+await client.onCall(async (call) => {
+  await call.answer();                        // UAS 2xx to the parked A-leg
+  try {
+    await call.transfer("sip:agent@pbx");     // REFER; awaits the correlated reply
+  } catch (error) {
+    if (error instanceof ControlError) {
+      console.log("transfer rejected:", error.code);  // stable code
+    }
+  }
+  await call.hangup();
+});                                            // connect, dispatch, reconnect + resync
+```
+
+The same `Call` verbs as the Python and Rust facades. `SipClient` / `SipServer`
+are the SIP facade over the generic `ControlClient` / `ControlServer` core; both
+expose `onCall(handler)` and the identical `Call` handle — `SipServer` is the
+per-call-connect twin (siphon dials the app).
+
 ## Connection modes
 
-Both SDKs support the two modes, over the same JSON-over-WebSocket protocol.
+All three SDKs support the two modes, over the same JSON-over-WebSocket protocol.
 
 - **Outbound per-call-connect (the multi-pod default).** Your app runs a
   WebSocket server; siphon dials it once per handed-over call and the accepting

--- a/examples/remote_control/README.md
+++ b/examples/remote_control/README.md
@@ -14,7 +14,7 @@ request-id correlation, and reconnect + `resync`. You write `call.answer()` /
 would.
 
 - **Python** (`control_client.py`) uses [`siphon-control`](../../siphon-control-sdk/siphon-control),
-  which ships the **inbound-persistent** client.
+  which ships **both** connection modes.
 - **TypeScript** (`control_client.ts`) uses [`@siphon-project/control`](../../siphon-control-sdk/typescript),
   which ships **both** connection modes.
 
@@ -39,9 +39,8 @@ the control-plane reference at <https://siphon-sip.org/reference/control-plane/>
   configured application) and `resync`s to re-attach its calls after a reconnect.
   This is `SipClient` (TypeScript) / `ControlClient` (Python).
 
-The TypeScript example selects the mode with `SIPHON_CONTROL_MODE`
-(`outbound` | `inbound`). The Python SDK ships the inbound-persistent client, so
-the Python example is inbound.
+Both examples select the mode with `SIPHON_CONTROL_MODE` (`outbound` |
+`inbound`), defaulting to `outbound`.
 
 ## siphon configuration
 
@@ -90,7 +89,11 @@ pip install siphon-control            # once published
 # ...or from this repo, into the active venv:
 #   cd ../../siphon-control-sdk/siphon-control && maturin develop
 
-IVR_APP_TOKEN=changeme-dev-token python control_client.py
+# outbound (default): this app is the server siphon dials
+SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token python control_client.py
+
+# inbound: this app dials siphon's control.listen
+SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token python control_client.py
 ```
 
 ## Run the TypeScript client
@@ -122,8 +125,8 @@ npm run typecheck
 
 | var | default | applies to | meaning |
 |---|---|---|---|
-| `SIPHON_CONTROL_MODE` | `outbound` | TypeScript | `outbound` (server) or `inbound` (client) |
+| `SIPHON_CONTROL_MODE` | `outbound` | both | `outbound` (server) or `inbound` (client) |
 | `IVR_APP_TOKEN` | `changeme-dev-token` | both | bearer token (must match `control.apps[].token`) |
 | `SIPHON_CONTROL_APP` | `ivr-app` | both | app name asserted in `hello` (inbound) |
-| `SIPHON_CONTROL_BIND` | `127.0.0.1:8443` | TypeScript outbound | `host:port` this app listens on for siphon's dials |
+| `SIPHON_CONTROL_BIND` | `127.0.0.1:8443` | outbound | `host:port` this app listens on for siphon's dials |
 | `SIPHON_CONTROL_URL` | `ws://127.0.0.1:9092/control/ws` | inbound | siphon's control listener URL |

--- a/examples/remote_control/control_client.py
+++ b/examples/remote_control/control_client.py
@@ -7,11 +7,20 @@ Python SDK. The SDK owns the wire completely: no manual JSON, no ``rpc()`` helpe
 no request-id bookkeeping — you get a ``Call`` whose verbs read like an in-process
 siphon script (``call.answer()`` / ``call.transfer(...)`` / ``call.hangup()``).
 
-Inbound-persistent mode: this app is a WebSocket *client* that connects in to
-``control.listen``, sends a ``hello``, and owns the calls assigned to it. On a
-reconnect the SDK ``resync``s and re-dispatches the calls it still owns. (The
-Python SDK ships the inbound-persistent client; for the per-call-connect model
-where siphon dials the app, see the TypeScript example.)
+Two connection modes, same wire (subprotocol ``siphon-control.v1``), same
+``@on_call`` decorator, same ``Call`` handle — only the transport differs:
+
+  - **outbound per-call-connect (the default)** — this app is a WebSocket
+    *server* (``ControlServer``); siphon dials it once per handed-over call and
+    the accepting socket owns that call. No ``hello`` — the first frame is
+    ``StasisStart``. Use this for multi-pod / autoscaled controllers (siphon
+    always dials *out*, so the "which pod owns the call" affinity problem cannot
+    arise).
+  - **inbound persistent** — this app is a WebSocket *client* (``ControlClient``)
+    that connects in to ``control.listen`` and owns calls assigned to it. It
+    sends a ``hello`` and ``resync``s to re-attach its calls after a reconnect.
+
+Select the mode with ``SIPHON_CONTROL_MODE`` (``outbound`` | ``inbound``).
 
 The demo answers each handed-over call, stamps a per-call variable, holds
 briefly, then hangs up. Calls that are not handed over are unaffected.
@@ -24,7 +33,10 @@ Install the SDK::
 
 Run::
 
-    IVR_APP_TOKEN=changeme-dev-token python control_client.py
+    # outbound (default): siphon dials this server
+    SIPHON_CONTROL_BIND=0.0.0.0:8443 IVR_APP_TOKEN=changeme-dev-token python control_client.py
+    # inbound: this app dials siphon
+    SIPHON_CONTROL_MODE=inbound IVR_APP_TOKEN=changeme-dev-token python control_client.py
 
 See README.md for the matching siphon ``control:`` config and handover script.
 """
@@ -33,18 +45,17 @@ from __future__ import annotations
 import asyncio
 import os
 
-from siphon_control import Call, ControlClient, ControlError
+from siphon_control import Call, ControlClient, ControlError, ControlServer
 
+MODE = os.environ.get("SIPHON_CONTROL_MODE", "outbound").lower()
 APP_NAME = os.environ.get("SIPHON_CONTROL_APP", "ivr-app")
 TOKEN = os.environ.get("IVR_APP_TOKEN", "changeme-dev-token")
 CONTROL_URL = os.environ.get("SIPHON_CONTROL_URL", "ws://127.0.0.1:9092/control/ws")
+BIND = os.environ.get("SIPHON_CONTROL_BIND", "127.0.0.1:8443")
 
 ANSWER_HOLD_SECONDS = 5.0
 
-client = ControlClient(app=APP_NAME, token=TOKEN, url=CONTROL_URL)
 
-
-@client.on_call
 async def handle_call(call: Call) -> None:
     """Answer, stamp a per-call variable, hold, then hang up."""
     print(f"[call] StasisStart {call.channel_id} sip_call_id={call.sip_call_id}")
@@ -65,11 +76,36 @@ async def handle_call(call: Call) -> None:
         print(f"[call] {call.channel_id} rejected: {error.code}")
 
 
-async def main() -> None:
-    print(f"[control] connecting to {CONTROL_URL} as {APP_NAME!r}")
+async def run_inbound() -> None:
+    """Inbound persistent: dial siphon, hello, resync, then drive assigned calls."""
+    client = ControlClient(app=APP_NAME, token=TOKEN, url=CONTROL_URL)
+    client.on_call(handle_call)
+    print(f"[control] connecting (inbound) to {CONTROL_URL} as {APP_NAME!r}")
     # run() connects + hello, then drives the supervised reconnect + resync loop,
-    # dispatching each handed-over call to @client.on_call.
+    # dispatching each handed-over call to handle_call.
     await client.run()
+
+
+async def run_outbound() -> None:
+    """Outbound per-call-connect: siphon dials this server once per handed-over call."""
+    server = ControlServer(app=APP_NAME, token=TOKEN, bind=BIND)
+    server.on_call(handle_call)
+    # bind() resolves to the bound address (bind to `…:0` to learn an ephemeral
+    # port before siphon dials in); serve() then accepts one call per dial forever.
+    await server.bind()
+    print(f"[control] listening (outbound per-call-connect) on ws://{server.local_addr}")
+    await server.serve()
+
+
+async def main() -> None:
+    if MODE == "inbound":
+        await run_inbound()
+    elif MODE == "outbound":
+        await run_outbound()
+    else:
+        raise SystemExit(
+            f"SIPHON_CONTROL_MODE must be 'outbound' or 'inbound' (got {MODE!r})"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Small cleanup for the control-plane SDKs (examples / docs / CI only — the SDKs themselves are already merged and published).

## 1. Python example gains the per-call-connect mode
`examples/remote_control/control_client.py` only drove the inbound `ControlClient`. The Python SDK now also ships `ControlServer` (per-call-connect — siphon dials the app), so the example mirrors the TypeScript one: a single file with a shared `handle_call`, `SIPHON_CONTROL_MODE` selecting `outbound` (default, `ControlServer` + `bind()`/`local_addr`/`serve()`) or `inbound` (`ControlClient` + `run()`). SDK-only — no manual JSON/WebSocket. `examples/remote_control/README.md` updated to match (Python now does both modes).

## 2. Docs show all three languages
`docs/reference/control-plane.md` led with `pip install siphon-control` / `cargo add siphon-control-client` but was missing the now-published TypeScript SDK. Added a `TypeScript — @siphon-project/control` section (`npm i` + a short `onCall` / `await call.answer()` snippet) and a table row, alongside the Python/Rust ones. No restructure; nav unchanged.

## 3. Idempotent re-tag guards on the publish workflows
So re-running a `control-sdk-v*` tag never fails on an already-published version:
- `release-control-sdk.yaml` PyPI job: `skip-existing: true` on `pypa/gh-action-pypi-publish`.
- `release-control-sdk.yaml` crates.io job: before each `cargo publish`, probe `https://crates.io/api/v1/crates/<crate>/<version>` (version read from `siphon-control-sdk/Cargo.toml`, with a `User-Agent` since crates.io requires one) and skip on 200 — for both `siphon-control-proto` and `siphon-control-client`, proto-then-client order and the OIDC `CARGO_REGISTRY_TOKEN` env preserved.
- `release-control-sdk-ts.yaml` npm step: `npm view @siphon-project/control@<version>` (version from `package.json`); skip if present, else `npm publish --provenance --access public`. Tag-gate kept.

Tag triggers, OIDC permissions, and the wheel matrix are unchanged.

## Verify
- `python -m py_compile examples/remote_control/*.py` clean.
- Both workflow YAMLs parse; the crates.io and npm guard fragments pass `bash -n` and were exercised against the live registries (present → skip, absent → publish).
