### PR TITLE
fix(sdk): model Contact.received on the SDK mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,28 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   raises/rejects the typed `unsupported_verb` / `bad_request` / `not_found`
   errors like the sibling verbs. The control SDK version is unchanged (its own
   `control-sdk-v*` train cuts the release).
+- **`Contact.received` on the SDK mock — the field the engine tells you to
+  route on.** `PyContact` exposes it and its doc-comment says to prefer it over
+  `uri` (a Contact URI can carry a private/NATed address), but the SDK's
+  `Contact` dataclass did not model it: `contact.received or contact.uri`
+  raised `AttributeError` under the mocks, and because
+  `docs/reference/types.md` renders that dataclass, the field was documented
+  nowhere. It is now on the dataclass, `registrar.save()` / `save_proxy()`
+  stamp it from the REGISTER's source address in the engine's URI shape, and
+  `add_contact()` carries an explicitly-built one through — so the NAT case the
+  field exists for (private Contact URI, public source) is finally
+  constructible in a test. Additive, defaulting to `None`.
 
 ### Changed
+- **`Contact.received` is a SIP URI, not a bare `host:port` — the doc-comment
+  now says so.** The value has always been
+  `sip:<ip>:<port>;transport=<proto>` (the OpenSIPS `received_avp` shape),
+  which is what lets `request.fork([c.received or c.uri for c in contacts])`
+  work, but the getter's doc-comment described it as "source IP:port". Only
+  the comment changed.
+- **`request.fix_nated_register()` writes the observed source port into
+  `rport=`** instead of a hardcoded `5060`. SDK mock only; the engine already
+  used the real port.
 - **`tls.method` is now enforced — it used to be parsed and ignored.** The
   setting was deserialized into the TLS config and never read: the acceptor was
   built from a bare `rustls::ServerConfig::builder()`, so a config asking for

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -280,6 +280,22 @@ harness.reset()
 | `reginfo_xml(aor, state, version) -> str` | Generate reginfo XML (RFC 3680) |
 | `on_change` | Decorator: fires on registration state changes |
 
+`lookup()` returns `Contact` objects:
+
+| Field | Description |
+|-------|-------------|
+| `uri` | Contact URI as advertised by the UE |
+| `received` | Transport source of the REGISTER as a SIP URI (`sip:<ip>:<port>;transport=<proto>`), or `None`. Prefer it over `uri` when routing — the Contact URI may carry a private/NAT address (`contact.received or contact.uri`) |
+| `q` | Quality value (0.0–1.0), higher wins |
+| `expires` | Seconds remaining on the binding |
+| `age_secs` | Seconds since the binding was created or refreshed |
+| `path` | RFC 3327 Path headers stored with the binding |
+| `instance_id` / `instance_epoch` | Which siphon instance/process accepted the REGISTER |
+| `is_local` | `True` when *this* process accepted the binding |
+| `flow_token` / `flow` | Captured inbound flow for RFC 5626 connection reuse |
+| `params` | Contact-header params preserved from the REGISTER (RFC 3840 feature tags) |
+| `kind` | `"ue"` (routable) or `"as"` (AS capability record) |
+
 ### Auth
 
 | Method | Description |

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -795,6 +795,25 @@ class MockB2bua:
 # Registrar namespace
 # ---------------------------------------------------------------------------
 
+def _received_of(request: Any) -> str:
+    """Source address a REGISTER arrived from, as the engine records it.
+
+    The production registrar stamps every binding with the transport-level
+    source address so scripts can route on ``contact.received`` rather than
+    the (possibly private / NATed) Contact URI.  It stores it as a SIP URI —
+    ``"sip:<ip>:<port>;transport=<proto>"``, the OpenSIPS ``received_avp``
+    shape — so the value can go straight into ``fork()`` / ``relay()``.
+    Mirror that exactly here, or a script that tests green against the mock
+    would fork to something the engine never produces.
+
+    Falls back to port 5060 / ``udp`` for duck-typed request stand-ins that
+    only model ``source_ip``.
+    """
+    port = getattr(request, "source_port", 5060)
+    transport = getattr(request, "transport", "udp") or "udp"
+    return f"sip:{request.source_ip}:{port};transport={transport}"
+
+
 class MockRegistrar:
     """Mock registrar with an in-memory contact store.
 
@@ -855,7 +874,11 @@ class MockRegistrar:
         must **not** call ``request.reply(200, "OK")`` afterwards.
 
         In the mock, extracts the To URI as AoR and stores a default
-        contact binding.
+        contact binding.  The binding is stamped with
+        :attr:`~siphon_sdk.types.Contact.received` from the request's
+        source address, as the production registrar does — so
+        ``contact.received or contact.uri`` resolves the same way it
+        will on the engine.
 
         Args:
             request: The REGISTER request object.
@@ -897,7 +920,7 @@ class MockRegistrar:
         default_uri = f"sip:{request.ruri.user or 'user'}@{request.source_ip}:5060"
         already_exists = any(c.uri == default_uri for c in contacts)
         if not already_exists:
-            contact = Contact(uri=default_uri)
+            contact = Contact(uri=default_uri, received=_received_of(request))
             if flow_token is not None:
                 contact.flow_token = flow_token
                 # Reconstitute the Flow view from request context.
@@ -954,6 +977,10 @@ class MockRegistrar:
         3. No 200 OK is generated — the proxy will relay the upstream's
            response itself.
 
+        Like :meth:`save`, the cached binding is stamped with
+        :attr:`~siphon_sdk.types.Contact.received` from the REGISTER's
+        source address.
+
         A grace of ~32 s (RFC 3261 Timer F = 64·T1) is added on top so
         a ``NOTIFY[reg-event;state=terminated]`` from the registrar at
         expiry has a transaction-timer window to land before the proxy
@@ -1006,7 +1033,9 @@ class MockRegistrar:
         default_uri = f"sip:{request.ruri.user or 'user'}@{request.source_ip}:5060"
         already_exists = any(c.uri == default_uri for c in contacts)
         if not already_exists:
-            contacts.append(Contact(uri=default_uri))
+            contacts.append(
+                Contact(uri=default_uri, received=_received_of(request))
+            )
         event_type = "refreshed" if already_exists else "registered"
         self._fire_on_change(aor, event_type)
         if aliases:

--- a/sdk/siphon_sdk/request.py
+++ b/sdk/siphon_sdk/request.py
@@ -1140,11 +1140,17 @@ class Request:
     def fix_nated_register(self) -> None:
         """Add ``received=`` and ``rport=`` to top Via using source IP:port.
 
-        Used by edge proxies / P-CSCFs for NAT traversal on REGISTER.
+        Used by edge proxies / P-CSCFs for NAT traversal on REGISTER.  Both
+        values come from :attr:`source_ip` / :attr:`source_port`, so a
+        ``Request`` constructed with a NATed source port writes that port
+        into ``rport=`` rather than a fixed 5060.
         """
         via = self.get_header("Via")
         if via:
-            self.set_header("Via", f"{via};received={self._source_ip};rport=5060")
+            self.set_header(
+                "Via",
+                f"{via};received={self._source_ip};rport={self._source_port}",
+            )
 
     def fix_nated_contact(self) -> None:
         """Rewrite Contact URI host:port with source IP:port.

--- a/sdk/siphon_sdk/types.py
+++ b/sdk/siphon_sdk/types.py
@@ -120,6 +120,7 @@ class Contact:
 
     Attributes:
         uri: The contact URI string (e.g. ``"sip:alice@192.168.1.5:5060"``).
+        received: Source address of the REGISTER as a SIP URI, or ``None``.
         q: Quality value between 0.0 and 1.0 (higher = preferred).
         expires: Seconds remaining until this binding expires.
         age_secs: Seconds since the binding was created or last refreshed.
@@ -127,6 +128,24 @@ class Contact:
 
     uri: str
     """Contact URI as a string."""
+
+    received: Optional[str] = None
+    """Transport source address of the REGISTER that created this binding, as
+    a SIP URI — ``"sip:<ip>:<port>;transport=<proto>"``, the shape OpenSIPS
+    puts in its ``received_avp``.  ``None`` when the binding was saved without
+    source address info.
+
+    Prefer this over :attr:`uri` when routing: a Contact URI can carry a
+    private or NATed address, while this is the address the UE is actually
+    reachable on::
+
+        request.fork([c.received or c.uri for c in contacts])
+
+    Behind NAT the two differ — the UE advertises ``sip:alice@10.0.0.5:5060``
+    in its Contact while the packet arrives from ``198.51.100.20:41234`` — and
+    only the latter is routable.  It is a full URI rather than a bare
+    ``host:port`` precisely so it can be handed to ``fork()`` / ``relay()``
+    verbatim."""
 
     q: float = 1.0
     """Quality value (0.0–1.0).  Higher values are preferred.

--- a/sdk/tests/test_registrar_received.py
+++ b/sdk/tests/test_registrar_received.py
@@ -1,0 +1,193 @@
+"""Tests for ``Contact.received`` — the transport source of the REGISTER.
+
+The engine records the source address on every binding and its doc-comment
+says to route on it instead of the Contact URI: behind NAT the UE advertises
+a private address in its Contact while the packet arrives from a public one,
+and only the latter is reachable (the OpenSIPS ``received_avp`` equivalent).
+
+It is stored as a full SIP URI — ``sip:<ip>:<port>;transport=<proto>``, see
+``PyContact::received_string`` — not a bare ``host:port``, which is what lets
+``examples/registrar_proxy.py`` fork straight on ``c.received or c.uri``.
+The mock has to produce that same shape or a script that tests green here
+would fork to a non-URI on the engine.
+"""
+from types import SimpleNamespace
+
+from siphon_sdk import mock_module
+from siphon_sdk.request import Request
+from siphon_sdk.types import Contact
+
+
+def _fresh_registrar():
+    mock_module.install()
+    registrar = mock_module.get_registrar()
+    registrar._store.clear()
+    registrar._associated_uris.clear()
+    registrar._aliases.clear()
+    registrar._tokens.clear()
+    return registrar
+
+
+def _register(
+    source_ip: str = "198.51.100.20",
+    source_port: int = 41234,
+    transport: str = "udp",
+    to_uri: str = "sip:alice@example.com",
+):
+    return Request(
+        method="REGISTER",
+        ruri="sip:registrar.example.com",
+        to_uri=to_uri,
+        from_uri=to_uri,
+        transport=transport,
+        source_ip=source_ip,
+        source_port=source_port,
+    )
+
+
+def test_contact_defaults_to_no_received():
+    """Existing scripts and fixtures are unaffected — the field is additive."""
+    assert Contact(uri="sip:alice@192.0.2.10:5060").received is None
+
+
+def test_save_stamps_received_from_the_register_source():
+    registrar = _fresh_registrar()
+
+    assert registrar.save(_register("198.51.100.20", 41234)) is True
+
+    contacts = registrar.lookup("sip:alice@example.com")
+    assert len(contacts) == 1
+    assert contacts[0].received == "sip:198.51.100.20:41234;transport=udp"
+
+
+def test_received_carries_the_registers_transport():
+    """A TCP REGISTER must not be described as UDP — the URI is a routing hint."""
+    registrar = _fresh_registrar()
+    registrar.save(_register("198.51.100.20", 41234, transport="tcp"))
+
+    assert (
+        registrar.lookup("sip:alice@example.com")[0].received
+        == "sip:198.51.100.20:41234;transport=tcp"
+    )
+
+
+def test_lookup_returns_received_intact():
+    """The field survives the store round-trip, not just the save call."""
+    registrar = _fresh_registrar()
+    registrar.save(_register("198.51.100.21", 5062))
+
+    first = registrar.lookup("sip:alice@example.com")[0]
+    second = registrar.lookup("sip:alice@example.com")[0]
+    assert first.received == second.received
+    assert first.received == "sip:198.51.100.21:5062;transport=udp"
+
+
+def test_save_proxy_stamps_received_from_the_register_source():
+    registrar = _fresh_registrar()
+    reply = SimpleNamespace(
+        status_code=200,
+        get_header=lambda name: {"Expires": "3600"}.get(name),
+        relay=lambda: None,
+    )
+
+    assert registrar.save_proxy(_register("198.51.100.22", 33445), reply) is True
+    assert (
+        registrar.lookup("sip:alice@example.com")[0].received
+        == "sip:198.51.100.22:33445;transport=udp"
+    )
+
+
+def test_save_falls_back_for_requests_without_a_source_port():
+    """Duck-typed stand-ins that only model ``source_ip`` still work."""
+    registrar = _fresh_registrar()
+    request = SimpleNamespace(
+        to_uri="sip:bob@example.com",
+        ruri=SimpleNamespace(user="bob"),
+        source_ip="198.51.100.23",
+        method="REGISTER",
+        reply=lambda code, reason: None,
+    )
+
+    registrar.save(request)
+
+    assert (
+        registrar.lookup("sip:bob@example.com")[0].received
+        == "sip:198.51.100.23:5060;transport=udp"
+    )
+
+
+def test_add_contact_carries_received_through():
+    registrar = _fresh_registrar()
+    registrar.add_contact(
+        "sip:carol@example.com",
+        Contact(
+            uri="sip:carol@10.0.0.5:5060",
+            received="sip:198.51.100.24:19876;transport=udp",
+        ),
+    )
+
+    assert (
+        registrar.lookup("sip:carol@example.com")[0].received
+        == "sip:198.51.100.24:19876;transport=udp"
+    )
+
+
+def test_received_wins_over_a_private_contact_uri_when_routing():
+    """The behaviour the engine doc-comment promises, now expressible.
+
+    The UE put its private address in the Contact; the REGISTER arrived from
+    a public one.  ``received or uri`` has to pick the routable address, and
+    the result has to be a URI ``fork()`` will accept.
+    """
+    registrar = _fresh_registrar()
+    registrar.add_contact(
+        "sip:dave@example.com",
+        Contact(
+            uri="sip:dave@10.0.0.5:5060",
+            received="sip:198.51.100.25:47001;transport=udp",
+        ),
+    )
+
+    contact = registrar.lookup("sip:dave@example.com")[0]
+    target = contact.received or contact.uri
+
+    assert target == "sip:198.51.100.25:47001;transport=udp"
+    assert target != contact.uri
+    assert target.startswith("sip:")
+
+
+def test_received_falls_back_to_uri_for_a_binding_without_source_info():
+    """A binding restored from a backend that never captured the source."""
+    registrar = _fresh_registrar()
+    registrar.add_contact(
+        "sip:erin@example.com", Contact(uri="sip:erin@198.51.100.26:5060")
+    )
+
+    contact = registrar.lookup("sip:erin@example.com")[0]
+    assert (contact.received or contact.uri) == "sip:erin@198.51.100.26:5060"
+
+
+def test_a_mock_saved_binding_can_be_forked_on():
+    """End-to-end shape check: the idiomatic NAT-safe line reaches fork()."""
+    registrar = _fresh_registrar()
+    registrar.save(_register("198.51.100.28", 52001))
+
+    invite = Request(method="INVITE", ruri="sip:alice@example.com")
+    contacts = registrar.lookup("sip:alice@example.com")
+    invite.fork([c.received or c.uri for c in contacts])
+
+    assert invite.actions[-1].targets == [
+        "sip:198.51.100.28:52001;transport=udp"
+    ]
+
+
+def test_fix_nated_register_writes_the_observed_source_port():
+    """``rport=`` is the real source port, not a hardcoded 5060."""
+    request = _register("198.51.100.27", 41234)
+    request.set_header("Via", "SIP/2.0/UDP 10.0.0.5:5060;branch=z9hG4bKnashds7")
+
+    request.fix_nated_register()
+
+    via = request.get_header("Via")
+    assert ";received=198.51.100.27" in via
+    assert ";rport=41234" in via

--- a/src/script/api/registrar.rs
+++ b/src/script/api/registrar.rs
@@ -222,12 +222,15 @@ impl PyContact {
         self.age_seconds
     }
 
-    /// The received address (source IP:port of the REGISTER).
+    /// The transport source address of the REGISTER, as a SIP URI:
+    /// `"sip:<ip>:<port>;transport=<proto>"` (the OpenSIPS `received_avp`
+    /// shape), *not* a bare `host:port` — so it can be handed straight to
+    /// `fork()` / `relay()`.
     ///
     /// Returns `None` if the contact was not saved with source address info.
     /// When present, this should be used for routing instead of `uri` — the
     /// Contact URI may contain a private/NAT address, while `received` has
-    /// the actual reachable address (like OpenSIPS `received_avp`).
+    /// the actual reachable address.
     #[getter]
     fn received(&self) -> Option<&str> {
         self.received_string.as_deref()


### PR DESCRIPTION
## What is wrong

`PyContact` exposes 13 getters; `siphon_sdk.types.Contact` mirrored 12. The missing one is `received`, and the engine's own doc-comment says it is the field to route on:

> When present, this should be used for routing instead of `uri` — the Contact URI may contain a private/NAT address, while `received` has the actual reachable address (like OpenSIPS `received_avp`).

Three consequences:

- **Undocumented.** `docs/reference/types.md` renders the Contact reference from the dataclass with mkdocstrings, so a field absent from the dataclass is documented nowhere.
- **Untestable.** The idiomatic NAT-safe line raises `AttributeError` under the mocks — including the one already shipped in `examples/registrar_proxy.py:116`:
  ```python
  request.fork([c.received or c.uri for c in contacts])
  ```
- **Unrepresentable.** `MockRegistrar.save()` builds its binding URI from `request.source_ip`, so the Contact URI *is* the source address. The whole point of `received` is that those differ behind NAT, and no mock-driven test could construct that.

## The shape is a URI, not `host:port`

Worth calling out because it is easy to get backwards. The getter's doc-comment describes "source IP:port", but the code three lines above the field builds a full URI:

```rust
// src/script/api/registrar.rs
format!("sip:{}:{};transport={}", addr.ip(), addr.port(), transport)
```

and the field declaration documents that format. The URI form is load-bearing: the value is used as a `fork()` target, and a bare `host:port` is not a URI. A mock that stamped `"198.51.100.20:41234"` would let a script test green and then fork to something the engine never produces — the failure the mocks exist to catch, just moved. So the mock produces the engine's shape, and this also corrects the getter doc-comment that keeps propagating the wrong one (comment only, no behaviour change).

## Changes

- `sdk/siphon_sdk/types.py` — `received: Optional[str] = None` on `Contact`, placed next to `uri` since the docs render in field order. Every `Contact(...)` construction in the repo is keyword-only, so the field-order shift is safe.
- `sdk/siphon_sdk/mock_module.py` — `registrar.save()` and `save_proxy()` stamp it from the REGISTER's source address via a shared `_received_of()` helper. Falls back to port 5060 / `udp` for duck-typed request stand-ins that only model `source_ip` (the existing registrar tests use those). `add_contact()` needed nothing — it stores a `Contact` and carries the field for free.
- `sdk/siphon_sdk/request.py` — `fix_nated_register()` writes the observed source port into `rport=` instead of a hardcoded `5060`. `Request` has modelled `source_port` for a while; the hardcode was left over from when it did not. The engine already used the real port.
- `sdk/README.md` — the registrar section had only a method table, no `Contact` field list, so `received` had no home there. Added the field table.
- `CHANGELOG.md` — `Unreleased` entries.

## Tests

`sdk/tests/test_registrar_received.py`, 11 cases: a saved binding exposes `received` matching the REGISTER's source; `lookup()` returns it intact; the transport is carried through (a TCP REGISTER is not described as UDP); a `Contact` built without the argument reports `None`; `received` wins over a private Contact URI and loses to nothing when absent; `save_proxy()` and `add_contact()` both carry it; and one end-to-end case that runs a mock-saved binding through `fork()` and asserts the captured target, which is the shape check that matters.

## Verification

- SDK suite 525 passed (514 before), run from `sdk/`.
- `mkdocs build --strict` clean; `received` renders in the published Contact reference.
- `cargo check --all-targets` and `cargo clippy --all-targets --all-features -- -D warnings` clean.
- No perf/mem baseline: nothing here touches a datapath.

## Compatibility

Additive with a `None` default. No existing script or test changes behaviour.
