### PR TITLE
fix(config): resolve a relative script.path against the config file's directory so siphon starts under systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Fixed
+- **A relative `script.path` now resolves against the config file's directory,
+  so siphon starts under a supervisor.** It was resolved against the process
+  working directory, which is the config directory when you run siphon by hand
+  and `/` under systemd. The packaged `siphon.yaml` ships
+  `script.path: "scripts/proxy_default.py"`, so the packaged unit looked for
+  `/scripts/proxy_default.py`, failed the script load, exited non-zero and
+  restart-looped — while the same config started fine from `/etc/siphon`. A
+  container `WORKDIR` or an embedding binary that chdirs hit the same trap.
+  `script.include_paths` is anchored the same way. The rewrite only applies
+  when the config-relative file exists, so a config that relies on the working
+  directory keeps resolving as before; this can only make a previously-failing
+  config start. `Config::from_str` is unchanged (no file to anchor on), and the
+  startup log line prints the resolved path.
+- **The packaged systemd unit can write its state and log directories.**
+  `ProtectSystem=strict` was paired with `ReadWritePaths=/var/lib/siphon` only,
+  while every default write path (`cdr.file.path` at `/var/log/siphon/cdr.jsonl`,
+  `lawful_intercept.audit_log`, the `log.file` example) lives under `/var/log`,
+  which was read-only and never created. The unit now declares
+  `StateDirectory=siphon` and `LogsDirectory=siphon`, so systemd creates both
+  owned by the service user, and pins `WorkingDirectory=/etc/siphon`. It also
+  documents, as commented lines, the `CAP_NET_ADMIN` + `AF_NETLINK` an IMS
+  P-CSCF needs for `ipsec:` sec-agree.
+
 ### Added
 - **SIGTRAN/SS7 extension module.** `siphon-bin` gains a `sigtran` feature that
   composes [siphon-sigtran](https://github.com/siphon-project/siphon-sigtran)

--- a/dist/siphon.service
+++ b/dist/siphon.service
@@ -1,11 +1,17 @@
 [Unit]
 Description=SIPhon SIP Proxy and B2BUA
-Documentation=https://github.com/siphon-project/siphon
+Documentation=https://siphon-sip.org/
+Documentation=https://github.com/siphon-project/siphon-sip
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
+# A relative script.path in siphon.yaml is resolved against the config
+# file's directory, but anything else relative in the config (and any
+# relative path a script itself opens) still follows the working
+# directory, so pin it to where the config lives.
+WorkingDirectory=/etc/siphon
 ExecStart=/usr/bin/siphon --config /etc/siphon/siphon.yaml
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
@@ -19,15 +25,26 @@ Group=siphon
 # File system
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/var/lib/siphon
 ReadOnlyPaths=/etc/siphon
 PrivateTmp=yes
+
+# Writable state and logs. ProtectSystem=strict leaves the whole of /var
+# read-only, so these are what make registrar persistence, recordings,
+# CDR files and log.file work at all — they create the directories owned
+# by the service user and add them to the writable set.
+StateDirectory=siphon
+LogsDirectory=siphon
 
 # Capabilities — SIP typically needs to bind to privileged ports (5060)
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
-# Network
+# Network. AF_NETLINK is deliberately absent — add it, together with
+# CAP_NET_ADMIN, only for an IMS P-CSCF using the ipsec: sec-agree block,
+# which installs kernel XFRM state:
+#   RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+#   AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+#   CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
 # Misc hardening

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,6 +145,21 @@ install — you enable it explicitly. Building the packages yourself, and the
 from-source path, are covered in the
 [README](https://github.com/siphon-project/siphon-sip#installation).
 
+If the unit does not come up, `journalctl -u siphon -n 50` has the reason: siphon
+exits non-zero on a config or script error, so `Restart=on-failure` turns any
+such error into a restart loop rather than a running-but-broken proxy. Two
+things the sandboxed unit imposes that a manual run does not:
+
+- **Writable paths.** `ProtectSystem=strict` leaves the filesystem read-only
+  apart from `/var/lib/siphon` and `/var/log/siphon`. Point `log.file`,
+  `cdr.file.path`, registrar persistence and recordings inside those.
+- **Capabilities.** The unit grants `CAP_NET_BIND_SERVICE` only. An IMS P-CSCF
+  using the `ipsec:` sec-agree block also needs `CAP_NET_ADMIN` and `AF_NETLINK`
+  — the unit ships both as commented lines.
+
+Override either with `systemctl edit siphon` rather than editing the packaged
+unit, which an upgrade replaces.
+
 ### Running a native binary directly
 
 ```bash

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -1221,7 +1221,10 @@ auth:
 log:
   level: info      # debug | info | warn | error
   format: pretty   # pretty (human-readable) | json (structured, for log aggregators)
-  # file: /var/log/siphon.log   # optional: also write logs to file (for logrotate)
+  # Optional: also write logs to a file (for logrotate). The packaged systemd
+  # unit runs with ProtectSystem=strict, so only /var/log/siphon and
+  # /var/lib/siphon are writable — keep this and cdr.file.path inside them.
+  # file: /var/log/siphon/siphon.log
 
 # External remote-control plane (ARI/ESL-class). A management plane — OFF by
 # default. An out-of-process app drives calls a Python @b2bua.on_invite handler

--- a/src/config.rs
+++ b/src/config.rs
@@ -3496,11 +3496,60 @@ pub enum LogFormat {
 
 impl Config {
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
-        let content = std::fs::read_to_string(path.as_ref()).map_err(|e| {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path).map_err(|e| {
             SiphonError::Config(format!("cannot read siphon.yaml: {e}"))
         })?;
         let expanded = expand_env_vars(&content);
-        Self::from_str_raw(&expanded)
+        let mut config = Self::from_str_raw(&expanded)?;
+        config.anchor_script_paths(path);
+        Ok(config)
+    }
+
+    /// Re-anchor a relative `script.path` / `script.include_paths` on the
+    /// directory holding the config file.
+    ///
+    /// Both are resolved against the process working directory
+    /// (`ScriptEngine::new` does `PathBuf::from(&config.path)`), which is fine
+    /// when siphon is started from its config directory and wrong under any
+    /// supervisor. systemd hands a unit `/` as its working directory, so the
+    /// packaged `script.path: "scripts/proxy_default.py"` resolves to
+    /// `/scripts/proxy_default.py`, the script load fails, and the service
+    /// restart-loops — while the identical config starts by hand from
+    /// `/etc/siphon`. Same trap for a container `WORKDIR` and for an embedding
+    /// binary that chdirs.
+    ///
+    /// A relative entry therefore now prefers the config-relative location, the
+    /// way nginx and Kamailio resolve a relative include. The rewrite only
+    /// happens when the candidate actually exists, so a config that relies on
+    /// the working directory keeps resolving exactly as before — this can make
+    /// a previously-failing config start, never the reverse.
+    ///
+    /// Only applies to `from_file`: `from_str` has no file to anchor on.
+    fn anchor_script_paths(&mut self, config_path: &Path) {
+        let Some(config_dir) = config_path.parent() else {
+            return;
+        };
+        // A bare `siphon.yaml` yields an empty parent, which would turn every
+        // relative path into itself — nothing to anchor on.
+        if config_dir.as_os_str().is_empty() {
+            return;
+        }
+
+        let anchor = |value: &mut String| {
+            if Path::new(&*value).is_absolute() {
+                return;
+            }
+            let candidate = config_dir.join(&*value);
+            if candidate.exists() {
+                *value = candidate.to_string_lossy().into_owned();
+            }
+        };
+
+        anchor(&mut self.script.path);
+        for include_path in &mut self.script.include_paths {
+            anchor(include_path);
+        }
     }
 
     #[allow(clippy::should_implement_trait)]
@@ -3996,6 +4045,167 @@ tls:
         assert!(config.registrant.is_none());
         assert!(config.lawful_intercept.is_none());
         assert!(config.diameter.is_none());
+    }
+
+    // --- script path anchoring (Config::from_file) ---
+
+    /// Build a config dir holding `siphon.yaml` plus a `scripts/main.py`, and
+    /// return `(tempdir, config_path)`.
+    fn config_dir_with_script(script_body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("scripts")).unwrap();
+        std::fs::write(dir.path().join("scripts/main.py"), script_body).unwrap();
+        let config_path = dir.path().join("siphon.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/main.py"
+  include_paths:
+    - "lib"
+    - "/etc/siphon/shared"
+auth:
+  realm: "example.com"
+"#,
+        )
+        .unwrap();
+        (dir, config_path)
+    }
+
+    /// The systemd case: the working directory is not the config directory, so
+    /// a relative `script.path` must still resolve.
+    #[test]
+    fn relative_script_path_anchors_on_config_dir() {
+        let (dir, config_path) = config_dir_with_script("# script\n");
+
+        let config = Config::from_file(&config_path).unwrap();
+
+        assert_eq!(
+            config.script.path,
+            dir.path().join("scripts/main.py").to_string_lossy()
+        );
+        assert!(std::path::Path::new(&config.script.path).exists());
+    }
+
+    #[test]
+    fn relative_include_paths_anchor_on_config_dir() {
+        let (dir, config_path) = config_dir_with_script("# script\n");
+        std::fs::create_dir(dir.path().join("lib")).unwrap();
+
+        let config = Config::from_file(&config_path).unwrap();
+
+        assert_eq!(
+            config.script.include_paths,
+            vec![
+                dir.path().join("lib").to_string_lossy().into_owned(),
+                // Absolute entries are never touched.
+                "/etc/siphon/shared".to_string(),
+            ]
+        );
+    }
+
+    /// Anchoring must not change a config that already worked: when there is no
+    /// config-relative candidate, the value is left alone so the process
+    /// working directory still resolves it (and the same "script not found"
+    /// error still names what the operator wrote).
+    #[test]
+    fn missing_config_relative_candidate_leaves_path_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("siphon.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/absent.py"
+  include_paths:
+    - "absent-lib"
+auth:
+  realm: "example.com"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::from_file(&config_path).unwrap();
+
+        assert_eq!(config.script.path, "scripts/absent.py");
+        assert_eq!(config.script.include_paths, vec!["absent-lib".to_string()]);
+    }
+
+    /// An absolute `script.path` is never rewritten, even when a same-named
+    /// file sits beside the config.
+    #[test]
+    fn absolute_script_path_is_not_anchored() {
+        let dir = tempfile::tempdir().unwrap();
+        let elsewhere = dir.path().join("elsewhere.py");
+        std::fs::write(&elsewhere, "# script\n").unwrap();
+        let config_path = dir.path().join("siphon.yaml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "{}"
+auth:
+  realm: "example.com"
+"#,
+                elsewhere.display()
+            ),
+        )
+        .unwrap();
+
+        let config = Config::from_file(&config_path).unwrap();
+
+        assert_eq!(config.script.path, elsewhere.to_string_lossy());
+    }
+
+    /// `from_str` has no file to anchor on and must stay byte-for-byte what the
+    /// caller wrote (embedding / `--config-string` path).
+    #[test]
+    fn from_str_does_not_anchor_script_path() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/main.py"
+auth:
+  realm: "example.com"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert_eq!(config.script.path, "scripts/main.py");
+    }
+
+    /// A bare filename config (`siphon --config siphon.yaml`) has an empty
+    /// parent — anchoring is a no-op rather than a self-join.
+    #[test]
+    fn bare_config_filename_anchors_nothing() {
+        let mut config = Config::from_str(minimal_yaml()).unwrap();
+        config.script.path = "scripts/main.py".to_string();
+
+        config.anchor_script_paths(std::path::Path::new("siphon.yaml"));
+
+        assert_eq!(config.script.path, "scripts/main.py");
     }
 
     #[test]


### PR DESCRIPTION
The packaged `.deb`/`.rpm` install a config and a systemd unit that cannot start each other.

`ScriptEngine::new` resolves `script.path` with `PathBuf::from(&config.path)`, i.e. against the **process working directory**. That is the config directory exactly when you run siphon by hand, and `/` under systemd. The packaged `siphon.yaml` ships a relative path:

```yaml
script:
  path: "scripts/proxy_default.py"
```

so the packaged unit looks for `/scripts/proxy_default.py`. Reproduced against `main`:

```
$ cd / && siphon --config /etc/siphon/siphon.yaml
INFO siphon::server: SIPhon v1.5.0 starting — script: scripts/proxy_default.py
Failed to load script: Script error: script not found: scripts/proxy_default.py
exit=1
```

Exit 1 plus `Restart=on-failure` is a restart loop. The same config started from `/etc/siphon` runs fine, which is what makes it look like a permissions problem — it isn't, `/etc/siphon` is 755 with 644 files and the `siphon` user reads it fine. A container `WORKDIR`, or an embedding binary that chdirs, hits the same trap.

## Change

A relative `script.path` (and each relative `script.include_paths` entry) now prefers the location relative to the config file, the way nginx and Kamailio resolve a relative include. **Only when that candidate exists** — otherwise the value is left alone and still resolves against the working directory, so a config that relies on the CWD keeps behaving exactly as before, and the "script not found" error still names what the operator actually wrote. The rewrite can only make a previously-failing config start, never the reverse.

`Config::from_str` is untouched: no file to anchor on, so the embedding and `--config-string` paths are byte-for-byte unchanged. The existing startup line prints the resolved path, which is the diagnostic you want in the journal.

After:

```
$ cd / && siphon --config /etc/siphon/siphon.yaml
INFO siphon::server: SIPhon v1.5.1 starting — script: /etc/siphon/scripts/proxy_default.py
INFO siphon::script::engine: script loaded path=/etc/siphon/scripts/proxy_default.py handlers=1
INFO siphon::server: starting UDP transport addr=0.0.0.0:5060
```

## Second defect in the same unit

`ProtectSystem=strict` was paired with `ReadWritePaths=/var/lib/siphon` only, while every default write path we ship lives under `/var/log`, which was read-only and which nothing created:

- `cdr.file.path` → `/var/log/siphon/cdr.jsonl` (`config.rs`)
- `lawful_intercept.audit_log` → `/var/log/siphon/li-audit.log`
- the `log.file` example → `/var/log/siphon.log`

So a service that had just started fine broke the moment an operator turned any of them on. The unit now declares `StateDirectory=siphon` + `LogsDirectory=siphon`, which creates both owned by the service user and adds them to the writable set, and the `log.file` example moves inside the writable directory.

Also in the unit: `WorkingDirectory=/etc/siphon` for everything relative that is *not* `script.path`; the `CAP_NET_ADMIN` + `AF_NETLINK` an `ipsec:` sec-agree P-CSCF needs, as commented lines rather than widening the default sandbox for everyone; and the pre-rename `Documentation=` URL.

## Verification

- Six new unit tests in `config.rs`: anchoring from a foreign CWD, `include_paths`, absolute paths untouched, missing candidate left alone (the backwards-compatibility guard), `from_str` unaffected, bare-filename config a no-op.
- Full suite green: **3850 passed, 0 failed**. Clippy clean with `-D warnings`.
- End-to-end: the repro above, before and after, against a release build.
- `systemd-analyze verify` clean, and the sandbox directives exercised under a real transient unit — `WorkingDirectory` applied, `StateDirectory`/`LogsDirectory` created and writable, the rest of `/var/log` still blocked by `ProtectSystem=strict`.

No datapath code is touched, so the perf baseline is unaffected.
