### PR TITLE
test(cdr): cover the single-leg media summary

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -20554,6 +20554,56 @@ mod tests {
         assert_eq!(cdr.extra.get("media_reason").map(String::as_str), Some("media_timeout"));
     }
 
+    #[test]
+    fn media_summary_to_cdr_handles_a_single_leg_call() {
+        use crate::rtpengine::events::{CallLegSummary, CallSummary};
+
+        // A single-leg call (`answer_local` — IVR, announcement, and every
+        // voice-AI call where the engine itself is the far side) has exactly one
+        // media party, and `siphon-rtp` reports it as one leg. Everything the
+        // caller sent must land under `near_`, and no `far_` key may be
+        // synthesised for a party that does not exist — a media CDR showing a
+        // far leg on a call that never had one is worse than one showing none.
+        let leg = CallLegSummary {
+            tag: "caller".to_string(),
+            codec: Some("PCMU".to_string()),
+            packets_in: 60,
+            bytes_in: 10_320,
+            packets_out: 64,
+            bytes_out: 11_008,
+            packets_dropped: 0,
+            ssrc: Some(0x0000_2222),
+            packets_lost: Some(0),
+            loss_percent: Some(0.0),
+            jitter_ms: Some(19.25),
+            rtt_ms: None,
+            mos_average: None,
+            mos_min: None,
+            mos_max: None,
+            mos_basis: Some("loss+jitter".to_string()),
+        };
+        let summary = CallSummary {
+            call_id: "voice-ai-1".to_string(),
+            reason: "delete".to_string(),
+            duration_ms: 1_000,
+            legs: vec![leg],
+        };
+
+        let cdr = media_summary_to_cdr(&summary);
+        assert_eq!(cdr.extra.get("near_tag").map(String::as_str), Some("caller"));
+        assert_eq!(cdr.extra.get("near_packets_in").map(String::as_str), Some("60"));
+        assert_eq!(cdr.extra.get("near_packets_out").map(String::as_str), Some("64"));
+        assert_eq!(cdr.extra.get("near_codec").map(String::as_str), Some("PCMU"));
+        // Quality belongs to the same leg as the counters, not a separate one.
+        assert_eq!(cdr.extra.get("near_jitter_ms").map(String::as_str), Some("19.25"));
+        // No second party.
+        assert!(
+            !cdr.extra.keys().any(|key| key.starts_with("far_")),
+            "single-leg summary must not synthesise a far leg: {:?}",
+            cdr.extra.keys().collect::<Vec<_>>()
+        );
+    }
+
     // -----------------------------------------------------------------------
     // A-leg advertised port (multi-homed Contact / reply-socket anchoring)
     // -----------------------------------------------------------------------


### PR DESCRIPTION
siphon-rtp#200 makes the engine bind one leg for `answer_local` and report a single-leg call as **one** CDR party, instead of two where the second had no tag, no remote and all the counters. That shape is now what every IVR, announcement and voice-AI call produces.

siphon already handles it correctly — `media_summary_to_cdr` iterates `summary.legs` and prefixes by index (`0 → near`, `1 → far`, `n → legN`), so a one-element vec yields only `near_*` with no indexing assumption to break. Nothing asserted that, though. The existing tests cover two legs and three; one leg was the gap.

Adds a test pinning:

- the caller's counters, codec and quality all land under `near_*`
- **no `far_*` key is synthesised** for a party that never existed — a media CDR inventing a second leg is worse than one showing a single party

Mutation-checked rather than assumed: flipping the prefix map to `0 => "far"` fails the test, restoring it passes.

Test-only, no behaviour change. `cargo clippy --all-targets --all-features -- -D warnings` clean; 3468 + 311 + 45 and the rest green.

## Verified against the fixed engine

Rebuilt `siphon-rtp` at `c4c6afb` and re-ran the case from the spec — plain `answer_local`, no `ws_uri`, caller streams 60 frames:

```
leg="near" tag="caller" local=58732 remote=47040 packets_in=60 packets_out=64
           ssrc=00002222 jitter_ms=19.25
```

One leg, `local` is the port the engine advertised to the caller, counters match what it sent, quality on the same leg. Previously this reported `packets_in=0` on `near` with the traffic on an untagged `far`.

Two-legged relay re-checked for regression (asymmetric 100/20 so attribution errors can't hide): `near` 100 in / 20 out, `far` 20 in / 100 out. Correct.
