### PR TITLE
feat(control): forward in-band DTMF on controlled calls as ChannelDtmfReceived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   P-CSCF needs for `ipsec:` sec-agree.
 
 ### Added
+- **In-band DTMF on a controlled call is forwarded to the control plane as a
+  `ChannelDtmfReceived` event.** When the media engine detects a DTMF digit on a
+  B2BUA call that was handed over to a control app, siphon pushes a
+  `ChannelDtmfReceived` event (payload `{digit, duration_ms, volume, from_tag}`)
+  to the owning control connection, so an external IVR / AI app collects digits
+  from the event stream (there is deliberately no blocking server-side
+  `collect_dtmf` verb). This is additive: the in-process `@rtpengine.on_dtmf`
+  dispatch still fires unchanged, and it is emitted whether or not any Python
+  handler is registered. The event carries the stable id triple
+  `{channel, call_id, sip_call_id}` like every other control event, and the SIP
+  adapter's `describe` now lists `ChannelDtmfReceived`.
 - **SIGTRAN/SS7 extension module.** `siphon-bin` gains a `sigtran` feature that
   composes [siphon-sigtran](https://github.com/siphon-project/siphon-sigtran)
   v1.0.0 into the drop-in `siphon` binary, alongside the existing `smpp` and

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -260,6 +260,15 @@ same way every other verb does — never a hang:
   cannot perform the op answers `unsupported_verb`; any other backend failure
   answers `unavailable`.
 
+Inbound in-band DTMF on a controlled call is pushed to the owning connection as
+a `ChannelDtmfReceived` event, payload `{digit, duration_ms, volume, from_tag}`
+(`from_tag` identifies which party pressed), so an IVR / AI app **collects digits
+off the event stream** rather than through a blocking verb — there is
+deliberately no server-side `collect_dtmf` (it would park an I/O worker). This is
+additive to the in-process `@rtpengine.on_dtmf` dispatch: the digit fires both,
+and it needs no extra configuration beyond the DTMF-log wiring the media engine
+already uses.
+
 `bridge` / `originate` verbs arrive in later phases over the same envelope. The
 client SDK facade methods for the media verbs land alongside them (until then,
 reach the verbs through the generic `command(verb, args)` escape hatch).

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -740,6 +740,66 @@ impl ControlBus {
         debug!(%channel_id, %sip_call_id, reason, "control plane: StasisEnd + channel removed");
     }
 
+    /// Forward an in-band DTMF digit (detected by the media engine on a
+    /// controlled call's leg) to the owning control connection as a
+    /// `ChannelDtmfReceived` event, so an external IVR / AI app collects digits
+    /// from the event stream. **Additive** — this runs alongside, never in place
+    /// of, the in-process `@rtpengine.on_dtmf` dispatch; a controlled channel
+    /// gets the event *in addition*.
+    ///
+    /// `sip_call_id` is the media call-id the DTMF event carries. For every
+    /// control-anchored call that is byte-identical to the SIP Call-ID the
+    /// channel is keyed on: the ordinary anchored path records the media session
+    /// with `rtpengine_call_id == call_id == SIP Call-ID`, and the answer-first
+    /// (AI-park) path anchors on the INVITE's Call-ID for both the media session
+    /// and the channel. The only path that decouples the media call-id from the
+    /// SIP Call-ID is a siphon-terminated REFER re-anchor, which never applies to
+    /// a control-owned channel. So the direct
+    /// [`channel_id_for_sip_call_id`](Self::channel_id_for_sip_call_id) lookup is
+    /// correct for every controlled call.
+    ///
+    /// Idempotent no-op — never panics — when the call is uncontrolled (the
+    /// common case), the channel is orphaned, or the owning connection is gone.
+    /// Adds and removes **no** per-call state (a channel scan + an
+    /// [`EventFrame`] push), so it needs no leak coverage of its own. Returns
+    /// whether an event was pushed to a connection.
+    pub fn forward_dtmf(
+        &self,
+        sip_call_id: &str,
+        digit: &str,
+        duration_ms: u32,
+        volume: i32,
+        from_tag: &str,
+    ) -> bool {
+        let Some(channel_id) = self.channel_id_for_sip_call_id(sip_call_id) else {
+            return false;
+        };
+        let (app, call_actor_id) = match self.channels.get(&channel_id) {
+            Some(entry) => (entry.app.clone(), entry.call_actor_id.clone()),
+            None => return false,
+        };
+        let pushed = self.publish_to_channel(
+            &channel_id,
+            EventFrame::new(
+                "ChannelDtmfReceived",
+                &channel_id,
+                &app,
+                &call_actor_id,
+                sip_call_id,
+                serde_json::json!({
+                    "digit": digit,
+                    "duration_ms": duration_ms,
+                    "volume": volume,
+                    "from_tag": from_tag,
+                }),
+            ),
+        );
+        if pushed {
+            debug!(%channel_id, %sip_call_id, digit, "control plane: ChannelDtmfReceived forwarded");
+        }
+        pushed
+    }
+
     /// Offer a handed-over call to an app: assign a persistent owner (round
     /// robin) and push `StasisStart`, or launch a per-call-connect dial. Returns
     /// the outcome so the dispatcher knows whether to arm the handoff deadline
@@ -1165,6 +1225,59 @@ mod tests {
             assert_eq!(bus.app_count(), 0, "apps leaked on cycle {cycle}");
             assert!(bus.app_calls.is_empty(), "app_calls index leaked on cycle {cycle}");
         }
+    }
+
+    #[tokio::test]
+    async fn forward_dtmf_pushes_event_to_owning_connection() {
+        // An in-band DTMF digit on a controlled call reaches the owning
+        // connection as a ChannelDtmfReceived event carrying the digit + tag,
+        // additive to (never in place of) the @rtpengine.on_dtmf dispatch.
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid@h",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+        assert_eq!(bus.channel_count(), 1);
+
+        // The media call-id equals the SIP Call-ID for a control-anchored call.
+        assert!(bus.forward_dtmf("sipcid@h", "5", 120, -8, "ftag-a"));
+
+        let frames = conn.events.recv_many().await;
+        let dtmf = frames
+            .iter()
+            .find_map(|frame| match frame {
+                OutboundFrame::Event(event) if event.event == "ChannelDtmfReceived" => Some(event),
+                _ => None,
+            })
+            .expect("owning app must receive ChannelDtmfReceived");
+        assert_eq!(dtmf.channel.as_deref(), Some("ch1"));
+        assert_eq!(dtmf.call_id.as_deref(), Some("call-uuid"));
+        assert_eq!(dtmf.sip_call_id.as_deref(), Some("sipcid@h"));
+        assert_eq!(dtmf.payload["digit"], "5");
+        assert_eq!(dtmf.payload["duration_ms"], 120);
+        assert_eq!(dtmf.payload["volume"], -8);
+        assert_eq!(dtmf.payload["from_tag"], "ftag-a");
+
+        // Additive: forwarding neither creates nor removes per-call state.
+        assert_eq!(bus.channel_count(), 1, "forward_dtmf must not touch channel state");
+        assert_eq!(bus.owned_channels("ivr-app").len(), 1);
+    }
+
+    #[test]
+    fn forward_dtmf_on_uncontrolled_call_is_clean_noop() {
+        // A DTMF event for a call no control app owns must be a silent no-op —
+        // no panic, no state change, nothing pushed.
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        assert!(!bus.forward_dtmf("unknown-cid", "1", 100, 0, "ftag"));
+        assert_eq!(conn.events.depth(), 0, "no event for an uncontrolled call");
+        assert_eq!(bus.channel_count(), 0);
     }
 
     #[test]

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -68,6 +68,7 @@ impl ControlAdapter for SipControlAdapter {
                 "StasisEnd".to_string(),
                 "ChannelStateChange".to_string(),
                 "ChannelHangupRequest".to_string(),
+                "ChannelDtmfReceived".to_string(),
             ],
         }
     }
@@ -791,6 +792,16 @@ mod tests {
             "stream_stop",
         ] {
             assert!(verbs.contains(&expected), "missing verb {expected}");
+        }
+        let events: Vec<&str> = schema.events.iter().map(String::as_str).collect();
+        for expected in [
+            "StasisStart",
+            "StasisEnd",
+            "ChannelStateChange",
+            "ChannelHangupRequest",
+            "ChannelDtmfReceived",
+        ] {
+            assert!(events.contains(&expected), "missing event {expected}");
         }
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1102,6 +1102,13 @@ pub async fn run(
             while let Some(event) = events_rx.recv().await {
                 match event {
                     crate::rtpengine::events::RtpEngineEvent::Dtmf(dtmf) => {
+                        // Additive control-plane forward: a controlled channel
+                        // gets the digit as a ChannelDtmfReceived event too, so an
+                        // external IVR / AI app collects digits from the event
+                        // stream. Runs before the Python-handler short-circuit so
+                        // it fires whether or not @rtpengine.on_dtmf is registered.
+                        control_forward_dtmf(&dtmf);
+
                         let engine_state = state_for_events.engine.state();
                         let handlers = engine_state.dtmf_handlers(&dtmf.call_id, &dtmf.from_tag);
                         if handlers.is_empty() {
@@ -17118,6 +17125,28 @@ fn b2bua_terminate_call_inner(
 fn control_notify_terminated(sip_call_id: &str, reason: &str) {
     if let Some(bus) = crate::control::ControlBus::global() {
         bus.on_call_terminated(sip_call_id, reason);
+    }
+}
+
+/// Forward an in-band DTMF digit the media engine detected on a controlled
+/// B2BUA call's leg to the owning control connection as a `ChannelDtmfReceived`
+/// event, so an external IVR / AI app collects digits off the event stream.
+///
+/// **Additive** — this runs *next to*, never in place of, the Python
+/// `@rtpengine.on_dtmf` dispatch, and fires independently of whether any Python
+/// handler is registered. A no-op when the control plane isn't configured or the
+/// call isn't controlled. `dtmf.call_id` is the media call-id, which equals the
+/// SIP Call-ID the control bus keys the channel on for every control-anchored
+/// call (see [`crate::control::ControlBus::forward_dtmf`]).
+fn control_forward_dtmf(dtmf: &crate::rtpengine::events::DtmfEvent) {
+    if let Some(bus) = crate::control::ControlBus::global() {
+        bus.forward_dtmf(
+            &dtmf.call_id,
+            &dtmf.digit,
+            dtmf.duration_ms,
+            dtmf.volume,
+            &dtmf.from_tag,
+        );
     }
 }
 


### PR DESCRIPTION
## What

When the media engine detects an in-band DTMF digit on a B2BUA call that was handed over to a control app (tracked in `ControlBus`), siphon now pushes a `ChannelDtmfReceived` event to the owning control connection. An external IVR / AI app collects digits from the event stream.

There is deliberately **no** blocking server-side `collect_dtmf` verb (it would park an I/O worker) — the app collects from this event stream instead.

## Additive, not a replacement

This runs **next to**, never in place of, the in-process `@rtpengine.on_dtmf` Python dispatch. The forward fires *before* the Python-handler short-circuit, so a controlled channel gets `ChannelDtmfReceived` whether or not any `@rtpengine.on_dtmf` handler is registered. Uncontrolled calls are a clean no-op.

## Media-call-id → channel resolution

The DTMF event carries the **media** call-id (`dtmf.call_id`), while `ControlBus` keys channels on the **SIP** Call-ID. For every control-anchored call these are byte-identical:

- Ordinary anchored path (`rtpengine.offer`) records the media session with `rtpengine_call_id == call_id == SIP Call-ID`.
- Answer-first / AI-park (`answer_local`) anchors both the media session and the control channel on the INVITE's Call-ID.
- The only path that decouples the media call-id from the SIP Call-ID is a siphon-terminated REFER re-anchor, which never applies to a control-owned channel.

So the direct `ControlBus::channel_id_for_sip_call_id(&dtmf.call_id)` lookup is correct for every controlled call.

## Payload

`ChannelDtmfReceived` carries the stable id triple `{channel, call_id, sip_call_id}` like every other control event, plus payload `{digit, duration_ms, volume, from_tag}` (`from_tag` identifies which party pressed, for multi-leg consumers).

## Tests

- `forward_dtmf_pushes_event_to_owning_connection` — asserts the event reaches the owner with the right digit/duration/volume/from_tag/ids.
- `forward_dtmf_on_uncontrolled_call_is_clean_noop` — no panic, nothing pushed, no state change.
- `describe_lists_core_verbs` extended to assert the events list includes `ChannelDtmfReceived`.
- No new per-call/per-conn store is added, so no leak test is needed.

`PYO3_PYTHON=python3 cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` are green.

## Follow-up

The SDK facade helper + the SDK's `ChannelDtmfReceived` event-type mirror are a separate follow-up (this is a server-only change).
