### PR TITLE
feat(auth): challenge an INVITE in B2BUA mode — digest helpers take a Call, not just a Request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -553,6 +553,49 @@ jobs:
             rtpengine-real.log
             *.log
 
+  # ── B2BUA A-leg INVITE authentication ──────────────────────────────────
+  # siphon challenges the CALLER from @b2bua.on_invite. With a @b2bua handler
+  # registered the dispatcher routes INVITE to the B2BUA path and
+  # @proxy.on_request never sees it, so the challenge runs against the Call
+  # object (auth.require_proxy_digest(call, realm=...)).
+  #
+  # The UAC asserts siphon's own 407 carries a Proxy-Authenticate challenge and
+  # a UAS To-tag, then completes the authenticated re-INVITE end to end. The UAS
+  # runs with -m 1 and asserts no Proxy-Authorization crossed the B2BUA, so a
+  # build that cannot challenge (dialling the unauthenticated INVITE through)
+  # fails on the extra INVITE.
+  sipp-b2bua-invite-auth:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-b2bua-invite-auth image
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-invite-auth build siphon-b2bua-invite-auth
+
+      - name: Start siphon-b2bua-invite-auth
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-invite-auth up -d --wait siphon-b2bua-invite-auth
+
+      - name: B2BUA A-leg INVITE auth (407 from siphon, then the authenticated re-INVITE bridges)
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-invite-auth up --abort-on-container-exit --exit-code-from sipp-b2bua-invite-auth-uac sipp-b2bua-invite-auth-uac sipp-b2bua-invite-auth-uas
+
+      - name: Collect logs
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml logs siphon-b2bua-invite-auth > siphon-b2bua-invite-auth.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-invite-auth down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-b2bua-invite-auth-logs
+          path: |
+            siphon-b2bua-invite-auth.log
+            *.log
+
   # ── rtpproxy functional test ───────────────────────────────────────────
   # Drives a real INVITE→200→ACK→BYE through siphon configured with
   # `media.backend: rtpproxy`, anchoring media via a mock rtpproxy. Proves the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`auth.require_proxy_digest()` / `require_www_digest()` / `require_digest()` /
+  `verify_digest()` now take a B2BUA `Call` as well as a proxy `Request`, so a
+  B2BUA can challenge its own caller.** Registering any `@b2bua.*` handler makes
+  the dispatcher route INVITE straight to the B2BUA path, so `@proxy.on_request`
+  never sees it — and the digest helpers only accepted a `Request`. There was no
+  way to authenticate an INVITE in B2BUA mode at all; the only auth on that path
+  was relaying a *downstream* challenge (`call.dial(auth_passthrough=True)`).
+  Now:
+
+  ```python
+  @b2bua.on_invite
+  def new_call(call):
+      if not auth.require_proxy_digest(call, realm="example.com"):
+          return                      # 407 armed; siphon answers the A-leg
+      log.info(f"call from {call.auth_user}")
+      call.dial(str(call.ruri))
+  ```
+
+  On a `Call` the challenge is armed as the same deferred reject
+  `call.reject()` produces, so siphon answers the A-leg INVITE and drops the
+  call actor without ever building a B-leg INVITE. On success the caller's
+  hop-by-hop `Proxy-Authorization` is stripped from the message the B-leg INVITE
+  is built from (RFC 3261 §22.3). Passing anything other than a `Request` or a
+  `Call` raises `TypeError` naming both. `require_ims_digest` /
+  `require_aka_digest` stay `Request`-only: IMS and AKA digest are REGISTER-time
+  procedures and REGISTER never reaches the B2BUA path.
+- **`call.auth_user`** — the B2BUA twin of `request.auth_user`, carrying the
+  username the A-leg authenticated as (`None` if never challenged). Also stamped
+  onto the call's CDR as `auth_user`; a B2BUA call is tracked at INVITE time, so
+  a caller authenticated inside `@b2bua.on_invite` previously left the field empty.
 - **Worked voice-AI example — a carrier call answered by an AI over a WebSocket.**
   `examples/voice_ai_b2bua.py` + `.yaml` compose the shipped pieces into the
   single-leg shape: identify the carrier by source IP, `rtpengine.answer_local()`
@@ -27,6 +57,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   engine's media address rather than echoing the caller's own `c=` back.
 
 ### Fixed
+- **Every digest challenge but the weakest was dropped on the wire.**
+  `auth.require_*_digest` builds one challenge per algorithm — MD5 + SHA-256 +
+  SHA-512-256, as RFC 7616 §3.7 asks for — so a single 401/407 serves RFC 2617
+  and RFC 7616 clients alike. The response builder copied only the first value,
+  so the wire carried MD5 alone and no client could negotiate up from it. All
+  values are now copied, as separate header lines.
+- **A locally-generated B2BUA final response carried no `To` tag.** RFC 3261
+  §8.2.6.2 requires a UAS to tag every response but 100, and siphon is the UAS
+  on the A-leg. The 408 ring-timeout path stamped the A-leg dialog's tag but
+  `call.reject()` did not, so every script-driven rejection answered a
+  dialog-forming INVITE with the request's tagless `To`. Both paths now share one
+  helper.
 - **A UAS-mode B2BUA answer carried no `Contact`, so no in-dialog request could
   be addressed to it.** RFC 3261 §12.1.1 / §13.3.1.4 require a dialog-establishing
   response to carry the Contact the UAC builds its remote target from. The

--- a/README.md
+++ b/README.md
@@ -408,9 +408,10 @@ registrar.save(request)
 registrar.lookup(uri)       # -> list[Contact]
 registrar.is_registered(uri)
 
-# Auth
+# Auth — takes a Request (proxy) or a Call (B2BUA)
 auth.require_www_digest(request, realm)    # 401 challenge (REGISTER)
 auth.require_proxy_digest(request, realm)  # 407 challenge (INVITE)
+auth.require_proxy_digest(call, realm)     # 407 challenge from @b2bua.on_invite
 
 # Gateway routing
 gateway.select("carriers")                  # weighted round-robin

--- a/docs/cookbook/sbc.md
+++ b/docs/cookbook/sbc.md
@@ -163,6 +163,49 @@ def on_invite(call):
     call.dial(gateway.select("carriers").uri)
 ```
 
+## Authenticate the caller before dialling anything
+
+A B2BUA facing untrusted callers should challenge them, not just route them.
+Registering any `@b2bua.*` handler takes INVITE off the proxy path, so a
+`@proxy.on_request("INVITE")` challenge would never run — pass the `call` to the
+digest helpers instead:
+
+```python
+from siphon import auth, b2bua, gateway, log
+
+@b2bua.on_invite
+def on_invite(call):
+    if not auth.require_proxy_digest(call, realm=DOMAIN):
+        return                      # 407 armed; siphon answers the A-leg
+
+    log.info(f"authenticated {call.auth_user}")
+    call.media.anchor(engine="rtpengine")
+    call.dial(gateway.select("carriers").uri)
+```
+
+An unauthenticated caller gets siphon's own 407 and **no B-leg is dialled** —
+the challenge is armed as the call's deferred reject, so the call actor is
+dropped before any trunk sees traffic. That ordering is the point: a toll-fraud
+probe never reaches your carrier. The caller re-INVITEs with credentials,
+`require_proxy_digest` returns `True`, and the hop-by-hop `Proxy-Authorization`
+is stripped before the B-leg INVITE is built (RFC 3261 §22.3).
+
+Pair it with anti-spoofing on the caller ID, as on the proxy path:
+
+```python
+    from_user = call.from_uri.user if call.from_uri else None
+    if call.auth_user != from_user:
+        call.reject(403, "Forbidden")
+        return
+```
+
+!!! note "Two different auth directions"
+    Challenging on the `call` is siphon authenticating **its caller**.
+    `call.dial(..., auth_passthrough=True)` is the opposite: a *downstream* PBX
+    or trunk challenges, and siphon relays that challenge to the caller to answer
+    end-to-end. A third option, `call.set_credentials(user, password)`, has
+    siphon answer the downstream challenge itself.
+
 ## Upstream trunk requiring mutual TLS
 
 Some upstream SIP trunks require siphon to present a **client certificate** when

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -84,6 +84,8 @@ This document tracks the maturity of every SIPhon feature across three readiness
 |---------|-----------|--------|-------|
 | Digest auth — 401 (UAS) | **Production** | `auth.require_digest()` | REGISTER challenges |
 | Digest auth — 407 (proxy) | **Production** | `auth.require_proxy_digest()` | INVITE challenges |
+| Digest auth — B2BUA A-leg | Implemented | `auth.require_proxy_digest(call, …)` | Challenge the caller from `@b2bua.on_invite`. With a `@b2bua.*` handler registered the INVITE never reaches `@proxy.on_request`, so the digest helpers take the `Call` too; the 407 is armed as the call's deferred reject, so no B-leg is dialled, and the caller's hop-by-hop `Proxy-Authorization` is stripped before it could reach one. Verified username on `call.auth_user` and on the CDR. Gated by `scripts/run-tests.sh --b2bua-invite-auth`. |
+| Multi-algorithm challenge (RFC 7616 §3.7) | Implemented | | One `WWW-Authenticate`/`Proxy-Authenticate` per algorithm (MD5, SHA-256, SHA-512-256) on a single 401/407, so RFC 2617 and RFC 7616 clients both negotiate. Wire shape validated against the Wireshark dissector. |
 | HTTP backend (HA1 lookup) | **Production** | `auth.backend: http` | REST credential lookup; optional per-username TTL cache (`auth.http.cache_ttl_secs`) flattens registration storms so repeat REGISTERs skip the blocking fetch |
 | Static users backend | Implemented | `auth.backend: static` | Inline config credentials |
 | Diameter Cx backend (HSS) | **Production** | `auth.backend: diameter_cx` | 3GPP TS 29.228 |

--- a/docs/migrating-from-kamailio-opensips.md
+++ b/docs/migrating-from-kamailio-opensips.md
@@ -63,6 +63,7 @@ them (see the framework-handles-automatically notes in the API reference).
 |---|---|
 | `www_authorize()` / `auth_check()` | `auth.require_www_digest(request, realm)` |
 | `proxy_authorize()` | `auth.require_proxy_digest(request, realm)` |
+| `proxy_authorize()` in a B2BUA route | `auth.require_proxy_digest(call, realm)` — same call, `Call` instead of `Request` (a `@b2bua.*` handler takes INVITE off the proxy path) |
 | `pv_www_authenticate()` w/ AKA | `auth.require_aka_digest()` / `auth.require_ims_digest()` |
 
 ## State, data & dispatch

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -15,6 +15,41 @@ def route(request):
     request.relay()
 ```
 
+## Challenging in B2BUA mode
+
+The digest helpers take a `Request` **or** a `Call`. This matters: registering
+any `@b2bua.*` handler makes the dispatcher route INVITE straight to the B2BUA
+path, so `@proxy.on_request` never sees it and a proxy-style challenge would
+simply never run.
+
+```python
+from siphon import auth, b2bua, log
+
+@b2bua.on_invite
+def new_call(call):
+    if not auth.require_proxy_digest(call, realm="example.com"):
+        return                      # 407 armed; siphon answers the A-leg
+    log.info(f"call from {call.auth_user}")
+    call.dial(str(call.ruri))
+```
+
+Returning `False` arms the challenge as the call's deferred reject, the same one
+`call.reject()` produces — siphon answers the A-leg INVITE and drops the call
+actor, so **no B-leg is dialled** for an unauthenticated caller. On success the
+caller's `Proxy-Authorization` is stripped from the message the B-leg INVITE is
+built from, because it is hop-by-hop (RFC 3261 §22.3); forwarding it would only
+make the next hop challenge credentials that were minted for us. The verified
+username lands on `call.auth_user` and on the call's CDR.
+
+This is the opposite direction from `call.dial(auth_passthrough=True)`, where a
+*downstream* PBX issues the challenge and siphon relays it end-to-end for the
+caller to answer. Use `auth_passthrough` when the credentials live at the far
+end; challenge on the `Call` when siphon owns them.
+
+`require_ims_digest` and `require_aka_digest` take a `Request` only — IMS and
+AKA digest are REGISTER-time procedures, and REGISTER never reaches the B2BUA
+path.
+
 ## `auth` namespace
 
 ::: siphon_sdk.mock_module.MockAuth

--- a/scripts/b2bua_invite_auth.py
+++ b/scripts/b2bua_invite_auth.py
@@ -1,0 +1,61 @@
+"""
+SIPhon B2BUA A-leg INVITE authentication test script.
+
+siphon itself challenges the *caller* before dialling anything — the opposite of
+scripts/b2bua_auth_passthrough.py, where the downstream PBX issues the challenge
+and siphon merely relays it.
+
+The point being gated: with any ``@b2bua.*`` handler registered, the dispatcher
+routes INVITE straight to the B2BUA path, so ``@proxy.on_request`` never sees it.
+Authenticating the caller therefore has to happen against the ``Call`` object:
+
+    auth.require_proxy_digest(call, realm=...)
+
+Returning ``False`` arms the 407 as the call's deferred reject, so siphon answers
+the A-leg and drops the call actor without ever building a B-leg INVITE.
+
+Used by the b2bua_invite_auth SIPp scenario to prove:
+  1. an unauthenticated INVITE is answered 407 with a Proxy-Authenticate
+     challenge, and no INVITE reaches the B-leg UAS,
+  2. the authenticated re-INVITE is let through and bridged normally,
+  3. the caller's hop-by-hop Proxy-Authorization does not cross to the B-leg.
+"""
+from siphon import auth, b2bua, log, proxy
+
+# The downstream UAS the authenticated call is bridged to.
+NEXT_HOP = "sip:172.20.0.101:5060"
+
+REALM = "siphon.test"
+
+
+@proxy.on_request
+def route(request):
+    # OPTIONS keepalive (health probe)
+    if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+
+
+@b2bua.on_invite
+def new_call(call):
+    # Challenge the caller. On the first INVITE this arms a 407 carrying a fresh
+    # nonce and returns False — siphon answers the A-leg itself and no B-leg is
+    # dialled. On the authenticated re-INVITE it returns True and strips the
+    # hop-by-hop Proxy-Authorization off the message the B-leg INVITE is built
+    # from.
+    if not auth.require_proxy_digest(call, realm=REALM):
+        log.info(f"challenged {call.from_uri} with 407 (realm={REALM})")
+        return
+
+    log.info(f"authenticated {call.auth_user} -> dialling {NEXT_HOP}")
+    call.dial(str(call.ruri), timeout=30, next_hop=NEXT_HOP)
+
+
+@b2bua.on_failure
+def call_failed(call, code, reason):
+    log.warn(f"B leg failed {code} {reason} for call {call.id}")
+    call.reject(code, reason)
+
+
+@b2bua.on_bye
+def call_ended(call, initiator):
+    call.terminate()

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -36,6 +36,7 @@ RUN_VOICE_AI=false
 RUN_REINVITE=false
 RUN_B2BUA=false
 RUN_B2BUA_AUTH=false
+RUN_B2BUA_INVITE_AUTH=false
 RUN_GATEWAY=false
 RUN_AUTO100=false
 RUN_HTTP_AUTH=false
@@ -62,6 +63,7 @@ for arg in "$@"; do
     --reinvite)   RUN_REINVITE=true;   SELECTED_MODES+=("$arg") ;;
     --b2bua)      RUN_B2BUA=true;      SELECTED_MODES+=("$arg") ;;
     --b2bua-auth) RUN_B2BUA_AUTH=true; SELECTED_MODES+=("$arg") ;;
+    --b2bua-invite-auth) RUN_B2BUA_INVITE_AUTH=true; SELECTED_MODES+=("$arg") ;;
     --gateway)    RUN_GATEWAY=true;    SELECTED_MODES+=("$arg") ;;
     --auto100)    RUN_AUTO100=true;    SELECTED_MODES+=("$arg") ;;
     --http-auth)  RUN_HTTP_AUTH=true;  SELECTED_MODES+=("$arg") ;;
@@ -77,7 +79,8 @@ for arg in "$@"; do
       echo "Scenario modes (pick at most ONE per run):"
       echo "  --ipsec --charging --call --presence --rtpengine --rtpproxy --reinvite"
       echo "  --voice-ai"
-      echo "  --b2bua --b2bua-auth --gateway --auto100 --http-auth --wedge --banscan"
+      echo "  --b2bua --b2bua-auth --b2bua-invite-auth --gateway --auto100 --http-auth"
+      echo "  --wedge --banscan"
       echo "  --security --rfc4475 --webrtc"
       echo
       echo "  --skip-rust   skip the Rust test step (combines with any mode)"
@@ -293,6 +296,25 @@ if [[ "$RUN_B2BUA_AUTH" == true ]]; then
   echo "=== B2BUA auth-passthrough test (outbound call to a PBX that 407s; challenge relayed, no spurious 502) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua-auth up --abort-on-container-exit --exit-code-from sipp-b2bua-auth-uac sipp-b2bua-auth-uac sipp-b2bua-auth-uas
   docker compose -f "$COMPOSE_FILE" --profile b2bua-auth rm -sf sipp-b2bua-auth-uac sipp-b2bua-auth-uas 2>/dev/null || true
+fi
+
+# ── Step 9c: B2BUA A-leg INVITE authentication test (optional) ──────────────
+# The mirror of 9b: siphon challenges the CALLER from @b2bua.on_invite. With a
+# @b2bua handler registered the INVITE never reaches @proxy.on_request, so the
+# challenge runs against the Call object. The UAC asserts the 407 + its
+# Proxy-Authenticate challenge and its UAS To-tag; the UAS asserts it sees
+# exactly one B-leg INVITE (a build that cannot challenge dials the
+# unauthenticated one through) carrying no leaked Proxy-Authorization.
+if [[ "$RUN_B2BUA_INVITE_AUTH" == true ]]; then
+  echo "=== Building siphon-b2bua-invite-auth image ==="
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-invite-auth build siphon-b2bua-invite-auth
+
+  echo "=== Starting siphon-b2bua-invite-auth ==="
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-invite-auth up -d --wait siphon-b2bua-invite-auth
+
+  echo "=== B2BUA A-leg INVITE auth test (siphon 407s the caller, then bridges the authenticated re-INVITE) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua-invite-auth up --abort-on-container-exit --exit-code-from sipp-b2bua-invite-auth-uac sipp-b2bua-invite-auth-uac sipp-b2bua-invite-auth-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua-invite-auth rm -sf sipp-b2bua-invite-auth-uac sipp-b2bua-invite-auth-uas 2>/dev/null || true
 fi
 
 # ── Step 10: Gateway routing tests (optional) ──────────────────────────────────

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -102,6 +102,9 @@ class Call:
         # (default a grant), and a record of each call for test assertions.
         self._ro_authorize_result: Optional[dict] = None
         self._ro_authorizations: list[dict] = []
+        # Username the A-leg authenticated as, set by
+        # ``auth.require_proxy_digest(call, realm)`` / ``require_www_digest``.
+        self._auth_user: Optional[str] = None
 
     # -- Properties ------------------------------------------------------------
 
@@ -126,6 +129,31 @@ class Call:
     def source_ip(self) -> str:
         """Source IP address of the A-leg caller."""
         return self._source_ip
+
+    @property
+    def auth_user(self) -> Optional[str]:
+        """Username the A-leg authenticated as, or ``None`` if never challenged.
+
+        The B2BUA twin of ``request.auth_user``.  Set by
+        ``auth.require_proxy_digest(call, realm)`` /
+        ``auth.require_www_digest(call, realm)`` in ``@b2bua.on_invite`` once
+        the caller answers the challenge correctly, and carried onto the call's
+        CDR as ``auth_user``.
+
+        Example::
+
+            @b2bua.on_invite
+            def new_call(call):
+                if not auth.require_proxy_digest(call, realm="example.com"):
+                    return          # 407 armed; siphon answers the A-leg
+                log.info(f"call from {call.auth_user}")
+                call.dial(call.ruri)
+        """
+        return self._auth_user
+
+    @auth_user.setter
+    def auth_user(self, value: Optional[str]) -> None:
+        self._auth_user = value
 
     def from_gateway(self, group_name: str) -> bool:
         """Check if the A-leg source IP is a member of a gateway group.

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -1567,14 +1567,36 @@ class MockAuth:
         """
         self._credentials.setdefault(realm, {})[username] = password
 
-    def require_www_digest(self, request: Any, realm: Optional[str] = None) -> bool:
+    @staticmethod
+    def _challenge(target: Any, code: int, reason: str) -> None:
+        """Arm the challenge response on whichever object was passed.
+
+        A ``Request`` replies; a B2BUA ``Call`` has no ``reply()`` — its
+        deferred reject is what the dispatcher turns into the 401/407 on the
+        A-leg, so the caller never reaches a B-leg.
+        """
+        reply = getattr(target, "reply", None)
+        if callable(reply):
+            reply(code, reason)
+            return
+        reject = getattr(target, "reject", None)
+        if callable(reject):
+            reject(code, reason)
+            return
+        raise TypeError(
+            "auth digest methods take a Request (@proxy.on_request) or a Call "
+            "(@b2bua.on_invite)"
+        )
+
+    def require_www_digest(self, target: Any, realm: Optional[str] = None) -> bool:
         """Challenge with 401 WWW-Authenticate, or verify existing credentials.
 
-        If credentials are valid: sets ``request.auth_user``, returns ``True``.
-        Otherwise: sends 401 response, returns ``False``.
+        If credentials are valid: sets ``target.auth_user``, returns ``True``.
+        Otherwise: arms a 401 response, returns ``False``.
 
         Args:
-            request: The SIP request.
+            target: The SIP ``Request`` (``@proxy.on_request``) or B2BUA
+                ``Call`` (``@b2bua.on_invite``).
             realm: Auth realm (e.g. ``"example.com"``).
 
         Returns:
@@ -1582,42 +1604,50 @@ class MockAuth:
         """
         if self._allow:
             # Derive auth_user from From URI when auto-allowing.
-            user = getattr(request.from_uri, "user", None) if request.from_uri else None
-            request.auth_user = user or "mock_user"
+            user = getattr(target.from_uri, "user", None) if target.from_uri else None
+            target.auth_user = user or "mock_user"
             return True
-        # Check if request has Authorization header
-        auth_header = request.get_header("Authorization")
+        # Check if the message carries an Authorization header
+        auth_header = target.get_header("Authorization")
         if auth_header and self._check_auth(auth_header, realm):
-            request.auth_user = self._extract_username(auth_header)
+            target.auth_user = self._extract_username(auth_header)
             return True
-        request.reply(401, "Unauthorized")
+        self._challenge(target, 401, "Unauthorized")
         return False
 
-    def require_proxy_digest(self, request: Any,
+    def require_proxy_digest(self, target: Any,
                              realm: Optional[str] = None) -> bool:
         """Challenge with 407 Proxy-Authenticate.
 
-        Same as :meth:`require_www_digest` but uses 407.
+        Same as :meth:`require_www_digest` but uses 407.  This is the challenge
+        an INVITE normally gets, including from a B2BUA authenticating its own
+        A-leg::
+
+            @b2bua.on_invite
+            def new_call(call):
+                if not auth.require_proxy_digest(call, realm="example.com"):
+                    return          # 407 armed; siphon answers the A-leg
+                call.dial(call.ruri)
 
         Args:
-            request: The SIP request.
+            target: The SIP ``Request`` or B2BUA ``Call``.
             realm: Auth realm.
         """
         if self._allow:
-            user = getattr(request.from_uri, "user", None) if request.from_uri else None
-            request.auth_user = user or "mock_user"
+            user = getattr(target.from_uri, "user", None) if target.from_uri else None
+            target.auth_user = user or "mock_user"
             return True
-        auth_header = request.get_header("Proxy-Authorization")
+        auth_header = target.get_header("Proxy-Authorization")
         if auth_header and self._check_auth(auth_header, realm):
-            request.auth_user = self._extract_username(auth_header)
+            target.auth_user = self._extract_username(auth_header)
             return True
-        request.reply(407, "Proxy Authentication Required")
+        self._challenge(target, 407, "Proxy Authentication Required")
         return False
 
-    def require_digest(self, request: Any,
+    def require_digest(self, target: Any,
                        realm: Optional[str] = None) -> bool:
         """Convenience alias for :meth:`require_www_digest`."""
-        return self.require_www_digest(request, realm=realm)
+        return self.require_www_digest(target, realm=realm)
 
     def require_ims_digest(self, request: Any,
                           realm: Optional[str] = None) -> bool:
@@ -1626,9 +1656,15 @@ class MockAuth:
         Sends a Multimedia-Auth-Request to the HSS and uses the returned
         authentication vector to challenge or verify the UE.
 
+        Takes a ``Request`` only — unlike :meth:`require_www_digest` /
+        :meth:`require_proxy_digest`, IMS and AKA digest are REGISTER-time
+        procedures and REGISTER never reaches the B2BUA path, so the engine
+        does not accept a ``Call`` here either.
+
         Returns:
             ``True`` if credentials are valid, ``False`` if a 401 challenge was sent.
         """
+        self._reject_call_target(request, "require_ims_digest")
         return self.require_www_digest(request, realm=realm)
 
     def require_aka_digest(self, request: Any,
@@ -1646,21 +1682,47 @@ class MockAuth:
                 log.info("sent 401 AKA challenge")
                 return
 
+        Takes a ``Request`` only, for the same reason as
+        :meth:`require_ims_digest`.
+
         Returns:
             ``True`` if credentials are valid, ``False`` if a 401 challenge was sent.
         """
+        self._reject_call_target(request, "require_aka_digest")
         return self.require_www_digest(request, realm=realm)
 
-    def verify_digest(self, request: Any,
+    @staticmethod
+    def _reject_call_target(target: Any, method: str) -> None:
+        """Raise if a B2BUA ``Call`` is passed to a REGISTER-only helper.
+
+        Mirrors the engine, which types these two on ``Request`` — without this
+        the mock would silently accept a ``Call`` and a script that passes one
+        would only fail in production.
+        """
+        if hasattr(target, "dial") and not hasattr(target, "reply"):
+            raise TypeError(
+                f"auth.{method}() takes a Request; IMS/AKA digest is a "
+                "REGISTER-time procedure and REGISTER never reaches the B2BUA "
+                "path"
+            )
+
+    def verify_digest(self, target: Any,
                       realm: Optional[str] = None) -> bool:
         """Verify credentials without sending a challenge.
+
+        Args:
+            target: The SIP ``Request`` or B2BUA ``Call``.
+            realm: Auth realm.
 
         Returns:
             ``True`` if valid credentials are present.
         """
         if self._allow:
             return True
-        auth_header = request.get_header("Authorization")
+        auth_header = (
+            target.get_header("Authorization")
+            or target.get_header("Proxy-Authorization")
+        )
         return auth_header is not None and self._check_auth(auth_header, realm)
 
     def _check_auth(self, auth_header: str, realm: Optional[str]) -> bool:
@@ -1668,13 +1730,23 @@ class MockAuth:
         return self._allow
 
     def _extract_username(self, auth_header: str) -> str:
-        """Extract username from Authorization header."""
-        # Parse: Digest username="alice", ...
-        for part in auth_header.split(","):
-            part = part.strip()
-            if part.lower().startswith("username="):
-                return part.split("=", 1)[1].strip('"')
-        return "unknown"
+        """Extract username from an Authorization/Proxy-Authorization header.
+
+        Mirrors the engine's ``extract_username``: scan for ``username=``
+        anywhere in the value, case-insensitively.  Splitting on ``,`` and
+        matching the start of each part misses the very common
+        ``Digest username="alice", realm=…`` because the first part carries the
+        ``Digest`` scheme token.
+        """
+        lowered = auth_header.lower()
+        position = lowered.find("username=")
+        if position < 0:
+            return "unknown"
+        rest = auth_header[position + len("username="):]
+        if rest.startswith('"'):
+            end = rest.find('"', 1)
+            return rest[1:end] if end > 0 else "unknown"
+        return rest.split(",", 1)[0].strip()
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/tests/test_b2bua_invite_auth.py
+++ b/sdk/tests/test_b2bua_invite_auth.py
@@ -1,0 +1,167 @@
+"""Unit tests for challenging an INVITE from ``@b2bua.on_invite``.
+
+With any ``@b2bua.*`` handler registered, the dispatcher hands INVITE straight
+to the B2BUA path — ``@proxy.on_request`` never sees it — so the digest helpers
+have to work off the ``Call`` object for a B2BUA to authenticate its caller.
+
+Mirrors the engine semantics:
+
+- ``auth.require_www_digest`` / ``require_proxy_digest`` / ``require_digest`` /
+  ``verify_digest`` accept a ``Request`` **or** a ``Call``.
+- On a ``Call``, the challenge is armed as the same deferred reject
+  ``call.reject()`` produces (the dispatcher turns it into the 401/407 and
+  drops the call actor without dialling a B-leg).
+- A verified username lands on ``call.auth_user``.
+- ``require_ims_digest`` / ``require_aka_digest`` stay Request-only: IMS/AKA
+  digest is a REGISTER-time procedure and REGISTER never reaches the B2BUA path.
+"""
+import pytest
+
+from siphon_sdk.call import Call
+from siphon_sdk.mock_module import MockAuth
+from siphon_sdk.request import Request
+
+
+def _invite_call(proxy_auth: str | None = None) -> Call:
+    headers = {"Proxy-Authorization": proxy_auth} if proxy_auth else None
+    return Call(
+        call_id="b2bua-auth-1",
+        from_uri="sip:alice@example.com",
+        to_uri="sip:bob@example.com",
+        ruri="sip:bob@example.com",
+        headers=headers,
+    )
+
+
+def test_require_proxy_digest_on_call_arms_a_407_reject():
+    auth = MockAuth()
+    call = _invite_call()
+
+    assert auth.require_proxy_digest(call, realm="example.com") is False
+
+    # The deferred reject the dispatcher turns into the 407 — no B-leg dialled.
+    assert call.last_action.kind == "reject"
+    assert call.last_action.status_code == 407
+    assert call.last_action.reason == "Proxy Authentication Required"
+    assert call.auth_user is None
+
+
+def test_require_www_digest_on_call_arms_a_401_reject():
+    auth = MockAuth()
+    call = _invite_call()
+
+    assert auth.require_www_digest(call, realm="example.com") is False
+    assert call.last_action.kind == "reject"
+    assert call.last_action.status_code == 401
+    assert call.last_action.reason == "Unauthorized"
+
+
+def test_require_digest_alias_on_call_arms_a_401_reject():
+    auth = MockAuth()
+    call = _invite_call()
+
+    assert auth.require_digest(call, realm="example.com") is False
+    assert call.last_action.status_code == 401
+
+
+def test_authenticated_call_sets_auth_user_and_arms_nothing():
+    auth = MockAuth()
+    auth._allow = True
+    call = _invite_call()
+
+    assert auth.require_proxy_digest(call, realm="example.com") is True
+    assert call.auth_user == "alice"
+    assert call.last_action is None, "no reject may be armed on success"
+
+
+def test_authenticated_call_takes_username_from_the_credentials():
+    auth = MockAuth()
+    auth._allow = True
+    call = _invite_call(
+        proxy_auth='Digest username="trunk-7", realm="example.com", nonce="abc"'
+    )
+
+    assert auth.require_proxy_digest(call, realm="example.com") is True
+    # _allow short-circuits to the From user; with credentials present and a
+    # backend that accepts them, the username comes off the header.
+    auth._allow = False
+    fresh = _invite_call(
+        proxy_auth='Digest username="trunk-7", realm="example.com", nonce="abc"'
+    )
+    auth._check_auth = lambda header, realm: True  # type: ignore[method-assign]
+    assert auth.require_proxy_digest(fresh, realm="example.com") is True
+    assert fresh.auth_user == "trunk-7"
+    assert fresh.last_action is None
+
+
+def test_verify_digest_on_call_reads_proxy_authorization():
+    auth = MockAuth()
+    auth._check_auth = lambda header, realm: True  # type: ignore[method-assign]
+
+    without = _invite_call()
+    assert auth.verify_digest(without, realm="example.com") is False
+
+    with_credentials = _invite_call(
+        proxy_auth='Digest username="alice", realm="example.com", nonce="abc"'
+    )
+    assert auth.verify_digest(with_credentials, realm="example.com") is True
+    # verify_digest never challenges and never sets auth_user.
+    assert with_credentials.last_action is None
+    assert with_credentials.auth_user is None
+
+
+def test_request_path_is_unchanged():
+    auth = MockAuth()
+    request = Request(method="INVITE", ruri="sip:bob@example.com")
+
+    assert auth.require_proxy_digest(request, realm="example.com") is False
+    assert request.last_action.kind == "reply"
+    assert request.last_action.status_code == 407
+
+
+@pytest.mark.parametrize("method", ["require_ims_digest", "require_aka_digest"])
+def test_ims_and_aka_digest_reject_a_call(method):
+    # REGISTER never reaches the B2BUA path, so the engine types these two on
+    # Request. The mock has to refuse a Call too, or a script that passes one
+    # would only fail in production.
+    auth = MockAuth()
+    with pytest.raises(TypeError, match="REGISTER"):
+        getattr(auth, method)(_invite_call(), realm="example.com")
+
+
+def test_challenging_an_unsupported_object_raises_type_error():
+    auth = MockAuth()
+
+    class NotAMessage:
+        from_uri = None
+
+        def get_header(self, name):
+            return None
+
+    with pytest.raises(TypeError, match="Request .* or a Call"):
+        auth.require_proxy_digest(NotAMessage(), realm="example.com")
+
+
+def test_b2bua_challenge_then_dial_flow():
+    """The shape a real ``@b2bua.on_invite`` handler takes."""
+    auth = MockAuth()
+
+    def on_invite(call):
+        if not auth.require_proxy_digest(call, realm="example.com"):
+            return
+        call.dial(call.ruri)
+
+    # First INVITE, no credentials -> challenged, never dialled.
+    first = _invite_call()
+    on_invite(first)
+    assert [action.kind for action in first.actions] == ["reject"]
+    assert first.last_action.status_code == 407
+
+    # Re-INVITE with credentials the backend accepts -> dialled.
+    auth._allow = True
+    second = _invite_call(
+        proxy_auth='Digest username="alice", realm="example.com", nonce="abc"'
+    )
+    on_invite(second)
+    assert [action.kind for action in second.actions] == ["dial"]
+    assert second.auth_user == "alice"

--- a/sipp/b2bua_invite_auth_uac.xml
+++ b/sipp/b2bua_invite_auth_uac.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA A-leg INVITE authentication UAC scenario (caller side).
+
+  siphon itself challenges the caller before dialling anything. This is the
+  opposite of b2bua_auth_uac.xml, where the challenge originates at the
+  downstream PBX and siphon only relays it (auth_passthrough).
+
+  Acceptance gate for "siphon cannot challenge an INVITE in b2bua mode": with a
+  @b2bua handler registered, the dispatcher routes INVITE to the B2BUA path and
+  @proxy.on_request never sees it, so the script has to authenticate against the
+  Call object (auth.require_proxy_digest(call, realm=...)).
+
+    1. INVITE (CSeq 1, no credentials) -> siphon answers 407 itself. Asserted
+       on the response:
+         - a Proxy-Authenticate challenge is present (without the multi-value
+           copy fix the response builder dropped every algorithm but the first;
+           without the Call-typed auth API there is no 407 at all, the call is
+           just dialled through unauthenticated),
+         - the To header carries a UAS tag (RFC 3261 §8.2.6.2).
+       b2bua_invite_auth_uas.xml asserts it receives exactly ONE INVITE, so a
+       build that lets the unauthenticated call through fails there.
+    2. ACK the 407.
+    3. Authenticated INVITE (CSeq 2) -> siphon verifies, strips the hop-by-hop
+       Proxy-Authorization, dials the B-leg -> 180 -> 200.
+    4. ACK, then BYE -> 200, call completes.
+
+  Run: sipp <siphon>:5060 -sf b2bua_invite_auth_uac.xml -au alice -ap secret -m 1
+-->
+<scenario name="B2BUA INVITE auth UAC">
+
+  <!-- Step 1: initial INVITE, no credentials -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-invite-auth-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <!-- siphon's own 407. auth="true" primes [authentication] for the re-INVITE;
+       the eregs are the actual assertions. -->
+  <recv response="407" auth="true">
+    <action>
+      <ereg regexp="Digest.*realm=\"siphon\.test\""
+            search_in="hdr" header="Proxy-Authenticate:" check_it="true"
+            assign_to="challenge_ok" />
+      <ereg regexp=";tag="
+            search_in="hdr" header="To:" check_it="true"
+            assign_to="uas_tag_ok" />
+      <!-- Reference the vars so SIPp doesn't reject them as unused; check_it
+           on the eregs above is the pass/fail gate. -->
+      <log message="407 assertions: challenge=[$challenge_ok] to_tag=[$uas_tag_ok]" />
+    </action>
+  </recv>
+
+  <!-- Step 2: ACK the 407 (CSeq 1) -->
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Step 3: authenticated INVITE (CSeq 2) -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 2 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+[authentication]
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-invite-auth-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="180" optional="true" />
+
+  <!-- The authenticated call is bridged to the B-leg and answered. A second
+       407 here means the credentials were not accepted off the Call. -->
+  <recv response="200" rtd="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!-- Step 4: tear the call down -->
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+</scenario>

--- a/sipp/b2bua_invite_auth_uas.xml
+++ b/sipp/b2bua_invite_auth_uas.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA A-leg INVITE authentication UAS scenario (B-leg side).
+
+  Pairs with b2bua_invite_auth_uac.xml + scripts/b2bua_invite_auth.py.
+
+  Two jobs:
+
+  1. Answer the ONE B-leg INVITE the authenticated call produces (180 -> 200 ->
+     ACK -> BYE -> 200), so the UAC's call completes.
+
+  2. Assert the caller's hop-by-hop credentials never crossed the B2BUA. The
+     A-leg re-INVITE carries Proxy-Authorization; RFC 3261 §22.3 makes it
+     hop-by-hop, and auth verification strips it off the message the B-leg
+     INVITE is built from. `Proxy-Authorization: [^ ]` with check_it_inverse
+     fails the call if any survived.
+
+  Run with -m 1: the UAC sends two INVITEs but only the authenticated one is
+  meant to reach here. A build that cannot challenge in B2BUA mode dials the
+  first (unauthenticated) INVITE through as well, and the extra INVITE lands
+  after the scenario has ended -> "Unexpected message" -> non-zero exit.
+-->
+<scenario name="B2BUA INVITE auth UAS">
+
+  <!-- The single B-leg INVITE, from the authenticated A-leg call -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="[^ ]"
+            search_in="hdr" header="Proxy-Authorization:" check_it_inverse="true"
+            assign_to="no_creds_leaked" />
+      <log message="B-leg credential leak check: [$no_creds_leaked]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/configs/siphon.b2bua-invite-auth-test.yaml
+++ b/sipp/configs/siphon.b2bua-invite-auth-test.yaml
@@ -1,0 +1,46 @@
+# siphon.b2bua-invite-auth-test.yaml — B2BUA A-leg INVITE authentication config
+#
+# Used with: sipp/docker-compose.yaml (b2bua-invite-auth profile)
+# Script:    scripts/b2bua_invite_auth.py
+# Tests:     siphon challenges the CALLER's INVITE from @b2bua.on_invite
+#            (auth.require_proxy_digest(call, realm=...)) — with a @b2bua
+#            handler registered the INVITE never reaches @proxy.on_request, so
+#            the challenge has to work off the Call object. The unauthenticated
+#            INVITE must be answered 407 without a B-leg being dialled, and the
+#            authenticated re-INVITE must bridge normally with the caller's
+#            hop-by-hop Proxy-Authorization stripped.
+#
+# Contrast with siphon.b2bua-auth-test.yaml, where the DOWNSTREAM PBX issues the
+# challenge and siphon relays it (auth_passthrough).
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.100"
+    - "127.0.0.1"
+
+script:
+  path: "scripts/b2bua_invite_auth.py"
+  reload: auto
+
+advertised_address: "172.20.0.100"
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -1044,6 +1044,93 @@ services:
     profiles:
       - b2bua-auth
 
+  # --- B2BUA A-leg INVITE authentication test ---
+  #
+  # siphon challenges the CALLER from @b2bua.on_invite. The mirror image of the
+  # b2bua-auth profile above, where the challenge comes from the downstream PBX
+  # and siphon only relays it.
+  #
+  #   172.20.0.100 — siphon-b2bua-invite-auth (B2BUA that challenges the A-leg)
+  #   172.20.0.101 — SIPp UAS (B-leg destination)
+  #   172.20.0.102 — SIPp UAC (A-leg caller)
+
+  siphon-b2bua-invite-auth:
+    build:
+      context: ..
+    container_name: siphon-b2bua-invite-auth-test
+    volumes:
+      - ./configs/siphon.b2bua-invite-auth-test.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.100
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - b2bua-invite-auth
+
+  sipp-b2bua-invite-auth-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-invite-auth:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.101
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_invite_auth_uas.xml
+      - -p
+      - "5060"
+      # Exactly one B-leg INVITE is expected: the unauthenticated A-leg INVITE
+      # must be answered 407 by siphon and never dialled through.
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-invite-auth
+
+  sipp-b2bua-invite-auth-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-invite-auth:
+        condition: service_healthy
+      sipp-b2bua-invite-auth-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.102
+    entrypoint:
+      - sipp
+      - "172.20.0.100:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_invite_auth_uac.xml
+      - -au
+      - alice
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-invite-auth
+
   # --- B2BUA early media test (183 with SDP) ---
 
   sipp-b2bua-early-media-uas:

--- a/src/cdr/mod.rs
+++ b/src/cdr/mod.rs
@@ -326,6 +326,17 @@ impl CdrSession {
         }
     }
 
+    /// Record the authenticated username after the fact.
+    ///
+    /// The proxy path knows `auth_user` before the session is built, but a
+    /// B2BUA call is tracked at INVITE time — *before* `@b2bua.on_invite` runs
+    /// — so a caller authenticated inside that handler
+    /// (`auth.require_proxy_digest(call, …)`) can only be stamped on once the
+    /// handler returns.
+    pub fn set_auth_user(&mut self, auth_user: String) {
+        self.auth_user = Some(auth_user);
+    }
+
     /// Merge extra fields to auto-stamp onto the finalized CDR (later keys win).
     /// Used for LCR route `cdr_fields` when a carrier wins.
     pub fn merge_extra(&mut self, fields: &std::collections::HashMap<String, String>) {
@@ -879,6 +890,30 @@ mod tests {
             Some("Ozona/5.0".to_string()),
             Some("alice".to_string()),
         )
+    }
+
+    #[test]
+    fn cdr_session_set_auth_user_after_the_fact() {
+        // A B2BUA call is tracked at INVITE time, before @b2bua.on_invite runs,
+        // so a caller authenticated inside that handler
+        // (auth.require_proxy_digest(call, …)) can only be stamped on once the
+        // handler returns.
+        let mut session = CdrSession::new(
+            "b2bua-call@host".to_string(),
+            "sip:alice@example.com".to_string(),
+            "sip:bob@example.com".to_string(),
+            "sip:bob@10.0.0.2".to_string(),
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+            None,
+            None,
+        );
+        assert!(session.clone().finalize("caller", None, None).auth_user.is_none());
+
+        session.set_auth_user("alice".to_string());
+        session.mark_answered(200);
+        let cdr = session.finalize("caller", None, None);
+        assert_eq!(cdr.auth_user.as_deref(), Some("alice"));
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -7128,6 +7128,25 @@ fn is_coroutine(python: Python<'_>, obj: &Bound<'_, pyo3::PyAny>) -> PyResult<bo
     result.is_truthy()
 }
 
+/// Stamp the UAS To-tag of a B2BUA A-leg dialog onto a locally-generated
+/// response.
+///
+/// RFC 3261 §8.2.6.2: a UAS MUST put a tag in the To header of every response
+/// but 100, and siphon is the UAS on the A-leg. [`build_response`] copies the
+/// request's To verbatim, which for a dialog-forming INVITE has no tag yet, so
+/// any response siphon answers itself has to add the tag the A-leg dialog was
+/// created with — the same one the caller saw on our provisionals, so a final
+/// response terminates the dialog it belongs to.
+///
+/// No-op when the To header already carries a tag (an in-dialog request) or is
+/// absent.
+fn stamp_uas_to_tag(response: &mut SipMessage, local_tag: &str) {
+    if let Some(to) = response.headers.to() {
+        let tagged = crate::b2bua::actor::ensure_tag(to, Some(local_tag));
+        response.headers.set("To", tagged);
+    }
+}
+
 /// Build a SIP response from a request, copying mandatory headers.
 fn build_response(
     request: &SipMessage,
@@ -7162,12 +7181,19 @@ fn build_response(
         builder = builder.cseq(cseq.clone());
     }
 
-    // Copy any auth challenge headers the script may have set
-    if let Some(www_auth) = request.headers.get("WWW-Authenticate") {
-        builder = builder.header("WWW-Authenticate", www_auth.clone());
-    }
-    if let Some(proxy_auth) = request.headers.get("Proxy-Authenticate") {
-        builder = builder.header("Proxy-Authenticate", proxy_auth.clone());
+    // Copy any auth challenge headers the script may have set.
+    //
+    // ALL values, not just the first: `auth.require_*_digest` stacks one
+    // challenge per algorithm (MD5 + SHA-256 + SHA-512-256, RFC 7616 §3.7) so a
+    // single 401/407 serves both RFC 2617 and RFC 7616 clients. Copying only
+    // `get()` put the weakest one on the wire and silently dropped the rest,
+    // which no client could then negotiate up from.
+    for name in ["WWW-Authenticate", "Proxy-Authenticate"] {
+        if let Some(values) = request.headers.get_all(name) {
+            for value in values {
+                builder = builder.header(name, value.clone());
+            }
+        }
     }
 
 
@@ -11385,11 +11411,7 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
                 build_response(&invite, 408, "Request Timeout", state.server_header.as_deref(), &[]);
             // Carry the UAS To-tag we assigned the A-leg dialog (the A-leg saw it
             // on our 1xx) so the final response terminates the same dialog.
-            if let Some(to) = response.headers.to() {
-                let to_with_tag =
-                    crate::b2bua::actor::ensure_tag(to, Some(&a_leg.dialog.local_tag));
-                response.headers.set("To", to_with_tag);
-            }
+            stamp_uas_to_tag(&mut response, &a_leg.dialog.local_tag);
             // Pin the A-leg's arrival socket so the 408 leaves the port the caller
             // sent the INVITE to (multi-homed UDP symmetric signalling).
             send_message_from(
@@ -11675,12 +11697,13 @@ fn handle_b2bua_invite(
         contact_user_override,
         contact_override,
         auth_passthrough,
+        auth_user,
     ) = Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {
             Ok(obj) => obj,
             Err(error) => {
                 error!("failed to create PyCall: {error}");
-                return (CallAction::None, None, None, false, false, None, None, None, None, None, false);
+                return (CallAction::None, None, None, false, false, None, None, None, None, None, false, None);
             }
         };
 
@@ -11694,7 +11717,7 @@ fn handle_b2bua_invite(
                             return (CallAction::Reject {
                                 code: 500,
                                 reason: "Script Error".to_string(),
-                            }, None, None, false, false, None, None, None, None, None, false);
+                            }, None, None, false, false, None, None, None, None, None, false, None);
                         }
                     }
                 }
@@ -11703,7 +11726,7 @@ fn handle_b2bua_invite(
                     return (CallAction::Reject {
                         code: 500,
                         reason: "Script Error".to_string(),
-                    }, None, None, false, false, None, None, None, None, None, false);
+                    }, None, None, false, false, None, None, None, None, None, false, None);
                 }
             }
         }
@@ -11720,11 +11743,22 @@ fn handle_b2bua_invite(
         let contact_user_ovr = borrowed.contact_user_override().map(String::from);
         let contact_ovr = borrowed.contact_override().map(String::from);
         let auth_passthrough = borrowed.auth_passthrough();
-        (action, timer_override, credentials, li_record, preserve_cid, policy_input, from_host_ovr, to_host_ovr, contact_user_ovr, contact_ovr, auth_passthrough)
+        let auth_user = borrowed.get_auth_user().map(String::from);
+        (action, timer_override, credentials, li_record, preserve_cid, policy_input, from_host_ovr, to_host_ovr, contact_user_ovr, contact_ovr, auth_passthrough, auth_user)
     });
 
     // Store the A-leg INVITE for later use by on_answer/on_failure/on_bye handlers
     state.call_actors.set_a_leg_invite(&call_id, Arc::clone(&message_arc));
+
+    // A caller that answered a digest challenge inside `@b2bua.on_invite`
+    // (`auth.require_proxy_digest(call, …)`) authenticated after
+    // `cdr_track_b2bua_start` already opened the CDR session, so stamp the
+    // username on now — the proxy path gets it at session-build time.
+    if let Some(ref auth_user) = auth_user {
+        if let Some(mut session) = state.cdr_sessions.get_mut(&call_id) {
+            session.set_auth_user(auth_user.clone());
+        }
+    }
 
     // Resolve script-side header policy input into a per-call ResolvedPolicy.
     // Done outside the call_actors lock so the registry lookup + delta
@@ -11833,7 +11867,20 @@ fn handle_b2bua_invite(
         }
         CallAction::Reject { code, reason } => {
             debug!(call_id = %call_id, code, "B2BUA: rejecting call");
-            let response = build_response(&message_guard, code, &reason, state.server_header.as_deref(), &[]);
+            let mut response = build_response(&message_guard, code, &reason, state.server_header.as_deref(), &[]);
+            // siphon is the UAS on the A-leg, so this locally-generated final
+            // response needs the dialog's UAS To-tag (RFC 3261 §8.2.6.2) — same
+            // as the 408-timeout path. Load-bearing for a digest challenge:
+            // the caller matches our 407 to its transaction and echoes the tag
+            // on its ACK (RFC 3261 §17.1.1.3) before re-INVITEing with
+            // credentials.
+            if let Some(local_tag) = state
+                .call_actors
+                .get_call(&call_id)
+                .map(|call| call.a_leg.dialog.local_tag.clone())
+            {
+                stamp_uas_to_tag(&mut response, &local_tag);
+            }
             send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
             state.call_actors.remove_call(&call_id);
             state.call_event_receivers.remove(&call_id);
@@ -22169,6 +22216,98 @@ mod tests {
         assert!(
             response.headers.get("Expires").is_none(),
             "Expires should not appear in response when not set on request"
+        );
+    }
+
+    #[test]
+    fn build_response_copies_every_auth_challenge_algorithm() {
+        // `auth.require_*_digest` stacks one challenge per algorithm (RFC 7616
+        // §3.7) so a single 401/407 serves RFC 2617 and RFC 7616 clients alike.
+        // Copying only the first value put MD5 on the wire and silently dropped
+        // the stronger two, leaving nothing for a client to negotiate up to.
+        let mut request = sample_invite();
+        for algorithm in ["MD5", "SHA-256", "SHA-512-256"] {
+            request.headers.add(
+                "Proxy-Authenticate",
+                format!(
+                    "Digest realm=\"example.com\", nonce=\"abc\", algorithm={algorithm}, qop=\"auth\""
+                ),
+            );
+            request.headers.add(
+                "WWW-Authenticate",
+                format!(
+                    "Digest realm=\"example.com\", nonce=\"abc\", algorithm={algorithm}, qop=\"auth\""
+                ),
+            );
+        }
+
+        let response = build_response(
+            &request,
+            407,
+            "Proxy Authentication Required",
+            None,
+            &[],
+        );
+
+        for name in ["Proxy-Authenticate", "WWW-Authenticate"] {
+            let values = response.headers.get_all(name).unwrap();
+            assert_eq!(values.len(), 3, "{name} lost algorithms: {values:?}");
+            assert!(values[0].contains("algorithm=MD5"));
+            assert!(values[1].contains("algorithm=SHA-256"));
+            assert!(values[2].contains("algorithm=SHA-512-256"));
+        }
+
+        // And all three reach the wire as separate header lines.
+        let text = String::from_utf8(response.to_bytes()).unwrap();
+        assert_eq!(text.matches("Proxy-Authenticate:").count(), 3);
+    }
+
+    #[test]
+    fn build_response_omits_auth_challenge_when_request_has_none() {
+        let request = sample_invite();
+        let response = build_response(&request, 200, "OK", None, &[]);
+        assert!(response.headers.get("Proxy-Authenticate").is_none());
+        assert!(response.headers.get("WWW-Authenticate").is_none());
+    }
+
+    #[test]
+    fn stamp_uas_to_tag_adds_the_dialog_tag_to_a_tagless_response() {
+        // The shape every locally-generated B2BUA final response has: the
+        // INVITE's To is tagless, so build_response copies a tagless To and the
+        // UAS tag has to be added (RFC 3261 §8.2.6.2). A 407 challenge without
+        // it leaves the caller unable to key our response to its dialog.
+        let request = sample_invite();
+        let mut response = build_response(
+            &request,
+            407,
+            "Proxy Authentication Required",
+            None,
+            &[],
+        );
+        assert!(!response.headers.to().unwrap().contains(";tag="));
+
+        stamp_uas_to_tag(&mut response, "a-leg-uas-tag");
+        assert!(response
+            .headers
+            .to()
+            .unwrap()
+            .ends_with(";tag=a-leg-uas-tag"));
+    }
+
+    #[test]
+    fn stamp_uas_to_tag_leaves_an_existing_tag_alone() {
+        // An in-dialog request already carries the tag we assigned; re-stamping
+        // would corrupt the dialog identifier.
+        let mut request = sample_invite();
+        request
+            .headers
+            .set("To", "<sip:bob@example.com>;tag=already-here".to_string());
+        let mut response = build_response(&request, 481, "Call/Transaction Does Not Exist", None, &[]);
+
+        stamp_uas_to_tag(&mut response, "a-different-tag");
+        assert_eq!(
+            response.headers.to().unwrap(),
+            "<sip:bob@example.com>;tag=already-here"
         );
     }
 

--- a/src/script/api/auth.rs
+++ b/src/script/api/auth.rs
@@ -13,6 +13,7 @@ use dashmap::DashMap;
 use pyo3::prelude::*;
 use tracing::{debug, warn};
 
+use super::call::PyCall;
 use super::request::PyRequest;
 use crate::config::{AkaCredential, AuthBackendType, HttpAuthConfig};
 use crate::diameter::DiameterManager;
@@ -56,6 +57,114 @@ static IMS_AUTH_STORE: OnceLock<Arc<DashMap<String, ImsAuthVector>>> = OnceLock:
 
 fn ims_auth_store() -> &'static Arc<DashMap<String, ImsAuthVector>> {
     IMS_AUTH_STORE.get_or_init(|| Arc::new(DashMap::new()))
+}
+
+/// A message object the digest helpers can authenticate: the proxy-mode
+/// [`PyRequest`] or the B2BUA-mode [`PyCall`].
+///
+/// Once a script registers any `@b2bua.*` handler the dispatcher routes INVITE
+/// straight to the B2BUA path, so `@proxy.on_request` never sees it and a
+/// B2BUA that wants to challenge its caller has only the `Call` object to work
+/// with.  Both objects already carry everything digest verification needs — the
+/// shared `Arc<Mutex<SipMessage>>` holding the INVITE, the source address and
+/// the transport — and both can carry a final response back to the caller.
+/// They only spell "reply" and "authenticated user" differently, which is what
+/// this enum normalises.
+pub enum AuthTarget<'a> {
+    /// Proxy-mode request (`@proxy.on_request`).
+    Request(&'a mut PyRequest),
+    /// B2BUA-mode call (`@b2bua.on_invite`).
+    Call(&'a mut PyCall),
+}
+
+/// The mutable Python borrow behind an [`AuthTarget`], held for the duration of
+/// one auth call.
+///
+/// Separate from `AuthTarget` itself so the Rust-side API (`challenge_www` and
+/// friends, used by the integration tests) can build an `AuthTarget` straight
+/// from a `&mut PyRequest` with no interpreter borrow in play.
+enum AuthTargetGuard<'py> {
+    Request(PyRefMut<'py, PyRequest>),
+    Call(PyRefMut<'py, PyCall>),
+}
+
+impl<'py> AuthTargetGuard<'py> {
+    /// Resolve a Python argument to a `Request` or a `Call`, mutably borrowed
+    /// for the duration of the auth call.
+    ///
+    /// Taken as `&Bound<PyAny>` rather than via `FromPyObject` so the type
+    /// error names both accepted types — a script that passes a `Reply` (the
+    /// obvious mistake when copying an `@proxy.on_reply` handler) gets told
+    /// what to pass instead.
+    fn extract(object: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(request) = object.cast::<PyRequest>() {
+            return Ok(AuthTargetGuard::Request(request.try_borrow_mut()?));
+        }
+        if let Ok(call) = object.cast::<PyCall>() {
+            return Ok(AuthTargetGuard::Call(call.try_borrow_mut()?));
+        }
+        Err(pyo3::exceptions::PyTypeError::new_err(
+            "auth digest methods take a Request (@proxy.on_request) or a Call \
+             (@b2bua.on_invite)",
+        ))
+    }
+
+    /// Borrow the guarded object as an [`AuthTarget`].
+    fn as_target(&mut self) -> AuthTarget<'_> {
+        match self {
+            AuthTargetGuard::Request(request) => AuthTarget::Request(request),
+            AuthTargetGuard::Call(call) => AuthTarget::Call(call),
+        }
+    }
+}
+
+impl AuthTarget<'_> {
+    /// The SIP message being authenticated — the inbound request for a
+    /// `Request`, the A-leg INVITE for a `Call`.
+    fn message(&self) -> Arc<std::sync::Mutex<crate::sip::message::SipMessage>> {
+        match self {
+            AuthTarget::Request(request) => request.message(),
+            AuthTarget::Call(call) => call.message(),
+        }
+    }
+
+    /// Record the verified username so it reaches `request.auth_user` /
+    /// `call.auth_user` and the CDR.
+    fn set_auth_user(&mut self, username: String) {
+        match self {
+            AuthTarget::Request(request) => request.set_auth_user(username),
+            AuthTarget::Call(call) => call.set_auth_user(username),
+        }
+    }
+
+    /// Arm the challenge response (401/407).  On a `Request` this is the same
+    /// deferred reply `request.reply()` sets; on a `Call` it is the same
+    /// deferred reject `call.reject()` sets, so the dispatcher answers the
+    /// INVITE and drops the call actor without ever dialling a B-leg.
+    fn set_challenge(&mut self, code: u16, reason: &str) {
+        match self {
+            AuthTarget::Request(request) => request.set_reply(code, reason.to_string()),
+            AuthTarget::Call(call) => call.set_reject(code, reason),
+        }
+    }
+
+    /// Source IP of the peer that sent the message (auto-ban bookkeeping).
+    fn source_ip_str(&self) -> &str {
+        match self {
+            AuthTarget::Request(request) => request.source_ip_str(),
+            AuthTarget::Call(call) => call.source_ip_str(),
+        }
+    }
+
+    /// Transport the message arrived on — decides whether a bad-credentials
+    /// attempt counts as a strong auto-ban signal (a spoofable UDP source
+    /// must not).
+    fn transport_name(&self) -> &str {
+        match self {
+            AuthTarget::Request(request) => request.transport_name(),
+            AuthTarget::Call(call) => call.transport_str(),
+        }
+    }
 }
 
 /// Python-visible auth namespace.
@@ -227,30 +336,44 @@ impl PyAuth {
 impl PyAuth {
     /// Challenge with 401 WWW-Authenticate if not yet authenticated.
     ///
-    /// If the request contains valid credentials, sets `request.auth_user`
-    /// and returns True. Otherwise, sends a 401 response with a nonce and
-    /// returns False.
-    #[pyo3(signature = (request, realm=None))]
-    fn require_www_digest(&self, request: &mut PyRequest, realm: Option<&str>) -> PyResult<bool> {
-        self.require_digest_inner(request, realm, 401, "WWW-Authenticate")
+    /// `target` is a `Request` (`@proxy.on_request`) or a `Call`
+    /// (`@b2bua.on_invite`) — see [`AuthTarget`].
+    ///
+    /// If the message carries valid credentials, sets `request.auth_user` /
+    /// `call.auth_user` and returns True. Otherwise arms a 401 response with a
+    /// nonce and returns False.
+    #[pyo3(signature = (target, realm=None))]
+    fn require_www_digest(
+        &self,
+        target: &Bound<'_, PyAny>,
+        realm: Option<&str>,
+    ) -> PyResult<bool> {
+        let mut guard = AuthTargetGuard::extract(target)?;
+        self.require_digest_inner(&mut guard.as_target(), realm, 401, "WWW-Authenticate")
     }
 
     /// Challenge with 407 Proxy-Authenticate if not yet authenticated.
     ///
-    /// Same as `require_www_digest` but uses 407 status code.
-    #[pyo3(signature = (request, realm=None))]
+    /// Same as `require_www_digest` but uses 407 status code. This is the
+    /// challenge an INVITE normally gets, including from a B2BUA authenticating
+    /// its own A-leg (`auth.require_proxy_digest(call, realm)` inside
+    /// `@b2bua.on_invite`): the caller's re-INVITE carries
+    /// `Proxy-Authorization`, which is stripped again before the B-leg is
+    /// dialled because it is hop-by-hop (RFC 3261 §22.3).
+    #[pyo3(signature = (target, realm=None))]
     fn require_proxy_digest(
         &self,
-        request: &mut PyRequest,
+        target: &Bound<'_, PyAny>,
         realm: Option<&str>,
     ) -> PyResult<bool> {
-        self.require_digest_inner(request, realm, 407, "Proxy-Authenticate")
+        let mut guard = AuthTargetGuard::extract(target)?;
+        self.require_digest_inner(&mut guard.as_target(), realm, 407, "Proxy-Authenticate")
     }
 
     /// Convenience alias: same as `require_www_digest`.
-    #[pyo3(signature = (request, realm=None))]
-    fn require_digest(&self, request: &mut PyRequest, realm: Option<&str>) -> PyResult<bool> {
-        self.require_www_digest(request, realm)
+    #[pyo3(signature = (target, realm=None))]
+    fn require_digest(&self, target: &Bound<'_, PyAny>, realm: Option<&str>) -> PyResult<bool> {
+        self.require_www_digest(target, realm)
     }
 
     /// IMS digest authentication via Diameter Cx MAR/MAA.
@@ -520,12 +643,16 @@ impl PyAuth {
 
     /// Verify credentials without sending a challenge.
     ///
-    /// Returns True if the request contains valid Authorization credentials
-    /// for the given realm. Does not send a 401/407 if invalid — just returns False.
-    #[pyo3(signature = (request, realm=None))]
-    fn verify_digest(&self, request: &PyRequest, realm: Option<&str>) -> PyResult<bool> {
+    /// `target` is a `Request` (`@proxy.on_request`) or a `Call`
+    /// (`@b2bua.on_invite`). Returns True if it carries valid
+    /// Authorization/Proxy-Authorization credentials for the given realm. Does
+    /// not arm a 401/407 if invalid — just returns False, and never touches
+    /// `auth_user`.
+    #[pyo3(signature = (target, realm=None))]
+    fn verify_digest(&self, target: &Bound<'_, PyAny>, realm: Option<&str>) -> PyResult<bool> {
+        let mut guard = AuthTargetGuard::extract(target)?;
         let realm = realm.unwrap_or(&self.default_realm);
-        let message = request.message();
+        let message = guard.as_target().message();
         let message = message.lock().map_err(|error| {
             pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
         })?;
@@ -555,12 +682,36 @@ impl PyAuth {
 impl PyAuth {
     /// Challenge with 401 WWW-Authenticate (Rust API).
     pub fn challenge_www(&self, request: &mut PyRequest, realm: Option<&str>) -> PyResult<bool> {
-        self.require_digest_inner(request, realm, 401, "WWW-Authenticate")
+        self.require_digest_inner(
+            &mut AuthTarget::Request(request),
+            realm,
+            401,
+            "WWW-Authenticate",
+        )
     }
 
     /// Challenge with 407 Proxy-Authenticate (Rust API).
     pub fn challenge_proxy(&self, request: &mut PyRequest, realm: Option<&str>) -> PyResult<bool> {
-        self.require_digest_inner(request, realm, 407, "Proxy-Authenticate")
+        self.require_digest_inner(
+            &mut AuthTarget::Request(request),
+            realm,
+            407,
+            "Proxy-Authenticate",
+        )
+    }
+
+    /// Challenge a B2BUA A-leg with 407 Proxy-Authenticate (Rust API).
+    ///
+    /// The `Call` twin of [`challenge_proxy`](Self::challenge_proxy) — the same
+    /// path `auth.require_proxy_digest(call, realm)` takes from
+    /// `@b2bua.on_invite`.
+    pub fn challenge_proxy_call(&self, call: &mut PyCall, realm: Option<&str>) -> PyResult<bool> {
+        self.require_digest_inner(&mut AuthTarget::Call(call), realm, 407, "Proxy-Authenticate")
+    }
+
+    /// Challenge a B2BUA A-leg with 401 WWW-Authenticate (Rust API).
+    pub fn challenge_www_call(&self, call: &mut PyCall, realm: Option<&str>) -> PyResult<bool> {
+        self.require_digest_inner(&mut AuthTarget::Call(call), realm, 401, "WWW-Authenticate")
     }
 
     /// Verify credentials without sending a challenge (Rust API).
@@ -592,14 +743,14 @@ impl PyAuth {
 impl PyAuth {
     fn require_digest_inner(
         &self,
-        request: &mut PyRequest,
+        target: &mut AuthTarget<'_>,
         realm: Option<&str>,
         challenge_code: u16,
         _header_name: &str,
     ) -> PyResult<bool> {
         let realm = realm.unwrap_or(&self.default_realm);
 
-        let message = request.message();
+        let message = target.message();
         let message_guard = message.lock().map_err(|error| {
             pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
         })?;
@@ -611,19 +762,15 @@ impl PyAuth {
             .or_else(|| message_guard.headers.get("Proxy-Authorization"))
             .cloned();
 
-        drop(message_guard);
-
-        // Extract the SIP method for digest HA2 computation
-        let method = {
-            let msg = request.message();
-            let guard = msg.lock().map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {e}"))
-            })?;
-            match &guard.start_line {
-                crate::sip::message::StartLine::Request(rl) => rl.method.as_str().to_string(),
-                _ => "REGISTER".to_string(),
-            }
+        // Extract the SIP method for digest HA2 computation. On a B2BUA `Call`
+        // this is the A-leg INVITE, so the HA2 the caller computed over
+        // "INVITE:<uri>" is what we verify against.
+        let method = match &message_guard.start_line {
+            crate::sip::message::StartLine::Request(rl) => rl.method.as_str().to_string(),
+            _ => "REGISTER".to_string(),
         };
+
+        drop(message_guard);
 
         // Distinguish a credential-less first leg (the legitimate opening of
         // challenge-response, or a toll-fraud probe — weight 1) from a present-
@@ -635,13 +782,15 @@ impl PyAuth {
             Some(value) if self.validate_credentials(&value, realm, &method) => {
                 // Extract username from the Authorization header
                 if let Some(username) = extract_username(&value) {
-                    request.set_auth_user(username);
+                    target.set_auth_user(username);
                 }
 
                 // Strip Authorization/Proxy-Authorization after successful verification.
                 // These are hop-by-hop credentials — forwarding them downstream causes
                 // the next hop to attempt (and fail) its own validation (e.g. 407).
-                let message = request.message();
+                // On a B2BUA `Call` this is what keeps the caller's credentials off
+                // the B-leg INVITE built from this same message.
+                let message = target.message();
                 let mut guard = message.lock().map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {e}"))
                 })?;
@@ -652,7 +801,7 @@ impl PyAuth {
                 // Valid credentials — clear any accrued auto-ban failure count so
                 // a legit client that challenges-then-succeeds never accumulates.
                 if let Some(ban) = crate::security::auto_ban() {
-                    if let Ok(source) = request.source_ip_str().parse::<std::net::IpAddr>() {
+                    if let Ok(source) = target.source_ip_str().parse::<std::net::IpAddr>() {
                         ban.record_success(source);
                     }
                 }
@@ -673,10 +822,10 @@ impl PyAuth {
                 //    a heavier weight would amplify a reflected ban. Over UDP it
                 //    falls back to weight 1 (today's behaviour, unchanged).
                 // trusted_cidrs are exempt inside the store.
-                let source_validated = request.transport_name() != "udp";
+                let source_validated = target.transport_name() != "udp";
                 let strong = credentials_present && source_validated;
                 if let Some(ban) = crate::security::auto_ban() {
-                    if let Ok(source) = request.source_ip_str().parse::<std::net::IpAddr>() {
+                    if let Ok(source) = target.source_ip_str().parse::<std::net::IpAddr>() {
                         let newly_banned = if strong {
                             ban.record_strong_failure(source)
                         } else {
@@ -699,13 +848,17 @@ impl PyAuth {
                     }
                 }
 
-                // Send challenge
+                // Arm the challenge response. On a `Request` this is the same
+                // deferred reply `request.reply()` produces; on a B2BUA `Call`
+                // it is the same deferred reject `call.reject()` produces, so
+                // the dispatcher answers the A-leg INVITE and drops the call
+                // actor without ever dialling a B-leg.
                 let reason = if challenge_code == 401 {
                     "Unauthorized"
                 } else {
                     "Proxy Authentication Required"
                 };
-                request.set_reply(challenge_code, reason.to_string());
+                target.set_challenge(challenge_code, reason);
 
                 // RFC 7616 §3.7: a server that supports multiple algorithms
                 // SHOULD include one challenge per algorithm, weakest first.
@@ -725,12 +878,15 @@ impl PyAuth {
                     format!("Digest realm=\"{realm}\", nonce=\"{nonce}\", algorithm=SHA-512-256, qop=\"auth\""),
                 ];
 
-                let message = request.message();
+                let message = target.message();
                 let mut message_guard = message.lock().map_err(|error| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
                 })?;
 
                 // Store the challenge headers so the response builder can pick them up.
+                // Cleared first so a handler that challenges twice (a retry loop, or
+                // 401-then-407) emits one set of algorithms, not two stacked ones.
+                message_guard.headers.remove(header_name);
                 for value in &header_values {
                     message_guard.headers.add(header_name, value.clone());
                 }
@@ -1624,7 +1780,7 @@ mod tests {
         let auth = make_auth();
         let mut request = make_register_request();
 
-        let result = auth.require_www_digest(&mut request, None).unwrap();
+        let result = auth.challenge_www(&mut request, None).unwrap();
         assert!(!result);
         assert_eq!(
             *request.action(),
@@ -1641,7 +1797,7 @@ mod tests {
         let auth = make_auth();
         let mut request = make_register_request();
 
-        let result = auth.require_proxy_digest(&mut request, None).unwrap();
+        let result = auth.challenge_proxy(&mut request, None).unwrap();
         assert!(!result);
         assert_eq!(
             *request.action(),
@@ -1658,7 +1814,7 @@ mod tests {
         let auth = make_auth();
         let mut request = make_request_with_auth("alice");
 
-        let result = auth.require_www_digest(&mut request, None).unwrap();
+        let result = auth.challenge_www(&mut request, None).unwrap();
         assert!(result);
         assert_eq!(request.get_auth_user(), Some("alice"));
         // Action should remain None (no reply sent)
@@ -1677,7 +1833,7 @@ mod tests {
             assert!(guard.headers.get("Authorization").is_some());
         }
 
-        let result = auth.require_www_digest(&mut request, None).unwrap();
+        let result = auth.challenge_www(&mut request, None).unwrap();
         assert!(result);
 
         // After successful auth, Authorization must be stripped
@@ -1694,7 +1850,7 @@ mod tests {
         let auth = make_auth();
         let mut request = make_request_with_auth("eve"); // unknown user
 
-        let result = auth.require_www_digest(&mut request, None).unwrap();
+        let result = auth.challenge_www(&mut request, None).unwrap();
         assert!(!result);
 
         // On failure, the original request headers are not stripped (challenge is sent instead)
@@ -1709,7 +1865,7 @@ mod tests {
         let auth = make_auth();
         let mut request = make_request_with_auth("eve");
 
-        let result = auth.require_www_digest(&mut request, None).unwrap();
+        let result = auth.challenge_www(&mut request, None).unwrap();
         assert!(!result);
         assert_eq!(
             *request.action(),
@@ -1725,10 +1881,211 @@ mod tests {
     fn verify_digest_without_sending_challenge() {
         let auth = make_auth();
         let request_no_auth = make_register_request();
-        assert!(!auth.verify_digest(&request_no_auth, None).unwrap());
+        assert!(!auth.check_credentials(&request_no_auth, None).unwrap());
 
         let request_with_auth = make_request_with_auth("alice");
-        assert!(auth.verify_digest(&request_with_auth, None).unwrap());
+        assert!(auth.check_credentials(&request_with_auth, None).unwrap());
+    }
+
+    // -----------------------------------------------------------------------
+    // B2BUA `Call` targets — a script with any `@b2bua.*` handler never sees
+    // the INVITE through `@proxy.on_request`, so the digest helpers have to
+    // work off the `Call` object for a B2BUA to authenticate its caller.
+    // -----------------------------------------------------------------------
+
+    /// Build an A-leg INVITE, optionally carrying a `Proxy-Authorization`
+    /// digest response computed for `credentials_for` over `hash_method`.
+    ///
+    /// `hash_method` is separate from the on-wire method so a test can prove
+    /// HA2 is hashed over the message's real method (INVITE) rather than the
+    /// REGISTER default.
+    fn make_invite_call(
+        credentials_for: Option<&str>,
+        hash_method: &str,
+    ) -> super::super::call::PyCall {
+        let realm = "example.com";
+        let digest_uri = "sip:bob@example.com";
+        let mut builder = SipMessageBuilder::new()
+            .request(
+                Method::Invite,
+                SipUri::new("example.com".to_string()).with_user("bob".to_string()),
+            )
+            .via("SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-b2bua-auth".to_string())
+            .from("<sip:alice@example.com>;tag=a-leg-tag".to_string())
+            .to("<sip:bob@example.com>".to_string())
+            .call_id("b2bua-auth-call@host".to_string())
+            .cseq("1 INVITE".to_string());
+
+        if let Some(username) = credentials_for {
+            let password = match username {
+                "alice" => "pass123",
+                "bob" => "secret",
+                _ => "wrong",
+            };
+            let nonce = format!("{:016x}.test", now_unix_secs());
+            let ha1 = md5_hex(&format!("{username}:{realm}:{password}"));
+            let ha2 = md5_hex(&format!("{hash_method}:{digest_uri}"));
+            let response = md5_hex(&format!("{ha1}:{nonce}:{ha2}"));
+            builder = builder.header(
+                "Proxy-Authorization",
+                format!(
+                    "Digest username=\"{username}\", realm=\"{realm}\", nonce=\"{nonce}\", \
+                     uri=\"{digest_uri}\", response=\"{response}\""
+                ),
+            );
+        }
+
+        let message = builder.content_length(0).build().unwrap();
+        super::super::call::PyCall::new(
+            "b2bua-auth-test".to_string(),
+            Arc::new(Mutex::new(message)),
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+        )
+    }
+
+    /// All values of `name` on the call's A-leg INVITE.
+    fn call_header_values(call: &super::super::call::PyCall, name: &str) -> Vec<String> {
+        let message = call.message();
+        let guard = message.lock().unwrap();
+        guard.headers.get_all(name).cloned().unwrap_or_default()
+    }
+
+    #[test]
+    fn require_proxy_digest_on_call_arms_407_reject() {
+        use super::super::call::CallAction;
+
+        let auth = make_auth();
+        let mut call = make_invite_call(None, "INVITE");
+
+        let authenticated = auth.challenge_proxy_call(&mut call, None).unwrap();
+        assert!(!authenticated);
+
+        // The deferred reject the dispatcher turns into the 407 on the wire —
+        // the B-leg is never dialled.
+        assert_eq!(
+            *call.action(),
+            CallAction::Reject {
+                code: 407,
+                reason: "Proxy Authentication Required".to_string(),
+            }
+        );
+        assert_eq!(call.get_auth_user(), None);
+
+        // RFC 7616 §3.7: one challenge per supported algorithm, weakest first.
+        let challenges = call_header_values(&call, "Proxy-Authenticate");
+        assert_eq!(challenges.len(), 3, "got {challenges:?}");
+        assert!(challenges[0].contains("algorithm=MD5"));
+        assert!(challenges[1].contains("algorithm=SHA-256"));
+        assert!(challenges[2].contains("algorithm=SHA-512-256"));
+        assert!(challenges
+            .iter()
+            .all(|value| value.contains("realm=\"example.com\"")));
+        // A 407 must not carry the 401 header (RFC 3261 §22.3).
+        assert!(call_header_values(&call, "WWW-Authenticate").is_empty());
+    }
+
+    #[test]
+    fn require_www_digest_on_call_arms_401_reject() {
+        use super::super::call::CallAction;
+
+        let auth = make_auth();
+        let mut call = make_invite_call(None, "INVITE");
+
+        assert!(!auth.challenge_www_call(&mut call, None).unwrap());
+        assert_eq!(
+            *call.action(),
+            CallAction::Reject {
+                code: 401,
+                reason: "Unauthorized".to_string(),
+            }
+        );
+        assert_eq!(call_header_values(&call, "WWW-Authenticate").len(), 3);
+        assert!(call_header_values(&call, "Proxy-Authenticate").is_empty());
+    }
+
+    #[test]
+    fn require_proxy_digest_on_call_accepts_valid_user() {
+        use super::super::call::CallAction;
+
+        let auth = make_auth();
+        let mut call = make_invite_call(Some("alice"), "INVITE");
+        assert!(!call_header_values(&call, "Proxy-Authorization").is_empty());
+
+        let authenticated = auth.challenge_proxy_call(&mut call, None).unwrap();
+        assert!(authenticated);
+        assert_eq!(call.get_auth_user(), Some("alice"));
+        // No action armed — the handler is free to dial the B-leg.
+        assert_eq!(*call.action(), CallAction::None);
+        assert!(call_header_values(&call, "Proxy-Authenticate").is_empty());
+
+        // Proxy-Authorization is hop-by-hop (RFC 3261 §22.3) and must not
+        // survive onto the B-leg INVITE, which is built from this same message.
+        assert!(call_header_values(&call, "Proxy-Authorization").is_empty());
+        assert!(call_header_values(&call, "Authorization").is_empty());
+    }
+
+    #[test]
+    fn call_challenge_hashes_ha2_over_the_invite_method() {
+        // The credentials are cryptographically well-formed but hashed over
+        // REGISTER, so they must NOT authenticate an INVITE — proof that HA2
+        // comes from the message's own start line and not the REGISTER default
+        // the helper falls back to for non-request messages.
+        let auth = make_auth();
+        let mut wrong_method = make_invite_call(Some("alice"), "REGISTER");
+        assert!(!auth.challenge_proxy_call(&mut wrong_method, None).unwrap());
+        assert_eq!(wrong_method.get_auth_user(), None);
+
+        let mut right_method = make_invite_call(Some("alice"), "INVITE");
+        assert!(auth.challenge_proxy_call(&mut right_method, None).unwrap());
+    }
+
+    #[test]
+    fn repeated_call_challenge_emits_one_algorithm_set() {
+        // A handler that challenges twice (a retry path, or 401-then-407) must
+        // not stack two sets of algorithms onto the same response.
+        let auth = make_auth();
+        let mut call = make_invite_call(None, "INVITE");
+
+        assert!(!auth.challenge_proxy_call(&mut call, None).unwrap());
+        assert!(!auth.challenge_proxy_call(&mut call, None).unwrap());
+
+        assert_eq!(call_header_values(&call, "Proxy-Authenticate").len(), 3);
+    }
+
+    #[test]
+    fn digest_methods_accept_request_and_call_and_reject_others() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|python| {
+            let auth = make_auth();
+
+            // A proxy Request still works (unchanged behaviour).
+            let request_obj = pyo3::Py::new(python, make_register_request()).unwrap();
+            let challenged = auth
+                .require_www_digest(request_obj.bind(python).as_any(), None)
+                .unwrap();
+            assert!(!challenged);
+
+            // A B2BUA Call is accepted — this is the case that used to raise
+            // "'Call' object cannot be converted to 'Request'".
+            let call_obj = pyo3::Py::new(python, make_invite_call(None, "INVITE")).unwrap();
+            let challenged = auth
+                .require_proxy_digest(call_obj.bind(python).as_any(), None)
+                .unwrap();
+            assert!(!challenged);
+            assert!(auth
+                .verify_digest(call_obj.bind(python).as_any(), None)
+                .is_ok());
+
+            // Anything else is a clear TypeError naming both accepted types,
+            // not a silent pass.
+            let bogus = pyo3::types::PyString::new(python, "not a request or call");
+            let error = auth.require_proxy_digest(bogus.as_any(), None).unwrap_err();
+            assert!(error.is_instance_of::<pyo3::exceptions::PyTypeError>(python));
+            assert!(auth.require_www_digest(bogus.as_any(), None).is_err());
+            assert!(auth.require_digest(bogus.as_any(), None).is_err());
+            assert!(auth.verify_digest(bogus.as_any(), None).is_err());
+        });
     }
 
     #[test]
@@ -1754,7 +2111,7 @@ mod tests {
         let auth = make_auth();
         let mut request = make_register_request();
 
-        auth.require_www_digest(&mut request, None).unwrap();
+        auth.challenge_www(&mut request, None).unwrap();
 
         // The WWW-Authenticate header should be set on the message
         let message = request.message();
@@ -1771,7 +2128,7 @@ mod tests {
         let auth = make_auth();
         let mut request = make_register_request();
 
-        auth.require_www_digest(&mut request, Some("custom.realm")).unwrap();
+        auth.challenge_www(&mut request, Some("custom.realm")).unwrap();
 
         let message = request.message();
         let message = message.lock().unwrap();
@@ -1784,7 +2141,7 @@ mod tests {
         let auth = PyAuth::empty();
         let mut request = make_request_with_auth("alice");
 
-        let result = auth.require_www_digest(&mut request, None).unwrap();
+        let result = auth.challenge_www(&mut request, None).unwrap();
         assert!(!result);
     }
 

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -331,6 +331,12 @@ pub struct PyCall {
     /// `route_sequence.active`. Read by scripts via `call.active_route` to stamp
     /// the winning carrier onto a CDR / charging record.
     active_route: Option<crate::lcr::Route>,
+    /// Username verified by `auth.require_proxy_digest(call, …)` /
+    /// `require_www_digest` on the A-leg INVITE. `None` until a challenge is
+    /// answered correctly. The B2BUA twin of `request.auth_user`; the
+    /// dispatcher stamps it onto the call's CDR session after `on_invite`
+    /// returns.
+    auth_user: Option<String>,
 }
 
 /// Per-call header policy input from `call.dial(header_policy=…, copy=…, strip=…, translate=…)`.
@@ -422,7 +428,33 @@ impl PyCall {
             header_policy_input: None,
             auth_passthrough_flag: false,
             active_route: None,
+            auth_user: None,
         }
+    }
+
+    /// Source IP of the A-leg caller (Rust-side accessor — the `source_ip`
+    /// getter lives in `#[pymethods]`). Used by the digest helpers for
+    /// auto-ban bookkeeping.
+    pub fn source_ip_str(&self) -> &str {
+        &self.source_ip
+    }
+
+    /// Transport the A-leg INVITE arrived on (Rust-side accessor). Used by the
+    /// digest helpers to decide whether a bad-credentials attempt is a strong
+    /// auto-ban signal (it is not over spoofable UDP).
+    pub fn transport_str(&self) -> &str {
+        &self.transport_name
+    }
+
+    /// Record the username verified by `auth.require_*_digest(call, …)`.
+    pub fn set_auth_user(&mut self, username: String) {
+        self.auth_user = Some(username);
+    }
+
+    /// The verified username, if the A-leg answered a digest challenge
+    /// (Rust-side accessor behind the `auth_user` getter).
+    pub fn get_auth_user(&self) -> Option<&str> {
+        self.auth_user.as_deref()
     }
 
     /// Attach the winning carrier route (from the call actor's
@@ -924,6 +956,18 @@ impl PyCall {
     #[getter]
     fn source_ip(&self) -> &str {
         &self.source_ip
+    }
+
+    /// Username the A-leg authenticated as, or `None` if it was never
+    /// challenged (the B2BUA twin of `request.auth_user`).
+    ///
+    /// Set by `auth.require_proxy_digest(call, realm)` /
+    /// `auth.require_www_digest(call, realm)` in `@b2bua.on_invite` once the
+    /// caller answers the challenge correctly. Carried onto the call's CDR as
+    /// `auth_user`.
+    #[getter]
+    fn auth_user(&self) -> Option<&str> {
+        self.auth_user.as_deref()
     }
 
     /// True when the A-leg source IP is a member of the resolved addresses
@@ -2086,6 +2130,42 @@ mod tests {
         assert_eq!(call.id, "test-id");
         assert_eq!(call.state, "calling");
         assert_eq!(call.action(), &CallAction::None);
+    }
+
+    #[test]
+    fn call_auth_user_starts_unset_and_records_the_verified_username() {
+        // The B2BUA twin of request.auth_user, set by
+        // auth.require_proxy_digest(call, …) once the caller answers a
+        // challenge, and read back by the dispatcher for the call's CDR.
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new(
+            "test-id".to_string(),
+            message,
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+        );
+        assert_eq!(call.get_auth_user(), None);
+        assert_eq!(call.auth_user(), None);
+
+        call.set_auth_user("alice".to_string());
+        assert_eq!(call.get_auth_user(), Some("alice"));
+        assert_eq!(call.auth_user(), Some("alice"));
+    }
+
+    #[test]
+    fn call_exposes_source_ip_and_transport_to_rust_callers() {
+        // The digest helpers read both off the Call for auto-ban bookkeeping
+        // (a bad-credentials attempt is only a strong signal over a
+        // handshake-validated transport).
+        let message = Arc::new(Mutex::new(make_invite()));
+        let call = PyCall::new(
+            "test-id".to_string(),
+            message,
+            "203.0.113.9".to_string(),
+            "tls".to_string(),
+        );
+        assert_eq!(call.source_ip_str(), "203.0.113.9");
+        assert_eq!(call.transport_str(), "tls");
     }
 
     #[test]

--- a/tests/integration/auth_tests.rs
+++ b/tests/integration/auth_tests.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use siphon::script::api::auth::PyAuth;
+use siphon::script::api::call::{CallAction, PyCall};
 use siphon::script::api::request::{PyRequest, RequestAction};
 use siphon::sip::builder::SipMessageBuilder;
 use siphon::sip::message::Method;
@@ -214,4 +215,215 @@ fn multi_realm_users() {
         "Digest username=\"dave\", realm=\"realm1.com\", nonce=\"abc\", uri=\"sip:realm1.com\", response=\"xyz\""
     ));
     assert!(!auth.check_credentials(&request, Some("realm1.com")).unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// B2BUA A-leg challenge — the digest cycle against a `Call` instead of a
+// `Request`.
+//
+// A script with any `@b2bua.*` handler never sees the INVITE through
+// `@proxy.on_request` (the dispatcher routes it straight to the B2BUA path),
+// so authenticating the caller has to work off the `Call` object.
+// ---------------------------------------------------------------------------
+
+/// Build an A-leg INVITE `Call`, optionally carrying a `Proxy-Authorization`.
+fn make_invite_call(proxy_auth: Option<&str>) -> PyCall {
+    let mut builder = SipMessageBuilder::new()
+        .request(
+            Method::Invite,
+            SipUri::new("atlanta.com".to_string()).with_user("bob".to_string()),
+        )
+        .via("SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-b2bua-auth".to_string())
+        .to("Bob <sip:bob@atlanta.com>".to_string())
+        .from("Alice <sip:alice@atlanta.com>;tag=a-leg-tag".to_string())
+        .call_id("b2bua-auth-call@10.0.0.1".to_string())
+        .cseq("1 INVITE".to_string())
+        .max_forwards(70)
+        .content_length(0);
+
+    if let Some(header) = proxy_auth {
+        builder = builder.header("Proxy-Authorization", header.to_string());
+    }
+
+    PyCall::new(
+        "b2bua-auth-integration".to_string(),
+        Arc::new(Mutex::new(builder.build().unwrap())),
+        "10.0.0.1".to_string(),
+        "udp".to_string(),
+    )
+}
+
+/// All values of `name` on the call's A-leg INVITE.
+fn call_headers(call: &PyCall, name: &str) -> Vec<String> {
+    let message = call.message();
+    let guard = message.lock().unwrap();
+    guard.headers.get_all(name).cloned().unwrap_or_default()
+}
+
+/// Pull the `nonce="…"` out of a challenge header value.
+fn nonce_of(challenge: &str) -> String {
+    challenge
+        .split_once("nonce=\"")
+        .and_then(|(_, rest)| rest.split_once('"'))
+        .map(|(nonce, _)| nonce.to_string())
+        .expect("challenge carries a nonce")
+}
+
+#[test]
+fn b2bua_invite_challenge_arms_a_407_reject_on_the_call() {
+    let auth = make_auth("atlanta.com", &[("alice", "secret123")]);
+    let mut call = make_invite_call(None);
+
+    let authenticated = auth
+        .challenge_proxy_call(&mut call, Some("atlanta.com"))
+        .unwrap();
+    assert!(!authenticated, "no credentials — must not authenticate");
+
+    // The deferred reject the dispatcher turns into the 407 on the wire. The
+    // B-leg is never dialled, and the call actor is dropped with it.
+    assert_eq!(
+        *call.action(),
+        CallAction::Reject {
+            code: 407,
+            reason: "Proxy Authentication Required".to_string(),
+        }
+    );
+
+    // The challenge is parked on the A-leg INVITE, which is where the
+    // dispatcher's response builder reads it from when it answers the caller.
+    let challenges = call_headers(&call, "Proxy-Authenticate");
+    assert_eq!(challenges.len(), 3, "one per algorithm: {challenges:?}");
+    for challenge in &challenges {
+        assert!(challenge.starts_with("Digest "), "{challenge}");
+        assert!(challenge.contains("realm=\"atlanta.com\""), "{challenge}");
+        assert!(challenge.contains("qop=\"auth\""), "{challenge}");
+    }
+}
+
+#[test]
+fn b2bua_invite_challenge_then_authenticated_reinvite() {
+    // The full device-driven cycle a caller drives against a B2BUA:
+    //   INVITE (no creds) -> 407 + nonce -> INVITE (creds) -> authenticated.
+    let auth = make_auth("atlanta.com", &[("alice", "secret123")]);
+
+    // 1. Challenge.
+    let mut first = make_invite_call(None);
+    assert!(!auth
+        .challenge_proxy_call(&mut first, Some("atlanta.com"))
+        .unwrap());
+    let nonce = nonce_of(&call_headers(&first, "Proxy-Authenticate")[0]);
+
+    // 2. The caller answers with credentials hashed over INVITE (not REGISTER)
+    //    and the nonce we just minted.
+    let credentials = digest_header(
+        "alice",
+        "secret123",
+        "atlanta.com",
+        &nonce,
+        "sip:bob@atlanta.com",
+        "INVITE",
+    );
+    let mut second = make_invite_call(Some(&credentials));
+
+    let authenticated = auth
+        .challenge_proxy_call(&mut second, Some("atlanta.com"))
+        .unwrap();
+    assert!(authenticated, "valid credentials must authenticate");
+    assert_eq!(second.get_auth_user(), Some("alice"));
+
+    // No action armed — the handler goes on to dial the B-leg normally.
+    assert_eq!(*second.action(), CallAction::None);
+    assert!(call_headers(&second, "Proxy-Authenticate").is_empty());
+
+    // Proxy-Authorization is hop-by-hop (RFC 3261 §22.3). The B-leg INVITE is
+    // built from this same message, so it must be gone by the time the handler
+    // returns — otherwise the next hop challenges credentials minted for us.
+    assert!(
+        call_headers(&second, "Proxy-Authorization").is_empty(),
+        "hop-by-hop credentials leaked toward the B-leg"
+    );
+}
+
+#[test]
+fn b2bua_invite_challenge_rejects_wrong_password() {
+    let auth = make_auth("atlanta.com", &[("alice", "secret123")]);
+
+    let mut first = make_invite_call(None);
+    assert!(!auth
+        .challenge_proxy_call(&mut first, Some("atlanta.com"))
+        .unwrap());
+    let nonce = nonce_of(&call_headers(&first, "Proxy-Authenticate")[0]);
+
+    let credentials = digest_header(
+        "alice",
+        "wrong-password",
+        "atlanta.com",
+        &nonce,
+        "sip:bob@atlanta.com",
+        "INVITE",
+    );
+    let mut second = make_invite_call(Some(&credentials));
+
+    assert!(!auth
+        .challenge_proxy_call(&mut second, Some("atlanta.com"))
+        .unwrap());
+    assert_eq!(second.get_auth_user(), None);
+    // Re-challenged rather than let through.
+    assert_eq!(
+        *second.action(),
+        CallAction::Reject {
+            code: 407,
+            reason: "Proxy Authentication Required".to_string(),
+        }
+    );
+}
+
+#[test]
+fn b2bua_invite_challenge_rejects_credentials_hashed_over_another_method() {
+    // A captured REGISTER credential replayed onto an INVITE must not pass:
+    // HA2 is hashed over the message's own method.
+    let auth = make_auth("atlanta.com", &[("alice", "secret123")]);
+
+    let mut first = make_invite_call(None);
+    assert!(!auth
+        .challenge_proxy_call(&mut first, Some("atlanta.com"))
+        .unwrap());
+    let nonce = nonce_of(&call_headers(&first, "Proxy-Authenticate")[0]);
+
+    let register_credentials = digest_header(
+        "alice",
+        "secret123",
+        "atlanta.com",
+        &nonce,
+        "sip:bob@atlanta.com",
+        "REGISTER",
+    );
+    let mut second = make_invite_call(Some(&register_credentials));
+
+    assert!(!auth
+        .challenge_proxy_call(&mut second, Some("atlanta.com"))
+        .unwrap());
+    assert_eq!(second.get_auth_user(), None);
+}
+
+#[test]
+fn b2bua_invite_www_challenge_arms_a_401_reject() {
+    // A B2BUA is a UAS, so 401/WWW-Authenticate is available too (RFC 3261
+    // §22.2) for deployments that authenticate as an endpoint rather than a
+    // proxy.
+    let auth = make_auth("atlanta.com", &[("alice", "secret123")]);
+    let mut call = make_invite_call(None);
+
+    assert!(!auth
+        .challenge_www_call(&mut call, Some("atlanta.com"))
+        .unwrap());
+    assert_eq!(
+        *call.action(),
+        CallAction::Reject {
+            code: 401,
+            reason: "Unauthorized".to_string(),
+        }
+    );
+    assert_eq!(call_headers(&call, "WWW-Authenticate").len(), 3);
+    assert!(call_headers(&call, "Proxy-Authenticate").is_empty());
 }


### PR DESCRIPTION
Register any `@b2bua.*` handler and the dispatcher routes INVITE straight to the B2BUA path, so `@proxy.on_request` never sees it. The digest helpers only accepted a `Request`. Net effect: you could not authenticate a caller in B2BUA mode at all. The only auth on that path was relaying somebody else's challenge (`call.dial(auth_passthrough=True)`).

```python
@b2bua.on_invite
def new_call(call):
    if not auth.require_proxy_digest(call, realm="example.com"):
        return                      # 407 armed; siphon answers the A-leg
    log.info(f"call from {call.auth_user}")
    call.dial(str(call.ruri))
```

`require_www_digest` / `require_proxy_digest` / `require_digest` / `verify_digest` now take a `Request` **or** a `Call`, through an `AuthTarget` enum that normalises the three things digest verification needs off either object (the shared `Arc<Mutex<SipMessage>>`, source IP, transport) and the two they spell differently (reply vs. reject, `auth_user`). Anything else raises `TypeError` naming both accepted types.

On a `Call` the challenge is armed as the same deferred `CallAction::Reject` that `call.reject()` produces, so siphon answers the A-leg and drops the call actor **before any B-leg INVITE is built** — a toll-fraud probe never reaches the carrier. On success the caller's hop-by-hop `Proxy-Authorization` is stripped from the very message the B-leg is built from (RFC 3261 §22.3); forwarding it would only make the next hop challenge credentials minted for us.

`require_ims_digest` / `require_aka_digest` stay `Request`-only. IMS and AKA digest are REGISTER-time procedures and REGISTER never reaches the B2BUA path, so accepting a `Call` there would be wiring with nothing behind it. The SDK mock refuses one too, rather than accepting what the engine rejects.

Adds `call.auth_user` (the B2BUA twin of `request.auth_user`) and stamps it onto the call's CDR. A B2BUA CDR session opens at INVITE time, before `@b2bua.on_invite` runs, so a caller authenticated inside the handler previously left the field empty.

## Two bugs found on the way

**Every digest challenge but the weakest was dropped on the wire.** `auth.require_*_digest` deliberately builds one challenge per algorithm (MD5 + SHA-256 + SHA-512-256) so a single 401/407 serves RFC 2617 and RFC 7616 clients alike, per RFC 7616 §3.7. `build_response` copied it with `get()` instead of `get_all()`, so MD5 alone went out and no client had anything to negotiate up from. Affected the proxy path too, not just this new one.

**A script-driven B2BUA reject carried no `To` tag.** RFC 3261 §8.2.6.2 makes tagging every response but 100 a MUST for a UAS, and siphon is the UAS on the A-leg. The 408 ring-timeout path stamped the A-leg dialog's tag; `call.reject()` did not, so every script rejection answered a dialog-forming INVITE with the request's tagless `To`. Both paths now share one `stamp_uas_to_tag` helper.

## Testing

- 3783 Rust tests green, clippy clean (`--all-targets --all-features -D warnings`), 525 SDK tests green.
- New unit tests on the `Call` digest path (407/401 arming, credential acceptance, `Proxy-Authorization` stripping, HA2 hashed over the message's own method so a captured REGISTER credential can't be replayed onto an INVITE, repeat-challenge idempotency, PyO3 type dispatch), new `build_response` and `stamp_uas_to_tag` tests, and six integration tests driving the full challenge → authenticated-re-INVITE cycle.
- New SIPp gate `scripts/run-tests.sh --b2bua-invite-auth` plus a CI job: INVITE → 407 → ACK → authenticated INVITE → 180 → 200 → ACK → BYE. The UAC asserts the 407 carries a `Proxy-Authenticate` challenge and a UAS `To` tag; the UAS runs `-m 1` and asserts no `Proxy-Authorization` crossed the B2BUA, so a build that cannot challenge fails on the extra INVITE it dials through.
- Existing `--b2bua-auth` (auth-passthrough) gate re-run green.
- Wire shape validated against the Wireshark dissector, not just our own round-trip: dumped the real 407 off the socket, `text2pcap` + `tshark` reads back three `Proxy-Authenticate` headers as MD5 / SHA-256 / SHA-512-256 with `sip.to.tag` present and zero malformed fields.

## Not in this PR

The `--b2bua` suite's topology step fails locally with 0 successful calls, and reports green while doing it. Pre-existing and unrelated: the preceding failure test rebinds bob to the failure UAS (`b2bua_bob_contact_failure.csv`) and nothing re-registers him, so the topology call is dialled into a black hole; sipp then hits its global `-timeout` with the call still up and exits 0, which `run_sipp` reads as a pass. Confirmed by rebuilding with this branch's `src/` changes stashed — identical failure on base. CI never runs that step. Wants its own change.

No perf/mem baseline yet.
