### PR TITLE
ci: run the voice-AI scenario, and move it off the b2bua IP block

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -657,6 +657,46 @@ jobs:
             mock-rtpproxy.log
             *.log
 
+  # ── Voice-AI B2BUA (single-leg answer + WebSocket bridge) ──────────────
+  sipp-voice-ai:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-voice-ai image
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai build siphon-voice-ai
+
+      - name: Start mock siphon-rtp + siphon-voice-ai
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai up -d --wait mock-siphon-rtp siphon-voice-ai
+
+      - name: Voice-AI call (INVITE → answer_local → 200 → BYE)
+        # No UAS and no register: siphon answers the call itself as a single-leg
+        # UAS, so the UAC is the only party. The scenario asserts the answer SDP
+        # is anchored on the engine's media address and that the 2xx carries a
+        # Contact (RFC 3261 §12.1.1) — without one the UAC has no remote target
+        # and the BYE goes out with an empty Request-URI.
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai up --abort-on-container-exit --exit-code-from sipp-voice-ai-uac sipp-voice-ai-uac
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-voice-ai > siphon-voice-ai.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs mock-siphon-rtp > mock-siphon-rtp.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-voice-ai-logs
+          path: |
+            siphon-voice-ai.log
+            mock-siphon-rtp.log
+
   # ── Fuzz testing (nightly) ─────────────────────────────────────────────
   fuzz:
     runs-on: ubuntu-latest

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -4119,6 +4119,11 @@ services:
   # ── Voice-AI B2BUA (single-leg answer + WebSocket bridge) ─────────────────
   # Requires the "voice-ai" profile.
   #
+  # IP assignments:
+  #   172.20.0.103 — mock siphon-rtp control server
+  #   172.20.0.104 — siphon (B2BUA)
+  #   172.20.0.105 — carrier UAC
+  #
   # Flow: UAC → siphon B2BUA (rtpengine.answer_local with ws_uri) → 200 OK
   # There is no UAS: siphon answers the call itself with the SDP the engine
   # synthesised, so the test asserts the answer is anchored on the engine's
@@ -4145,7 +4150,7 @@ services:
       MOCK_MEDIA_PORT: "30000"
     networks:
       sipnet:
-        ipv4_address: 172.20.0.50
+        ipv4_address: 172.20.0.103
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import socket,struct,json; s=socket.create_connection(('127.0.0.1',8080),2); b=json.dumps({'id':1,'command':'ping'}).encode(); s.sendall(struct.pack('!I',len(b))+b); h=s.recv(4); n=struct.unpack('!I',h)[0]; d=s.recv(n); s.close(); exit(0 if b'pong' in d else 1)\""]
       interval: 2s
@@ -4169,7 +4174,7 @@ services:
       - ../examples:/etc/siphon/examples:ro
     networks:
       sipnet:
-        ipv4_address: 172.20.0.51
+        ipv4_address: 172.20.0.104
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
       interval: 3s
@@ -4189,10 +4194,10 @@ services:
       - .:/sipp/scenarios:ro
     networks:
       sipnet:
-        ipv4_address: 172.20.0.52
+        ipv4_address: 172.20.0.105
     entrypoint:
       - sipp
-      - "172.20.0.51:5060"
+      - "172.20.0.104:5060"
       - -sf
       - /sipp/scenarios/voice_ai_uac.xml
       - -m

--- a/sipp/siphon-rtp/siphon-voice-ai.yaml
+++ b/sipp/siphon-rtp/siphon-voice-ai.yaml
@@ -14,7 +14,7 @@ domain:
   local:
     - "ai.example.com"
 
-advertised_address: "172.20.0.51"
+advertised_address: "172.20.0.104"
 
 script:
   path: "/etc/siphon/examples/voice_ai_b2bua.py"
@@ -22,7 +22,7 @@ script:
 media:
   backend: siphon-rtp
   siphon_rtp:
-    address: "172.20.0.50:8080"
+    address: "172.20.0.103:8080"
     timeout_ms: 2000
 
   profiles:
@@ -48,7 +48,7 @@ gateway:
         enabled: false
       destinations:
         - uri: "sip:uac.test:5060"
-          address: "172.20.0.52:5060"
+          address: "172.20.0.105:5060"
 
 log:
   level: info


### PR DESCRIPTION
The `--voice-ai` mode shipped in #156 with a scenario, a mock control server and compose services — but no CI job. So the test that guards the UAS `Contact` regression only ran when someone remembered to type it by hand.

Adds `sipp-voice-ai`, modelled on `sipp-rtpproxy`. Simpler: no register step and no UAS, since siphon answers the call itself as a single-leg UAS and the UAC is the only other party.

## And a latent IP clash it surfaced

Wiring the job is what exposed it: the three voice-AI services were given `172.20.0.50/51/52`, which this file's **own allocation map** already assigns to `siphon-b2bua`, the registration helper and the B-leg UAS.

Invisible in normal use, because the `voice-ai` and `b2bua` profiles never run together — which is exactly why it passed local runs and CI in #156. But any leftover b2bua container makes the whole voice-AI stack fail to start with a bare `Error response from daemon: failed to set up container networking: Address already in use`, which says nothing about the actual cause.

Moved to the free `172.20.0.103–105` block and documented it the way the neighbouring sections are. `.68/.69`, `.76–79` and `.88/.89` are the other gaps if anyone needs them.

## Verified

Ran the job's exact command sequence locally **with a stale `siphon-b2bua-auth-test` container still holding `.50`** — the adversarial case:

- before the move: `up --wait` fails, `Address already in use`
- after: `up --wait` = 0, call = 0, **1 successful call / 0 failed**

`scripts/run-tests.sh --skip-rust --voice-ai` green on the new addresses. `docker compose config` valid, CI YAML parses (22 jobs).

No Rust change, so no clippy/test run beyond what the workflow does itself.
