### PR TITLE
chore(deps): siphon-smpp v1.5.1, h2 0.4.16 for RUSTSEC-2026-0258, and de-race three sipp log assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   list is currently **empty** — all 50 fixtures are handled as the RFC requires.
 
 ### Fixed
+- **The extension binary picks up the SMPP bind-handshake fix.** `siphon-bin/`
+  moves its `siphon-smpp` pin to v1.5.1, which carries smpp34 1.4.1: both sides
+  read the bind handshake with a single `read()` and rejected the buffer when
+  anything the peer pipelined behind its bind PDU coalesced into the same
+  segment, so an SMSC with queued MT — which sends its first `deliver_sm` the
+  moment it accepts the bind — took the session down on arrival and the
+  supervisor reconnected into the same failure. The bump also brings the
+  listener-failure hooks from v1.5.0 (a refused connect no longer parks the
+  server task for the process lifetime), and moves `h2` to 0.4.16 for
+  RUSTSEC-2026-0258 (unbounded empty DATA frames), which reaches that graph
+  through the HTTP extension.
 - **The two excluded workspaces are now covered by the security audit.**
   `siphon-bin/` and `siphon-control-sdk/` are standalone workspaces with their
   own `Cargo.lock`, so the scheduled `cargo-deny` run — which resolves the

--- a/scripts/b2bua_path_test.sh
+++ b/scripts/b2bua_path_test.sh
@@ -51,6 +51,21 @@ edge_received_invite() {
   "${COMPOSE[@]}" logs "$1" 2>/dev/null | grep -a "> INVITE" | grep -qE "INVITE +[1-9]"
 }
 
+# `docker compose logs` is not synchronous with a container's stdout: a line the
+# container has already written can take a moment to reach the log driver, so
+# grepping once the instant a call returns is a race. Poll to a deadline for the
+# assertions that expect a line to BE there.
+wait_edge_received_invite() {
+  local deadline=$((SECONDS + 15))
+  while (( SECONDS < deadline )); do
+    if edge_received_invite "$1"; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
 echo "=== B2BUA: routing a binding through its RFC 3327 Path ==="
 echo "[*] Building siphon image..."
 "${COMPOSE[@]}" build siphon-b2bua-path
@@ -78,7 +93,7 @@ if [[ ${rc} -ne 0 ]]; then
   "${COMPOSE[@]}" logs sipp-b2bua-path-edge-answer 2>/dev/null | tail -30 || true
   fail "the call was not answered (exit ${rc}) — the B-leg did not follow the binding's Path"
 fi
-edge_received_invite sipp-b2bua-path-edge-answer \
+wait_edge_received_invite sipp-b2bua-path-edge-answer \
   || fail "the edge never received the INVITE — the B-leg was sent to the Contact URI"
 
 "${COMPOSE[@]}" rm -sf sipp-b2bua-path-edge-answer >/dev/null 2>&1 || true
@@ -108,9 +123,9 @@ if [[ ${rc} -ne 0 ]]; then
   "${COMPOSE[@]}" logs sipp-b2bua-path-edge-answer-b 2>/dev/null | tail -30 || true
   fail "the call was not answered (exit ${rc}) — the failover branch did not reach binding B's edge"
 fi
-edge_received_invite sipp-b2bua-path-edge-reject \
+wait_edge_received_invite sipp-b2bua-path-edge-reject \
   || fail "binding A's edge never received the INVITE — branch 0 was not routed by its Path"
-edge_received_invite sipp-b2bua-path-edge-answer-b \
+wait_edge_received_invite sipp-b2bua-path-edge-answer-b \
   || fail "binding B's edge never received the INVITE — the failover branch reused binding A's route set"
 
 "${COMPOSE[@]}" rm -sf sipp-b2bua-path-edge-reject sipp-b2bua-path-edge-answer-b >/dev/null 2>&1 || true
@@ -136,7 +151,7 @@ if [[ ${rc} -ne 0 ]]; then
   "${COMPOSE[@]}" logs sipp-b2bua-path-edge-answer 2>/dev/null | tail -30 || true
   fail "the call was not answered (exit ${rc}) — dial's route= set the header but not the destination"
 fi
-edge_received_invite sipp-b2bua-path-edge-answer \
+wait_edge_received_invite sipp-b2bua-path-edge-answer \
   || fail "the edge never received the INVITE — dial ignored its route set when picking a destination"
 
 "${COMPOSE[@]}" rm -sf sipp-b2bua-path-edge-answer >/dev/null 2>&1 || true
@@ -168,8 +183,11 @@ if [[ ${rc} -ne 0 ]]; then
   "${COMPOSE[@]}" logs sipp-b2bua-path-decoy 2>/dev/null | tail -30 || true
   fail "the call was not answered (exit ${rc}) — the over-MTU B-leg left the route set"
 fi
-edge_received_invite sipp-b2bua-path-edge-answer \
+wait_edge_received_invite sipp-b2bua-path-edge-answer \
   || fail "the edge never received the over-MTU INVITE"
+# One-shot on purpose: this asserts a line is ABSENT, so polling for it would
+# only burn the deadline. The preceding wait_ call already gave the log driver
+# time to catch up on this run's output.
 if edge_received_invite sipp-b2bua-path-decoy; then
   fail "the decoy received the INVITE — the §18.1.1 re-probe resolved the Contact host and moved the B-leg there"
 fi

--- a/scripts/failover_test.sh
+++ b/scripts/failover_test.sh
@@ -70,9 +70,24 @@ fi
 edge_received_invite() {
   "${COMPOSE[@]}" logs "$1" 2>/dev/null | grep -a "> INVITE" | grep -qE "INVITE +[1-9]"
 }
-edge_received_invite sipp-failover-reject \
+
+# `docker compose logs` is not synchronous with a container's stdout: a line the
+# container has already written can take a moment to reach the log driver, so
+# grepping once the instant a call returns is a race. Poll to a deadline for the
+# assertions that expect a line to BE there.
+wait_edge_received_invite() {
+  local deadline=$((SECONDS + 15))
+  while (( SECONDS < deadline )); do
+    if edge_received_invite "$1"; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+wait_edge_received_invite sipp-failover-reject \
   || fail "binding A's edge never received the INVITE — branch 0 was not routed by its Path"
-edge_received_invite sipp-failover-answer \
+wait_edge_received_invite sipp-failover-answer \
   || fail "binding B's edge never received the INVITE — the failover branch reused binding A's route set"
 
 "${COMPOSE[@]}" rm -sf sipp-failover-reject sipp-failover-answer >/dev/null 2>&1 || true
@@ -97,9 +112,9 @@ if [[ ${rc} -ne 0 ]]; then
   fail "the call was not answered (exit ${rc}) — on_failure did not re-target the relay"
 fi
 
-edge_received_invite sipp-failover-backend-primary \
+wait_edge_received_invite sipp-failover-backend-primary \
   || fail "the primary backend never received the INVITE"
-edge_received_invite sipp-failover-backend-backup \
+wait_edge_received_invite sipp-failover-backend-backup \
   || fail "the backup backend never received the INVITE — on_failure's request.relay() did not re-send"
 
 echo "PASS: on_failure fired for a single-destination relay and its retry reached the backup"

--- a/scripts/transport_error_test.sh
+++ b/scripts/transport_error_test.sh
@@ -24,6 +24,22 @@ fail() {
   exit 1
 }
 
+# `docker compose logs` is not synchronous with the container's stdout: a line
+# the container has already written can take a moment to reach the log driver.
+# Grepping once, the instant the call returns, is therefore a race — it has gone
+# red on a run whose own failure dump (the same logs, read 200 ms later) did
+# contain the line. Poll to a deadline instead of sampling once.
+wait_for_log() {
+  local pattern="$1" deadline=$((SECONDS + 15))
+  while (( SECONDS < deadline )); do
+    if "${COMPOSE[@]}" logs siphon-transport-error 2>/dev/null | grep -q "${pattern}"; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
 echo "=== Transport error on forwarding must be answered (RFC 3261 §16.9 / §16.7) ==="
 echo "[*] Building siphon image..."
 "${COMPOSE[@]}" build siphon-transport-error
@@ -41,7 +57,7 @@ if [[ ${rc} -ne 0 ]]; then
 fi
 
 # The 500 must be the proxy's own §16.7 downgrade, not a relayed 503.
-if "${COMPOSE[@]}" logs siphon-transport-error 2>/dev/null | grep -q "TCP pool send failed"; then
+if wait_for_log "TCP pool send failed"; then
   echo "[*] confirmed: the pool send did fail (so the 500 came from the error path)"
 else
   fail "the pool send never failed — the test did not exercise the transport-error path"

--- a/siphon-bin/Cargo.lock
+++ b/siphon-bin/Cargo.lock
@@ -67,7 +67,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -765,7 +765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1835,7 +1835,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2669,7 +2669,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "siphon-sip"
 version = "1.5.1"
-source = "git+https://github.com/siphon-project/siphon-sip?branch=main#9b31ea61de803508eacd1649695ff6602d064569"
+source = "git+https://github.com/siphon-project/siphon-sip?branch=main#8222581b3236cd083a6c466f13258cb5fcc23000"
 dependencies = [
  "aes",
  "arc-swap",
@@ -3100,8 +3100,8 @@ dependencies = [
 
 [[package]]
 name = "siphon-smpp"
-version = "1.4.0"
-source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.4.0#0e5a0bc7c5ef7f3e766bf611f485596f51d3753b"
+version = "1.5.1"
+source = "git+https://github.com/siphon-project/siphon-smpp?tag=v1.5.1#0d64d37f5421302afa59de6f03afc4b3e7f38051"
 dependencies = [
  "async-trait",
  "pyo3",
@@ -3129,9 +3129,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smpp34"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2bbbf21f2c9c4c943f866103b00e9de6f4dfff1fb9bddcbf8254dd988a8a9e"
+checksum = "954f5d0904730fc4ee59e340aa524b25add16920c37a30ba191e561f8db29a09"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3334,7 +3334,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4045,7 +4045,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -38,7 +38,7 @@ full = ["smpp", "http"]    # convenience aggregate: every extension module
 # reproducible builds (advance with `cargo update`). Extension crates themselves
 # are pinned to their released tags for stable, intentional bumps.
 siphon-sip = { git = "https://github.com/siphon-project/siphon-sip", branch = "main" }
-siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.4.0", optional = true }
+siphon-smpp = { git = "https://github.com/siphon-project/siphon-smpp", tag = "v1.5.1", optional = true }
 siphon-http = { git = "https://github.com/siphon-project/siphon-http", tag = "v1.0.2", optional = true }
 
 clap = { version = "4", features = ["derive"] }

--- a/siphon-control-sdk/.gitignore
+++ b/siphon-control-sdk/.gitignore
@@ -2,6 +2,6 @@
 **/__pycache__/
 *.so
 *.pyd
-/dist
+dist/
 .pytest_cache/
 *.egg-info/


### PR DESCRIPTION
Three unrelated-but-small things that all fell out of the cargo-deny split in #155.

## siphon-smpp v1.4.0 → v1.5.1

Carries smpp34 1.4.1, the bind-handshake framing fix: both ends read the handshake with a single `read()` and hand the whole buffer to `CommandHeader::decode`, which rejects it when the buffer length and `command_length` disagree. So anything a peer pipelines behind its bind PDU coalesces into that segment and takes the session down before it carried anything. An upstream SMSC with queued MT does exactly that — it sends its first `deliver_sm` the moment it accepts our bind — and the supervisor then reconnects into the same failure for as long as the peer has traffic waiting.

Also picks up v1.5.0's listener-failure hooks, so a refused connect no longer parks the server task for the process lifetime.

## h2 0.4.16 (RUSTSEC-2026-0258)

Unbounded empty DATA frames, low severity, patched in 0.4.16. It landed against a lock nobody had touched, and reaches only the siphon-bin graph — through the http extension's axum-server/reqwest. The root and control-SDK graphs resolve without `h2` at all.

Worth noting this is the #155 split behaving as designed on day one: a fresh advisory against unchanged dependencies showed up in the weekly half while the deterministic PR gate stayed green.

## Three sipp scripts stop racing the docker log driver

`docker compose logs` is not synchronous with a container's stdout, so grepping once the instant a call returns is a race. `sipp-transport-error` has already gone red on a run whose own failure dump — the same logs, read 200 ms later — contained the line it had just failed to find.

Nine positive assertions across `transport_error_test.sh`, `failover_test.sh` and `b2bua_path_test.sh` now poll to a 15 s deadline. The single negative assertion (the decoy must NOT have been contacted) deliberately stays a one-shot read: polling for a line you expect to be absent only burns the deadline.

All three scripts re-run green locally against docker.

## siphon-control-sdk/.gitignore

`/dist` was root-anchored, so it only ever matched `siphon-control-sdk/dist` and never the per-package build output that actually exists (`siphon-control/dist/`, a wheel and an sdist). Now `dist/`. Nothing named `dist` was ever tracked, so no history is disturbed.

## Validation

- `cargo deny check advisories` and `check bans licenses sources` — green on all three workspaces
- `cargo build` / `cargo clippy -D warnings` on siphon-bin, `--features smpp` and `--features full`
- `scripts/transport_error_test.sh`, `scripts/failover_test.sh`, `scripts/b2bua_path_test.sh` — all pass locally
