### PR TITLE
feat(control-sdk): add route() to the sip facade in all three bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   server (`sipp/siphon-rtp/mock_siphon_rtp.py`, the JSON-over-TCP twin of the
   existing rtpengine NG mock) and asserts the answer SDP is anchored on the
   engine's media address rather than echoing the caller's own `c=` back.
+- **`route()` on the control-plane SDK's `sip` facade — all three bindings.**
+  Wraps the server's `route` verb (un-parks a handed-over call and dials the
+  B-leg via siphon's LCR sequential-failover engine, returning control to
+  siphon): `call.route(targets, strategy="sequential", headers=…)` in Python and
+  TypeScript, and an async `Call::route(targets, strategy, headers)` on the Rust
+  client, where a target is a bare URI or `{uri, next_hop?, headers?, timeout?}`.
+  It returns the reply result (`{channel, state: "routing", targets}`) and
+  raises/rejects the typed `unsupported_verb` / `bad_request` / `not_found`
+  errors like the sibling verbs. The control SDK version is unchanged (its own
+  `control-sdk-v*` train cuts the release).
 
 ### Fixed
 - **A UAS-mode B2BUA answer carried no `Contact`, so no in-dialog request could

--- a/siphon-control-sdk/siphon-control-client/src/lib.rs
+++ b/siphon-control-sdk/siphon-control-client/src/lib.rs
@@ -62,7 +62,7 @@ pub use error::ControlError;
 pub use server::{ControlServer, ServerConfig};
 
 // Ergonomic top-level re-exports of the common SIP facade.
-pub use sip::{Call, CallEvent, CallStream, SipClient, SipServer};
+pub use sip::{Call, CallEvent, CallStream, RouteTarget, SipClient, SipServer};
 
 // Re-export the wire contract so downstreams need only depend on this crate.
 pub use siphon_control_proto::{self as proto, ControlErrorCode};

--- a/siphon-control-sdk/siphon-control-client/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-client/src/sip.rs
@@ -30,6 +30,84 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 }
 
 // ---------------------------------------------------------------------------
+// route() target
+// ---------------------------------------------------------------------------
+
+/// One entry in a [`Call::route`] target list: a B-leg URI plus optional
+/// per-target overrides.
+///
+/// A bare URI (no overrides) serializes to a plain string on the wire; a target
+/// carrying any override serializes to `{uri, next_hop?, headers?, timeout?}` —
+/// both shapes the server's `route` verb accepts. Build a bare-URI target with
+/// [`RouteTarget::uri`], or from a `&str` / `String`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RouteTarget {
+    /// The B-leg request URI to dial.
+    pub uri: String,
+    /// Route egress to this next hop instead of resolving `uri` (optional).
+    pub next_hop: Option<String>,
+    /// Headers injected on this attempt's B-leg INVITE (optional).
+    pub headers: Vec<(String, String)>,
+    /// Per-target ring timeout in seconds (optional).
+    pub timeout_secs: Option<u32>,
+}
+
+impl RouteTarget {
+    /// A bare-URI target with no overrides.
+    pub fn uri(uri: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            next_hop: None,
+            headers: Vec::new(),
+            timeout_secs: None,
+        }
+    }
+
+    /// True when this target carries no overrides (serializes as a bare string).
+    fn is_bare(&self) -> bool {
+        self.next_hop.is_none() && self.headers.is_empty() && self.timeout_secs.is_none()
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        if self.is_bare() {
+            return json!(self.uri);
+        }
+        let mut object = serde_json::Map::new();
+        object.insert("uri".to_string(), json!(self.uri));
+        if let Some(next_hop) = &self.next_hop {
+            object.insert("next_hop".to_string(), json!(next_hop));
+        }
+        if !self.headers.is_empty() {
+            object.insert("headers".to_string(), headers_to_json(&self.headers));
+        }
+        if let Some(timeout) = self.timeout_secs {
+            object.insert("timeout".to_string(), json!(timeout));
+        }
+        serde_json::Value::Object(object)
+    }
+}
+
+impl From<&str> for RouteTarget {
+    fn from(uri: &str) -> Self {
+        Self::uri(uri)
+    }
+}
+
+impl From<String> for RouteTarget {
+    fn from(uri: String) -> Self {
+        Self::uri(uri)
+    }
+}
+
+fn headers_to_json(headers: &[(String, String)]) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    for (name, value) in headers {
+        object.insert(name.clone(), json!(value));
+    }
+    serde_json::Value::Object(object)
+}
+
+// ---------------------------------------------------------------------------
 // Call handle
 // ---------------------------------------------------------------------------
 
@@ -238,6 +316,40 @@ impl Call {
             "replaces": { "call_id": call_id, "from_tag": from_tag, "to_tag": to_tag, "early_only": early_only }
         });
         self.sip(SipVerb::Refer, args).await.map(drop)
+    }
+
+    /// Un-park this controlled call and dial the B-leg via siphon's LCR
+    /// sequential-failover engine, returning control to siphon.
+    ///
+    /// `targets` is a non-empty ordered list of carriers tried cheapest-first: a
+    /// bare URI ([`RouteTarget::uri`] / a `&str`) or a [`RouteTarget`] carrying
+    /// `next_hop` / `headers` / `timeout_secs` overrides. `strategy` defaults to
+    /// `"sequential"` when `None` (the server's default; v1 supports only
+    /// `sequential`/`single` — anything else resolves to
+    /// [`ControlError::is_unsupported_verb`]). `headers` is applied to every
+    /// attempt's B-leg INVITE.
+    ///
+    /// On success siphon owns the call thereafter and the control app is
+    /// released; the returned value is the reply `result`
+    /// (`{channel, state: "routing", targets: N}`). An empty / invalid `targets`
+    /// list resolves to a `bad_request` error, and a call that is already gone to
+    /// `not_found`.
+    pub async fn route(
+        &self,
+        targets: Vec<RouteTarget>,
+        strategy: Option<&str>,
+        headers: Vec<(String, String)>,
+    ) -> Result<serde_json::Value, ControlError> {
+        let mut args = json!({
+            "targets": targets.iter().map(RouteTarget::to_json).collect::<Vec<_>>(),
+        });
+        if let Some(strategy) = strategy {
+            args["strategy"] = json!(strategy);
+        }
+        if !headers.is_empty() {
+            args["headers"] = headers_to_json(&headers);
+        }
+        self.sip(SipVerb::Route, args).await
     }
 
     /// Set a header on the stored A-leg INVITE.
@@ -630,5 +742,130 @@ impl SipServer {
     /// Accept siphon's per-call dials forever.
     pub async fn run(&self) -> Result<(), ControlError> {
         self.server.run().await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the emitted `route` frame shape (recording CommandTransport).
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use siphon_control_proto::ChannelSnapshot;
+    use std::collections::HashMap;
+
+    #[derive(Clone)]
+    struct Recorded {
+        module: Option<String>,
+        verb: String,
+        target: serde_json::Value,
+        args: serde_json::Value,
+    }
+
+    /// A [`CommandTransport`] that records every command and returns a canned
+    /// result — the Rust twin of the TypeScript `RecordingTransport`.
+    struct RecordingTransport {
+        calls: Mutex<Vec<Recorded>>,
+        result: serde_json::Value,
+    }
+
+    impl CommandTransport for RecordingTransport {
+        fn command(
+            &self,
+            module: Option<String>,
+            verb: String,
+            target: serde_json::Value,
+            args: serde_json::Value,
+        ) -> BoxFuture<'_, Result<serde_json::Value, ControlError>> {
+            lock(&self.calls).push(Recorded {
+                module,
+                verb,
+                target,
+                args,
+            });
+            let result = self.result.clone();
+            Box::pin(async move { Ok(result) })
+        }
+    }
+
+    fn make_call(transport: Arc<dyn CommandTransport>) -> Call {
+        let (_event_tx, event_rx) = mpsc::unbounded_channel();
+        let snapshot = ChannelSnapshot {
+            channel: "ch1".to_string(),
+            call_id: "call-uuid".to_string(),
+            sip_call_id: "sip@host".to_string(),
+            state: "answered".to_string(),
+            vars: HashMap::new(),
+        };
+        Call::from_snapshot(transport, snapshot, event_rx)
+    }
+
+    #[tokio::test]
+    async fn route_emits_targets_strategy_and_headers() {
+        let recorder = Arc::new(RecordingTransport {
+            calls: Mutex::new(Vec::new()),
+            result: json!({ "channel": "ch1", "state": "routing", "targets": 2 }),
+        });
+        let call = make_call(recorder.clone());
+
+        let result = call
+            .route(
+                vec![
+                    RouteTarget::from("sip:carrier1@gw1"),
+                    RouteTarget {
+                        uri: "sip:carrier2@gw2".to_string(),
+                        next_hop: Some("sip:1.2.3.4:5060".to_string()),
+                        headers: vec![("X-Foo".to_string(), "bar".to_string())],
+                        timeout_secs: Some(30),
+                    },
+                ],
+                Some("sequential"),
+                vec![("X-Trace".to_string(), "abc".to_string())],
+            )
+            .await
+            .expect("route ok");
+
+        assert_eq!(result["state"], "routing");
+        assert_eq!(result["targets"], 2);
+
+        let recorded = lock(&recorder.calls).clone();
+        assert_eq!(recorded.len(), 1);
+        let frame = &recorded[0];
+        assert_eq!(frame.module.as_deref(), Some("sip"));
+        assert_eq!(frame.verb, "route");
+        assert_eq!(frame.target, json!({ "channel": "ch1" }));
+        assert_eq!(
+            frame.args,
+            json!({
+                "targets": [
+                    "sip:carrier1@gw1",
+                    {
+                        "uri": "sip:carrier2@gw2",
+                        "next_hop": "sip:1.2.3.4:5060",
+                        "headers": { "X-Foo": "bar" },
+                        "timeout": 30
+                    }
+                ],
+                "strategy": "sequential",
+                "headers": { "X-Trace": "abc" }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn route_omits_strategy_and_headers_when_absent() {
+        let recorder = Arc::new(RecordingTransport {
+            calls: Mutex::new(Vec::new()),
+            result: json!({ "channel": "ch1", "state": "routing", "targets": 1 }),
+        });
+        let call = make_call(recorder.clone());
+
+        call.route(vec![RouteTarget::uri("sip:only@gw")], None, Vec::new())
+            .await
+            .expect("route ok");
+
+        let recorded = lock(&recorder.calls).clone();
+        assert_eq!(recorded[0].args, json!({ "targets": ["sip:only@gw"] }));
     }
 }

--- a/siphon-control-sdk/siphon-control-proto/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-proto/src/sip.rs
@@ -25,6 +25,8 @@ pub enum SipVerb {
     Hangup,
     /// Send an in-dialog REFER on the A-leg.
     Refer,
+    /// Un-park the call and dial the B-leg via LCR sequential failover.
+    Route,
     /// Set a header on the stored A-leg INVITE.
     SetHeader,
     /// Read a header from the stored A-leg INVITE.
@@ -40,6 +42,7 @@ impl SipVerb {
             SipVerb::Reject => "reject",
             SipVerb::Hangup => "hangup",
             SipVerb::Refer => "refer",
+            SipVerb::Route => "route",
             SipVerb::SetHeader => "set_header",
             SipVerb::GetHeader => "get_header",
         }
@@ -122,6 +125,7 @@ mod tests {
     #[test]
     fn sip_verb_wire_tokens() {
         assert_eq!(SipVerb::Answer.as_str(), "answer");
+        assert_eq!(SipVerb::Route.as_str(), "route");
         assert_eq!(SipVerb::SetHeader.as_str(), "set_header");
         assert_eq!(SipVerb::GetHeader.to_string(), "get_header");
     }

--- a/siphon-control-sdk/siphon-control/src/lib.rs
+++ b/siphon-control-sdk/siphon-control/src/lib.rs
@@ -60,7 +60,7 @@ use pyo3::types::PyList;
 use pyo3_async_runtimes::TaskLocals;
 
 use siphon_control_client::proto::ControlErrorCode;
-use siphon_control_client::sip::{Call as RustCall, SipClient, SipServer};
+use siphon_control_client::sip::{Call as RustCall, RouteTarget, SipClient, SipServer};
 use siphon_control_client::{ClientConfig, ControlError as ClientError, ServerConfig};
 
 pyo3::create_exception!(
@@ -112,6 +112,53 @@ fn to_pyerr(error: ClientError) -> PyErr {
         let _ = err.value(py).setattr("code", code);
         err
     })
+}
+
+/// Extract one `route` target: a bare URI `str`, or a dict
+/// `{uri, next_hop?, headers?, timeout?}`.
+fn extract_route_target(item: &Bound<'_, PyAny>) -> PyResult<RouteTarget> {
+    if let Ok(uri) = item.extract::<String>() {
+        return Ok(RouteTarget::uri(uri));
+    }
+    let dict = item.cast::<pyo3::types::PyDict>().map_err(|_| {
+        PyValueError::new_err(
+            "each route target must be a URI str or a dict {uri, next_hop, headers, timeout}",
+        )
+    })?;
+    let uri: String = match dict.get_item("uri")? {
+        Some(value) => value.extract()?,
+        None => return Err(PyValueError::new_err("route target dict requires a string 'uri'")),
+    };
+    let next_hop = match dict.get_item("next_hop")? {
+        Some(value) if !value.is_none() => Some(value.extract::<String>()?),
+        _ => None,
+    };
+    let headers = match dict.get_item("headers")? {
+        Some(value) if !value.is_none() => extract_headers(&value)?,
+        _ => Vec::new(),
+    };
+    let timeout_secs = match dict.get_item("timeout")? {
+        Some(value) if !value.is_none() => Some(value.extract::<u32>()?),
+        _ => None,
+    };
+    Ok(RouteTarget {
+        uri,
+        next_hop,
+        headers,
+        timeout_secs,
+    })
+}
+
+/// Extract a `{name: value}` header dict into ordered string pairs.
+fn extract_headers(object: &Bound<'_, PyAny>) -> PyResult<Vec<(String, String)>> {
+    let dict = object
+        .cast::<pyo3::types::PyDict>()
+        .map_err(|_| PyValueError::new_err("headers must be a dict of str -> str"))?;
+    let mut pairs = Vec::with_capacity(dict.len());
+    for (key, value) in dict.iter() {
+        pairs.push((key.extract::<String>()?, value.extract::<String>()?));
+    }
+    Ok(pairs)
 }
 
 // ---------------------------------------------------------------------------
@@ -222,6 +269,44 @@ impl Call {
     /// Blind-transfer alias for `refer`.
     fn transfer<'py>(&self, py: Python<'py>, to: String) -> PyResult<Bound<'py, PyAny>> {
         self.refer(py, to)
+    }
+
+    /// Un-park this controlled call and dial the B-leg via siphon's LCR
+    /// sequential-failover engine, returning control to siphon.
+    ///
+    /// `targets` is a non-empty list of carriers tried cheapest-first: each entry
+    /// is a bare URI `str` or a dict `{"uri", "next_hop"?, "headers"?, "timeout"?}`.
+    /// `strategy` defaults to `"sequential"` (v1 supports only sequential/single —
+    /// anything else raises `ControlError` with `code == "unsupported_verb"`).
+    /// `headers` is an optional dict applied to every attempt's B-leg INVITE.
+    ///
+    /// Returns the reply `result` (`{"channel", "state": "routing", "targets": N}`).
+    /// An empty / invalid `targets` list raises `ControlError` (`code ==
+    /// "bad_request"`); a call that is already gone raises `code == "not_found"`.
+    #[pyo3(signature = (targets, strategy="sequential".to_string(), headers=None))]
+    fn route<'py>(
+        &self,
+        py: Python<'py>,
+        targets: Vec<Bound<'py, PyAny>>,
+        strategy: String,
+        headers: Option<Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let mut route_targets = Vec::with_capacity(targets.len());
+        for item in targets {
+            route_targets.push(extract_route_target(&item)?);
+        }
+        let extra_headers = match headers {
+            Some(headers) => extract_headers(&headers)?,
+            None => Vec::new(),
+        };
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let value = call
+                .route(route_targets, Some(strategy.as_str()), extra_headers)
+                .await
+                .map_err(to_pyerr)?;
+            Python::attach(|py| json_to_py(py, &value))
+        })
     }
 
     fn set_header<'py>(

--- a/siphon-control-sdk/siphon-control/tests/test_smoke.py
+++ b/siphon-control-sdk/siphon-control/tests/test_smoke.py
@@ -118,6 +118,7 @@ def test_module_surface():
     assert hasattr(ControlServer, "serve")
     assert hasattr(ControlServer, "run")
     assert hasattr(Call, "answer")
+    assert hasattr(Call, "route")
     assert issubclass(ControlError, Exception)
 
 
@@ -162,6 +163,114 @@ def test_on_call_async_dispatch():
             assert channel == "ch1"
             assert reattached is False
             assert header == "203.0.113.7"
+
+            client.shutdown()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(run_task, timeout=5)
+
+    asyncio.run(scenario())
+
+
+def test_route_verb_roundtrip():
+    """`call.route(...)` emits the `route` command and returns the routing result."""
+
+    async def scenario():
+        recorded = {}
+
+        async def route_stub(websocket):
+            auth = websocket.request.headers.get("Authorization", "")
+            if auth != f"Bearer {TOKEN}":
+                await websocket.close(code=1008, reason="unauthorized")
+                return
+            said_hello = False
+            async for message in websocket:
+                frame = json.loads(message)
+                frame_id = frame.get("id")
+                verb = frame.get("verb")
+                if not said_hello:
+                    assert verb == "hello", "first frame must be hello"
+                    await _reply_ok(
+                        websocket,
+                        frame_id,
+                        {"app": APP, "protocol": 1, "subprotocol": SUBPROTOCOL},
+                    )
+                    said_hello = True
+                elif verb == "test_push_stasis":
+                    await websocket.send(
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": "StasisStart",
+                                "channel": "ch1",
+                                "app": APP,
+                                "call_id": "call-uuid",
+                                "sip_call_id": "sipcid@host",
+                                "payload": {},
+                            }
+                        )
+                    )
+                    await _reply_ok(websocket, frame_id, {})
+                elif verb == "route":
+                    recorded["frame"] = frame
+                    await _reply_ok(
+                        websocket,
+                        frame_id,
+                        {"channel": "ch1", "state": "routing", "targets": 2},
+                    )
+                else:
+                    await _reply_ok(websocket, frame_id, {"state": "answered"})
+
+        async with websockets.serve(
+            route_stub, "127.0.0.1", 0, subprotocols=[SUBPROTOCOL]
+        ) as server:
+            port = server.sockets[0].getsockname()[1]
+            url = f"ws://127.0.0.1:{port}/control/ws"
+            client = ControlClient(app=APP, token=TOKEN, url=url)
+            done = asyncio.get_event_loop().create_future()
+
+            @client.on_call
+            async def handle(call):
+                result = await call.route(
+                    [
+                        "sip:carrier1@gw1",
+                        {
+                            "uri": "sip:carrier2@gw2",
+                            "next_hop": "sip:1.2.3.4:5060",
+                            "headers": {"X-Foo": "bar"},
+                            "timeout": 30,
+                        },
+                    ],
+                    strategy="sequential",
+                    headers={"X-Trace": "abc"},
+                )
+                if not done.done():
+                    done.set_result(result)
+
+            await client.connect()
+            run_task = asyncio.ensure_future(client.run())
+            await asyncio.sleep(0.3)
+            await client.command("test_push_stasis")
+
+            result = await asyncio.wait_for(done, timeout=5)
+            assert result == {"channel": "ch1", "state": "routing", "targets": 2}
+
+            frame = recorded["frame"]
+            assert frame["module"] == "sip"
+            assert frame["verb"] == "route"
+            assert frame["target"]["channel"] == "ch1"
+            assert frame["args"] == {
+                "targets": [
+                    "sip:carrier1@gw1",
+                    {
+                        "uri": "sip:carrier2@gw2",
+                        "next_hop": "sip:1.2.3.4:5060",
+                        "headers": {"X-Foo": "bar"},
+                        "timeout": 30,
+                    },
+                ],
+                "strategy": "sequential",
+                "headers": {"X-Trace": "abc"},
+            }
 
             client.shutdown()
             with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):

--- a/siphon-control-sdk/typescript/src/index.ts
+++ b/siphon-control-sdk/typescript/src/index.ts
@@ -92,4 +92,6 @@ export type {
   ResponseOptions,
   ReferReplaces,
   AcceptReferOptions,
+  RouteTarget,
+  RouteTargetObject,
 } from "./sip";

--- a/siphon-control-sdk/typescript/src/protocol.ts
+++ b/siphon-control-sdk/typescript/src/protocol.ts
@@ -165,8 +165,8 @@ export function parseInboundFrame(text: string): ReplyFrame | EventFrame | null 
 /**
  * The verbs the built-in SIP adapter accepts (`module = "sip"`).
  *
- * These are the exact wire tokens. The Phase-1 server implements
- * `answer`/`progress`/`reject`/`hangup`/`refer`/`set_header`/`get_header`;
+ * These are the exact wire tokens. The server implements
+ * `answer`/`progress`/`reject`/`hangup`/`refer`/`route`/`set_header`/`get_header`;
  * the rest (`remove_header`, `accept_refer`, `reject_refer`, `play`, `dtmf`)
  * are accepted names the server answers `unsupported_verb` until it implements
  * them.
@@ -177,6 +177,7 @@ export const SipVerb = {
   Reject: "reject",
   Hangup: "hangup",
   Refer: "refer",
+  Route: "route",
   SetHeader: "set_header",
   GetHeader: "get_header",
   RemoveHeader: "remove_header",

--- a/siphon-control-sdk/typescript/src/sip.ts
+++ b/siphon-control-sdk/typescript/src/sip.ts
@@ -90,6 +90,41 @@ export interface AcceptReferOptions {
   mode?: "terminate" | "transparent";
 }
 
+/** A {@link Call.route} target carrying per-target overrides. */
+export interface RouteTargetObject {
+  /** The B-leg request URI to dial. */
+  uri: string;
+  /** Route egress to this next hop instead of resolving `uri`. */
+  nextHop?: string;
+  /** Headers injected on this attempt's B-leg INVITE. */
+  headers?: Record<string, string>;
+  /** Per-target ring timeout in seconds. */
+  timeout?: number;
+}
+
+/**
+ * One entry in a {@link Call.route} target list: a bare URI string, or a
+ * {@link RouteTargetObject} with per-target overrides.
+ */
+export type RouteTarget = string | RouteTargetObject;
+
+function routeTargetToWire(target: RouteTarget): unknown {
+  if (typeof target === "string") {
+    return target;
+  }
+  const object: Record<string, unknown> = { uri: target.uri };
+  if (target.nextHop !== undefined) {
+    object.next_hop = target.nextHop;
+  }
+  if (target.headers !== undefined) {
+    object.headers = target.headers;
+  }
+  if (target.timeout !== undefined) {
+    object.timeout = target.timeout;
+  }
+  return object;
+}
+
 function stringValue(result: unknown): string | null {
   if (typeof result === "object" && result !== null) {
     const value = (result as { value?: unknown }).value;
@@ -189,6 +224,36 @@ export class Call {
         early_only: replaces.earlyOnly ?? false,
       },
     });
+  }
+
+  /**
+   * Un-park this controlled call and dial the B-leg via siphon's LCR
+   * sequential-failover engine, returning control to siphon.
+   *
+   * `targets` is a non-empty list of carriers tried cheapest-first: each entry
+   * is a bare URI string or a {@link RouteTargetObject}
+   * (`{uri, nextHop?, headers?, timeout?}`). `strategy` defaults to
+   * `"sequential"` (v1 supports only sequential/single — anything else rejects
+   * with `code === "unsupported_verb"`). `headers` is applied to every
+   * attempt's B-leg INVITE.
+   *
+   * Resolves to the reply `result` (`{channel, state: "routing", targets}`). An
+   * empty / invalid `targets` list rejects with `code === "bad_request"`; a call
+   * that is already gone rejects with `code === "not_found"`.
+   */
+  async route(
+    targets: RouteTarget[],
+    strategy = "sequential",
+    headers?: Record<string, string>,
+  ): Promise<unknown> {
+    const args: Record<string, unknown> = {
+      targets: targets.map(routeTargetToWire),
+      strategy,
+    };
+    if (headers !== undefined) {
+      args.headers = headers;
+    }
+    return this.sip(SipVerb.Route, args);
   }
 
   /**

--- a/siphon-control-sdk/typescript/test/wire.test.ts
+++ b/siphon-control-sdk/typescript/test/wire.test.ts
@@ -46,6 +46,7 @@ describe("SipVerb wire tokens + event names", () => {
   it("maps verbs to the exact wire tokens", () => {
     expect(SipVerb.Answer).toBe("answer");
     expect(SipVerb.Hangup).toBe("hangup");
+    expect(SipVerb.Route).toBe("route");
     expect(SipVerb.SetHeader).toBe("set_header");
     expect(SipVerb.GetHeader).toBe("get_header");
     expect(SipVerb.RemoveHeader).toBe("remove_header");
@@ -149,6 +150,59 @@ describe("Call verbs map to the in-process-mirrored wire verbs", () => {
       { module: MODULE_SIP, verb: "remove_header", target: { channel: "ch1" }, args: { name: "X-Tag" } },
       { module: null, verb: "set_var", target: { channel: "ch1" }, args: { key: "queue", value: "support" } },
       { module: null, verb: "get_var", target: { channel: "ch1" }, args: { key: "queue" } },
+    ]);
+  });
+
+  it("route — bare-URI + full-object targets, strategy + command headers", async () => {
+    const transport = new RecordingTransport({ channel: "ch1", state: "routing", targets: 2 });
+    const call = makeCall(transport);
+    const result = await call.route(
+      [
+        "sip:carrier1@gw1",
+        {
+          uri: "sip:carrier2@gw2",
+          nextHop: "sip:1.2.3.4:5060",
+          headers: { "X-Foo": "bar" },
+          timeout: 30,
+        },
+      ],
+      "sequential",
+      { "X-Trace": "abc" },
+    );
+    expect(result).toEqual({ channel: "ch1", state: "routing", targets: 2 });
+    expect(transport.calls).toEqual([
+      {
+        module: MODULE_SIP,
+        verb: "route",
+        target: { channel: "ch1" },
+        args: {
+          targets: [
+            "sip:carrier1@gw1",
+            {
+              uri: "sip:carrier2@gw2",
+              next_hop: "sip:1.2.3.4:5060",
+              headers: { "X-Foo": "bar" },
+              timeout: 30,
+            },
+          ],
+          strategy: "sequential",
+          headers: { "X-Trace": "abc" },
+        },
+      },
+    ]);
+  });
+
+  it("route — defaults strategy to sequential, omits headers when unset", async () => {
+    const transport = new RecordingTransport({ channel: "ch1", state: "routing", targets: 1 });
+    const call = makeCall(transport);
+    await call.route(["sip:only@gw"]);
+    expect(transport.calls).toEqual([
+      {
+        module: MODULE_SIP,
+        verb: "route",
+        target: { channel: "ch1" },
+        args: { targets: ["sip:only@gw"], strategy: "sequential" },
+      },
     ]);
   });
 


### PR DESCRIPTION
Adds a `route()` method to the control-plane SDK's `sip` facade across all three language bindings (Rust, Python, TypeScript), mirroring the shipped server `route` verb (PR #159). The method un-parks a handed-over/controlled call and dials the B-leg via siphon's LCR sequential-failover engine, returning control to siphon.

## Wire
Sends verb `route` on module `sip` with the channel target and args:

```json
{ "targets": [ "sip:carrier1@gw1",
               { "uri": "sip:carrier2@gw2", "next_hop": "sip:1.2.3.4:5060", "headers": {"X-Foo":"bar"}, "timeout": 30 } ],
  "strategy": "sequential",
  "headers": { "X-Trace": "abc" } }
```

A target is either a bare URI string or an object `{uri, next_hop?, headers?, timeout?}`. Bare-URI targets serialize as plain strings; targets carrying any override serialize as objects. On success the reply `result` (`{channel, state: "routing", targets: N}`) is returned; typed errors `unsupported_verb` (non-sequential/single strategy), `bad_request` (no/invalid targets) and `not_found` (call gone) raise/reject exactly like the sibling verbs.

## Signatures
- **Rust** (`siphon-control-client`): `Call::route(targets: Vec<RouteTarget>, strategy: Option<&str>, headers: Vec<(String, String)>) -> Result<serde_json::Value, ControlError>`, plus a public `RouteTarget` type (bare-URI via `RouteTarget::uri` / `From<&str>` / `From<String>`). `strategy = None` omits the field (server default sequential).
- **Python** (`siphon-control`): `await call.route(targets, strategy="sequential", headers=None)` — targets is a list of `str` or `dict`, headers an optional `dict`.
- **TypeScript** (`@siphon-project/control`): `route(targets: RouteTarget[], strategy = "sequential", headers?: Record<string,string>)` with exported `RouteTarget` / `RouteTargetObject` types.

Reuses the existing `command(module, verb, target, args)` core in every binding — no new transport/correlation code. `SipVerb::Route` / `SipVerb.Route` added to the proto verb enums.

## Tests
- Rust unit tests (recording `CommandTransport`) assert the emitted frame shape for the full-object and bare-URI/omit-defaults cases.
- Python smoke test drives `call.route(...)` end to end against a recording websockets stub and asserts both the returned result and the exact command frame.
- TS wire tests assert the emitted args for the full and defaulted forms, plus the `route` wire token.

All green: `cargo test` + `cargo clippy --all-targets --all-features -D warnings` clean on the `siphon-control-sdk` workspace; `npm run build` + `npm test` (17) pass; Python `pytest` (6) pass.

## Notes
- Does not bump the version — `[workspace.package]` stays `0.1.1`; the `control-sdk-v*` release train cuts the bump separately.
- Only `route` is added (the server does not support `continue` yet).