### PR TITLE
feat(control): header-remove + media-control verbs on the sip control adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,27 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   "expose one namespace object" case and keep their built-in-name collision
   check — a module extension picks its own attribute names and is not
   collision-checked.
+- **Control-plane header-remove + media-control verbs on the SIP adapter.** The
+  `siphon-control.v1` `sip` module gains `remove_header` (remove a header from
+  the stored A-leg INVITE, the mirror of `set_header`) plus the media verbs
+  `play` / `stop` / `dtmf` / `hold` / `unhold` / `stream_start` / `stream_stop`,
+  each bound to the configured media backend and applied against the controlled
+  A-leg's anchored media session. `play` is fire-and-forget — the reply confirms
+  the backend accepted the command, it does not block on prompt completion — with
+  the source as exactly one of `file` / `db_id` / `blob` (base64 over the JSON
+  wire). `hold`/`unhold` map to the engine's silence/unsilence (a gentle hold
+  that keeps the path up; packet drop stays a future gate verb). `stream_start`/
+  `stream_stop` attach/detach an additive WebSocket audio tee (a copy of the live
+  audio for transcription / agent-assist / compliance, not a media takeover);
+  this is a `siphon-rtp`-backend feature, so on rtpengine/rtpproxy it answers
+  `unsupported_verb` rather than a hollow success. Errors are typed, never a
+  hang: a call with no anchored media session → `not_found`, a backend that
+  cannot perform the op → `unsupported_verb`, any other backend failure →
+  `unavailable`. The media call-id + from-tag are resolved from the call's SIP
+  Call-ID through the same media-session mapping the dispatcher uses for
+  re-INVITE / SIPREC, so a re-anchored transfer is addressed on its real media
+  id. Server-side only — the client SDK facade methods are a follow-up (reach the
+  verbs meanwhile through the generic `command(verb, args)` escape hatch).
 - **`auth.require_proxy_digest()` / `require_www_digest()` / `require_digest()` /
   `verify_digest()` now take a B2BUA `Call` as well as a proxy `Request`, so a
   B2BUA can challenge its own caller.** Registering any `@b2bua.*` handler makes

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -212,7 +212,13 @@ chunk, so logs join Homer and billing with no mapping table.
 | `hangup` | sip | `{reason?}` | BYE an answered call, or reject an unanswered one |
 | `refer` | sip | `{to, replaces?}` | in-dialog REFER on the A-leg |
 | `route` | sip | `{targets, strategy?, headers?}` | return control to siphon: un-park the call and dial the B-leg via LCR sequential failover |
-| `set_header` / `get_header` | sip | `{name, value?}` | on the stored A-leg INVITE |
+| `set_header` / `remove_header` / `get_header` | sip | `{name, value?}` | on the stored A-leg INVITE |
+| `play` | sip | `{file\|db_id\|blob, repeat?, start_ms?, duration_ms?, to_tag?}` | play an announcement on the A-leg media (fire-and-forget) |
+| `stop` | sip | — | stop the announcement currently playing |
+| `dtmf` | sip | `{digits, duration_ms?, volume_dbm0?, pause_ms?, to_tag?}` | inject DTMF digits toward the A-leg |
+| `hold` / `unhold` | sip | — | media hold via silence |
+| `stream_start` | sip | `{ws_uri, direction?, channels?}` | attach a WebSocket audio tee (siphon-rtp backend only) |
+| `stream_stop` | sip | — | detach the WebSocket audio tee |
 | `set_var` / `get_var` | — | `{key, value?}` | per-call variables (drain with the call) |
 | `resync` | — | — | re-attach + enumerate this app's owned calls |
 | `describe` | — | — | list the registered adapters + their verb/event schema |
@@ -232,8 +238,31 @@ failover. `continue` (bare hand-back, siphon re-decides routing through the
 script's `@b2bua.on_*` handlers) is a follow-up, pending the control-loss
 `fallback` re-dispatch path.
 
-`play` / `dtmf` / `bridge` / `originate` / media-stream verbs arrive in later
-phases over the same envelope.
+The media verbs (`play` / `stop` / `dtmf` / `hold` / `unhold` / `stream_start` /
+`stream_stop`) act on the controlled A-leg's anchored media session. They are
+resolved against the configured media backend and answer with a typed reply the
+same way every other verb does — never a hang:
+
+- `play` is **fire-and-forget**: the reply confirms the backend *accepted* the
+  command (`{state: "playing"}`), it does not wait for the prompt to finish. The
+  source is exactly one of `file` (a path on the media host), `db_id` (a prompt
+  in the engine's DB), or `blob` (base64-encoded audio, since the wire is JSON).
+- `hold` maps to the engine's *silence* (comfort-noise) mode and `unhold`
+  restores it — a gentle hold that keeps the media path up. Dropping packets
+  outright (`block`/`unblock`) is a separate future gate verb.
+- `stream_start` / `stream_stop` attach and detach a **WebSocket audio tee** —
+  an *additive* copy of the live call's audio for transcription / agent-assist /
+  compliance, not a takeover of the media path. This is a `siphon-rtp`-backend
+  feature: on rtpengine / rtpproxy it answers `unsupported_verb` rather than a
+  hollow success. `direction` is `both` (default) / `caller` / `callee`, and
+  `channels` is `1` (mixed mono) or `2` (caller/callee stereo).
+- A call with no anchored media session answers `not_found`; a backend that
+  cannot perform the op answers `unsupported_verb`; any other backend failure
+  answers `unavailable`.
+
+`bridge` / `originate` verbs arrive in later phases over the same envelope. The
+client SDK facade methods for the media verbs land alongside them (until then,
+reach the verbs through the generic `command(verb, args)` escape hatch).
 
 The complete wire reference, both connection modes end to end, and two
 low-level example clients (one Python, one TypeScript) that drive calls with no

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -31,7 +31,15 @@ impl ControlAdapter for SipControlAdapter {
     }
 
     fn apply<'a>(&'a self, command: AdapterCommand) -> BoxFuture<'a, ControlResult> {
-        Box::pin(async move { apply_sip(command) })
+        // Media verbs bind to the async MediaBackend, so they run on the async
+        // path; every other verb is a synchronous decision over the B2BUA rail.
+        Box::pin(async move {
+            if is_media_verb(&command.verb) {
+                apply_media_verb(command).await
+            } else {
+                apply_sip(command)
+            }
+        })
     }
 
     fn describe(&self) -> AdapterSchema {
@@ -45,7 +53,15 @@ impl ControlAdapter for SipControlAdapter {
                 verb("refer", "Send an in-dialog REFER on the A-leg (args: to, replaces)"),
                 verb("route", "Return control to siphon with a routing decision: un-park the call and dial the B-leg via LCR sequential failover (args: targets, strategy, headers)"),
                 verb("set_header", "Set a header on the stored A-leg INVITE (args: name, value)"),
+                verb("remove_header", "Remove a header from the stored A-leg INVITE (args: name)"),
                 verb("get_header", "Read a header from the stored A-leg INVITE (args: name)"),
+                verb("play", "Play an announcement on the A-leg media, fire-and-forget (args: one of file|db_id|blob, repeat, start_ms, duration_ms, to_tag)"),
+                verb("stop", "Stop the announcement currently playing on the A-leg media"),
+                verb("dtmf", "Inject DTMF digits toward the A-leg (args: digits, duration_ms, volume_dbm0, pause_ms, to_tag)"),
+                verb("hold", "Hold the A-leg media via silence"),
+                verb("unhold", "Resume the A-leg media after a hold"),
+                verb("stream_start", "Attach a WebSocket audio tee — siphon-rtp backend only (args: ws_uri, direction, channels)"),
+                verb("stream_stop", "Detach the WebSocket audio tee"),
             ],
             events: vec![
                 "StasisStart".to_string(),
@@ -64,25 +80,45 @@ fn verb(name: &str, summary: &str) -> VerbSchema {
     }
 }
 
-/// Dispatch one SIP verb. Synchronous (the imperative rail is non-blocking) —
-/// returns the local result immediately.
-fn apply_sip(command: AdapterCommand) -> ControlResult {
-    // All SIP verbs act on a channel.
+/// The media-control verbs the SIP adapter dispatches asynchronously against the
+/// configured [`crate::rtpengine::MediaBackend`] (rather than the synchronous
+/// B2BUA rail). Kept in one place so `apply` and the tests agree on the split.
+fn is_media_verb(verb: &str) -> bool {
+    matches!(
+        verb,
+        "play" | "stop" | "dtmf" | "hold" | "unhold" | "stream_start" | "stream_stop"
+    )
+}
+
+/// Resolve the command's channel target and mark the controller as having acted
+/// (clearing the answer-timeout handoff default). Shared by the synchronous SIP
+/// verbs and the asynchronous media verbs. Returns the typed error result to
+/// send back when the command carries no channel target.
+fn controlled_channel(command: &AdapterCommand) -> Result<ChannelRef, ControlResult> {
     let channel = match &command.target {
         ResolvedTarget::Channel(channel) => channel.clone(),
         ResolvedTarget::None => {
-            return ControlResult::error(
+            return Err(ControlResult::error(
                 ControlErrorCode::BadRequest,
                 format!("verb '{}' requires a channel target", command.verb),
-            );
+            ));
         }
     };
-
     // The controller has acted: clear the handoff deadline so the answer-timeout
     // sweep no longer applies the parked default action to this call.
     if let Some(store) = crate::b2bua::actor::global_call_store() {
         store.mark_controller_acted(&channel.call_actor_id);
     }
+    Ok(channel)
+}
+
+/// Dispatch one synchronous SIP verb (the imperative B2BUA rail is non-blocking)
+/// — returns the local result immediately.
+fn apply_sip(command: AdapterCommand) -> ControlResult {
+    let channel = match controlled_channel(&command) {
+        Ok(channel) => channel,
+        Err(result) => return result,
+    };
 
     match command.verb.as_str() {
         "answer" => answer(&channel, &command.args, true),
@@ -92,13 +128,308 @@ fn apply_sip(command: AdapterCommand) -> ControlResult {
         "refer" => refer(&channel, &command.args),
         "route" => route(&channel, &command.args),
         "set_header" => set_header(&channel, &command.args),
+        "remove_header" => remove_header(&channel, &command.args),
         "get_header" => get_header(&channel, &command.args),
-        // Media verbs (play/stop/dtmf/collect_dtmf) bind to MediaBackend and land
-        // with the AI-park mode — a typed error, never a hang.
         other => ControlResult::error(
             ControlErrorCode::UnsupportedVerb,
             format!("sip adapter does not implement verb '{other}' in this build"),
         ),
+    }
+}
+
+/// Dispatch one media verb asynchronously against the configured MediaBackend.
+///
+/// The `(media_call_id, from_tag)` tuple is resolved from the channel's SIP
+/// Call-ID via [`crate::dispatcher::b2bua_media_target`] (the stateless
+/// media-session accessor). A call with no anchored media session returns a typed
+/// `not_found` — never a hang, never a fabricated call-id. The verb `.await`s
+/// only the backend's *accept* of the command, not the far-end media outcome
+/// (playback completion, tee liveness), which arrives later as events.
+async fn apply_media_verb(command: AdapterCommand) -> ControlResult {
+    let channel = match controlled_channel(&command) {
+        Ok(channel) => channel,
+        Err(result) => return result,
+    };
+
+    match command.verb.as_str() {
+        "play" => play(&channel, &command.args).await,
+        "stop" => stop(&channel).await,
+        "dtmf" => dtmf(&channel, &command.args).await,
+        "hold" => hold(&channel, true).await,
+        "unhold" => hold(&channel, false).await,
+        "stream_start" => stream_start(&channel, &command.args).await,
+        "stream_stop" => stream_stop(&channel).await,
+        other => ControlResult::error(
+            ControlErrorCode::UnsupportedVerb,
+            format!("sip adapter does not implement verb '{other}' in this build"),
+        ),
+    }
+}
+
+/// Resolve the MediaBackend + media `(call_id, from_tag)` for a controlled call,
+/// or the typed `not_found` result to return when no media session is anchored.
+fn media_target(
+    channel: &ChannelRef,
+) -> Result<(std::sync::Arc<crate::rtpengine::MediaBackend>, String, String), ControlResult> {
+    crate::dispatcher::b2bua_media_target(&channel.sip_call_id).ok_or_else(|| {
+        ControlResult::error(
+            ControlErrorCode::NotFound,
+            "call has no anchored media session",
+        )
+    })
+}
+
+/// Map a [`crate::rtpengine::error::RtpEngineError`] to a typed control result —
+/// every media command answers, even on error, never a hang.
+///   - the engine has no such call → `not_found` (the media session is gone),
+///   - the backend can't do it (rtpproxy media / non-siphon-rtp ws_tee) →
+///     `unsupported_verb`,
+///   - anything else (transport, timeout, engine error) → `unavailable`.
+fn media_error(error: crate::rtpengine::error::RtpEngineError) -> ControlResult {
+    use crate::rtpengine::error::RtpEngineError;
+    if error.is_call_not_found() {
+        ControlResult::error(ControlErrorCode::NotFound, "media session is gone")
+    } else if matches!(error, RtpEngineError::Unsupported { .. }) {
+        ControlResult::error(ControlErrorCode::UnsupportedVerb, error.to_string())
+    } else {
+        ControlResult::error(ControlErrorCode::Unavailable, error.to_string())
+    }
+}
+
+/// Parse the `play` source args into a [`crate::rtpengine::client::PlayMediaSource`]:
+/// exactly one of `file` (path string), `db_id` (integer), or `blob` (base64
+/// string). Mirrors the script API's `resolve_play_media_source` (file/blob/db_id
+/// are mutually exclusive), with `blob` carried as base64 since the control wire
+/// is JSON text.
+fn parse_play_source(
+    args: &serde_json::Value,
+) -> Result<crate::rtpengine::client::PlayMediaSource, String> {
+    use crate::rtpengine::client::PlayMediaSource;
+    let file = args.get("file").and_then(|value| value.as_str());
+    let db_id = args.get("db_id").and_then(|value| value.as_u64());
+    let blob = args.get("blob").and_then(|value| value.as_str());
+    let count = [file.is_some(), db_id.is_some(), blob.is_some()]
+        .iter()
+        .filter(|present| **present)
+        .count();
+    if count != 1 {
+        return Err(
+            "play requires exactly one of args.file (path), args.db_id (int), or args.blob (base64)"
+                .to_string(),
+        );
+    }
+    if let Some(path) = file {
+        return Ok(PlayMediaSource::File(path.to_string()));
+    }
+    if let Some(id) = db_id {
+        return Ok(PlayMediaSource::DbId(id));
+    }
+    if let Some(encoded) = blob {
+        use base64::Engine as _;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|error| format!("play args.blob is not valid base64: {error}"))?;
+        return Ok(PlayMediaSource::Blob(bytes));
+    }
+    // Unreachable given count == 1, but return a typed error rather than panic.
+    Err("play requires a media source".to_string())
+}
+
+/// Parse an optional `channels` arg for `stream_start` (1 = mixed mono, 2 =
+/// caller/callee stereo). Absent → engine default (`None`).
+fn parse_stream_channels(value: Option<&serde_json::Value>) -> Result<Option<u8>, String> {
+    match value {
+        None => Ok(None),
+        Some(value) if value.is_null() => Ok(None),
+        Some(value) => match value.as_u64() {
+            Some(1) => Ok(Some(1)),
+            Some(2) => Ok(Some(2)),
+            _ => Err("stream_start args.channels must be 1 (mono) or 2 (stereo)".to_string()),
+        },
+    }
+}
+
+/// `play` — start an announcement on the A-leg's media. Fire-and-forget: `wait`
+/// is false, so this returns on the backend's *accept*, never blocking on
+/// playback completion (the far-end result is not the command reply).
+async fn play(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let source = match parse_play_source(args) {
+        Ok(source) => source,
+        Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
+    };
+    let repeat = args.get("repeat").and_then(|value| value.as_u64());
+    let start_ms = args.get("start_ms").and_then(|value| value.as_u64());
+    let duration_ms = args.get("duration_ms").and_then(|value| value.as_u64());
+    let to_tag = args
+        .get("to_tag")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+
+    let (backend, call_id, from_tag) = match media_target(channel) {
+        Ok(target) => target,
+        Err(result) => return result,
+    };
+    match backend
+        .play_media(
+            &call_id,
+            &from_tag,
+            &source,
+            repeat,
+            start_ms,
+            duration_ms,
+            to_tag.as_deref(),
+            false,
+        )
+        .await
+    {
+        Ok(_) => ControlResult::Ok(
+            serde_json::json!({ "channel": channel.channel_id, "state": "playing" }),
+        ),
+        Err(error) => media_error(error),
+    }
+}
+
+/// `stop` — stop any prompt currently playing on the A-leg's media.
+async fn stop(channel: &ChannelRef) -> ControlResult {
+    let (backend, call_id, from_tag) = match media_target(channel) {
+        Ok(target) => target,
+        Err(result) => return result,
+    };
+    match backend.stop_media(&call_id, &from_tag).await {
+        Ok(()) => ControlResult::Ok(
+            serde_json::json!({ "channel": channel.channel_id, "state": "stopped" }),
+        ),
+        Err(error) => media_error(error),
+    }
+}
+
+/// `dtmf` — inject DTMF digits toward the A-leg (fire-and-forget).
+async fn dtmf(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let digits = match args
+        .get("digits")
+        .or_else(|| args.get("code"))
+        .and_then(|value| value.as_str())
+    {
+        Some(digits) if !digits.is_empty() => digits.to_string(),
+        Some(_) => {
+            return ControlResult::error(
+                ControlErrorCode::BadRequest,
+                "dtmf args.digits must be a non-empty string",
+            );
+        }
+        None => {
+            return ControlResult::error(ControlErrorCode::BadRequest, "dtmf requires args.digits");
+        }
+    };
+    let duration_ms = args.get("duration_ms").and_then(|value| value.as_u64());
+    let volume_dbm0 = args.get("volume_dbm0").and_then(|value| value.as_i64());
+    let pause_ms = args.get("pause_ms").and_then(|value| value.as_u64());
+    let to_tag = args
+        .get("to_tag")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+
+    let (backend, call_id, from_tag) = match media_target(channel) {
+        Ok(target) => target,
+        Err(result) => return result,
+    };
+    match backend
+        .play_dtmf(
+            &call_id,
+            &from_tag,
+            &digits,
+            duration_ms,
+            volume_dbm0,
+            pause_ms,
+            to_tag.as_deref(),
+        )
+        .await
+    {
+        Ok(()) => ControlResult::Ok(
+            serde_json::json!({ "channel": channel.channel_id, "state": "playing", "digits": digits }),
+        ),
+        Err(error) => media_error(error),
+    }
+}
+
+/// `hold` / `unhold` — gentle media hold via silence. `hold` → `silence_media`,
+/// `unhold` → `unsilence_media` (drop/undrop of packets, `block_media`, is a
+/// separate future gate verb — deliberately not exposed here).
+async fn hold(channel: &ChannelRef, engage: bool) -> ControlResult {
+    let (backend, call_id, from_tag) = match media_target(channel) {
+        Ok(target) => target,
+        Err(result) => return result,
+    };
+    let outcome = if engage {
+        backend.silence_media(&call_id, &from_tag).await
+    } else {
+        backend.unsilence_media(&call_id, &from_tag).await
+    };
+    match outcome {
+        Ok(()) => {
+            let state = if engage { "held" } else { "unheld" };
+            ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "state": state }))
+        }
+        Err(error) => media_error(error),
+    }
+}
+
+/// `stream_start` — attach a WebSocket audio tee streaming a copy of the call's
+/// decoded audio to `ws_uri` while the call keeps relaying. siphon-rtp backend
+/// only: rtpengine / rtpproxy return `unsupported_verb` (a hollow success would
+/// read as "the tee is attached" while nothing reaches the consumer).
+async fn stream_start(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let Some(ws_uri) = args.get("ws_uri").and_then(|value| value.as_str()) else {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "stream_start requires args.ws_uri",
+        );
+    };
+    let ws_uri = ws_uri.to_string();
+    let direction = match args.get("direction").and_then(|value| value.as_str()) {
+        None => crate::rtpengine::profile::WsTeeDirection::Both,
+        Some(value) => match crate::rtpengine::profile::WsTeeDirection::parse(value) {
+            Some(direction) => direction,
+            None => {
+                return ControlResult::error(
+                    ControlErrorCode::BadRequest,
+                    format!("stream_start args.direction must be one of both/caller/callee, got '{value}'"),
+                );
+            }
+        },
+    };
+    let channels = match parse_stream_channels(args.get("channels")) {
+        Ok(channels) => channels,
+        Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
+    };
+
+    let (backend, call_id, from_tag) = match media_target(channel) {
+        Ok(target) => target,
+        Err(result) => return result,
+    };
+    match backend
+        .attach_ws_tee(&call_id, &from_tag, &ws_uri, direction, channels)
+        .await
+    {
+        Ok(()) => ControlResult::Ok(
+            serde_json::json!({ "channel": channel.channel_id, "state": "streaming" }),
+        ),
+        Err(error) => media_error(error),
+    }
+}
+
+/// `stream_stop` — detach the WebSocket audio tee (idempotent on siphon-rtp;
+/// `unsupported_verb` on the other backends, same reason as `stream_start`).
+async fn stream_stop(channel: &ChannelRef) -> ControlResult {
+    let (backend, call_id, from_tag) = match media_target(channel) {
+        Ok(target) => target,
+        Err(result) => return result,
+    };
+    match backend.detach_ws_tee(&call_id, &from_tag).await {
+        Ok(()) => ControlResult::Ok(
+            serde_json::json!({ "channel": channel.channel_id, "state": "detached" }),
+        ),
+        Err(error) => media_error(error),
     }
 }
 
@@ -384,6 +715,26 @@ fn set_header(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
     ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "header": name }))
 }
 
+/// Remove a header from the stored A-leg INVITE (mirror of [`set_header`], using
+/// the `Headers::remove` API). `removed` reports whether the header was present.
+fn remove_header(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let Some(name) = args.get("name").and_then(|v| v.as_str()) else {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "remove_header requires args.name",
+        );
+    };
+    let Some(invite_arc) = stored_invite(&channel.call_actor_id) else {
+        return ControlResult::error(ControlErrorCode::NotFound, "call is gone");
+    };
+    let Ok(mut invite) = invite_arc.lock() else {
+        return ControlResult::error(ControlErrorCode::Unavailable, "call invite lock poisoned");
+    };
+    let was_present = invite.headers.has(name);
+    invite.headers.remove(name);
+    ControlResult::Ok(serde_json::json!({ "channel": channel.channel_id, "header": name, "removed": was_present }))
+}
+
 fn get_header(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
     let Some(name) = args.get("name").and_then(|v| v.as_str()) else {
         return ControlResult::error(ControlErrorCode::BadRequest, "get_header requires args.name");
@@ -421,7 +772,24 @@ mod tests {
         let schema = SipControlAdapter::new().describe();
         assert_eq!(schema.module, "sip");
         let verbs: Vec<&str> = schema.verbs.iter().map(|v| v.verb.as_str()).collect();
-        for expected in ["answer", "progress", "reject", "hangup", "refer", "route"] {
+        for expected in [
+            "answer",
+            "progress",
+            "reject",
+            "hangup",
+            "refer",
+            "route",
+            "set_header",
+            "remove_header",
+            "get_header",
+            "play",
+            "stop",
+            "dtmf",
+            "hold",
+            "unhold",
+            "stream_start",
+            "stream_stop",
+        ] {
             assert!(verbs.contains(&expected), "missing verb {expected}");
         }
     }
@@ -453,18 +821,259 @@ mod tests {
     }
 
     #[test]
-    fn media_verb_is_unsupported_not_a_hang() {
-        for verb in ["play", "stop", "dtmf", "collect_dtmf"] {
-            let result = apply_sip(AdapterCommand {
-                verb: verb.to_string(),
-                args: serde_json::json!({}),
-                target: ResolvedTarget::Channel(channel()),
-            });
+    fn is_media_verb_splits_media_from_sip() {
+        for verb in ["play", "stop", "dtmf", "hold", "unhold", "stream_start", "stream_stop"] {
+            assert!(is_media_verb(verb), "{verb} should route to the async media path");
+        }
+        for verb in ["answer", "progress", "reject", "hangup", "refer", "route", "set_header", "remove_header", "get_header", "collect_dtmf", "teleport"] {
+            assert!(!is_media_verb(verb), "{verb} should NOT route to the async media path");
+        }
+    }
+
+    #[tokio::test]
+    async fn media_verbs_without_dispatcher_are_not_found_not_a_hang() {
+        // The media verbs now EXIST (they no longer fall to unsupported_verb).
+        // With no B2BUA_CONTROL installed, b2bua_media_target() is None, so each
+        // resolves to a typed not_found and returns immediately — never a hang,
+        // never a fabricated call-id. Args are well-formed so resolution is
+        // reached (not short-circuited on a bad_request).
+        let cases = [
+            ("play", serde_json::json!({ "file": "/prompts/welcome.wav" })),
+            ("stop", serde_json::json!({})),
+            ("dtmf", serde_json::json!({ "digits": "123#" })),
+            ("hold", serde_json::json!({})),
+            ("unhold", serde_json::json!({})),
+            ("stream_start", serde_json::json!({ "ws_uri": "ws://ai:9000/stream" })),
+            ("stream_stop", serde_json::json!({})),
+        ];
+        let adapter = SipControlAdapter::new();
+        for (verb, args) in cases {
+            let result = adapter
+                .apply(AdapterCommand {
+                    verb: verb.to_string(),
+                    args,
+                    target: ResolvedTarget::Channel(channel()),
+                })
+                .await;
             assert!(
-                matches!(result, ControlResult::Error { code: ControlErrorCode::UnsupportedVerb, .. }),
-                "verb {verb} should be a typed unsupported error"
+                matches!(result, ControlResult::Error { code: ControlErrorCode::NotFound, .. }),
+                "media verb {verb} without a dispatcher should be not_found, got {result:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn play_without_a_source_is_bad_request() {
+        // Parsed before media-target resolution, so it holds with no dispatcher.
+        let result = play(&channel(), &serde_json::json!({})).await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn play_with_two_sources_is_bad_request() {
+        let result = play(
+            &channel(),
+            &serde_json::json!({ "file": "/a.wav", "db_id": 7 }),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn dtmf_without_digits_is_bad_request() {
+        let missing = dtmf(&channel(), &serde_json::json!({})).await;
+        assert!(matches!(
+            missing,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+        let empty = dtmf(&channel(), &serde_json::json!({ "digits": "" })).await;
+        assert!(matches!(
+            empty,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn stream_start_without_ws_uri_is_bad_request() {
+        let result = stream_start(&channel(), &serde_json::json!({})).await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn stream_start_with_bad_direction_is_bad_request() {
+        let result = stream_start(
+            &channel(),
+            &serde_json::json!({ "ws_uri": "ws://ai:9000", "direction": "sideways" }),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn stream_start_with_bad_channels_is_bad_request() {
+        let result = stream_start(
+            &channel(),
+            &serde_json::json!({ "ws_uri": "ws://ai:9000", "channels": 3 }),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn parse_play_source_variants() {
+        use crate::rtpengine::client::PlayMediaSource;
+        // file
+        assert!(matches!(
+            parse_play_source(&serde_json::json!({ "file": "/p.wav" })),
+            Ok(PlayMediaSource::File(path)) if path == "/p.wav"
+        ));
+        // db_id
+        assert!(matches!(
+            parse_play_source(&serde_json::json!({ "db_id": 42 })),
+            Ok(PlayMediaSource::DbId(42))
+        ));
+        // blob (base64 of "hi")
+        assert!(matches!(
+            parse_play_source(&serde_json::json!({ "blob": "aGk=" })),
+            Ok(PlayMediaSource::Blob(bytes)) if bytes == b"hi"
+        ));
+        // none / two → error
+        assert!(parse_play_source(&serde_json::json!({})).is_err());
+        assert!(parse_play_source(&serde_json::json!({ "file": "/a", "db_id": 1 })).is_err());
+        // invalid base64 → error
+        assert!(parse_play_source(&serde_json::json!({ "blob": "not base64!!" })).is_err());
+    }
+
+    #[test]
+    fn parse_stream_channels_bounds() {
+        assert_eq!(parse_stream_channels(None), Ok(None));
+        assert_eq!(parse_stream_channels(Some(&serde_json::Value::Null)), Ok(None));
+        assert_eq!(parse_stream_channels(Some(&serde_json::json!(1))), Ok(Some(1)));
+        assert_eq!(parse_stream_channels(Some(&serde_json::json!(2))), Ok(Some(2)));
+        assert!(parse_stream_channels(Some(&serde_json::json!(3))).is_err());
+        assert!(parse_stream_channels(Some(&serde_json::json!(0))).is_err());
+    }
+
+    #[test]
+    fn media_error_maps_each_backend_error() {
+        use crate::rtpengine::error::RtpEngineError;
+        // Engine has no such call → not_found.
+        assert!(matches!(
+            media_error(RtpEngineError::EngineError("Unknown call-id".to_string())),
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+        // Backend can't do it → unsupported_verb.
+        assert!(matches!(
+            media_error(RtpEngineError::Unsupported { operation: "attach_ws_tee", backend: "rtpengine" }),
+            ControlResult::Error { code: ControlErrorCode::UnsupportedVerb, .. }
+        ));
+        // Anything else → unavailable.
+        assert!(matches!(
+            media_error(RtpEngineError::Timeout { timeout_ms: 1000 }),
+            ControlResult::Error { code: ControlErrorCode::Unavailable, .. }
+        ));
+    }
+
+    #[test]
+    fn remove_header_without_name_is_bad_request() {
+        let result = remove_header(&channel(), &serde_json::json!({}));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn remove_header_dispatches_through_apply_sip() {
+        // Prove the "remove_header" arm is wired in apply_sip: with a name but no
+        // stored invite (no call store for this call), it reaches remove_header and
+        // returns not_found — not the unsupported_verb catch-all.
+        let result = apply_sip(AdapterCommand {
+            verb: "remove_header".to_string(),
+            args: serde_json::json!({ "name": "X-Foo" }),
+            target: ResolvedTarget::Channel(channel()),
+        });
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[test]
+    fn remove_header_removes_from_the_stored_invite() {
+        use crate::b2bua::actor::{CallActorStore, Leg, TransportInfo};
+        use crate::transport::{ConnectionId, Transport};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        use std::sync::{Arc, Mutex};
+
+        // Build an A-leg INVITE carrying an X-Remove-Me header, park it in a fresh
+        // call store, and install that store globally (unique call-actor-id so it
+        // never collides with other tests that expect their own call absent).
+        let raw = concat!(
+            "INVITE sip:bob@biloxi.com SIP/2.0\r\n",
+            "Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bK-rm1\r\n",
+            "From: <sip:alice@atlanta.com>;tag=rmtag\r\n",
+            "To: <sip:bob@biloxi.com>\r\n",
+            "Call-ID: remove-header-call@atlanta.com\r\n",
+            "CSeq: 1 INVITE\r\n",
+            "X-Remove-Me: please\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        );
+        let invite = crate::sip::parser::parse_sip_message_bytes(raw.as_bytes()).unwrap();
+        assert!(invite.headers.has("X-Remove-Me"));
+        let invite_arc = Arc::new(Mutex::new(invite));
+
+        let store = Arc::new(CallActorStore::new());
+        let transport = TransportInfo {
+            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 5060),
+            connection_id: ConnectionId::default(),
+            transport: Transport::Udp,
+            local_addr: None,
+        };
+        let a_leg = Leg::new_a_leg(
+            "remove-header-call@atlanta.com".to_string(),
+            "rmtag".to_string(),
+            "z9hG4bK-rm1".to_string(),
+            transport,
+        );
+        let internal_call_id = store.create_call(a_leg);
+        store.set_a_leg_invite(&internal_call_id, Arc::clone(&invite_arc));
+        crate::b2bua::actor::set_global_call_store(Arc::clone(&store));
+
+        let controlled = ChannelRef {
+            channel_id: "ch-rm".to_string(),
+            call_actor_id: internal_call_id,
+            sip_call_id: "remove-header-call@atlanta.com".to_string(),
+            app: "ivr-app".to_string(),
+        };
+
+        let result = remove_header(&controlled, &serde_json::json!({ "name": "X-Remove-Me" }));
+        // was_present = true → removed: true.
+        match result {
+            ControlResult::Ok(value) => {
+                assert_eq!(value.get("removed").and_then(|v| v.as_bool()), Some(true));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+        // The header is really gone from the stored invite.
+        let invite = invite_arc.lock().unwrap();
+        assert!(!invite.headers.has("X-Remove-Me"));
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17208,6 +17208,39 @@ pub fn b2bua_route_call(
     Ok(true)
 }
 
+/// Resolve the A-leg media session of a controlled B2BUA call into the tuple the
+/// [`crate::rtpengine::MediaBackend`] keys on — `(backend, media_call_id, from_tag)`
+/// — for the SIP control adapter's media verbs (`play` / `stop` / `dtmf` /
+/// `hold` / `unhold` / `stream_start` / `stream_stop`).
+///
+/// The media backend does **not** key on the SIP Call-ID: it keys on the media
+/// call-id ([`crate::rtpengine::session::MediaSession::rtpengine_id`], which a
+/// siphon-terminated transfer can re-anchor to a fresh id) plus the A-leg SIP
+/// From-tag. The control adapter only holds the SIP Call-ID
+/// (`ChannelRef.sip_call_id`), so this reuses the exact resolution the dispatcher
+/// itself uses for re-INVITE / SIPREC media rewriting:
+/// `rtpengine_sessions.get(sip_call_id)` (the store is keyed by the A-leg SIP
+/// Call-ID) → `session.rtpengine_id()` + `session.from_tag`.
+///
+/// Returns `None` — mapped by the adapter to a typed `not_found`, never a
+/// fabricated call-id — when the dispatcher is not running, no media backend is
+/// configured, or the call has no anchored media session (already torn down, or
+/// never anchored). The accessor is **stateless** (a `OnceLock` read + a
+/// `DashMap` get + an `Arc` clone): it adds no per-call store of its own, so it
+/// needs no co-located leak test.
+pub fn b2bua_media_target(
+    sip_call_id: &str,
+) -> Option<(Arc<crate::rtpengine::MediaBackend>, String, String)> {
+    let control = B2BUA_CONTROL.get()?;
+    let backend = control.state.rtpengine_set.clone()?;
+    let session = control.state.rtpengine_sessions.as_ref()?.get(sip_call_id)?;
+    Some((
+        backend,
+        session.rtpengine_id().to_string(),
+        session.from_tag.clone(),
+    ))
+}
+
 /// Build and send a UAS response (final 2xx or provisional 1xx) for a B2BUA call
 /// from an imperative `call.answer()` / `call.progress()`.
 ///
@@ -20352,6 +20385,14 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    #[test]
+    fn b2bua_media_target_is_none_without_dispatcher() {
+        // No B2BUA_CONTROL installed in a unit-test binary → the media-target
+        // accessor resolves to None (the SIP control adapter maps that to a typed
+        // not_found), never a fabricated call-id and never a panic.
+        assert!(b2bua_media_target("sip-call-id@host").is_none());
+    }
 
     // -----------------------------------------------------------------------
     // Transport failure / timeout must become a response (RFC 3261 §16.7, §16.9)

--- a/src/rtpengine/rtpproxy.rs
+++ b/src/rtpengine/rtpproxy.rs
@@ -582,11 +582,17 @@ fn generate_cookie() -> String {
 }
 
 /// Error for the rtpengine-only verbs that rtpproxy cannot serve.
-fn unsupported(operation: &str) -> RtpEngineError {
-    RtpEngineError::EngineError(format!(
-        "rtpproxy backend does not support '{operation}' \
-         (use the rtpengine or siphon-rtp backend)"
-    ))
+///
+/// Uses the typed [`RtpEngineError::Unsupported`] variant (not a generic
+/// `EngineError`) so callers — the Python `rtpengine` namespace and the SIP
+/// control adapter's media verbs — can map "this backend has no way to do it" to
+/// a stable outcome (`unsupported_verb`) rather than a misleading transient
+/// `unavailable`. `operation` is always a static string literal at the call site.
+fn unsupported(operation: &'static str) -> RtpEngineError {
+    RtpEngineError::Unsupported {
+        operation,
+        backend: "rtpproxy",
+    }
 }
 
 /// Build the modifier suffix for a `U`/`L` command from the profile flags and
@@ -1245,7 +1251,10 @@ mod tests {
         let address = spawn_mock_rtpproxy("203.0.113.1", 30000).await;
         let set = RtpProxyClientSet::new(vec![(address, 1000, 1)], 1).await.unwrap();
         let error = set.silence_media("c1", "ft").await.unwrap_err();
-        assert!(matches!(error, RtpEngineError::EngineError(_)));
-        assert!(error.to_string().contains("does not support"));
+        assert!(matches!(
+            error,
+            RtpEngineError::Unsupported { operation: "silence_media", backend: "rtpproxy" }
+        ));
+        assert!(error.to_string().contains("not supported"));
     }
 }

--- a/tests/integration/rtpproxy_tests.rs
+++ b/tests/integration/rtpproxy_tests.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use siphon::rtpengine::profile::NgFlags;
-use siphon::rtpengine::{MediaBackend, RtpProxyClientSet};
+use siphon::rtpengine::{MediaBackend, RtpEngineError, RtpProxyClientSet};
 use siphon::sip::parser::parse_sip_message;
 
 use bytes::BytesMut;
@@ -108,9 +108,12 @@ async fn media_backend_rtpproxy_unsupported_op_errors_cleanly() {
     let set = RtpProxyClientSet::new(vec![(address, 1000, 1)], 2).await.unwrap();
     let backend = MediaBackend::RtpProxy(set);
 
-    // rtpengine-only verbs must surface a clear error, not panic or hang.
+    // rtpengine-only verbs must surface a clear typed error, not panic or hang.
     let error = backend.silence_media("c1", "ft").await.unwrap_err();
-    assert!(error.to_string().contains("does not support"), "{error}");
+    assert!(
+        matches!(error, RtpEngineError::Unsupported { backend: "rtpproxy", .. }),
+        "{error}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Adds header-remove + media-control verbs to the `sip` control adapter
(`siphon-control.v1`), reaching the configured media backend through a new
stateless imperative-rail accessor.

New verbs on the `sip` module:

| verb | args | action |
|---|---|---|
| `remove_header` | `{name}` | remove a header from the stored A-leg INVITE (mirror of `set_header`) |
| `play` | one of `{file\|db_id\|blob}`, `repeat?`, `start_ms?`, `duration_ms?`, `to_tag?` | play an announcement, **fire-and-forget** |
| `stop` | — | stop the current announcement |
| `dtmf` | `{digits, duration_ms?, volume_dbm0?, pause_ms?, to_tag?}` | inject DTMF |
| `hold` / `unhold` | — | media hold via silence |
| `stream_start` | `{ws_uri, direction?, channels?}` | attach a WebSocket audio tee |
| `stream_stop` | — | detach the WebSocket audio tee |

## How

The media backend does **not** key on the SIP Call-ID — it keys on the media
call-id (`MediaSession::rtpengine_id`, which a siphon-terminated transfer can
re-anchor to a fresh id) plus the A-leg SIP From-tag. The control adapter only
holds the SIP Call-ID (`ChannelRef.sip_call_id`), so this adds a new stateless
accessor `dispatcher::b2bua_media_target(sip_call_id) -> Option<(Arc<MediaBackend>,
media_call_id, from_tag)>` that reuses the exact resolution the dispatcher already
uses for re-INVITE / SIPREC media (`rtpengine_sessions.get(sip_call_id)` →
`session.rtpengine_id()` + `session.from_tag`). It adds no per-call store (a
`OnceLock` read + a `DashMap` get + an `Arc` clone), so no co-located leak test is
needed.

The media verbs run on the adapter's already-async `apply` path (they `.await`
the backend's *accept* of the command, not the far-end media outcome); the
header/other verbs stay on the synchronous rail. `play` passes `wait=false` — the
reply confirms acceptance, it never blocks on prompt completion.

Notes:

- **`hold` = silence / `unhold` = unsilence** (a gentle hold that keeps the media
  path up). Dropping packets outright (`block`/`unblock`) is deliberately left as
  a separate future gate verb.
- **`stream_start`/`stream_stop` are `siphon-rtp`-backend only** — an *additive*
  WebSocket tee (a copy of the live audio), not a media takeover. On rtpengine /
  rtpproxy they answer `unsupported_verb` rather than a hollow success.
- **Typed replies, never a hang**: no anchored media session → `not_found`; a
  backend that can't perform the op → `unsupported_verb`; any other backend
  failure → `unavailable`. Success → `{channel, state}` (`playing` / `stopped` /
  `held` / `unheld` / `streaming` / `detached`).
- Also switches rtpproxy's rtpengine-only-verb error from a generic `EngineError`
  to the typed `RtpEngineError::Unsupported` variant, so the adapter (and the
  Python `rtpengine` namespace) map "this backend can't" to a stable
  `unsupported_verb` rather than a misleading transient `unavailable`.

Server-side only. The client SDK facade methods for these verbs and the release
are separate follow-ups; reach the verbs meanwhile through the generic
`command(verb, args)` escape hatch.

## Tests

- Adapter: arg-parsing bad_request paths for every verb, `remove_header` really
  removes from a stored invite (installs a call store with an A-leg INVITE),
  `describe()` lists the new verbs, `apply_sip`/`apply` dispatch reaches each arm,
  and the old `media_verb_is_unsupported_not_a_hang` test is replaced — media
  verbs now exist, so they return `not_found` (not a hang) with no dispatcher, and
  an unknown verb still errors.
- Rail: `b2bua_media_target` returns `None` cleanly when nothing is installed.
- `media_error` maps each backend error to its control code.

`cargo test` (3854 passed, 7 ignored) and
`cargo clippy --all-targets --all-features -- -D warnings` are green.
