### PR TITLE
chore(ci): audit the two excluded workspaces that cargo-deny had never seen

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,9 +1,18 @@
 name: Security audit
 
-# RustSec advisories are time-varying: a new advisory can land against an
-# unchanged dependency, so this runs on a schedule (and whenever the dependency
-# set changes) instead of gating every PR — a new advisory never turns a green
-# PR red on unchanged code, but it still surfaces here within a week.
+# The TIME-VARYING half of cargo-deny: RustSec advisories. A new advisory can
+# land against an unchanged dependency, so this runs on a schedule (and whenever
+# the dependency set changes) instead of gating every PR — a new advisory never
+# turns a green PR red on unchanged code, but it still surfaces here within a
+# week.
+#
+# The deterministic half — bans / licenses / sources — runs per-PR in the `deny`
+# job of ci.yaml, where a failure lands on the change that introduced it.
+#
+# One job per workspace: siphon-bin/ and siphon-control-sdk/ are excluded
+# standalone workspaces with their own Cargo.lock + deny.toml, so a `cargo deny`
+# at the repo root resolves only the siphon-sip graph and would leave both
+# unaudited.
 on:
   schedule:
     - cron: "0 6 * * 1" # Mondays 06:00 UTC
@@ -11,8 +20,8 @@ on:
     branches: [main]
     paths:
       - "**/Cargo.toml"
-      - "Cargo.lock"
-      - "deny.toml"
+      - "**/Cargo.lock"
+      - "**/deny.toml"
   workflow_dispatch:
 
 permissions:
@@ -20,10 +29,21 @@ permissions:
 
 jobs:
   advisories:
-    name: cargo-deny advisories
+    name: cargo-deny advisories (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: siphon-sip
+            manifest: ./Cargo.toml
+          - name: siphon-bin
+            manifest: ./siphon-bin/Cargo.toml
+          - name: control-sdk
+            manifest: ./siphon-control-sdk/Cargo.toml
     steps:
       - uses: actions/checkout@v7
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
+          manifest-path: ${{ matrix.manifest }}
           command: check advisories

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,15 +108,54 @@ jobs:
       - name: Compile benches (no run)
         run: PYO3_PYTHON=python3.14 cargo bench --no-run --all-features
 
-  # ── siphon-bin extension binary (opt-in SMPP) ───────────────────────────
+  # ── Dependency policy gate (cargo-deny) ─────────────────────────────────
+  # The DETERMINISTIC half of cargo-deny: bans (duplicate / wildcard crates),
+  # licenses, and sources. These only move when the dependency set moves, so
+  # they belong on every PR — a GPL dependency, a new git source, or a
+  # duplicate-crate blowup fails right where it was introduced.
+  #
+  # The time-varying half — `check advisories` — deliberately does NOT run
+  # here: a fresh RustSec advisory can land against a dependency that has not
+  # changed and would turn a green PR red on untouched code. That runs weekly
+  # and on main instead (.github/workflows/audit.yml).
+  #
+  # One matrix entry per workspace: siphon-bin/ and siphon-control-sdk/ are
+  # excluded standalone workspaces with their own Cargo.lock + deny.toml, so a
+  # `cargo deny` at the repo root resolves only the siphon-sip graph.
+  deny:
+    name: cargo-deny (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: siphon-sip
+            manifest: ./Cargo.toml
+          - name: siphon-bin
+            manifest: ./siphon-bin/Cargo.toml
+          - name: control-sdk
+            manifest: ./siphon-control-sdk/Cargo.toml
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: ${{ matrix.manifest }}
+          command: check bans licenses sources
+
+  # ── siphon-bin extension binary (opt-in extensions) ─────────────────────
   # The siphon-bin/ package is a SEPARATE, excluded standalone workspace that
   # git-deps the published siphon-sip lib + the extension crates, so the main
   # jobs above never build it. This job is the bit-rot guard for the
   # composition: it proves the `siphon` binary still compiles (and is
-  # clippy-clean) both WITHOUT and WITH the `smpp` feature. Because the deps are
-  # git `branch = "main"`, this builds against current siphon-sip/siphon-smpp
-  # main — i.e. it validates the composition against the latest published lib,
-  # not the in-tree lib of this checkout (the deliberate git-dep tradeoff).
+  # clippy-clean) with no extensions, with each extension on its own, and with
+  # every extension at once. Because the deps are git `branch = "main"`, this
+  # builds against current siphon-sip / extension mains — i.e. it validates the
+  # composition against the latest published lib, not the in-tree lib of this
+  # checkout (the deliberate git-dep tradeoff).
+  #
+  # Adding an extension module: give it its own build + clippy pair below. The
+  # combined leg rides on the `full` aggregate feature, so it picks the new
+  # module up from Cargo.toml without a workflow edit.
   siphon-bin:
     runs-on: ubuntu-latest
     defaults:
@@ -152,6 +191,24 @@ jobs:
 
       - name: Clippy (--features smpp)
         run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features smpp -- -D warnings
+
+      # Same for siphon-http: inbound routes + the Rust-backed `http.Client`.
+      - name: Build (--features http)
+        run: PYO3_PYTHON=python3.14 cargo build --features http
+
+      - name: Clippy (--features http)
+        run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features http -- -D warnings
+
+      # Every module at once — the real drop-in binary, and the only leg that
+      # catches cross-extension breakage: a version skew between two extension
+      # crates' siphon-sip pins, or two modules claiming the same namespace.
+      # `full` is the aggregate in Cargo.toml, so a new module joins this leg
+      # by being added there.
+      - name: Build (--features full)
+        run: PYO3_PYTHON=python3.14 cargo build --features full
+
+      - name: Clippy (--features full)
+        run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features full -- -D warnings
 
   # ── Python SDK tests ──────────────────────────────────────────────────
   sdk-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,23 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   list is currently **empty** — all 50 fixtures are handled as the RFC requires.
 
 ### Fixed
+- **The two excluded workspaces are now covered by the security audit.**
+  `siphon-bin/` and `siphon-control-sdk/` are standalone workspaces with their
+  own `Cargo.lock`, so the scheduled `cargo-deny` run — which resolves the
+  repo-root graph — never saw either of them. `siphon-bin/` had consequently
+  drifted onto a `crossbeam-epoch` carrying RUSTSEC-2026-0204 (the advisory the
+  server itself moved off in 1.2.1) and a yanked `spin`, and its `siphon-http`
+  extension pin pulled the unmaintained `rustls-pemfile` (RUSTSEC-2025-0134);
+  all three are cleared — `siphon-http` moves to v1.0.2, which loads TLS certs
+  and keys through `rustls-pki-types` instead. Each workspace also gains its
+  own `deny.toml`, and the audit's path filters now match nested manifests and
+  lockfiles rather than only the root ones. The policy is also split by how it
+  behaves over time: `bans` / `licenses` / `sources` are deterministic — they only move when the dependency set moves —
+  so they gate every pull request across all three workspaces, failing a GPL
+  dependency, an unexpected git source or a duplicate-crate blowup right where
+  it was introduced. `advisories` stays on the weekly schedule (plus `main`),
+  because a fresh RustSec advisory can land against an unchanged dependency and
+  must not turn a green pull request red on untouched code.
 - **A branch the proxy failed itself no longer outranks a real answer from a
   sibling branch.** Now that a transport error becomes a 503 and a timeout a
   408, straight class ordering (5xx beats 4xx) handed a branch that never left

--- a/siphon-bin/Cargo.lock
+++ b/siphon-bin/Cargo.lock
@@ -161,6 +161,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -179,8 +180,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -548,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2686,15 +2689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,8 +3000,8 @@ dependencies = [
 
 [[package]]
 name = "siphon-http"
-version = "1.0.1"
-source = "git+https://github.com/siphon-project/siphon-http?tag=v1.0.1#9f5e03a7045ddf4b15b942866e191738ccb3b011"
+version = "1.0.2"
+source = "git+https://github.com/siphon-project/siphon-http?tag=v1.0.2#99b639d5734699ec4212503f92d6d61d1e2337d1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3021,7 +3015,6 @@ dependencies = [
  "pyo3-async-runtimes",
  "reqwest",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_yaml",
  "siphon-sip",
@@ -3048,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "siphon-sip"
 version = "1.5.1"
-source = "git+https://github.com/siphon-project/siphon-sip?branch=main#a37bc217b2ff4ae5335d1dfdaef3dffaf6805fab"
+source = "git+https://github.com/siphon-project/siphon-sip?branch=main#9b31ea61de803508eacd1649695ff6602d064569"
 dependencies = [
  "aes",
  "arc-swap",
@@ -3188,9 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -39,7 +39,7 @@ full = ["smpp", "http"]    # convenience aggregate: every extension module
 # are pinned to their released tags for stable, intentional bumps.
 siphon-sip = { git = "https://github.com/siphon-project/siphon-sip", branch = "main" }
 siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.4.0", optional = true }
-siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.1", optional = true }
+siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.2", optional = true }
 
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/siphon-bin/deny.toml
+++ b/siphon-bin/deny.toml
@@ -1,0 +1,68 @@
+# cargo-deny — dependency-graph security / license / source policy for siphon-bin.
+#
+# siphon-bin is a standalone, excluded workspace with its own Cargo.lock, so the
+# repo-root deny.toml does NOT cover it: `cargo deny check` at the root resolves
+# only the siphon-sip graph. This file is the siphon-bin equivalent and is run by
+# its own job in .github/workflows/audit.yml.
+#
+# Keep the [advisories] / [bans] / [licenses] policy byte-identical to the root
+# deny.toml — the only intentional divergence is [sources], because siphon-bin
+# composes first-party extension crates from git (see below).
+#
+# Local: `cargo deny check` from this directory.
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Evaluate the graph for the Linux targets we ship binaries/images for.
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+]
+# Every extension module (smpp, http, …) — the maximal dependency graph.
+all-features = true
+
+[advisories]
+# RustSec advisory database. A yanked crate or an open advisory fails the audit.
+version = 2
+yanked = "deny"
+ignore = [
+    # paste — unmaintained transitive (no vuln); remove when the parent crate drops it.
+    "RUSTSEC-2024-0436",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+[licenses]
+# The crate is MIT; keep dependencies OSI-permissive.
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",       # Boost Software License — permissive, OSI + FSF-Free (xxhash-rust via redis)
+    "CC0-1.0",       # public-domain dedication, FSF-Free (notify — hot-reload file watcher)
+    "CDLA-Permissive-2.0",  # Linux Foundation permissive data license (webpki-roots — Mozilla CA bundle)
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
+]
+confidence-threshold = 0.9
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
+[sources.allow-org]
+# The whole point of this package: siphon-sip plus opt-in extension crates, each
+# consumed straight from its own first-party repo (extensions are not published
+# to crates.io — see docs/extensions.md). Org-scoped rather than a per-repo list
+# so adding the next extension module doesn't need a policy edit; a git dep from
+# anywhere else still fails.
+github = ["siphon-project"]

--- a/siphon-control-sdk/deny.toml
+++ b/siphon-control-sdk/deny.toml
@@ -1,0 +1,59 @@
+# cargo-deny — dependency-graph security / license / source policy for the
+# control-plane client SDKs.
+#
+# siphon-control-sdk is a standalone, excluded workspace with its own Cargo.lock,
+# so the repo-root deny.toml does NOT cover it: `cargo deny check` at the root
+# resolves only the siphon-sip graph. Without this file the SDK graph would fall
+# back to the root config by directory walk-up — which works by accident and
+# silently changes if either tree moves. It is pinned here instead, and run by
+# its own job in .github/workflows/audit.yml.
+#
+# These crates PUBLISH (crates.io + PyPI), so an advisory here ships to third
+# parties embedding the SDK — this graph is gated at least as strictly as the
+# server's.
+#
+# Local: `cargo deny check` from this directory.
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+]
+all-features = true
+
+[advisories]
+# RustSec advisory database. A yanked crate or an open advisory fails the audit.
+version = 2
+yanked = "deny"
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+[licenses]
+# The crates are MIT; keep dependencies OSI-permissive.
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
+]
+confidence-threshold = 0.9
+
+[sources]
+# Everything the SDKs depend on comes from crates.io — no git deps (unlike
+# siphon-bin, which composes first-party extension crates from GitHub).
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
The scheduled `cargo-deny` job resolves the repo-root graph. `siphon-bin/` and `siphon-control-sdk/` are excluded standalone workspaces with their own `Cargo.lock`, so neither has ever been audited.

`siphon-bin/` had drifted accordingly:

| Crate | Advisory |
|---|---|
| `crossbeam-epoch` 0.9.18 | RUSTSEC-2026-0204 — the advisory the server itself moved off in 1.2.1 |
| `spin` 0.9.8 | yanked |
| `rustls-pemfile` 2.2.0 | RUSTSEC-2025-0134 — unmaintained, via the `siphon-http` pin |

`siphon-control-sdk/` was clean, but only by luck — and those crates publish to crates.io and PyPI, so an advisory there reaches third parties embedding the SDK.

## Changes

- **Lock refreshed** — `crossbeam-epoch` 0.9.20, `spin` 0.9.9. `siphon-http` repinned to v1.0.2, which loads TLS certs and keys through `rustls-pki-types`' `PemObject` instead of the archived `rustls-pemfile`.
- **A `deny.toml` per workspace.** `siphon-bin/` allows the `siphon-project` GitHub org, since composing first-party extension crates from git is the whole point of the package — a git dep from anywhere else still fails. `siphon-control-sdk/` stays crates.io-only, and is now pinned rather than falling back to the root config by directory walk-up.
- **Policy split by how it behaves over time.** `bans` / `licenses` / `sources` are deterministic — they only move when the dependency set moves — so they gate every PR across all three graphs, failing a copyleft dependency, an unexpected git source or a duplicate-crate blowup right where it was introduced. `advisories` stays weekly plus `main`, because a fresh RustSec entry can land against an unchanged dependency and must not turn a green PR red on untouched code.
- **Audit path filters fixed** — `Cargo.lock` and `deny.toml` are root-anchored and never matched the nested files; now `**/`-prefixed.
- `siphon-bin` CI gains `--features http` and `--features full` legs, so cross-extension breakage (a version skew between two extension crates' `siphon-sip` pins, two modules claiming one namespace) is caught.

## Verification

```
root workspace        advisories ok, bans ok, licenses ok, sources ok
siphon-bin            advisories ok, bans ok, licenses ok, sources ok
siphon-control-sdk    advisories ok, bans ok, licenses ok, sources ok
```

`siphon-bin` builds clean with the refreshed lock (`cargo check --all-features`).