### PR TITLE
feat(control): route verb that returns a parked call to siphon with a routing decision (LCR failover)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,24 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `siphon_control_commands_total`, `siphon_control_events_dropped_total`,
   `siphon_control_auth_failures_total` and `siphon_control_handoff_timeouts_total`.
   SDK: `call.handover(app, on_lost=, deadline_ms=, vars=)`.
+- **Control-plane `route` verb that returns control to siphon with a routing
+  decision.** A controller that parked a call (deferred handover) can now hand
+  control back so siphon dials the B-leg itself: `route` un-parks the call and
+  runs the shipped LCR sequential-failover engine across the supplied `targets`,
+  then owns the call thereafter (`@b2bua.on_failure` handles carrier failover).
+  This is the consult-and-return flow. An app queries an external LCR / rating
+  engine out-of-process (no pool blocked while it thinks) and returns the
+  decision as a command. `targets` is a non-empty array of bare URI strings or
+  `{uri, next_hop?, headers?, timeout?}` objects; `strategy` defaults to
+  `sequential` (v1 runs the sequential engine only, so a parallel/other strategy
+  is a typed `unsupported_verb`, never a silent sequential); an optional command
+  `headers` object is applied to every attempt's B-leg INVITE. On success siphon
+  replies `{state: "routing", targets: N}`, releases the control app (the
+  ControlBus channel drains and a `StasisEnd{reason: "routed"}` is emitted so the
+  app knows control returned, and the call lives on), and dials the first carrier.
+  No routable carrier answers the A-leg `503`; a later B-leg ring-timeout takes
+  the normal `408` path. Reuses the same `CallAction::RouteSequence` machinery as
+  in-process `call.route(...)` / `call.fork(strategy="sequential")`.
 - **Control-plane client SDKs are the official interop path**, now installable:
   `pip install siphon-control` (Python) and `cargo add siphon-control-client`
   (Rust) hide the `siphon-control.v1` wire so a controller is written with

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -211,10 +211,26 @@ chunk, so logs join Homer and billing with no mapping table.
 | `reject` | sip | `{code, reason?}` | final non-2xx + tear down |
 | `hangup` | sip | `{reason?}` | BYE an answered call, or reject an unanswered one |
 | `refer` | sip | `{to, replaces?}` | in-dialog REFER on the A-leg |
+| `route` | sip | `{targets, strategy?, headers?}` | return control to siphon: un-park the call and dial the B-leg via LCR sequential failover |
 | `set_header` / `get_header` | sip | `{name, value?}` | on the stored A-leg INVITE |
 | `set_var` / `get_var` | — | `{key, value?}` | per-call variables (drain with the call) |
 | `resync` | — | — | re-attach + enumerate this app's owned calls |
 | `describe` | — | — | list the registered adapters + their verb/event schema |
+
+`route` is the consult-and-return flow: an app parks a call (deferred handover),
+decides routing out-of-process (LCR / rating / business logic), then hands
+control back to siphon with the decision. `targets` is a non-empty array of
+either bare URI strings or objects `{uri, next_hop?, headers?, timeout?}`;
+`strategy` defaults to `"sequential"` (v1 runs the LCR sequential-failover
+engine only, so anything else is a typed `unsupported_verb`, never a silent
+sequential); `headers` is an optional object applied to every attempt's B-leg
+INVITE. On success siphon replies `{state: "routing", targets: N}`, emits a
+`StasisEnd{reason: "routed"}` on the owning connection (control returned, the
+call lives on), then owns the call: it dials the first carrier and advances
+through the rest on reject/timeout, with `@b2bua.on_failure` handling carrier
+failover. `continue` (bare hand-back, siphon re-decides routing through the
+script's `@b2bua.on_*` handlers) is a follow-up, pending the control-loss
+`fallback` re-dispatch path.
 
 `play` / `dtmf` / `bridge` / `originate` / media-stream verbs arrive in later
 phases over the same envelope.

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -2220,6 +2220,23 @@ impl CallActorStore {
         }
     }
 
+    /// Release a parked call from external control: clear the control owner + the
+    /// control-loss policy + the handoff-pending flag, so the call becomes an
+    /// ordinary autonomous B2BUA call. Used when the controller hands control
+    /// back to siphon with a routing decision (`route`): siphon dials the B-leg
+    /// itself and owns the call thereafter. Clearing `control_app` is what
+    /// disarms the handoff-timeout path in `fail_b2bua_call_on_timeout`
+    /// (`is_handoff_pending` gates on `control_app.is_some()`), so a later B-leg
+    /// ring-timeout takes the normal 408 path, not the parked-503 default.
+    /// Idempotent.
+    pub fn release_control_owner(&self, call_id: &str) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            call.control_app = None;
+            call.on_control_loss = None;
+            call.handoff_pending = false;
+        }
+    }
+
     /// Internal call IDs of calls that have blown their answer deadline while
     /// still un-answered (`Calling`/`Ringing`).
     ///
@@ -2532,6 +2549,66 @@ mod tests {
             actor.active_route().map(|route| route.carrier_id.as_str()),
             Some("c")
         );
+    }
+
+    #[test]
+    fn release_control_owner_clears_park_state() {
+        // A call parked under external control (deferred handover) → the
+        // controller hands control back with a routing decision. Releasing must
+        // clear the owner + control-loss policy AND disarm the handoff-pending
+        // path so a later B-leg ring-timeout takes the normal 408 route, not the
+        // parked-503 default.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.set_control_owner(&call_id, "ivr-app", Some("hangup"));
+        assert_eq!(store.control_app(&call_id).as_deref(), Some("ivr-app"));
+        assert!(store
+            .get_call(&call_id)
+            .is_some_and(|call| call.is_handoff_pending()));
+
+        store.release_control_owner(&call_id);
+
+        assert!(store.control_app(&call_id).is_none());
+        let call = store.get_call(&call_id).expect("call still present");
+        assert!(!call.is_handoff_pending(), "handoff must be disarmed after release");
+        assert!(call.on_control_loss.is_none());
+        // The call lives on — release does not remove it.
+        assert!(matches!(call.state, CallState::Calling));
+    }
+
+    #[test]
+    fn parked_call_unparks_into_route_sequence() {
+        // Models the store-level transition b2bua_route_call performs: a parked
+        // (deferred-handover) call, on a routing decision, is released from
+        // control AND a sequential route sequence is started — so the shipped LCR
+        // engine (b2bua_advance_route) then dials the B-leg. (The dispatcher
+        // wiring around this is the same shipped rail the imperative fns use.)
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        // Park under control (deferred handover): Ringing + control owner.
+        store.set_state(&call_id, CallState::Ringing);
+        store.set_control_owner(&call_id, "ivr-app", Some("hangup"));
+        assert!(!store.is_route_sequence(&call_id));
+
+        // Route: release control, then start the sequential-failover queue.
+        store.release_control_owner(&call_id);
+        store.start_route_sequence(
+            &call_id,
+            RouteSequenceState {
+                pending: [lcr_route("a"), lcr_route("b")].into_iter().collect(),
+                ..Default::default()
+            },
+        );
+
+        // The call is now an autonomous LCR sequence, no longer under control.
+        assert!(store.is_route_sequence(&call_id));
+        assert!(store.control_app(&call_id).is_none());
+        assert!(store.has_pending_routes(&call_id));
+        assert!(!store
+            .get_call(&call_id)
+            .is_some_and(|call| call.is_handoff_pending()));
+        // The first carrier is dialable.
+        assert_eq!(store.take_next_route(&call_id).unwrap().carrier_id, "a");
     }
 
     #[test]

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -626,14 +626,48 @@ impl ControlBus {
         }
     }
 
-    /// Remove the channel owning `sip_call_id`, returning its owning app + the
-    /// channel id (for a `StasisEnd` before removal). O(channels) — a per-call
-    /// teardown path, not per-packet.
-    fn channel_id_for_sip_call_id(&self, sip_call_id: &str) -> Option<String> {
+    /// The channel id owning `sip_call_id`, if controlled (for a `StasisEnd` /
+    /// release before removal). O(channels) — a per-call teardown path, not
+    /// per-packet.
+    pub fn channel_id_for_sip_call_id(&self, sip_call_id: &str) -> Option<String> {
         self.channels
             .iter()
             .find(|entry| entry.value().sip_call_id == sip_call_id)
             .map(|entry| entry.key().clone())
+    }
+
+    /// Release a controlled channel back to siphon (the controller handed control
+    /// back with a routing decision — `route`), emitting a `StasisEnd` with the
+    /// given `reason` to the owning connection and draining the channel from the
+    /// bus. **Distinct from teardown-on-hangup** ([`on_call_terminated`]): the
+    /// underlying call lives on — siphon now owns it and drives the B-leg dial
+    /// itself. Idempotent — a no-op when the channel is unknown. Returns whether
+    /// a channel was released.
+    ///
+    /// [`on_call_terminated`]: Self::on_call_terminated
+    pub fn release_channel(&self, channel_id: &str, reason: &str) -> bool {
+        let (app, call_actor_id, sip_call_id) = match self.channels.get(channel_id) {
+            Some(entry) => (
+                entry.app.clone(),
+                entry.call_actor_id.clone(),
+                entry.sip_call_id.clone(),
+            ),
+            None => return false,
+        };
+        self.publish_to_channel(
+            channel_id,
+            EventFrame::new(
+                "StasisEnd",
+                channel_id,
+                &app,
+                &call_actor_id,
+                &sip_call_id,
+                serde_json::json!({ "reason": reason }),
+            ),
+        );
+        self.remove_channel(channel_id);
+        debug!(%channel_id, %sip_call_id, reason, "control plane: channel released (control returned to siphon)");
+        true
     }
 
     /// Whether the given connection owns the channel (authZ for a command).
@@ -1047,6 +1081,90 @@ mod tests {
         // Every per-call entry drained to baseline (no leak).
         assert_eq!(bus.channel_count(), 0, "channel leaked after CANCEL");
         assert!(bus.owned_channels("ivr-app").is_empty(), "app_calls leaked after CANCEL");
+    }
+
+    #[tokio::test]
+    async fn release_channel_emits_stasis_end_routed_and_drains() {
+        // The `route` return-control path: the controller hands the call back to
+        // siphon. The owning app must be told (StasisEnd{reason:"routed"}) and the
+        // bus must drain — but unlike a hangup, the underlying call lives on
+        // (siphon dials the B-leg). Keyed by channel id (not sip_call_id).
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid@h",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+        assert_eq!(bus.channel_count(), 1);
+        assert_eq!(bus.channel_id_for_sip_call_id("sipcid@h").as_deref(), Some("ch1"));
+
+        assert!(bus.release_channel("ch1", "routed"));
+
+        let frames = conn.events.recv_many().await;
+        let stasis_end = frames
+            .iter()
+            .find_map(|frame| match frame {
+                OutboundFrame::Event(event) if event.event == "StasisEnd" => Some(event),
+                _ => None,
+            })
+            .expect("owning app must receive StasisEnd on release");
+        assert_eq!(stasis_end.payload["reason"], "routed");
+        assert_eq!(stasis_end.channel.as_deref(), Some("ch1"));
+
+        // Every per-call entry drained to baseline (no leak).
+        assert_eq!(bus.channel_count(), 0, "channel leaked after release");
+        assert!(bus.owned_channels("ivr-app").is_empty(), "app_calls leaked after release");
+        assert!(bus.channel_id_for_sip_call_id("sipcid@h").is_none());
+        // Idempotent: a second release is a clean no-op.
+        assert!(!bus.release_channel("ch1", "routed"));
+    }
+
+    /// Steady-state leak gate for the return-control (`route`) path: N cycles of
+    /// register-conn + offer-channel + release-channel → both maps drain to their
+    /// starting `len()`. The co-located analogue of `mem_leak_test.sh` gating
+    /// `siphon_proxy_dialog_sessions → 0`, for the release path specifically.
+    #[test]
+    fn release_channel_steady_state_drains_to_baseline() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        assert_eq!(bus.channel_count(), 0);
+
+        for cycle in 0..5 {
+            let mut conns = Vec::new();
+            for index in 0..8 {
+                let conn = bus.register_connection("ivr-app");
+                let channel = format!("ch-{cycle}-{index}");
+                bus.offer_channel(
+                    "ivr-app",
+                    &channel,
+                    &format!("call-{cycle}-{index}"),
+                    &format!("sip-{cycle}-{index}"),
+                    "hangup",
+                    HashMap::new(),
+                    serde_json::json!({}),
+                );
+                conns.push((conn, channel));
+            }
+            assert_eq!(bus.channel_count(), 8);
+
+            for (conn, channel) in conns {
+                // Return control to siphon (the call lives on) rather than hangup.
+                assert!(bus.release_channel(&channel, "routed"));
+                if let Some(fanout) = bus.apps.get(&conn.app) {
+                    fanout.remove(conn.id);
+                }
+                conn.events.close();
+                bus.apps.remove_if(&conn.app, |_, fanout| fanout.is_empty());
+            }
+
+            assert_eq!(bus.channel_count(), 0, "channels leaked on cycle {cycle}");
+            assert_eq!(bus.app_count(), 0, "apps leaked on cycle {cycle}");
+            assert!(bus.app_calls.is_empty(), "app_calls index leaked on cycle {cycle}");
+        }
     }
 
     #[test]

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -43,6 +43,7 @@ impl ControlAdapter for SipControlAdapter {
                 verb("reject", "Send a final non-2xx and tear the call down (args: code, reason)"),
                 verb("hangup", "BYE an answered call, or reject an unanswered one (args: reason)"),
                 verb("refer", "Send an in-dialog REFER on the A-leg (args: to, replaces)"),
+                verb("route", "Return control to siphon with a routing decision: un-park the call and dial the B-leg via LCR sequential failover (args: targets, strategy, headers)"),
                 verb("set_header", "Set a header on the stored A-leg INVITE (args: name, value)"),
                 verb("get_header", "Read a header from the stored A-leg INVITE (args: name)"),
             ],
@@ -89,6 +90,7 @@ fn apply_sip(command: AdapterCommand) -> ControlResult {
         "reject" => reject(&channel, &command.args),
         "hangup" => hangup(&channel, &command.args),
         "refer" => refer(&channel, &command.args),
+        "route" => route(&channel, &command.args),
         "set_header" => set_header(&channel, &command.args),
         "get_header" => get_header(&channel, &command.args),
         // Media verbs (play/stop/dtmf/collect_dtmf) bind to MediaBackend and land
@@ -263,6 +265,105 @@ fn parse_replaces_arg(
     }))
 }
 
+/// Return control to siphon with a routing decision (the `route` verb). Un-parks
+/// the deferred-handover call and dials the B-leg via siphon's LCR sequential
+/// failover; siphon owns the call thereafter and the control app is released.
+///
+/// `args.targets` is a non-empty array of either bare URI strings or objects
+/// `{uri, next_hop?, headers?, timeout?}`; `args.strategy` defaults to
+/// `"sequential"` (v1 supports only sequential/single — anything else is a typed
+/// error, never a silent sequential); `args.headers` is an optional object
+/// applied to every attempt's B-leg INVITE.
+fn route(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let Some(targets_json) = args.get("targets").and_then(|v| v.as_array()) else {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "route requires args.targets (a non-empty array of URIs or {uri, next_hop, headers, timeout})",
+        );
+    };
+    if targets_json.is_empty() {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "route requires at least one target",
+        );
+    }
+    let mut targets = Vec::with_capacity(targets_json.len());
+    for item in targets_json {
+        match parse_route_target(item) {
+            Ok(target) => targets.push(target),
+            Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
+        }
+    }
+    let strategy = args.get("strategy").and_then(|v| v.as_str()).unwrap_or("sequential");
+    let extra_headers = parse_extra_headers(args.get("headers"));
+    let target_count = targets.len();
+
+    match crate::dispatcher::b2bua_route_call(&channel.sip_call_id, targets, strategy, &extra_headers) {
+        Ok(true) => ControlResult::Ok(serde_json::json!({
+            "channel": channel.channel_id,
+            "state": "routing",
+            "targets": target_count,
+        })),
+        Ok(false) => ControlResult::error(ControlErrorCode::NotFound, "call is gone"),
+        Err(crate::dispatcher::RouteError::UnsupportedStrategy(strategy)) => ControlResult::error(
+            ControlErrorCode::UnsupportedVerb,
+            format!("unsupported routing strategy '{strategy}' — v1 supports sequential/single"),
+        ),
+        Err(crate::dispatcher::RouteError::NoTargets) => ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "route requires at least one target",
+        ),
+    }
+}
+
+/// Parse one `targets[]` entry: a bare URI string, or an object
+/// `{uri, next_hop?, headers?, timeout?}`.
+fn parse_route_target(item: &serde_json::Value) -> Result<crate::dispatcher::RouteTarget, String> {
+    if let Some(uri) = item.as_str() {
+        return Ok(crate::dispatcher::RouteTarget {
+            uri: uri.to_string(),
+            next_hop: None,
+            headers: Vec::new(),
+            timeout_secs: None,
+        });
+    }
+    let Some(object) = item.as_object() else {
+        return Err(
+            "each target must be a URI string or an object {uri, next_hop, headers, timeout}".to_string(),
+        );
+    };
+    let Some(uri) = object.get("uri").and_then(|v| v.as_str()) else {
+        return Err("target object requires a string 'uri'".to_string());
+    };
+    let next_hop = object.get("next_hop").and_then(|v| v.as_str()).map(|s| s.to_string());
+    let headers = object.get("headers").map(parse_json_headers).unwrap_or_default();
+    let timeout_secs = object.get("timeout").and_then(|v| v.as_u64()).map(|t| t as u32);
+    Ok(crate::dispatcher::RouteTarget {
+        uri: uri.to_string(),
+        next_hop,
+        headers,
+        timeout_secs,
+    })
+}
+
+/// Parse a command-level `headers` object (applied to every route attempt).
+fn parse_extra_headers(value: Option<&serde_json::Value>) -> Vec<(String, String)> {
+    value.map(parse_json_headers).unwrap_or_default()
+}
+
+/// Collect string→string pairs from a JSON object (non-string values skipped).
+fn parse_json_headers(value: &serde_json::Value) -> Vec<(String, String)> {
+    value
+        .as_object()
+        .map(|object| {
+            object
+                .iter()
+                .filter_map(|(name, value)| value.as_str().map(|v| (name.clone(), v.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn set_header(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
     let (Some(name), Some(header_value)) = (
         args.get("name").and_then(|v| v.as_str()),
@@ -320,7 +421,7 @@ mod tests {
         let schema = SipControlAdapter::new().describe();
         assert_eq!(schema.module, "sip");
         let verbs: Vec<&str> = schema.verbs.iter().map(|v| v.verb.as_str()).collect();
-        for expected in ["answer", "progress", "reject", "hangup", "refer"] {
+        for expected in ["answer", "progress", "reject", "hangup", "refer", "route"] {
             assert!(verbs.contains(&expected), "missing verb {expected}");
         }
     }
@@ -396,6 +497,110 @@ mod tests {
             result,
             ControlResult::Error { code: ControlErrorCode::NotFound, .. }
         ));
+    }
+
+    #[test]
+    fn route_without_targets_is_bad_request() {
+        // No args.targets at all → bad_request before touching the store.
+        let result = route(&channel(), &serde_json::json!({}));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn route_empty_targets_is_bad_request() {
+        let result = route(&channel(), &serde_json::json!({ "targets": [] }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn route_target_object_without_uri_is_bad_request() {
+        let result = route(
+            &channel(),
+            &serde_json::json!({ "targets": [{ "next_hop": "sip:gw@1.2.3.4" }] }),
+        );
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn route_unsupported_strategy_is_typed_error() {
+        // A non-sequential strategy must be a typed unsupported error, NEVER a
+        // silent fall-through to sequential. b2bua_route_call validates the
+        // strategy before touching the dispatcher, so this holds without one.
+        let result = route(
+            &channel(),
+            &serde_json::json!({ "targets": ["sip:1@carrier.example"], "strategy": "parallel" }),
+        );
+        assert!(
+            matches!(result, ControlResult::Error { code: ControlErrorCode::UnsupportedVerb, .. }),
+            "unsupported strategy must be a typed UnsupportedVerb, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn route_valid_targets_without_dispatcher_is_not_found() {
+        // With no B2BUA_CONTROL installed (unit context), a well-formed route
+        // reaches b2bua_route_call and returns not_found — never hangs.
+        let result = route(
+            &channel(),
+            &serde_json::json!({ "targets": ["sip:1@carrier.example"] }),
+        );
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[test]
+    fn route_dispatches_through_apply_sip() {
+        // Prove the "route" arm is wired in apply_sip (reaches b2bua_route_call →
+        // not_found with no dispatcher, rather than unsupported_verb).
+        let result = apply_sip(AdapterCommand {
+            verb: "route".to_string(),
+            args: serde_json::json!({ "targets": ["sip:1@carrier.example"] }),
+            target: ResolvedTarget::Channel(channel()),
+        });
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[test]
+    fn parse_route_target_string_and_object() {
+        // Bare URI string form.
+        let string_target = parse_route_target(&serde_json::json!("sip:1@carrier.example")).unwrap();
+        assert_eq!(string_target.uri, "sip:1@carrier.example");
+        assert!(string_target.next_hop.is_none());
+        assert!(string_target.headers.is_empty());
+        assert!(string_target.timeout_secs.is_none());
+
+        // Full object form.
+        let object_target = parse_route_target(&serde_json::json!({
+            "uri": "sip:2@carrier.example",
+            "next_hop": "sip:gw@203.0.113.7:5060",
+            "headers": { "X-Carrier-Token": "abc" },
+            "timeout": 12,
+        }))
+        .unwrap();
+        assert_eq!(object_target.uri, "sip:2@carrier.example");
+        assert_eq!(object_target.next_hop.as_deref(), Some("sip:gw@203.0.113.7:5060"));
+        assert_eq!(object_target.timeout_secs, Some(12));
+        assert_eq!(
+            object_target.headers,
+            vec![("X-Carrier-Token".to_string(), "abc".to_string())]
+        );
+
+        // A bare number is neither a string nor an object → error.
+        assert!(parse_route_target(&serde_json::json!(42)).is_err());
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -16980,6 +16980,159 @@ pub fn b2bua_refer_call(
     b2bua_send_outbound_refer(&control.state, &internal_call_id, /*on_a_leg=*/ true, &refer_to)
 }
 
+/// One routing target for [`b2bua_route_call`]. Built by the control adapter from
+/// the `route` verb's `targets[]` — a bare URI (`ruri` only) or an object
+/// carrying a per-target `next_hop` / `headers` / ring `timeout`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteTarget {
+    /// The Request-URI for this carrier attempt.
+    pub uri: String,
+    /// Optional wire next-hop (steer egress without reshaping the R-URI).
+    pub next_hop: Option<String>,
+    /// Headers to inject on this attempt's B-leg INVITE.
+    pub headers: Vec<(String, String)>,
+    /// Per-attempt ring timeout (seconds); falls back to the call default.
+    pub timeout_secs: Option<u32>,
+}
+
+/// Why [`b2bua_route_call`] could not accept a return-control routing decision —
+/// mapped to a typed control-plane error by the adapter (never a silent
+/// pretend-success).
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RouteError {
+    /// A strategy other than sequential/single was requested. v1 runs the LCR
+    /// sequential-failover engine only; parallel-fork return is a fast-follow.
+    #[error("unsupported routing strategy '{0}' (v1 supports 'sequential'/'single')")]
+    UnsupportedStrategy(String),
+    /// The routing decision named no targets.
+    #[error("route requires at least one target")]
+    NoTargets,
+}
+
+/// Imperatively hand a *parked* (deferred-handover) controlled B2BUA call back to
+/// siphon **with a routing decision** — the control-plane `route` verb.
+///
+/// The call is currently parked under external control (`CallState::Ringing`,
+/// un-dialed, `control_app=Some`, `handoff_pending=true`, the A-leg INVITE
+/// stored). This un-parks it: siphon runs its **normal B-leg dial with LCR
+/// sequential failover** across `targets` — the shipped [`CallAction::RouteSequence`]
+/// engine (`start_route_sequence` + [`b2bua_advance_route`], dialing via
+/// `b2bua_send_b_leg_invite`) — and owns the call thereafter
+/// (`@b2bua.on_failure` handles carrier failover). The control app is released:
+/// the ControlBus channel drains and a `StasisEnd{reason:"routed"}` is emitted so
+/// the app knows control returned (leak-critical).
+///
+/// v1 runs the sequential engine only; a strategy other than `sequential` /
+/// `single` returns [`RouteError::UnsupportedStrategy`] rather than silently
+/// doing sequential. Returns `Ok(true)` when the call was un-parked and the first
+/// carrier dialed (or a clean 503 sent to the A-leg when no carrier was
+/// routable), `Ok(false)` when the call / dispatcher is gone (never panics), and
+/// `Err(..)` for an invalid decision. Safe to call from any thread (enters the
+/// dispatcher runtime), mirroring [`b2bua_refer_call`] / [`b2bua_terminate_call`].
+pub fn b2bua_route_call(
+    sip_call_id: &str,
+    targets: Vec<RouteTarget>,
+    strategy: &str,
+    extra_headers: &[(String, String)],
+) -> Result<bool, RouteError> {
+    // v1 scope: sequential / single-target only (the shipped RouteSequence
+    // engine). Reject anything else with a typed error — never pretend to fork.
+    if !(strategy.eq_ignore_ascii_case("sequential") || strategy.eq_ignore_ascii_case("single")) {
+        return Err(RouteError::UnsupportedStrategy(strategy.to_string()));
+    }
+    if targets.is_empty() {
+        return Err(RouteError::NoTargets);
+    }
+
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return Ok(false);
+    };
+    let state = &control.state;
+    let Some(internal_call_id) = state.call_actors.find_by_sip_call_id(sip_call_id) else {
+        warn!(%sip_call_id, "b2bua_route_call: no such call");
+        return Ok(false);
+    };
+
+    // Clone the stored A-leg INVITE as the dial template (b2bua_advance_route
+    // derives each B-leg INVITE from it). A handed-over call always stores it.
+    let template = {
+        let Some(invite_arc) = state
+            .call_actors
+            .get_call(&internal_call_id)
+            .and_then(|call| call.a_leg_invite.clone())
+        else {
+            warn!(call_id = %internal_call_id, "b2bua_route_call: no stored A-leg INVITE to dial from");
+            return Ok(false);
+        };
+        let Ok(invite) = invite_arc.lock() else {
+            error!(call_id = %internal_call_id, "b2bua_route_call: invite lock poisoned");
+            return Ok(false);
+        };
+        invite.clone()
+    };
+
+    // The send path may spawn (TCP/TLS connect) and the caller may be on a
+    // non-tokio thread — establish the runtime.
+    let _enter = control.runtime.enter();
+
+    // Build the failover queue from the targets (R-URI-only carriers, mirroring
+    // call.rs's call.route() / fork(strategy="sequential") construction). A
+    // command-level `extra_headers` set applies to every attempt; a per-target
+    // header overrides it on key collision.
+    let default_timeout = 30u32;
+    let routes: Vec<crate::lcr::Route> = targets
+        .into_iter()
+        .map(|target| {
+            let mut headers: std::collections::HashMap<String, String> =
+                extra_headers.iter().cloned().collect();
+            headers.extend(target.headers);
+            crate::lcr::Route {
+                ruri: Some(target.uri),
+                next_hop: target.next_hop,
+                timeout_secs: Some(target.timeout_secs.unwrap_or(default_timeout)),
+                headers,
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    // Release control ownership: drain the ControlBus channel + emit
+    // StasisEnd{reason:"routed"} so the app knows control returned (leak-critical),
+    // and clear the park state so a later B-leg ring-timeout takes the normal 408
+    // path, not the parked-503 handoff default.
+    if let Some(bus) = crate::control::ControlBus::global() {
+        if let Some(channel_id) = bus.channel_id_for_sip_call_id(sip_call_id) {
+            bus.release_channel(&channel_id, "routed");
+        }
+    }
+    state.call_actors.release_control_owner(&internal_call_id);
+
+    // Un-park: start the sequential-failover sequence and dial the first carrier.
+    let carrier_count = routes.len();
+    state.call_actors.start_route_sequence(
+        &internal_call_id,
+        crate::b2bua::actor::RouteSequenceState {
+            pending: routes.into(),
+            active: None,
+            best_error: None,
+            send_socket: None,
+            default_timeout,
+        },
+    );
+    info!(
+        call_id = %internal_call_id,
+        carriers = carrier_count,
+        "control plane: route — un-parked, dialing B-leg via LCR sequential failover"
+    );
+    if !b2bua_advance_route(&internal_call_id, &template, state) {
+        // No carrier was routable — answer the A-leg 503 and tear down, mirroring
+        // the CallAction::RouteSequence "no routable carrier" arm.
+        warn!(call_id = %internal_call_id, "control plane: route — no routable carrier, 503 to A-leg");
+        b2bua_reject_call(&internal_call_id, 503, "No Route");
+    }
+    Ok(true)
+}
+
 /// Build and send a UAS response (final 2xx or provisional 1xx) for a B2BUA call
 /// from an imperative `call.answer()` / `call.progress()`.
 ///


### PR DESCRIPTION
## What

Adds the control-plane `route` verb (SIP adapter). A controller that parked a
call under deferred handover can now hand control **back** to siphon with a
routing decision: siphon un-parks the call, dials the B-leg via its normal LCR
sequential failover across the supplied targets, and owns the call thereafter
(`@b2bua.on_failure` handles carrier failover; the control app is released).

This is the consult-and-return flow. An app parks a call, queries an external
LCR / rating / business-logic engine out-of-process (no pool blocked while it
thinks, the decision arrives later as a command), then returns the decision.

## Why

Phase 1 shipped the control plane but a parked call could only be answered,
progressed, rejected, hung up or referred by the controller. There was no way
to hand it back to siphon *with routing*, which is the "external routing brain"
use case. `route` closes that, the highest-leverage next verb after Phase 1.

## How (reuses the shipped LCR engine)

`route` binds to a new imperative rail function `b2bua_route_call`, a sibling of
`b2bua_refer_call` / `b2bua_terminate_call`. It reuses the shipped
`CallAction::RouteSequence` machinery end to end (`start_route_sequence` +
`b2bua_advance_route`, dialing via `b2bua_send_b_leg_invite`), the exact engine
behind in-process `call.route(...)` / `call.fork(strategy="sequential")`. No new
media or dial code; the route construction mirrors `call.rs`'s R-URI-only
`lcr::Route` build.

`b2bua_route_call` signature:

```rust
pub fn b2bua_route_call(
    sip_call_id: &str,
    targets: Vec<RouteTarget>,   // { uri, next_hop?, headers, timeout_secs? }
    strategy: &str,
    extra_headers: &[(String, String)],
) -> Result<bool, RouteError>
```

- `Ok(true)`: un-parked and first carrier dialed (or a clean `503` to the
  A-leg if no carrier was routable).
- `Ok(false)`: call / dispatcher gone (adapter maps to `not_found`, never hangs).
- `Err(UnsupportedStrategy)`: a non-sequential strategy (adapter maps to
  `unsupported_verb`). v1 runs the sequential engine only and refuses to
  silently do sequential for a `parallel` ask.
- `Err(NoTargets)`: empty targets (adapter maps to `bad_request`).

On route it **releases control ownership** (leak-critical): drains the
ControlBus channel and emits `StasisEnd{reason:"routed"}` so the app knows
control returned (distinct from teardown-on-hangup, the call lives on), and
clears the park state so a later B-leg ring-timeout takes the normal `408` path,
not the parked-`503` handoff default.

New supporting pieces:
- `CallActorStore::release_control_owner`: clears `control_app` / `on_control_loss`
  / `handoff_pending`.
- `ControlBus::release_channel(channel_id, reason)` + `channel_id_for_sip_call_id`
  made `pub`: emit `StasisEnd` then drop the channel + app_calls index.
- `sip_adapter` `route` arm + `describe()` entry, targets parsed as bare URI
  strings or `{uri, next_hop?, headers?, timeout?}` objects.

## `continue` is deferred (not in this PR)

`continue` (bare hand-back: siphon re-decides routing through the script's
`@b2bua.on_*` handlers) depends on the control-loss `fallback` re-dispatch path,
which **does not exist yet** (`registry.rs` currently degrades `on_lost="fallback"`
to hangup, marked a Phase-2 item). Per the plan, `continue` is left out rather
than faked; it is a thin follow-up once that re-dispatch path lands.

## Tests (TDD)

- Adapter unit (`sip_adapter`): route args parse, missing/empty targets to
  `bad_request`, target object without `uri` to `bad_request`, unsupported
  strategy to typed `unsupported_verb`, valid targets without a dispatcher to
  `not_found`, `apply_sip` dispatch through the `route` arm, `parse_route_target`
  string + object forms, `describe_lists_core_verbs` includes `route`.
- State-transition unit (`actor`): `release_control_owner` clears park state +
  disarms handoff; park then route store transition starts `RouteSequence` and
  clears `control_app`.
- Co-located steady-state leak gate (`registry`): `release_channel` emits
  `StasisEnd{routed}` and drains; N cycles of offer + release drain `channels` /
  `app_calls` to baseline.

`PYO3_PYTHON=python3 cargo test`: 3765 passed, 7 ignored.
`cargo clippy --all-targets --all-features -- -D warnings`: clean.

No SDK changes (server-only; `call.route` already exists in-process). Docs +
`CHANGELOG [Unreleased]` updated.
