### PR TITLE
feat(examples): voice-AI over the WebSocket bridge, proven end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **Worked voice-AI example — a carrier call answered by an AI over a WebSocket.**
+  `examples/voice_ai_b2bua.py` + `.yaml` compose the shipped pieces into the
+  single-leg shape: identify the carrier by source IP, `rtpengine.answer_local()`
+  with the `voice_ai` profile and a per-call `ws_uri`, answer with the SDP the
+  engine synthesised, and surface DTMF. There is no B leg — the media engine
+  anchors the call with the WebSocket server as the far side. A control-plane
+  variant (`examples/voice_ai_control.py` + `voice_ai_control_app.py`) drives the
+  same media path with the policy in an external application via
+  `call.handover(..., answer=True, ws_uri=...)`. Documented end to end in
+  `docs/cookbook/voice-ai.md`, including how to tell a working bridge from a
+  call that merely returns audio. Requires a `siphon-rtp` engine of **0.1.5 or
+  later**: earlier builds accept `ws_uri` on `answer_local` and silently never
+  dial it.
+- **Functional coverage for the voice-AI path** — `scripts/run-tests.sh --voice-ai`
+  drives a real INVITE through the example against a mock siphon-rtp control
+  server (`sipp/siphon-rtp/mock_siphon_rtp.py`, the JSON-over-TCP twin of the
+  existing rtpengine NG mock) and asserts the answer SDP is anchored on the
+  engine's media address rather than echoing the caller's own `c=` back.
+
+### Fixed
+- **A UAS-mode B2BUA answer carried no `Contact`, so no in-dialog request could
+  be addressed to it.** RFC 3261 §12.1.1 / §13.3.1.4 require a dialog-establishing
+  response to carry the Contact the UAC builds its remote target from. The
+  relayed path set one from the B-leg's 2xx, but `call.answer()` / `call.progress()`
+  — every single-leg answer, including every voice-AI call — had no B-leg to copy
+  from and set none at all. A well-behaved UAC therefore had nowhere to send ACK,
+  BYE, re-INVITE or PRACK: SIPp renders the empty target as `BYE  SIP/2.0`, which
+  arrives unparseable, and the call is only released when a timer fires. Host and
+  port now resolve exactly as the relayed path resolves them, so the Contact names
+  the listener the INVITE actually arrived on rather than the first-configured one.
+- **A SIPp scenario that timed out reported success.** `run_sipp` in
+  `scripts/run-tests.sh` exempted exit code 255, which is precisely what SIPp
+  returns when a scenario times out — including when an assertion fails and the
+  call never completes. Any hanging scenario was green.
+
+### Added
 - **`Contact.age_secs`** — seconds since a binding was created or last
   refreshed, for scripts that need their own recency rule (`[c for c in
   registrar.lookup(uri) if c.age_secs < 3600]`). Monotonic, and preserved

--- a/docs/cookbook/voice-ai.md
+++ b/docs/cookbook/voice-ai.md
@@ -1,0 +1,169 @@
+# Voice AI: answer a call with an AI over a WebSocket
+
+A carrier call arrives, siphon answers it itself, and the caller's audio is
+bridged to an external WebSocket media server — your agent. The AI never touches
+RTP, jitter buffers or codecs: it reads and writes 16-bit linear PCM.
+
+There is **no B leg**. The media engine anchors the call as a *single-leg*
+session with the WebSocket server as the far side. That is what
+`rtpengine.answer_local()` means, and it is why this is not a relay.
+
+Requires `media.backend: siphon-rtp`. The WebSocket bridge is a native engine
+extension — rtpengine and rtpproxy have no equivalent and fail the config load
+rather than answering the call and bridging it nowhere.
+
+## The shape
+
+```python
+@b2bua.on_invite
+async def answer_with_ai(call):
+    if not call.from_gateway("carriers"):
+        call.reject(403, "Forbidden")
+        return
+
+    answer_sdp = await rtpengine.answer_local(
+        call,
+        profile="voice_ai",
+        ws_uri="ws://127.0.0.1:9001/stream?call={call_id}",
+    )
+    if answer_sdp is None:
+        return          # no encodable codec; auto-rejected 488
+
+    call.answer(200, "OK", body=answer_sdp, content_type="application/sdp")
+```
+
+The full worked example is [`examples/voice_ai_b2bua.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/voice_ai_b2bua.py)
+with its config in `examples/voice_ai_b2bua.yaml`.
+
+`{call_id}` expands per call, so the AI can correlate the audio stream with the
+call without a side channel. `{from_tag}`, `{from_user}` and `{to_user}` expand
+too; an unknown placeholder is an error rather than a literal, so a typo cannot
+reach the engine as a URI path segment.
+
+## Bridge, not tee
+
+Two different things stream audio to a WebSocket, and picking the wrong one is
+the most common mistake here:
+
+- **`ws_uri` — bridge / takeover.** The WebSocket server *becomes* the far side.
+  There is no A↔B relay. This is the page you are reading.
+- **`ws_tee` — additive copy.** The call relays normally *and* a copy streams
+  out, leaving SIPREC and recording untouched. That is for transcription or
+  compliance on an ordinary two-party call. See
+  [media engines](../media-engines.md#websocket-audio-bridge-vs-tee).
+
+## The profile
+
+The built-in `voice_ai` profile sets everything except the endpoint:
+
+```yaml
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "127.0.0.1:8080"
+  profiles:
+    voice_ai:
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"     # plain RTP toward the carrier
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        noise_suppression: true           # clean the uplink toward the AI
+        echo_cancellation: true           # AI downlink is the echo reference
+        ws_vad: true                      # turn boundaries without server-side VAD
+        ws_barge_in: true                 # cut playout on the caller's speech edge
+        ws_vad_hangover_ms: 300
+      answer: *voice_ai_flags
+```
+
+`ws_uri` is deliberately unset in the built-in — there is no sensible default
+endpoint — so it comes from your profile override or, as above, per call from the
+script.
+
+## The wire your server sees
+
+The engine dials your server as a WebSocket client and speaks a small envelope:
+
+- **Text frames** — `{"type": ..., "data": ...}`, camelCase fields. The first is
+  `start`, announcing `streamId` and the audio `media` format.
+- **Binary frames** — one raw little-endian L16 mono PCM frame per ptime. At
+  8 kHz / 20 ms that is **320 bytes** (`sampleRate/1000 * ptime * 2`). Send binary
+  frames back to play audio; no announcement needed.
+- **`clear`** flushes queued playout for barge-in; the engine answers with a
+  `mark` named `cleared`.
+- **`stop`**, or closing the socket, ends the bridge. Deleting the call also
+  tears it down.
+
+A reference server lives in the engine repo at
+[`examples/voice-ai/server.py`](https://github.com/siphon-project/siphon-rtp/blob/main/examples/voice-ai/server.py).
+It echoes the caller back, which is the quickest way to prove the whole path.
+The protocol reference is
+[siphon-rtp's voice-AI cookbook](https://github.com/siphon-project/siphon-rtp/blob/main/docs/cookbook/voice-ai.md).
+
+## Running it end to end
+
+```sh
+# 1. the AI side (echo server proves the path; swap in your agent later)
+pip install websockets
+python3 siphon-rtp/examples/voice-ai/server.py      # ws://127.0.0.1:9001/stream
+
+# 2. the media engine
+siphon-rtp --control 127.0.0.1:8080 --relay-bind-ip 127.0.0.1
+
+# 3. siphon
+siphon -c examples/voice_ai_b2bua.yaml
+```
+
+Then place a call from a source inside the `carriers` gateway group. With the
+echo server, the caller hears themselves back with a couple of frames of delay.
+
+What a working run looks like:
+
+```
+# the AI server
+connection open
+start ws-<call-id> {'encoding': 'L16', 'sampleRate': 8000, 'channels': 1,
+                    'bitDepth': 16, 'endianness': 'little', 'ptime': 20}
+control speech_started {'streamId': 'ws-<call-id>'}
+
+# the engine
+websocket bridge attached to the single-leg answer  role="uas_local_ws"
+call finished  pipeline=Ws  near_codec="PCMU"  far_codec="-"
+```
+
+`pipeline=Ws` and `far_codec="-"` are the two to check. They mean the leg is
+bridged to the socket and there is no far SIP party — if you see `pipeline=Media`
+and a real `far_codec`, the bridge did not attach and the audio you are hearing
+is coming from somewhere else.
+
+!!! warning "Returned audio is not proof on its own"
+    A single-leg call can generate audio locally, so hearing *something* back
+    does not mean the bridge works. Check the WebSocket server's own log for the
+    `start` envelope. That is the only signal that says your server is in the
+    path.
+
+## Requirements
+
+The bridge needs `siphon-rtp` **0.1.5 or later** on both sides: siphon's pinned
+`siphon-rtp-proto`, and the running engine. Earlier engine builds accept
+`ws_uri` on `answer_local` and silently never dial it.
+
+## Where the policy lives
+
+The example above keeps everything in the in-process script. To drive the same
+call from an external application instead — the ARI/ESL model — hand it over:
+
+```python
+call.handover("voice-ai-app", answer=True,
+              ws_uri="ws://127.0.0.1:9001/stream?call={call_id}")
+```
+
+`answer=True` answers and anchors the media *before* handing over, so the
+controller inherits a connected channel. The audio still goes directly between
+the engine and your WebSocket server; the control plane carries call control
+only. See [`examples/voice_ai_control.py`](https://github.com/siphon-project/siphon-sip/blob/main/examples/voice_ai_control.py)
+and the [control-plane reference](../reference/control-plane.md).
+
+Note that prompt playback and DTMF are not control-plane verbs yet, so an app
+that needs them reads DTMF in-process via `@rtpengine.on_dtmf` or handles it
+inside the AI over the audio stream.

--- a/examples/voice_ai_b2bua.py
+++ b/examples/voice_ai_b2bua.py
@@ -1,0 +1,99 @@
+"""
+SIPhon voice-AI B2BUA — a carrier call answered by an AI over a WebSocket.
+
+siphon answers the carrier's INVITE itself as a UAS. There is no B leg: the media
+engine anchors the call as a *single-leg* session and bridges the caller's audio to
+an external WebSocket media server, which becomes the far side. The engine decodes
+RTP to linear PCM and streams it up; PCM the server sends back is encoded to RTP
+toward the caller. The AI never touches RTP, jitter buffers or codecs.
+
+All policy is in this file — nothing external drives the call. For the same media
+path with policy in an *external* application instead, see voice_ai_control.py.
+
+The shape:
+
+  1. identify the carrier by source IP against a gateway group,
+  2. `rtpengine.answer_local(...)` — the engine synthesises an RFC 3264 answer for
+     the caller's own offer and dials the WebSocket bridge,
+  3. answer the call with that SDP,
+  4. surface DTMF and bridge failures to the script.
+
+Requires `media.backend: siphon-rtp` — the bridge is a native engine extension.
+rtpengine and rtpproxy have no equivalent and fail the config load.
+
+Run:
+    # 1. the AI side (siphon-rtp's reference echo server, or your own agent)
+    python3 siphon-rtp/examples/voice-ai/server.py     # ws://127.0.0.1:9001/stream
+    # 2. the media engine
+    siphon-rtp --control 127.0.0.1:8080
+    # 3. siphon
+    siphon -c examples/voice_ai_b2bua.yaml
+
+See docs/cookbook/voice-ai.md for the full run-book.
+"""
+from siphon import b2bua, proxy, rtpengine, log
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    request.reply(200, "OK")
+
+
+@b2bua.on_invite
+async def answer_with_ai(call):
+    # Source-IP membership of the carrier pool. On UDP this is a direction hint
+    # only (spoofable); the trunk is TLS/TCP in production, where the handshake
+    # makes it a real trust signal.
+    if not call.from_gateway("carriers"):
+        log.warn(f"[{call.id}] INVITE from unknown source {call.source_ip}")
+        call.reject(403, "Forbidden")
+        return
+
+    # Single-leg answer: the engine picks one encodable codec from the caller's
+    # offer and returns the answer SDP. `ws_uri` makes the WebSocket server this
+    # leg's far side rather than a SIP peer — {call_id} expands per call, so the
+    # AI can correlate the stream with the call without a side channel.
+    #
+    # Returns None when the offer carried no codec this engine build can encode:
+    # auto_reject has already set a deferred 488 (RFC 3261 §13.3.1.2) on the call,
+    # so there is nothing left to answer.
+    answer_sdp = await rtpengine.answer_local(
+        call,
+        profile="voice_ai",
+        ws_uri="ws://127.0.0.1:9001/stream?call={call_id}",
+    )
+    if answer_sdp is None:
+        log.warn(f"[{call.id}] no encodable codec in offer — rejected 488")
+        return
+
+    call.answer(200, "OK", body=answer_sdp, content_type="application/sdp")
+    log.info(f"[{call.id}] answered; audio bridged to the AI")
+
+
+@b2bua.on_bye
+async def on_bye(call, initiator):
+    # The engine tears the bridge down with the call, so there is no media
+    # cleanup to do here. Release whatever per-call state the AI side holds.
+    log.info(f"[{call.id}] call ended by {initiator}")
+
+
+@rtpengine.on_dtmf
+def on_digit(call_id, from_tag, digit, duration_ms, volume):
+    # In-band / RFC 4733 DTMF the engine detected, surfaced as a script event.
+    # An IVR would accumulate these; the AI usually just wants the digit.
+    log.info(f"[{call_id}] DTMF {digit} ({duration_ms}ms)")
+
+
+@rtpengine.on_ws_tee_ended
+def on_tee_ended(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
+    # Only fires if this script also attaches a tee (it does not by default) —
+    # kept here because a tee dying is otherwise invisible: the call carries on
+    # and the consumer simply stops receiving audio. See docs/media-engines.md.
+    if reason != "detached":
+        log.warn(f"[{call_id}] tee {stream_id} died: {reason}")
+
+
+# Handing the caller off to a human is a REFER on the A dialog —
+# call.refer("sip:agent@pbx.example.com"). Not wired here: this example is the
+# answer-and-stream path, and a carrier that challenges an in-dialog REFER needs
+# credentials on the retry, which is a separate concern from the media bridge.

--- a/examples/voice_ai_b2bua.yaml
+++ b/examples/voice_ai_b2bua.yaml
@@ -1,0 +1,76 @@
+# SIPhon voice-AI B2BUA — see examples/voice_ai_b2bua.py
+#
+# A carrier call is answered by siphon itself and its audio bridged to an external
+# WebSocket media server (the AI). There is no B leg: the media engine anchors the
+# call as a single-leg session with the WebSocket server as the far side.
+#
+# Requires the native siphon-rtp engine — the WebSocket bridge is an engine
+# extension with no rtpengine or rtpproxy equivalent, so a profile that sets
+# ws_uri on either of those backends fails the config load rather than answering
+# the call and bridging it nowhere.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+  tcp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "ai.example.com"
+
+advertised_address: "ai.example.com"
+
+script:
+  path: "examples/voice_ai_b2bua.py"
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "127.0.0.1:8080"     # siphon-rtp --control
+    timeout_ms: 2000
+
+  profiles:
+    # Overrides the built-in `voice_ai` profile. The built-in leaves ws_uri unset
+    # (there is no sensible default endpoint) and the script passes it per call;
+    # everything else here is live on its own.
+    voice_ai:
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"   # plain RTP toward the carrier
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        # Clean the uplink toward the inference server. The AI downlink is the
+        # echo reference, so AEC cancels the phone's return path.
+        noise_suppression: true
+        echo_cancellation: true
+        # Turn boundaries without the server running its own VAD, and local
+        # barge-in so playout is cut on the caller's speech edge with no server
+        # round-trip.
+        ws_vad: true
+        ws_barge_in: true
+        ws_vad_hangover_ms: 300
+      answer: *voice_ai_flags
+
+# The carrier trunk. Membership is what call.from_gateway("carriers") tests —
+# source-IP only, so treat it as a trust signal on TLS/TCP and a direction hint
+# on UDP. Addresses are RFC 5737 documentation range.
+gateway:
+  groups:
+    - name: "carriers"
+      probe:
+        enabled: true
+        interval_secs: 15
+        failure_threshold: 3
+      destinations:
+        - uri: "sip:gw1.carrier.example:5060"
+          address: "198.51.100.11:5060"
+        - uri: "sip:gw2.carrier.example:5060"
+          address: "198.51.100.12:5060"
+
+# Readiness / liveness for a container or load balancer.
+admin:
+  listen: "127.0.0.1:8081"
+
+log:
+  level: info

--- a/examples/voice_ai_control.py
+++ b/examples/voice_ai_control.py
@@ -1,0 +1,70 @@
+"""
+SIPhon voice-AI, control-plane variant — the in-process half.
+
+Same media path as voice_ai_b2bua.py: the call is answered by siphon and its audio
+bridged to a WebSocket media server, with no B leg. The difference is *where the
+policy lives*. Here the script does the minimum — identify the carrier, then hand
+the call to an external application — and everything after that (how long to run,
+when to transfer, when to hang up) is decided out of process.
+
+`call.handover(..., answer=True, ws_uri=...)` is answer-first, sometimes called
+AI-park: siphon answers the call and anchors its media to the WebSocket bridge
+*before* handing over, so the controller inherits an already-connected channel
+rather than having to answer it and then wire media. That commits the call —
+CDR answer-time starts here, not in the controller.
+
+Two things worth knowing before choosing this over the in-process example:
+
+  * The audio never travels over the control plane. The AI reads and writes PCM on
+    the WebSocket the media engine dialled; the control plane carries call
+    control only. The two are independent connections to two different services.
+  * Prompt playback and DTMF are not control-plane verbs yet, so an app that
+    needs them still reads DTMF in-process via `@rtpengine.on_dtmf` (below) or
+    handles it inside the AI over the audio stream.
+
+Run:
+    # 1. the AI side
+    python3 siphon-rtp/examples/voice-ai/server.py     # ws://127.0.0.1:9001/stream
+    # 2. the media engine
+    siphon-rtp --control 127.0.0.1:8080
+    # 3. the external controller
+    IVR_APP_TOKEN=changeme-dev-token python3 examples/voice_ai_control_app.py
+    # 4. siphon
+    siphon -c examples/voice_ai_control.yaml
+"""
+from siphon import b2bua, proxy, rtpengine, log
+
+APP = "voice-ai-app"
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    request.reply(200, "OK")
+
+
+@b2bua.on_invite
+async def hand_to_controller(call):
+    if not call.from_gateway("carriers"):
+        log.warn(f"[{call.id}] INVITE from unknown source {call.source_ip}")
+        call.reject(403, "Forbidden")
+        return
+
+    # Answer-first handover: siphon answers and bridges the audio to the AI, then
+    # hands control out. `on_lost` decides what happens if the controller dies
+    # mid-call — hang up rather than strand a caller on a bridge nobody owns.
+    call.handover(
+        APP,
+        answer=True,
+        profile="voice_ai",
+        ws_uri="ws://127.0.0.1:9001/stream?call={call_id}",
+        on_lost="hangup",
+        deadline_ms=3000,
+    )
+    log.info(f"[{call.id}] answered and handed to {APP}")
+
+
+@rtpengine.on_dtmf
+def on_digit(call_id, from_tag, digit, duration_ms, volume):
+    # DTMF is not a control-plane verb yet, so it surfaces here even though the
+    # rest of the policy is out of process.
+    log.info(f"[{call_id}] DTMF {digit} ({duration_ms}ms)")

--- a/examples/voice_ai_control.yaml
+++ b/examples/voice_ai_control.yaml
@@ -1,0 +1,77 @@
+# SIPhon voice-AI, control-plane variant — see examples/voice_ai_control.py
+#
+# Identical media path to examples/voice_ai_b2bua.yaml (single-leg answer, audio
+# bridged to a WebSocket media server). The difference is the `control:` block:
+# the script hands each answered call to an external application, which owns the
+# policy from there.
+#
+# The audio does not traverse the control plane. The media engine dials the AI's
+# WebSocket directly; `control:` carries call control only.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+  tcp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "ai.example.com"
+
+advertised_address: "ai.example.com"
+
+script:
+  path: "examples/voice_ai_control.py"
+
+# The external application. Inbound-persistent here (the app connects in to
+# `listen`) because the Python SDK ships that client; for the outbound
+# per-call-connect model — siphon dials the app once per call, which is what you
+# want for a multi-pod controller — use `apps:` with `per_call_connect: true`
+# instead. See examples/remote_control/README.md.
+control:
+  listen: "127.0.0.1:9092"
+  apps:
+    - name: "voice-ai-app"
+      token: "${IVR_APP_TOKEN:-changeme-dev-token}"
+  limits:
+    event_queue_depth: 1024
+    reattach_grace_secs: 10
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "127.0.0.1:8080"     # siphon-rtp --control
+    timeout_ms: 2000
+
+  profiles:
+    voice_ai:
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        noise_suppression: true
+        echo_cancellation: true
+        ws_vad: true
+        ws_barge_in: true
+        ws_vad_hangover_ms: 300
+      answer: *voice_ai_flags
+
+gateway:
+  groups:
+    - name: "carriers"
+      probe:
+        enabled: true
+        interval_secs: 15
+        failure_threshold: 3
+      destinations:
+        - uri: "sip:gw1.carrier.example:5060"
+          address: "198.51.100.11:5060"
+        - uri: "sip:gw2.carrier.example:5060"
+          address: "198.51.100.12:5060"
+
+admin:
+  listen: "127.0.0.1:8081"
+
+log:
+  level: info

--- a/examples/voice_ai_control_app.py
+++ b/examples/voice_ai_control_app.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+SIPhon voice-AI, control-plane variant — the external application.
+
+The out-of-process half of examples/voice_ai_control.py. siphon has already
+answered the call and bridged its audio to the WebSocket media server, so this
+app inherits a live, already-connected channel: there is nothing to answer and no
+media to wire. It owns what happens *next*.
+
+The audio does not come through here. The AI reads and writes PCM on the
+WebSocket the media engine dialled; this connection carries call control only.
+Keeping them separate is the point — the media path survives a controller restart
+(and `on_lost` in the handover script decides whether the call should).
+
+Install the SDK:
+    pip install siphon-control
+    # ...or from this repo, into the active venv:
+    #   cd siphon-control-sdk/siphon-control && maturin develop
+
+Run:
+    IVR_APP_TOKEN=changeme-dev-token python3 examples/voice_ai_control_app.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+from siphon_control import Call, ControlClient, ControlError
+
+APP_NAME = os.environ.get("SIPHON_CONTROL_APP", "voice-ai-app")
+TOKEN = os.environ.get("IVR_APP_TOKEN", "changeme-dev-token")
+CONTROL_URL = os.environ.get("SIPHON_CONTROL_URL", "ws://127.0.0.1:9092/control/ws")
+
+# How long to let the AI run before giving up on it. A real deployment ends the
+# call when the AI decides it is done (over its own side channel) rather than on
+# a wall-clock timer; this keeps the example self-contained.
+MAX_CALL_SECONDS = 120.0
+
+client = ControlClient(app=APP_NAME, token=TOKEN, url=CONTROL_URL)
+
+
+@client.on_call
+async def handle_call(call: Call) -> None:
+    """Own one AI call. It arrives answered, with audio already bridged."""
+    print(f"[call] StasisStart {call.channel_id} sip_call_id={call.sip_call_id}")
+    try:
+        # Stamp something the rest of the estate can correlate on. Per-call
+        # variables live on the control channel and drain with the call.
+        await call.set_var("handled_by", APP_NAME)
+
+        # The AI is already talking to the caller over the WebSocket. Hold the
+        # channel open until it is done, then release.
+        await asyncio.sleep(MAX_CALL_SECONDS)
+
+        # Handing off to a human instead of hanging up:
+        #   await call.transfer("sip:agent@pbx.example.com")
+        await call.hangup()
+        print(f"[call] released {call.channel_id}")
+    except ControlError as error:
+        # A call that ended underneath us is a typed `not_found`; a verb this
+        # server build does not implement is `unsupported_verb`. Neither is fatal
+        # to the other calls this app owns.
+        print(f"[call] {call.channel_id}: {error.code}")
+
+
+async def main() -> None:
+    print(f"[control] connecting to {CONTROL_URL} as {APP_NAME!r}")
+    await client.run()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n[control] interrupted")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - SBC (B2BUA): cookbook/sbc.md
       - WhatsApp calling: cookbook/whatsapp-calling.md
       - Call transfer (REFER): cookbook/call-transfer.md
+      - Voice AI (WebSocket bridge): cookbook/voice-ai.md
       - Number normalization: cookbook/number-normalization.md
       - Number routing (LNP / redirect): cookbook/number-routing.md
       - Media & RTP profiles: cookbook/media-rtp.md

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -16,7 +16,10 @@ set -euo pipefail
 run_sipp() {
   local rc=0
   "$@" || rc=$?
-  if [[ $rc -ne 0 && $rc -ne 255 ]]; then
+  if [[ $rc -ne 0 ]]; then
+    # 255 used to be exempted here. It is what SIPp returns when a scenario
+    # times out — including when an assertion fails and the call never
+    # completes — so exempting it made every scenario that hangs report green.
     echo "FAILED (exit $rc): $*"
     exit $rc
   fi
@@ -29,6 +32,7 @@ RUN_CALL=false
 RUN_PRESENCE=false
 RUN_RTPENGINE=false
 RUN_RTPPROXY=false
+RUN_VOICE_AI=false
 RUN_REINVITE=false
 RUN_B2BUA=false
 RUN_B2BUA_AUTH=false
@@ -54,6 +58,7 @@ for arg in "$@"; do
     --presence)   RUN_PRESENCE=true;   SELECTED_MODES+=("$arg") ;;
     --rtpengine)  RUN_RTPENGINE=true;  SELECTED_MODES+=("$arg") ;;
     --rtpproxy)   RUN_RTPPROXY=true;   SELECTED_MODES+=("$arg") ;;
+    --voice-ai)   RUN_VOICE_AI=true;   SELECTED_MODES+=("$arg") ;;
     --reinvite)   RUN_REINVITE=true;   SELECTED_MODES+=("$arg") ;;
     --b2bua)      RUN_B2BUA=true;      SELECTED_MODES+=("$arg") ;;
     --b2bua-auth) RUN_B2BUA_AUTH=true; SELECTED_MODES+=("$arg") ;;
@@ -71,6 +76,7 @@ for arg in "$@"; do
       echo
       echo "Scenario modes (pick at most ONE per run):"
       echo "  --ipsec --charging --call --presence --rtpengine --rtpproxy --reinvite"
+      echo "  --voice-ai"
       echo "  --b2bua --b2bua-auth --gateway --auto100 --http-auth --wedge --banscan"
       echo "  --security --rfc4475 --webrtc"
       echo
@@ -172,6 +178,14 @@ if [[ "$RUN_RTPENGINE" == true ]]; then
   echo "=== SIPp RTPEngine test (register bob → INVITE with media anchoring) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile rtpengine run --rm sipp-rtpengine-register
   run_sipp docker compose -f "$COMPOSE_FILE" --profile rtpengine up --abort-on-container-exit sipp-rtpengine-uac sipp-rtpengine-uas
+fi
+
+# ── Step 7a: Voice-AI B2BUA test (optional) ───────────────────────────────
+if [[ "$RUN_VOICE_AI" == true ]]; then
+  echo "=== SIPp voice-AI test (single-leg answer_local + WebSocket bridge) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile voice-ai up \
+    --abort-on-container-exit --exit-code-from sipp-voice-ai-uac sipp-voice-ai-uac
+  docker compose -f "$COMPOSE_FILE" --profile voice-ai rm -sf sipp-voice-ai-uac 2>/dev/null || true
 fi
 
 # ── Step 7b: Classic rtpproxy proxy test (optional) ───────────────────────

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -4029,6 +4029,96 @@ services:
     profiles:
       - b2bua-path
 
+  # ── Voice-AI B2BUA (single-leg answer + WebSocket bridge) ─────────────────
+  # Requires the "voice-ai" profile.
+  #
+  # Flow: UAC → siphon B2BUA (rtpengine.answer_local with ws_uri) → 200 OK
+  # There is no UAS: siphon answers the call itself with the SDP the engine
+  # synthesised, so the test asserts the answer is anchored on the engine's
+  # media address rather than echoing the caller's own c= line back.
+  #
+  # The mock records every control command it receives, so the offer's
+  # profile.ws_uri (placeholder-expanded) is visible in its logs.
+  #
+  # Usage:
+  #   docker compose -f sipp/docker-compose.yaml --profile voice-ai \
+  #     up --abort-on-container-exit sipp-voice-ai-uac
+
+  # Mock siphon-rtp — native JSON-over-TCP control on 8080
+  mock-siphon-rtp:
+    image: python:3.12-slim
+    container_name: mock-siphon-rtp
+    volumes:
+      - ./siphon-rtp:/app:ro
+    working_dir: /app
+    command: ["python3", "mock_siphon_rtp.py"]
+    environment:
+      SIPHON_RTP_PORT: "8080"
+      MOCK_MEDIA_IP: "203.0.113.1"
+      MOCK_MEDIA_PORT: "30000"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.50
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket,struct,json; s=socket.create_connection(('127.0.0.1',8080),2); b=json.dumps({'id':1,'command':'ping'}).encode(); s.sendall(struct.pack('!I',len(b))+b); h=s.recv(4); n=struct.unpack('!I',h)[0]; d=s.recv(n); s.close(); exit(0 if b'pong' in d else 1)\""]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+    profiles:
+      - voice-ai
+
+  # SIPhon B2BUA running examples/voice_ai_b2bua.py
+  siphon-voice-ai:
+    build:
+      context: ..
+    container_name: siphon-voice-ai-test
+    depends_on:
+      mock-siphon-rtp:
+        condition: service_healthy
+    volumes:
+      - ./siphon-rtp/siphon-voice-ai.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.51
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - voice-ai
+
+  # Carrier UAC: INVITE with SDP, expects an anchored answer, then BYE
+  sipp-voice-ai-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-voice-ai:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - "172.20.0.51:5060"
+      - -sf
+      - /sipp/scenarios/voice_ai_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - voice-ai
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:

--- a/sipp/siphon-rtp/mock_siphon_rtp.py
+++ b/sipp/siphon-rtp/mock_siphon_rtp.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Mock siphon-rtp native control server for functional testing.
+
+Speaks the native JSON-over-TCP control protocol (a 4-byte big-endian length
+prefix followed by a JSON body) so a SIPp scenario can exercise siphon's
+media-anchoring path without building or running the real engine — the CI
+analogue of sipp/rtpengine/mock_rtpengine.py, which does the same job for the
+rtpengine NG/bencode protocol.
+
+What it proves is the *composition*: that siphon identifies the carrier, issues
+the right control verb with the right profile, and answers the call with the SDP
+the engine handed back. It deliberately does not move audio. Proving the audio
+path needs the real engine plus a WebSocket media server; that run is gated on
+SIPHON_RTP_BIN (see tests/integration/siphon_rtp_tests.rs) because CI does not
+build the engine.
+
+For offer / answer / answer_local it returns SDP with the c-line rewritten to
+MOCK_MEDIA_IP and the audio port to MOCK_MEDIA_PORT, simulating anchoring.
+
+Every command received is echoed to stdout as one JSON line, so a scenario can
+assert on what siphon actually sent — in particular that `profile.ws_uri` is
+present and expanded.
+"""
+
+import json
+import os
+import re
+import socket
+import socketserver
+import struct
+import sys
+import threading
+
+LISTEN_HOST = os.environ.get("SIPHON_RTP_HOST", "0.0.0.0")
+LISTEN_PORT = int(os.environ.get("SIPHON_RTP_PORT", "8080"))
+MOCK_MEDIA_IP = os.environ.get("MOCK_MEDIA_IP", "203.0.113.1")
+MOCK_MEDIA_PORT = os.environ.get("MOCK_MEDIA_PORT", "30000")
+
+HEADER = struct.Struct("!I")
+
+
+def rewrite_sdp(sdp: str) -> str:
+    """Point the SDP at the mock's media address, as an anchoring engine would."""
+    sdp = re.sub(r"c=IN IP4 [\d.]+", f"c=IN IP4 {MOCK_MEDIA_IP}", sdp)
+    sdp = re.sub(r"m=audio \d+", f"m=audio {MOCK_MEDIA_PORT}", sdp)
+    return sdp
+
+
+def answer_sdp_for(offer: str) -> str:
+    """Synthesise a single-codec answer, the way answer_local does.
+
+    RFC 3264 §6.1: the answer selects from the offered formats. Take the first
+    offered payload type so the answer is consistent with the offer rather than
+    inventing a codec the caller never proposed.
+    """
+    match = re.search(r"m=audio \d+ RTP/AVP ([\d ]+)", offer)
+    payload = match.group(1).split()[0] if match else "0"
+    rtpmap = re.search(rf"a=rtpmap:{payload} (\S+)", offer)
+    codec = rtpmap.group(1) if rtpmap else "PCMU/8000"
+    return (
+        "v=0\r\n"
+        f"o=- 1 1 IN IP4 {MOCK_MEDIA_IP}\r\n"
+        "s=-\r\n"
+        f"c=IN IP4 {MOCK_MEDIA_IP}\r\n"
+        "t=0 0\r\n"
+        f"m=audio {MOCK_MEDIA_PORT} RTP/AVP {payload}\r\n"
+        f"a=rtpmap:{payload} {codec}\r\n"
+        "a=ptime:20\r\n"
+    )
+
+
+def handle_command(command: dict) -> dict:
+    verb = command.get("command")
+    if verb == "ping":
+        return {"result": "pong"}
+    if verb in ("offer", "answer"):
+        return {"result": "ok", "sdp": rewrite_sdp(command.get("sdp", ""))}
+    if verb == "answer_local":
+        return {"result": "ok", "sdp": answer_sdp_for(command.get("sdp", ""))}
+    if verb in ("delete", "attach_ws_tee", "detach_ws_tee", "play_media", "stop_media"):
+        return {"result": "ok"}
+    # Unknown verbs are an explicit error, never a silent ok — a mock that
+    # answers ok to everything hides exactly the bugs this exists to catch.
+    return {"result": "error", "reason": f"mock: unsupported verb {verb!r}"}
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        buffer = b""
+        while True:
+            try:
+                chunk = self.request.recv(65536)
+            except OSError:
+                return
+            if not chunk:
+                return
+            buffer += chunk
+            while len(buffer) >= HEADER.size:
+                (length,) = HEADER.unpack(buffer[: HEADER.size])
+                if len(buffer) < HEADER.size + length:
+                    break
+                body = buffer[HEADER.size : HEADER.size + length]
+                buffer = buffer[HEADER.size + length :]
+                try:
+                    command = json.loads(body)
+                except ValueError:
+                    continue
+                print(json.dumps(command), flush=True)
+                response = handle_command(command)
+                response["id"] = command.get("id", 0)
+                payload = json.dumps(response).encode()
+                try:
+                    self.request.sendall(HEADER.pack(len(payload)) + payload)
+                except OSError:
+                    return
+
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main() -> int:
+    with Server((LISTEN_HOST, LISTEN_PORT), Handler) as server:
+        print(
+            f"mock siphon-rtp control listening on {LISTEN_HOST}:{LISTEN_PORT} "
+            f"(media {MOCK_MEDIA_IP}:{MOCK_MEDIA_PORT})",
+            flush=True,
+        )
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sipp/siphon-rtp/siphon-voice-ai.yaml
+++ b/sipp/siphon-rtp/siphon-voice-ai.yaml
@@ -1,0 +1,54 @@
+# siphon config for the voice-AI functional test (sipp/voice_ai_uac.xml).
+#
+# Drives examples/voice_ai_b2bua.py against the mock siphon-rtp control server
+# (sipp/siphon-rtp/mock_siphon_rtp.py), so the composition is tested without
+# building the engine. The mock anchors SDP on 203.0.113.1 and records every
+# command it receives; it does not move audio. The audio path is proven
+# separately against a real engine — see docs/cookbook/voice-ai.md.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "ai.example.com"
+
+advertised_address: "172.20.0.51"
+
+script:
+  path: "/etc/siphon/examples/voice_ai_b2bua.py"
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "172.20.0.50:8080"
+    timeout_ms: 2000
+
+  profiles:
+    voice_ai:
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        noise_suppression: true
+        echo_cancellation: true
+        ws_vad: true
+        ws_barge_in: true
+        ws_vad_hangover_ms: 300
+      answer: *voice_ai_flags
+
+# The UAC's address, so call.from_gateway("carriers") passes and the script
+# answers instead of rejecting 403.
+gateway:
+  groups:
+    - name: "carriers"
+      probe:
+        enabled: false
+      destinations:
+        - uri: "sip:uac.test:5060"
+          address: "172.20.0.52:5060"
+
+log:
+  level: info

--- a/sipp/voice_ai_uac.xml
+++ b/sipp/voice_ai_uac.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Voice-AI B2BUA UAC scenario:
+  INVITE (with SDP) -> 100 -> 200 OK (with anchored SDP) -> ACK -> BYE -> 200
+
+  There is no UAS. siphon answers the call itself as a single-leg UAS
+  (rtpengine.answer_local), with the media engine as the far side, so the 200 OK
+  carries an answer the engine synthesised rather than one relayed from a B leg.
+
+  The scenario asserts the answer SDP is anchored on the engine's media address
+  (the mock's 203.0.113.1) rather than echoing the caller's own c= line back. An
+  un-anchored answer would mean the media never reached the engine at all, which
+  is the failure this test exists to catch.
+-->
+<scenario name="Voice-AI B2BUA UAC">
+
+  <!-- INVITE with a PCMU offer. The engine answers with one codec chosen from it. -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:ai@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/voice-ai-test-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <!-- 200 OK carrying the engine's synthesised answer. The regexp fails the
+       scenario unless the SDP is anchored on the engine's media address. -->
+  <recv response="200" rtd="true" crlf="true" rrs="true">
+    <action>
+      <ereg regexp="c=IN IP4 203\.0\.113\.1"
+            search_in="body"
+            check_it="true"
+            assign_to="anchored" />
+      <!-- SIPp treats a variable that is only ever assigned as a scenario
+           error and aborts before sending, so reference it here. -->
+      <log message="answer SDP anchored on the engine: [$anchored]" />
+      <!-- RFC 3261 §12.1.1 / §13.3.1.4: the dialog-establishing 2xx must carry
+           the Contact the UAC builds its remote target from. Without it SIPp's
+           [next_url] below is empty and the BYE goes out with no Request-URI,
+           which the far end cannot parse. Asserted here so a regression fails
+           on the missing header rather than as a scenario timeout. -->
+      <ereg regexp="Contact:[^\r\n]*sip:"
+            search_in="msg"
+            check_it="true"
+            assign_to="contact_present" />
+      <log message="2xx Contact present: [$contact_present]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Hold the call so the bridge is established for a moment. -->
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17041,6 +17041,35 @@ fn b2bua_send_uas_response(
 
     let mut response =
         build_response(invite, code, reason, state.server_header.as_deref(), &reply_headers);
+
+    // RFC 3261 §12.1.1 / §13.3.1.4: a UAS MUST put a Contact in a response that
+    // establishes a dialog — the 2xx, and an 18x that opens an early one. It is
+    // the remote target the UAC builds ACK / BYE / re-INVITE / PRACK against, so
+    // without it a well-behaved UAC has nowhere to send them: it renders an
+    // empty Request-URI and the in-dialog request is unparseable on arrival.
+    // The relayed B-leg path already does this; UAS mode (`call.answer()` /
+    // `call.progress()`, i.e. every single-leg answer including the voice-AI
+    // one) had no B-leg 2xx to copy a Contact from and set none at all.
+    //
+    // Host and port are resolved exactly as the relayed path resolves them:
+    // `a_leg_advertised_host` applies the advertised_address fallback and never
+    // leaks an unspecified bind address, and the port is the listener the INVITE
+    // actually arrived on — on a multi-homed host that is not `via_port()`, and
+    // a Contact naming the wrong port strands every in-dialog request.
+    if code > 100 {
+        let host = state.a_leg_advertised_host(local_addr, &transport);
+        let port = a_leg_advertised_port(local_addr, state.via_port(&transport));
+        response.headers.set(
+            "Contact",
+            format!(
+                "<sip:{}:{};transport={}>",
+                host,
+                port,
+                transport.to_string().to_lowercase()
+            ),
+        );
+    }
+
     if let Some(body_bytes) = body {
         if let Some(ct) = content_type {
             response.headers.set("Content-Type", ct.to_string());


### PR DESCRIPTION
Composes the voice-AI path into a worked example and runs it for real. Every piece already shipped — single-leg `answer_local`, the `ws_uri` bridge, the `voice_ai` profile, `from_gateway`, `on_dtmf` — but they had never been put together, and doing that surfaced two defects that only appear when a real UA drives a single-leg answered call.

## Fixed: a UAS-mode 2xx carried no `Contact`

RFC 3261 §12.1.1 / §13.3.1.4 require a dialog-establishing response to carry the Contact the UAC builds its remote target from. The relayed path set one from the B-leg's 2xx, but `call.answer()` / `call.progress()` have no B-leg to copy from and set **none at all** — so every single-leg answer, including every voice-AI call, gave the UAC nowhere to address ACK, BYE, re-INVITE or PRACK.

SIPp renders the empty target as `BYE  SIP/2.0`, which arrives unparseable; the call only clears when a timer fires. Host and port now resolve through the same advertised-host / arrival-port helpers the relayed path uses, so the Contact names the listener the INVITE actually arrived on rather than the first-configured one.

## Fixed: a SIPp scenario that timed out reported success

`run_sipp` exempted exit code 255 — precisely what SIPp returns on scenario timeout, including when an assertion fails and the call never completes. Any hanging scenario was green.

Removing that exemption is what caught the missing Contact. Verified both directions: a deliberately-broken assertion now fails the harness, and the correct one passes. Base, `--rtpengine`, `--rtpproxy` and `--voice-ai` all still pass under the stricter check.

## Added

- **`examples/voice_ai_b2bua.py` + `.yaml`** — policy in-process: identify the carrier by source IP, `answer_local()` with the `voice_ai` profile and a per-call `ws_uri`, answer with the engine's SDP, surface DTMF.
- **`examples/voice_ai_control.py` + `voice_ai_control_app.py` + `.yaml`** — same media path, policy in an external app via `call.handover(..., answer=True, ws_uri=...)`. The audio never crosses the control plane; the engine dials the AI directly.
- **`sipp/siphon-rtp/mock_siphon_rtp.py`** — JSON-over-TCP mock control server, the twin of the existing NG/bencode mock, so the composition is CI-testable without building the engine. It records every command, so `profile.ws_uri` (placeholder-expanded) is visible.
- **`scripts/run-tests.sh --voice-ai`** — drives a real INVITE and asserts both the anchored answer SDP and the 2xx Contact.
- **`docs/cookbook/voice-ai.md`** — the run-book, the bridge-vs-tee distinction, and why returned audio alone never proves the bridge attached.

## Verification

Run live against a real `siphon-rtp` and the engine repo's reference echo server:

- AI server: `connection open` → `start ws-<call-id>` with the L16/8k/20ms format → `speech_started` → clean close
- Engine: `websocket bridge attached to the single-leg answer`, `role="uas_local_ws"`, `pipeline=Ws`, `far_codec="-"`
- RTP: 150 sent, 150 returned

That last pair matters. A single-leg call generates audio locally, so returned RTP alone proves nothing — an earlier run of this same driver reported 150/175 and looked like a working demo while the WebSocket server had never been connected to. With `pipeline=Ws` and no far SIP leg the only possible source is the WS downlink. The cookbook documents this trap.

`cargo clippy --all-targets --all-features -- -D warnings` clean, 3382 + 306 + 45 + others green, 514 SDK tests green, `--voice-ai` green.

## Requires

A `siphon-rtp` engine of **0.1.5 or later**. Earlier builds accept `ws_uri` on `answer_local` and silently never dial it (fixed engine-side in siphon-rtp#181).

No perf baseline: examples, tests and docs, plus one header added to a response siphon already builds.
