### PR TITLE
chore(ci): let dependabot see the two excluded workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # Dependabot — weekly, grouped to keep PR noise low.
 #
-# NOTE: cargo PRs must NOT be auto-merged. CLAUDE.md mandates the 16-row perf
-# baseline + mem-leak test before every commit, and CI does not run perf — a
+# NOTE: cargo PRs must NOT be auto-merged. Project policy mandates the 16-row
+# perf baseline + mem-leak test before every commit, and CI does not run perf — a
 # crate bump that is green in CI can still regress throughput or leak. Treat
 # each cargo PR as "green CI AND I ran the perf/mem baseline". github-actions
 # and docker bumps are safe to merge on green CI.
@@ -17,6 +17,33 @@ updates:
     groups:
       cargo-minor-patch:
         update-types: ["minor", "patch"]
+
+  # The two EXCLUDED standalone workspaces. They carry their own Cargo.lock, so
+  # the "/" entry above never touches them — which is precisely how siphon-bin/
+  # drifted onto a crossbeam-epoch advisory (RUSTSEC-2026-0204) that the root
+  # workspace had already been bumped off, and a yanked spin, without anything
+  # noticing. Without this block the weekly audit only ever reports that drift
+  # after the fact; this is what stops it accumulating.
+  #
+  # siphon-bin also git-deps siphon-sip at `branch = "main"`, and Dependabot
+  # advances that locked SHA — which is what keeps the composition from quietly
+  # building an ever-older lib. The EXTENSION crates are pinned to release tags
+  # on purpose (deliberate, reviewed bumps — see siphon-bin/Cargo.toml), and
+  # Dependabot mis-resolves tag-pinned cargo git deps (dependabot-core#10913),
+  # so they are ignored here and bumped by hand.
+  - package-ecosystem: cargo
+    directories:
+      - "/siphon-bin"
+      - "/siphon-control-sdk"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-excluded-workspaces-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "siphon-smpp"
+      - dependency-name: "siphon-http"
 
   # Pinned action versions in the workflows (checkout, rust-cache, docker/*, …).
   - package-ecosystem: github-actions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,10 +148,16 @@ jobs:
   # jobs above never build it. This job is the bit-rot guard for the
   # composition: it proves the `siphon` binary still compiles (and is
   # clippy-clean) with no extensions, with each extension on its own, and with
-  # every extension at once. Because the deps are git `branch = "main"`, this
-  # builds against current siphon-sip / extension mains — i.e. it validates the
-  # composition against the latest published lib, not the in-tree lib of this
-  # checkout (the deliberate git-dep tradeoff).
+  # every extension at once. It builds the lib the way an operator would — from
+  # the git deps, NOT from the in-tree source of this checkout (the deliberate
+  # git-dep tradeoff), so an in-tree change reaches this job only once it is on
+  # main and siphon-bin/Cargo.lock has advanced onto it.
+  #
+  # That lock is the reason this is a bit-rot guard and not a freshness check:
+  # `cargo build` resolves the exact SHA committed there, so this job is green
+  # against a siphon-sip main it may be many commits behind. Dependabot advances
+  # the lock weekly (.github/dependabot.yml) — that, not this job, is what keeps
+  # the composition current.
   #
   # Adding an extension module: give it its own build + clippy pair below. The
   # combined leg rides on the `full` aggregate feature, so it picks the new


### PR DESCRIPTION
Follow-up to #155, which made the weekly audit *watch* `siphon-bin/` and `siphon-control-sdk/`. This stops the drift it would otherwise keep reporting.

## Why they drifted

Dependabot's cargo entry is `directory: "/"`. Both excluded workspaces carry their own `Cargo.lock`, so that entry has never touched either of them. That is exactly how `siphon-bin` ended up on a `crossbeam-epoch` carrying RUSTSEC-2026-0204 — the root workspace got the bump, `siphon-bin` did not — plus a yanked `spin`. Nothing was watching, and nothing was updating.

#155 fixed the watching half. Without this, the audit just reports the same class of drift after the fact, every time.

## Changes

- **`directories:` block for `/siphon-bin` and `/siphon-control-sdk`**, same weekly cadence and minor/patch grouping as the root (distinct group name, since group names must not collide across blocks).
- **Extension crates ignored.** `siphon-smpp` and `siphon-http` are pinned to release tags on purpose — deliberate, reviewed bumps, per the note in `siphon-bin/Cargo.toml` — and Dependabot mis-resolves tag-pinned cargo git deps ([dependabot-core#10913](https://github.com/dependabot/dependabot-core/issues/10913)). `siphon-sip` is *not* ignored: it is pinned `branch = "main"`, and having its locked SHA advance weekly is the point.
- **Corrected the `siphon-bin` job comment.** It claimed the job "builds against current siphon-sip / extension mains". It does not — `Cargo.lock` is committed, so `cargo build` resolves the exact SHA pinned there, and the job can be green against a `main` it is many commits behind. It is a bit-rot guard; Dependabot is what makes it fresh. The comment now says so.

## Note

Also scrubbed an internal-instructions filename that had leaked into the `dependabot.yml` header comment.