### PR TITLE
ci(control-sdk): drop macos-13 x86_64 wheels, macos is arm64-only

### DIFF
--- a/.github/workflows/release-control-sdk.yaml
+++ b/.github/workflows/release-control-sdk.yaml
@@ -97,10 +97,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS is arm64-only: GitHub's Intel (macos-13) runners are so
+          # starved that a release can queue for hours, and the publish jobs
+          # need every wheel. Intel-Mac users install from the sdist. Revisit
+          # via a cross-compile row (target: x86_64 on macos-14) if demand shows.
           - { os: macos-14,       target: aarch64, pyver: "3.14",  abi: cp314 }
           - { os: macos-14,       target: aarch64, pyver: "3.14t", abi: cp314t }
-          - { os: macos-13,       target: x86_64,  pyver: "3.14",  abi: cp314 }
-          - { os: macos-13,       target: x86_64,  pyver: "3.14t", abi: cp314t }
           - { os: windows-latest, target: x64,     pyver: "3.14",  abi: cp314 }
           - { os: windows-latest, target: x64,     pyver: "3.14t", abi: cp314t }
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub's Intel (macos-13) runners are starved to the point a release queues for hours, and the PyPI/crates publish jobs `need:` every wheel — so the control-sdk-v0.1.1 run stalled indefinitely on the two macos-13 rows while all Linux, macOS-arm64 and Windows wheels (cp314 + cp314t) went green.

Drop the macos-13 x86_64 rows; macOS ships arm64-only. Intel-Mac users install from the sdist. A cross-compile row (target x86_64 on macos-14) can bring Intel wheels back if demand shows up.