### PR TITLE
feat(embedding): register_module_extension — mount a multi-namespace addon onto the siphon module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`SiphonServer::register_module_extension(name, hook)`** — embedding API for
+  an extension whose surface is more than one attribute. The hook is handed the
+  `siphon` package module itself and mounts its own namespaces, shared types,
+  exception and module functions, so `from siphon import a, b, SomeError` all
+  resolve; it re-runs on every script load and reload. `register_namespace` /
+  `register_namespace_with` remain the right call for the common
+  "expose one namespace object" case and keep their built-in-name collision
+  check — a module extension picks its own attribute names and is not
+  collision-checked.
 - **`auth.require_proxy_digest()` / `require_www_digest()` / `require_digest()` /
   `verify_digest()` now take a B2BUA `Call` as well as a proxy `Request`, so a
   B2BUA can challenge its own caller.** Registering any `@b2bua.*` handler makes

--- a/src/script/api/mod.rs
+++ b/src/script/api/mod.rs
@@ -80,6 +80,22 @@ pub const BUILT_IN_NAMESPACE_NAMES: &[&str] = &[
 /// `install_siphon_module()` runs (i.e. on each script load / reload).
 static USER_NAMESPACES: Mutex<Vec<(String, Py<PyAny>)>> = Mutex::new(Vec::new());
 
+/// Hook that mounts an extension's own contents onto the `siphon` package
+/// module. Unlike a user namespace (one name, one object) this gets the module
+/// itself, so an extension whose surface is several namespaces plus shared
+/// types / exceptions / functions can install all of it in one pass.
+///
+/// `Fn` rather than `FnOnce` because `install_siphon_module()` rebuilds the
+/// module on every script load and reload — the hook must be replayable.
+pub type ModuleExtension =
+    Box<dyn Fn(Python<'_>, &Bound<'_, PyModule>) -> PyResult<()> + Send + Sync>;
+
+/// Host-registered module extensions, keyed by extension name (diagnostics +
+/// duplicate rejection only — the name is not itself an attribute). Populated
+/// by `SiphonServer` at startup, replayed every time `install_siphon_module()`
+/// runs.
+static MODULE_EXTENSIONS: Mutex<Vec<(String, ModuleExtension)>> = Mutex::new(Vec::new());
+
 /// Tuple of (auth, registrar, log, proxy_utils, cache) singletons.
 type SingletonTuple = (Py<PyAny>, Py<PyAny>, Py<PyAny>, Py<PyAny>, Py<PyAny>);
 
@@ -556,11 +572,42 @@ pub fn set_user_namespace(name: &str, py_obj: Py<PyAny>) -> Result<()> {
     Ok(())
 }
 
+/// Register a host-provided module extension under `name`.
+///
+/// The hook is handed the `siphon` package module itself on every
+/// `install_siphon_module()` (so, on every script load and reload) and mounts
+/// whatever the extension exposes: namespaces, shared types, exceptions,
+/// module-level functions. `name` is an identity for diagnostics and duplicate
+/// rejection — it is not turned into an attribute, and it is not checked
+/// against `BUILT_IN_NAMESPACE_NAMES` because the hook chooses its own
+/// attribute names.
+pub fn set_module_extension(name: &str, hook: ModuleExtension) -> Result<()> {
+    let mut guard = MODULE_EXTENSIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if guard.iter().any(|(existing, _)| existing == name) {
+        return Err(SiphonError::Script(format!(
+            "module extension '{name}' is already registered"
+        )));
+    }
+    guard.push((name.to_owned(), hook));
+    Ok(())
+}
+
 /// Test-only: clear all host-registered namespaces. Lets each test exercise
 /// `set_user_namespace` from a known-empty state.
 #[cfg(test)]
 pub fn clear_user_namespaces() {
     let mut guard = USER_NAMESPACES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.clear();
+}
+
+/// Test-only: clear all host-registered module extensions.
+#[cfg(test)]
+pub fn clear_module_extensions() {
+    let mut guard = MODULE_EXTENSIONS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     guard.clear();
@@ -854,6 +901,22 @@ pub fn install_siphon_module(python: Python<'_>) -> Result<()> {
                 .map_err(|error| {
                     SiphonError::Script(format!("setattr {name} (user namespace): {error}"))
                 })?;
+        }
+    }
+
+    // Run host-registered module extensions. These get the module itself, not a
+    // single attribute slot, because an extension's surface can be several
+    // namespaces plus shared types and exceptions (siphon-sigtran mounts `ss7`
+    // / `gsm_map` / `gsm_cap` / `inap` + `SigtranError` + `configure` /
+    // `metrics`). Runs last so an extension sees a fully-populated module.
+    {
+        let guard = MODULE_EXTENSIONS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for (name, hook) in guard.iter() {
+            hook(python, &module).map_err(|error| {
+                SiphonError::Script(format!("module extension '{name}': {error}"))
+            })?;
         }
     }
 

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -2873,6 +2873,178 @@ assert probe_ns.answer() == 42
 
         crate::script::api::clear_user_namespaces();
     }
+
+    // -----------------------------------------------------------------
+    // Host-registered module extensions
+    // -----------------------------------------------------------------
+    //
+    // The seam an addon whose surface is more than one attribute uses:
+    // siphon-sigtran mounts four namespaces (`ss7` / `gsm_map` / `gsm_cap` /
+    // `inap`) plus shared types, an exception and module functions in one
+    // `register(py, parent)` call.
+
+    #[pyclass]
+    struct ModuleExtensionProbe;
+
+    #[pymethods]
+    impl ModuleExtensionProbe {
+        #[new]
+        fn new() -> Self {
+            ModuleExtensionProbe
+        }
+
+        fn answer(&self) -> i64 {
+            7
+        }
+    }
+
+    #[test]
+    fn module_extension_mounts_several_attributes() {
+        let _guard = USER_NS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Python::initialize();
+        crate::script::api::clear_module_extensions();
+
+        crate::script::api::set_module_extension(
+            "probe_ext",
+            Box::new(|python: Python<'_>, parent: &Bound<'_, PyModule>| {
+                // Two namespace singletons + a shared type, all in one hook —
+                // the thing register_namespace_with cannot express.
+                parent.setattr("ext_alpha", Bound::new(python, ModuleExtensionProbe)?)?;
+                parent.setattr("ext_beta", Bound::new(python, ModuleExtensionProbe)?)?;
+                parent.add_class::<ModuleExtensionProbe>()?;
+                Ok(())
+            }),
+        )
+        .unwrap();
+
+        let source = r#"
+from siphon import ext_alpha, ext_beta, ModuleExtensionProbe
+
+assert ext_alpha.answer() == 7
+assert ext_beta.answer() == 7
+assert ModuleExtensionProbe().answer() == 7
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(source.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        ScriptEngine::compile_script(file.path(), &[]).unwrap();
+
+        crate::script::api::clear_module_extensions();
+    }
+
+    #[test]
+    fn module_extension_replays_on_every_install() {
+        // install_siphon_module() rebuilds the module on every script load and
+        // reload, so a hook that only fired once would leave a reloaded script
+        // importing a module without the extension on it.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _guard = USER_NS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Python::initialize();
+        crate::script::api::clear_module_extensions();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = calls.clone();
+        crate::script::api::set_module_extension(
+            "replay_ext",
+            Box::new(move |python: Python<'_>, parent: &Bound<'_, PyModule>| {
+                counter.fetch_add(1, Ordering::SeqCst);
+                parent.setattr("replay_probe", Bound::new(python, ModuleExtensionProbe)?)?;
+                Ok(())
+            }),
+        )
+        .unwrap();
+
+        let source = r#"
+from siphon import replay_probe
+
+assert replay_probe.answer() == 7
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(source.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        ScriptEngine::compile_script(file.path(), &[]).unwrap();
+        let after_first = calls.load(Ordering::SeqCst);
+        assert!(after_first >= 1, "hook never ran");
+
+        // A reload re-installs the module; the hook must run again.
+        ScriptEngine::compile_script(file.path(), &[]).unwrap();
+        assert!(
+            calls.load(Ordering::SeqCst) > after_first,
+            "hook did not replay on reload"
+        );
+
+        crate::script::api::clear_module_extensions();
+    }
+
+    #[test]
+    fn module_extension_duplicate_name_errors() {
+        let _guard = USER_NS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Python::initialize();
+        crate::script::api::clear_module_extensions();
+
+        crate::script::api::set_module_extension("dup_ext", Box::new(|_python, _parent| Ok(())))
+            .unwrap();
+        let result =
+            crate::script::api::set_module_extension("dup_ext", Box::new(|_python, _parent| Ok(())));
+        assert!(result.is_err());
+        let error = format!("{}", result.unwrap_err());
+        assert!(
+            error.contains("already registered"),
+            "unexpected error: {error}"
+        );
+
+        crate::script::api::clear_module_extensions();
+    }
+
+    #[test]
+    fn module_extension_failure_is_surfaced_not_swallowed() {
+        let _guard = USER_NS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Python::initialize();
+        crate::script::api::clear_module_extensions();
+
+        // The extension registry is process-global and install_siphon_module()
+        // runs on whichever thread compiles a script, so an unconditionally
+        // failing hook would break every *other* test compiling a script in
+        // parallel. Fail only for compiles driven from this test's own thread.
+        let owner = std::thread::current().id();
+        crate::script::api::set_module_extension(
+            "failing_ext",
+            Box::new(move |_python, _parent| {
+                if std::thread::current().id() == owner {
+                    Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "extension mount blew up",
+                    ))
+                } else {
+                    Ok(())
+                }
+            }),
+        )
+        .unwrap();
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"pass\n").unwrap();
+        file.flush().unwrap();
+
+        let result = ScriptEngine::compile_script(file.path(), &[]);
+        crate::script::api::clear_module_extensions();
+
+        let error = format!("{}", result.expect_err("mount failure must not be swallowed"));
+        assert!(
+            error.contains("failing_ext") && error.contains("extension mount blew up"),
+            "unexpected error: {error}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,10 @@ use crate::{dispatcher, shutdown};
 /// type and we need to type-erase it for storage on the builder.
 type UserNamespaceFactory = Box<dyn FnOnce(Python<'_>) -> PyResult<Py<PyAny>> + Send>;
 
+/// Deferred hook that mounts an extension's contents onto the `siphon` package
+/// module itself, rather than into a single named attribute.
+type ModuleExtension = crate::script::api::ModuleExtension;
+
 /// Deferred extension task — invoked after the script engine has been
 /// initialised, with a [`ScriptHandle`] cloned for the task's exclusive
 /// use. The closure typically calls `tokio_handle().spawn(...)` to
@@ -54,6 +58,7 @@ pub struct SiphonServer {
     product_name: Option<&'static str>,
     product_version: Option<&'static str>,
     user_namespaces: Vec<(String, UserNamespaceFactory)>,
+    module_extensions: Vec<(String, ModuleExtension)>,
     extension_tasks: Vec<ExtensionTask>,
     control_adapters: Vec<ControlAdapterHandle>,
 }
@@ -70,6 +75,7 @@ impl SiphonServer {
             product_name: None,
             product_version: None,
             user_namespaces: Vec::new(),
+            module_extensions: Vec::new(),
             extension_tasks: Vec::new(),
             control_adapters: Vec::new(),
         }
@@ -184,6 +190,46 @@ impl SiphonServer {
     {
         self.user_namespaces
             .push((name.to_owned(), Box::new(factory)));
+        self
+    }
+
+    /// Register a host-provided hook that mounts its contents onto the `siphon`
+    /// package module itself.
+    ///
+    /// Use this when an extension's surface is more than one attribute — several
+    /// namespaces, plus shared `#[pyclass]` types, an exception type, or
+    /// module-level functions — so that `from siphon import a, b, SomeError`
+    /// all resolve. For the common "expose one namespace object" case, prefer
+    /// [`register_namespace`](Self::register_namespace) /
+    /// [`register_namespace_with`](Self::register_namespace_with), which get
+    /// collision-checked against the built-in namespace names.
+    ///
+    /// `name` identifies the extension for diagnostics and duplicate rejection;
+    /// it is not itself turned into an attribute. The hook chooses its own
+    /// attribute names, so it is *not* protected from shadowing a built-in
+    /// namespace — that responsibility sits with the extension.
+    ///
+    /// The hook runs after every other namespace and singleton has been
+    /// installed, and re-runs on each script load and reload (hence `Fn`, not
+    /// `FnOnce`).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use siphon::SiphonServer;
+    ///
+    /// SiphonServer::builder()
+    ///     .config_path("siphon.yaml")
+    ///     // mounts `ss7` / `gsm_map` / `gsm_cap` / `inap` + shared types
+    ///     .register_module_extension("sigtran", siphon_sigtran::python::register)
+    ///     .run();
+    /// ```
+    pub fn register_module_extension<F>(mut self, name: &str, hook: F) -> Self
+    where
+        F: Fn(Python<'_>, &Bound<'_, PyModule>) -> PyResult<()> + Send + Sync + 'static,
+    {
+        self.module_extensions
+            .push((name.to_owned(), Box::new(hook)));
         self
     }
 
@@ -757,6 +803,18 @@ impl SiphonServer {
                     info!(name = %name, "user namespace registered for injection");
                 }
             });
+        }
+
+        // --- Host-registered module extensions ---
+        // Stored on the global registry the same way; install_siphon_module()
+        // replays them against the `siphon` module on every script load.
+        let module_extensions = std::mem::take(&mut self.module_extensions);
+        for (name, hook) in module_extensions {
+            if let Err(error) = crate::script::api::set_module_extension(&name, hook) {
+                eprintln!("Failed to register module extension '{name}': {error}");
+                std::process::exit(1);
+            }
+            info!(name = %name, "module extension registered for injection");
         }
 
         // --- IPsec SA manager + singleton ---


### PR DESCRIPTION
Adds one builder method to the embedding API. It is the seam the SIGTRAN
extension module needs (follow-up PR); nothing else changes behaviour.

## Why

`register_namespace` / `register_namespace_with` hand an addon exactly one named
attribute on the `siphon` package module. That fits `siphon-smpp` and
`siphon-http`, which each expose a single namespace object.

It does not fit `siphon-sigtran`. Its startup seam is one
`register(py, parent)` call that mounts **four** namespaces (`ss7`, `gsm_map`,
`gsm_cap`, `inap`) plus the `SigtranError` exception, the `siphon.configure` /
`siphon.metrics` module functions, and its shared `#[pyclass]` types. Composing
it through the namespace API would have registered the four namespaces and
silently dropped the rest, leaving documented script surface unreachable.

## What

```rust
SiphonServer::builder()
    .config_path("siphon.yaml")
    .register_module_extension("sigtran", siphon_sigtran::python::register)
    .run();
```

The hook is handed the module itself, so `from siphon import a, b, SomeError`
all resolve.

- Runs **last** in `install_siphon_module`, after every built-in namespace and
  singleton, so an extension sees a fully-populated module.
- `Fn`, not `FnOnce`: the module is rebuilt on every script load *and reload*, so
  a one-shot hook would leave a reloaded script importing a module without the
  extension on it.
- `name` is identity for diagnostics and duplicate rejection only — it is not
  turned into an attribute, and it is deliberately **not** collision-checked
  against `BUILT_IN_NAMESPACE_NAMES`, because the hook chooses its own attribute
  names. `register_namespace*` stays the right call for the ordinary
  one-namespace addon, where that check does apply.
- A hook that errors fails the script load with the extension name in the
  message, rather than being swallowed.

## Tests

Four unit tests in `src/script/engine.rs`:

| Test | Covers |
|---|---|
| `module_extension_mounts_several_attributes` | two namespaces + a shared type in one hook — the thing `register_namespace_with` cannot express |
| `module_extension_replays_on_every_install` | the hook re-runs on reload (the `Fn` requirement) |
| `module_extension_duplicate_name_errors` | duplicate registration rejected |
| `module_extension_failure_is_surfaced_not_swallowed` | a hook error propagates with the extension name |

The failure test scopes its failing hook to its own thread: the registry is
process-global and `install_siphon_module` runs on whichever thread compiles a
script, so an unconditionally-failing hook would break every other test
compiling a script in parallel.

## Verification

- `PYO3_PYTHON=python3 cargo test` — 3832 passed / 0 failed (run 3x)
- `PYO3_PYTHON=python3 cargo clippy --all-targets --all-features -- -D warnings` — clean
- `mkdocs build --strict` — clean

End-to-end proof that a real multi-namespace addon mounts through it lives in
the follow-up PR.
