### PR TITLE
chore(control-sdk): bump to 0.1.1 for the first tagged OIDC release

### DIFF
--- a/siphon-control-sdk/Cargo.lock
+++ b/siphon-control-sdk/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "futures-util",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/siphon-control-sdk/Cargo.toml
+++ b/siphon-control-sdk/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/siphon-control-sdk/siphon-control-client/Cargo.toml
+++ b/siphon-control-sdk/siphon-control-client/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 readme = "README.md"
 
 [dependencies]
-siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.0" }
+siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/siphon-control-sdk/siphon-control/Cargo.toml
+++ b/siphon-control-sdk/siphon-control/Cargo.toml
@@ -20,8 +20,8 @@ name = "siphon_control"
 crate-type = ["cdylib"]
 
 [dependencies]
-siphon-control-client = { path = "../siphon-control-client", version = "0.1.0" }
-siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.0" }
+siphon-control-client = { path = "../siphon-control-client", version = "0.1.1" }
+siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.1" }
 # No abi3: the target interpreter is free-threaded CPython 3.14t (the SIPhon
 # runtime), and the stable ABI (abi3) is not available on free-threaded builds.
 # A standard version-tagged wheel loads on both GIL and free-threaded 3.14.

--- a/siphon-control-sdk/typescript/package-lock.json
+++ b/siphon-control-sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siphon-project/control",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siphon-project/control",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/siphon-control-sdk/typescript/package.json
+++ b/siphon-control-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siphon-project/control",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript client for the SIPhon external control plane (siphon-control.v1) — an ARI/ESL-class rail for driving handed-over calls out of process.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Distribution/version bump only — no SDK code changes (0.1.1 == 0.1.0 code). The point is to exercise the tagged release path: the full cp314 + cp314t PyPI wheel matrix plus provenance via the release workflows, and to smoke-test the pipeline end to end.

## Rust (siphon-control-sdk/)
- `[workspace.package] version` 0.1.0 → 0.1.1 (all three crates inherit via `version.workspace = true`).
- Bumped the hardcoded inter-crate dependency pins to match: `siphon-control-proto` in siphon-control-client, and both `siphon-control-client` + `siphon-control-proto` in siphon-control.
- `Cargo.lock` synced (the three crates now resolve to 0.1.1).
- `cargo build` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

## TypeScript (@siphon-project/control)
- `npm version 0.1.1 --no-git-tag-version` — bumps `package.json` + `package-lock.json` together.
- `npm ci` succeeds (lockfile in sync), `npm run build` + `npm test` (15 tests) green.

No CHANGELOG entry (identical code). No tag pushed here — the maintainer pushes `control-sdk-v0.1.1` to trigger the release.