### PR TITLE
feat(b2bua): cold transfer off a single-leg answered call, with a credentialed REFER retry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -697,6 +697,47 @@ jobs:
             siphon-voice-ai.log
             mock-siphon-rtp.log
 
+  # ── Cold transfer off a single-leg answered call ───────────────────────
+  sipp-refer-single-leg:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-refer image
+        run: docker compose -f sipp/docker-compose.yaml --profile refer-single-leg build siphon-refer
+
+      - name: Start mock siphon-rtp + siphon-refer
+        run: docker compose -f sipp/docker-compose.yaml --profile refer-single-leg up -d --wait mock-siphon-rtp-refer siphon-refer
+
+      - name: Cold transfer (answer_local → in-dialog REFER → 202 → NOTIFY)
+        run: docker compose -f sipp/docker-compose.yaml --profile refer-single-leg up --abort-on-container-exit --exit-code-from sipp-refer-single-leg-uac sipp-refer-single-leg-uac
+
+      - name: Challenged REFER (407 → credentialed retry)
+        # The retry only exists because a REFER siphon originates carries a
+        # branch belonging to no leg; without tracking it, the 407 matched
+        # nothing and the transfer failed silently.
+        run: docker compose -f sipp/docker-compose.yaml --profile refer-single-leg up --abort-on-container-exit --exit-code-from sipp-refer-challenge-uac sipp-refer-challenge-uac
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-refer > siphon-refer.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs mock-siphon-rtp-refer > mock-siphon-rtp-refer.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile refer-single-leg down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-refer-single-leg-logs
+          path: |
+            siphon-refer.log
+            mock-siphon-rtp-refer.log
+
   # ── Fuzz testing (nightly) ─────────────────────────────────────────────
   fuzz:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **Cold transfer off a call siphon answered itself.** A voice-AI or IVR call has
+  no B leg, so the only way to hand the caller on is an in-dialog REFER on the A
+  dialog via the imperative `b2bua.refer(call_id, target)` — `call.refer()` is a
+  no-op from `@b2bua.on_invite` (the dialog is not confirmed yet) and
+  `@b2bua.on_answer` never fires without a B leg. Now covered end to end by a
+  functional scenario, wired into `examples/voice_ai_b2bua.py` as "press 0 for an
+  agent", and documented in `docs/cookbook/voice-ai.md`.
+
+### Fixed
+- **A challenged REFER was never retried, and its response was dropped
+  entirely.** A REFER siphon originates on one of its own legs is allocated a
+  fresh Via branch that belongs to no leg, and responses are matched to a call by
+  branch — so the 202 was ignored and a 401/407 equally so. A carrier that
+  challenges an in-dialog REFER therefore
+  killed the transfer silently, with the script still waiting on sipfrag NOTIFYs
+  that could never arrive. Such a REFER is now tracked so its response can be
+  matched, and a challenge is retried with the credentials from
+  `call.set_credentials()` — a new transaction on the same dialog (RFC 3261
+  §22.2), capped so a trunk that always challenges cannot loop, and with no ACK
+  (REFER is a non-INVITE transaction; §17.1.2). A REFER that cannot be retried
+  now clears its subscription and logs at WARN instead of leaving the transfer
+  pending forever.
+
 ### Fixed
 - **A relative `script.path` now resolves against the config file's directory,
   so siphon starts under a supervisor.** It was resolved against the process

--- a/docs/cookbook/voice-ai.md
+++ b/docs/cookbook/voice-ai.md
@@ -148,6 +148,47 @@ The bridge needs `siphon-rtp` **0.1.5 or later** on both sides: siphon's pinned
 `siphon-rtp-proto`, and the running engine. Earlier engine builds accept
 `ws_uri` on `answer_local` and silently never dial it.
 
+## Handing the caller to a human
+
+A cold transfer is an in-dialog REFER on the A dialog. On a call siphon answered
+itself there is one way to send it:
+
+```python
+@rtpengine.on_dtmf
+def on_digit(call_id, from_tag, digit, duration_ms, volume):
+    if digit == "0":
+        b2bua.refer(call_id, "sip:agent@pbx.example.com")
+```
+
+**Use the imperative `b2bua.refer(call_id, ...)`, not `call.refer()`.** That is
+not a style preference:
+
+- `@b2bua.on_answer` never fires for a call siphon answered itself — that hook is
+  a *B leg's* 2xx arriving, and there is no B leg.
+- `call.refer()` is deliberately a no-op from `@b2bua.on_invite`, because the
+  dialog is not confirmed until the 2xx has gone out.
+
+So on a single-leg call the transfer has to come from an event context — DTMF, a
+timer, an external controller — and those only have the SIP Call-ID, which is
+exactly what the imperative verb takes.
+
+### When the carrier challenges the REFER
+
+Plenty of trunks answer an in-dialog REFER with a 407.
+Give the call credentials and siphon retries with digest:
+
+```python
+@b2bua.on_invite
+async def answer_with_ai(call):
+    call.set_credentials("trunk-user", "trunk-secret")
+    ...
+```
+
+Set them before the transfer can fire — the retry reads them off the call. The
+retry is a new transaction on the same dialog (RFC 3261 §22.2) and is capped, so
+a trunk that challenges unconditionally cannot loop. Without credentials the
+challenge is logged at WARN and the transfer fails rather than retrying blind.
+
 ## Where the policy lives
 
 The example above keeps everything in the in-process script. To drive the same

--- a/examples/voice_ai_b2bua.py
+++ b/examples/voice_ai_b2bua.py
@@ -33,6 +33,9 @@ See docs/cookbook/voice-ai.md for the full run-book.
 """
 from siphon import b2bua, proxy, rtpengine, log
 
+# Where "press 0" sends the caller.
+AGENT_URI = "sip:agent@pbx.example.com"
+
 
 @proxy.on_request("OPTIONS")
 def health(request):
@@ -83,6 +86,18 @@ def on_digit(call_id, from_tag, digit, duration_ms, volume):
     # An IVR would accumulate these; the AI usually just wants the digit.
     log.info(f"[{call_id}] DTMF {digit} ({duration_ms}ms)")
 
+    # "Press 0 for a human" — cold-transfer the caller off the AI.
+    #
+    # This is the imperative verb, not call.refer(), and that is not a style
+    # choice: a call siphon answered itself never fires @b2bua.on_answer (that
+    # hook is a B leg's 2xx arriving), and call.refer() is a no-op from
+    # @b2bua.on_invite because the dialog is not confirmed until the 2xx is out.
+    # On a single-leg call the imperative b2bua.refer() from an event context is
+    # the only path. It keys on the SIP Call-ID, which is what on_dtmf hands us.
+    if digit == "0":
+        log.info(f"[{call_id}] caller asked for an agent — transferring")
+        b2bua.refer(call_id, AGENT_URI)
+
 
 @rtpengine.on_ws_tee_ended
 def on_tee_ended(call_id, from_tag, stream_id, reason, frames_sent, frames_dropped):
@@ -93,7 +108,12 @@ def on_tee_ended(call_id, from_tag, stream_id, reason, frames_sent, frames_dropp
         log.warn(f"[{call_id}] tee {stream_id} died: {reason}")
 
 
-# Handing the caller off to a human is a REFER on the A dialog —
-# call.refer("sip:agent@pbx.example.com"). Not wired here: this example is the
-# answer-and-stream path, and a carrier that challenges an in-dialog REFER needs
-# credentials on the retry, which is a separate concern from the media bridge.
+# A carrier that challenges the in-dialog REFER gets a credentialed retry,
+# using whatever call.set_credentials() was given.
+# Set it before the transfer can fire — the retry reads the credentials off the
+# call:
+#
+#     call.set_credentials("trunk-user", "trunk-secret")
+#
+# Without credentials a challenged REFER is logged at WARN and the transfer
+# fails; it will not retry blind.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -33,6 +33,7 @@ RUN_PRESENCE=false
 RUN_RTPENGINE=false
 RUN_RTPPROXY=false
 RUN_VOICE_AI=false
+RUN_REFER_SINGLE_LEG=false
 RUN_REINVITE=false
 RUN_B2BUA=false
 RUN_B2BUA_AUTH=false
@@ -60,6 +61,7 @@ for arg in "$@"; do
     --rtpengine)  RUN_RTPENGINE=true;  SELECTED_MODES+=("$arg") ;;
     --rtpproxy)   RUN_RTPPROXY=true;   SELECTED_MODES+=("$arg") ;;
     --voice-ai)   RUN_VOICE_AI=true;   SELECTED_MODES+=("$arg") ;;
+    --refer-single-leg) RUN_REFER_SINGLE_LEG=true; SELECTED_MODES+=("$arg") ;;
     --reinvite)   RUN_REINVITE=true;   SELECTED_MODES+=("$arg") ;;
     --b2bua)      RUN_B2BUA=true;      SELECTED_MODES+=("$arg") ;;
     --b2bua-auth) RUN_B2BUA_AUTH=true; SELECTED_MODES+=("$arg") ;;
@@ -78,7 +80,7 @@ for arg in "$@"; do
       echo
       echo "Scenario modes (pick at most ONE per run):"
       echo "  --ipsec --charging --call --presence --rtpengine --rtpproxy --reinvite"
-      echo "  --voice-ai"
+      echo "  --voice-ai --refer-single-leg"
       echo "  --b2bua --b2bua-auth --b2bua-invite-auth --gateway --auto100 --http-auth"
       echo "  --wedge --banscan"
       echo "  --security --rfc4475 --webrtc"
@@ -189,6 +191,19 @@ if [[ "$RUN_VOICE_AI" == true ]]; then
   run_sipp docker compose -f "$COMPOSE_FILE" --profile voice-ai up \
     --abort-on-container-exit --exit-code-from sipp-voice-ai-uac sipp-voice-ai-uac
   docker compose -f "$COMPOSE_FILE" --profile voice-ai rm -sf sipp-voice-ai-uac 2>/dev/null || true
+fi
+
+# ── Step 7a2: Single-leg cold transfer (optional) ─────────────────────────
+if [[ "$RUN_REFER_SINGLE_LEG" == true ]]; then
+  echo "=== SIPp cold-transfer test (single-leg answer -> in-dialog REFER) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile refer-single-leg up \
+    --abort-on-container-exit --exit-code-from sipp-refer-single-leg-uac sipp-refer-single-leg-uac
+  docker compose -f "$COMPOSE_FILE" --profile refer-single-leg rm -sf sipp-refer-single-leg-uac 2>/dev/null || true
+
+  echo "=== SIPp challenged-REFER test (407 -> credentialed retry) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile refer-single-leg up \
+    --abort-on-container-exit --exit-code-from sipp-refer-challenge-uac sipp-refer-challenge-uac
+  docker compose -f "$COMPOSE_FILE" --profile refer-single-leg rm -sf sipp-refer-challenge-uac 2>/dev/null || true
 fi
 
 # ── Step 7b: Classic rtpproxy proxy test (optional) ───────────────────────

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -4211,6 +4211,115 @@ services:
     profiles:
       - voice-ai
 
+  # ── Cold transfer off a single-leg answered call ──────────────────────────
+  # Requires the "refer-single-leg" profile.
+  #
+  # siphon answers the call itself (no B leg) and then transfers the caller away
+  # with an in-dialog REFER. Two UACs share the stack: one accepts the REFER,
+  # one challenges it with 407 and asserts the credentialed retry.
+  #
+  # IP assignments:
+  #   172.20.0.106 — mock siphon-rtp control server
+  #   172.20.0.107 — siphon (B2BUA)
+  #   172.20.0.108 — carrier UAC (plain + challenge)
+
+  mock-siphon-rtp-refer:
+    image: python:3.12-slim
+    container_name: mock-siphon-rtp-refer
+    volumes:
+      - ./siphon-rtp:/app:ro
+    working_dir: /app
+    command: ["python3", "mock_siphon_rtp.py"]
+    environment:
+      SIPHON_RTP_PORT: "8080"
+      MOCK_MEDIA_IP: "203.0.113.1"
+      MOCK_MEDIA_PORT: "30000"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.106
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket,struct,json; s=socket.create_connection(('127.0.0.1',8080),2); b=json.dumps({'id':1,'command':'ping'}).encode(); s.sendall(struct.pack('!I',len(b))+b); h=s.recv(4); n=struct.unpack('!I',h)[0]; d=s.recv(n); s.close(); exit(0 if b'pong' in d else 1)\""]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+    profiles:
+      - refer-single-leg
+
+  siphon-refer:
+    build:
+      context: ..
+    container_name: siphon-refer-test
+    depends_on:
+      mock-siphon-rtp-refer:
+        condition: service_healthy
+    volumes:
+      - ./siphon-rtp/siphon-refer.yaml:/etc/siphon/siphon.yaml:ro
+      - ./siphon-rtp/refer_single_leg.py:/etc/siphon/scripts/refer_single_leg.py:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.107
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - refer-single-leg
+
+  # Accepts the REFER (202) and reports the outcome with a sipfrag NOTIFY.
+  sipp-refer-single-leg-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-refer:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.108
+    entrypoint:
+      - sipp
+      - "172.20.0.107:5060"
+      - -sf
+      - /sipp/scenarios/refer_single_leg_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - refer-single-leg
+
+  # Challenges the REFER with 407 and asserts the credentialed retry.
+  sipp-refer-challenge-uac:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.108
+    entrypoint:
+      - sipp
+      - "172.20.0.107:5060"
+      - -sf
+      - /sipp/scenarios/refer_challenge_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - refer-single-leg
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:

--- a/sipp/refer_challenge_uac.xml
+++ b/sipp/refer_challenge_uac.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  A challenged cold transfer — the case where the trunk demands digest:
+  INVITE → 200 → ACK → [REFER] → 407 → [REFER w/ Proxy-Authorization] → 202
+         → [NOTIFY] → 200 → BYE → 200
+
+  A carrier that challenges an in-dialog REFER gets a credentialed retry from
+  siphon (call.set_credentials). Before that path existed the challenge matched
+  no branch at all — siphon had allocated a fresh branch for the REFER that
+  belonged to no leg — so the response was dropped and the transfer failed in
+  silence, with the script still waiting on sipfrag NOTIFYs.
+
+  The retry must also be a NEW transaction on the same dialog (RFC 3261 §22.2),
+  so its CSeq is asserted to differ from the challenged one.
+-->
+<scenario name="Challenged cold transfer UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:ai@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/refer-challenge-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="200" rtd="true" crlf="true" rrs="true" />
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- First REFER: capture its CSeq so the retry can be shown to be a new
+       transaction rather than a re-send of the same one. -->
+  <recv request="REFER" crlf="true">
+    <action>
+      <!-- siphon's own CSeq space on this leg starts at 1, so the first REFER
+           is CSeq 1 and the credentialed retry must be 2 (RFC 3261 §22.2 — a
+           retry is a new transaction, not a re-send). -->
+      <ereg regexp="CSeq:[ ]*1 REFER"
+            search_in="msg"
+            check_it="true"
+            assign_to="first_refer_cseq" />
+      <log message="REFER #1 [$first_refer_cseq], challenging with 407" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 407 Proxy Authentication Required
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Proxy-Authenticate: Digest realm="carrier.example", nonce="4f4e2b3a9c1d5e6f", algorithm=MD5, qop="auth"
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- The credentialed retry. Assert it carries Proxy-Authorization for the
+       realm we challenged with, the username the script configured, and a CSeq
+       that is not the one we just rejected. -->
+  <recv request="REFER" crlf="true">
+    <action>
+      <ereg regexp="Proxy-Authorization:[^\r\n]*realm=&quot;carrier\.example&quot;"
+            search_in="msg"
+            check_it="true"
+            assign_to="retry_realm" />
+      <log message="retry carries Proxy-Authorization: [$retry_realm]" />
+      <ereg regexp="Proxy-Authorization:[^\r\n]*username=&quot;siphon&quot;"
+            search_in="msg"
+            check_it="true"
+            assign_to="retry_user" />
+      <log message="retry username ok: [$retry_user]" />
+      <ereg regexp="Refer-To:[^\r\n]*sip:agent@pbx\.example\.com"
+            search_in="msg"
+            check_it="true"
+            assign_to="retry_refer_to" />
+      <log message="retry preserved Refer-To: [$retry_refer_to]" />
+      <ereg regexp="CSeq:[ ]*2 REFER"
+            search_in="msg"
+            check_it="true"
+            assign_to="retry_cseq" />
+      <log message="retry is a new transaction: [$retry_cseq]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 202 Accepted
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+NOTIFY [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 NOTIFY
+[routes]
+Event: refer
+Subscription-State: terminated;reason=noresource
+Max-Forwards: 70
+Content-Type: message/sipfrag;version=2.0
+Content-Length: [len]
+
+SIP/2.0 200 OK
+]]>
+  </send>
+
+  <recv response="200" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/refer_single_leg_uac.xml
+++ b/sipp/refer_single_leg_uac.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Cold transfer off a single-leg answered call:
+  INVITE → 200 (answer_local SDP) → ACK → [REFER] → 202 → [NOTIFY] → 200 → BYE → 200
+
+  siphon answers the call itself (no B leg) and then, from an event context,
+  sends an in-dialog REFER on the A dialog. This asserts the REFER actually
+  arrives, carries the right Refer-To, and is a proper in-dialog request — its
+  Call-ID must be the dialog's, not a fresh one.
+
+  The referrer (siphon) subscribes to the transfer's progress implicitly per
+  RFC 3515 §2.4.4, so the UAC reports the outcome with a sipfrag NOTIFY.
+-->
+<scenario name="Single-leg cold transfer UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:ai@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/refer-single-leg-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="200" rtd="true" crlf="true" rrs="true" />
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- siphon transfers the caller away. Assert the Refer-To target, and that
+       this is genuinely in-dialog (same Call-ID as the INVITE). -->
+  <recv request="REFER" crlf="true">
+    <action>
+      <ereg regexp="Refer-To:[^\r\n]*sip:agent@pbx\.example\.com"
+            search_in="msg"
+            check_it="true"
+            assign_to="refer_to" />
+      <log message="REFER received, Refer-To ok: [$refer_to]" />
+      <!-- In-dialog: a REFER inside an established dialog carries the peer's
+           To-tag. An out-of-dialog REFER (a fresh dialog, which would be the
+           bug) has none. Asserted this way because SIPp does not expand
+           keywords like [call_id] inside a regexp. -->
+      <ereg regexp="To:[^\r\n]*;tag="
+            search_in="msg"
+            check_it="true"
+            assign_to="refer_in_dialog" />
+      <log message="REFER is in-dialog (carries a To-tag): [$refer_in_dialog]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 202 Accepted
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- RFC 3515 §2.4.4: report the outcome to the referrer. -->
+  <send retrans="500">
+    <![CDATA[
+NOTIFY [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 NOTIFY
+[routes]
+Event: refer
+Subscription-State: terminated;reason=noresource
+Max-Forwards: 70
+Content-Type: message/sipfrag;version=2.0
+Content-Length: [len]
+
+SIP/2.0 200 OK
+]]>
+  </send>
+
+  <recv response="200" />
+
+  <!-- Blind transfer done: the referee releases the original call. -->
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/siphon-rtp/refer_single_leg.py
+++ b/sipp/siphon-rtp/refer_single_leg.py
@@ -1,0 +1,58 @@
+"""Functional-test script: answer a call single-leg, then cold-transfer it.
+
+Drives the transfer off a call siphon answered itself — no B leg — which is the
+shape a voice-AI call has. The transfer target is fixed and the trigger is a
+short timer standing in for whatever would really decide (an AI, a DTMF digit,
+an external controller).
+
+Why a timer and not `call.refer()`: a call siphon answered itself never fires
+`@b2bua.on_answer` (that hook is a B leg's 2xx arriving), and `call.refer()` is
+deliberately a no-op from `@b2bua.on_invite` because the dialog is not confirmed
+until the 2xx has gone out. So on a single-leg call the imperative
+`b2bua.refer(call_id, target)` from an event context is the only path — the same
+one the DTMF-triggered transfer in examples/voice_ai_b2bua.py takes.
+"""
+import os
+
+from siphon import b2bua, proxy, rtpengine, timer, log
+
+TRANSFER_TARGET = os.environ.get("TRANSFER_TARGET", "sip:agent@pbx.example.com")
+# Long enough that the UAC has ACKed and is waiting, short enough to keep the
+# scenario quick.
+TRANSFER_DELAY_MS = int(os.environ.get("TRANSFER_DELAY_MS", "500"))
+# Digest credentials for a trunk that challenges the in-dialog REFER.
+TRANSFER_USER = os.environ.get("TRANSFER_USER", "siphon")
+TRANSFER_PASSWORD = os.environ.get("TRANSFER_PASSWORD", "secret")
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    request.reply(200, "OK")
+
+
+@b2bua.on_invite
+async def answer_then_transfer(call):
+    answer_sdp = await rtpengine.answer_local(call, profile="voice_ai")
+    if answer_sdp is None:
+        log.warn(f"[{call.id}] no encodable codec — rejected 488")
+        return
+
+    # Credentials for the REFER retry if the peer challenges it. Set before the
+    # transfer is scheduled: the retry reads them off the call.
+    call.set_credentials(TRANSFER_USER, TRANSFER_PASSWORD)
+    call.answer(200, "OK", body=answer_sdp, content_type="application/sdp")
+
+    # The imperative verb keys on the SIP Call-ID, so carry it in the timer key.
+    timer.set(f"transfer:{call.call_id}", TRANSFER_DELAY_MS, send_transfer)
+    log.info(f"[{call.id}] answered; transfer scheduled in {TRANSFER_DELAY_MS}ms")
+
+
+def send_transfer(key):
+    sip_call_id = key.split(":", 1)[1]
+    sent = b2bua.refer(sip_call_id, TRANSFER_TARGET)
+    log.info(f"[{sip_call_id}] REFER to {TRANSFER_TARGET} sent={sent}")
+
+
+@b2bua.on_bye
+async def on_bye(call, initiator):
+    log.info(f"[{call.id}] call ended by {initiator}")

--- a/sipp/siphon-rtp/siphon-refer.yaml
+++ b/sipp/siphon-rtp/siphon-refer.yaml
@@ -1,0 +1,37 @@
+# siphon config for the single-leg cold-transfer tests
+# (sipp/refer_single_leg_uac.xml, sipp/refer_challenge_uac.xml).
+#
+# Same single-leg media shape as the voice-AI test — answer_local against the
+# mock siphon-rtp control server — but the script then transfers the caller away
+# with the imperative b2bua.refer(). See sipp/siphon-rtp/refer_single_leg.py.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "ai.example.com"
+
+advertised_address: "172.20.0.107"
+
+script:
+  path: "/etc/siphon/scripts/refer_single_leg.py"
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "172.20.0.106:8080"
+    timeout_ms: 2000
+
+  profiles:
+    voice_ai:
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+      answer: *voice_ai_flags
+
+log:
+  level: info

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -561,6 +561,37 @@ pub struct LegRegistry {
     by_call_id: DashMap<String, String>,
     /// Via branch → internal call ID (for matching responses).
     by_branch: DashMap<String, String>,
+    /// Via branch → the siphon-originated REFER that branch belongs to.
+    ///
+    /// Kept apart from [`Self::by_branch`], which maps a branch to a *leg* whose
+    /// responses run the INVITE/B-leg machinery in `handle_b2bua_response`. An
+    /// in-dialog REFER siphon originates is a non-INVITE transaction on an
+    /// existing leg, so it needs the call for a credentialed retry but none of
+    /// that machinery. Registering it in `by_branch` would send its 401 down the
+    /// B-leg path, which ACKs (wrong for a non-INVITE, RFC 3261 §17.1.2) and
+    /// reasons about legs that do not exist on a single-leg call.
+    originated_refers: DashMap<String, OriginatedRefer>,
+}
+
+/// A REFER siphon sent on one of its own legs, awaiting a response.
+///
+/// Tracked so a 401/407 can be retried with the call's credentials
+/// (`call.set_credentials()`); without this the challenge matches no branch at
+/// all and the transfer fails silently.
+#[derive(Debug, Clone)]
+pub struct OriginatedRefer {
+    /// Internal call id the REFER was sent on.
+    pub call_id: String,
+    /// Which leg it went out on (`true` = A-leg, the connected caller).
+    pub on_a_leg: bool,
+    /// Request-URI the REFER was addressed to — the digest `uri` parameter of
+    /// any credentialed retry must match it (RFC 7616 §3.4.6).
+    pub target_uri: String,
+    /// The `Refer-To` this REFER carried, so a retry reproduces it exactly.
+    pub refer_to: crate::sip::headers::refer::ReferTo,
+    /// Credentialed retries already sent for this REFER, capped so a peer that
+    /// challenges unconditionally cannot drive an unbounded loop.
+    pub auth_retries: u32,
 }
 
 impl LegRegistry {
@@ -568,7 +599,30 @@ impl LegRegistry {
         Self {
             by_call_id: DashMap::new(),
             by_branch: DashMap::new(),
+            originated_refers: DashMap::new(),
         }
+    }
+
+    /// Record a siphon-originated REFER so its response can be matched.
+    pub fn register_originated_refer(&self, branch: &str, refer: OriginatedRefer) {
+        self.originated_refers.insert(branch.to_string(), refer);
+    }
+
+    /// Look up (without removing) the originated REFER a branch belongs to.
+    pub fn lookup_originated_refer(&self, branch: &str) -> Option<OriginatedRefer> {
+        self.originated_refers.get(branch).map(|entry| entry.clone())
+    }
+
+    /// Remove and return the originated REFER a branch belongs to — the final
+    /// response for a non-INVITE transaction ends it, so the entry goes with it.
+    pub fn take_originated_refer(&self, branch: &str) -> Option<OriginatedRefer> {
+        self.originated_refers.remove(branch).map(|(_, refer)| refer)
+    }
+
+    /// Drop every originated REFER belonging to a call.
+    pub fn clear_originated_refers(&self, internal_id: &str) {
+        self.originated_refers
+            .retain(|_, refer| refer.call_id.as_str() != internal_id);
     }
 
     /// Register a SIP Call-ID → internal call ID mapping.
@@ -607,6 +661,11 @@ impl LegRegistry {
         self.by_call_id.retain(|_, v| v.as_str() != internal_id);
         // Remove all branch mappings for this call
         self.by_branch.retain(|_, v| v.as_str() != internal_id);
+        // ...including any REFER siphon originated on it and is still awaiting a
+        // response. A call that is gone cannot be transferred, and leaving the
+        // entry would leak one per abandoned transfer.
+        self.originated_refers
+            .retain(|_, refer| refer.call_id.as_str() != internal_id);
     }
 
     /// Number of registered calls (unique internal IDs in Call-ID map).
@@ -1700,6 +1759,26 @@ impl CallActorStore {
         self.registry.lookup_branch(branch)
     }
 
+    /// Record a siphon-originated REFER awaiting its response.
+    pub fn register_originated_refer(&self, branch: &str, refer: OriginatedRefer) {
+        self.registry.register_originated_refer(branch, refer);
+    }
+
+    /// Peek at the originated REFER a branch belongs to.
+    pub fn lookup_originated_refer(&self, branch: &str) -> Option<OriginatedRefer> {
+        self.registry.lookup_originated_refer(branch)
+    }
+
+    /// Take the originated REFER a branch belongs to, ending its transaction.
+    pub fn take_originated_refer(&self, branch: &str) -> Option<OriginatedRefer> {
+        self.registry.take_originated_refer(branch)
+    }
+
+    /// Drop any originated REFER still awaiting a response on this call.
+    pub fn clear_originated_refers(&self, call_id: &str) {
+        self.registry.clear_originated_refers(call_id);
+    }
+
     /// Get a call by internal ID.
     pub fn get_call(&self, call_id: &str) -> Option<dashmap::mapref::one::Ref<'_, String, CallActor>> {
         self.calls.get(call_id)
@@ -2064,6 +2143,10 @@ impl CallActorStore {
         if let Some((_, call)) = self.calls.remove(call_id) {
             // Shutdown any active B-leg actors
             call.shutdown_actors();
+            // Any REFER siphon originated on this call is now moot — the call it
+            // would transfer is gone. Cleared here rather than left to age out,
+            // so an abandoned transfer does not leak an entry per call.
+            self.registry.clear_originated_refers(call_id);
             // Clean up A-leg registry entries
             self.registry.remove_call_id(&call.a_leg.dialog.call_id);
             self.registry.remove_branch(&call.a_leg.branch);
@@ -3448,6 +3531,59 @@ mod tests {
     }
 
     // --- LegRegistry tests ---
+
+    fn originated_refer(call_id: &str) -> OriginatedRefer {
+        OriginatedRefer {
+            call_id: call_id.to_string(),
+            on_a_leg: true,
+            target_uri: "sip:caller@198.51.100.10:5060".to_string(),
+            refer_to: crate::sip::headers::refer::ReferTo {
+                uri: "sip:agent@pbx.example.com".to_string(),
+                replaces: None,
+            },
+            auth_retries: 0,
+        }
+    }
+
+    #[test]
+    fn originated_refer_is_matched_by_branch_and_taken_once() {
+        // A REFER siphon originates carries a branch belonging to no leg, so it
+        // is tracked separately; its final response ends the transaction and
+        // must consume the entry (a non-INVITE transaction has exactly one).
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.register_originated_refer("z9hG4bK-refer-1", originated_refer(&call_id));
+
+        assert!(store.lookup_originated_refer("z9hG4bK-refer-1").is_some());
+        let taken = store.take_originated_refer("z9hG4bK-refer-1").unwrap();
+        assert_eq!(taken.call_id, call_id);
+        assert!(taken.on_a_leg);
+        assert_eq!(taken.refer_to.uri, "sip:agent@pbx.example.com");
+        // Gone: a retransmitted final must not drive a second retry.
+        assert!(store.take_originated_refer("z9hG4bK-refer-1").is_none());
+    }
+
+    #[test]
+    fn originated_refer_does_not_leak_into_the_leg_branch_index() {
+        // Registering it in `by_branch` would send the REFER's 401 down the
+        // INVITE/B-leg response path, which ACKs a non-2xx — wrong for a
+        // non-INVITE transaction (RFC 3261 §17.1.2).
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.register_originated_refer("z9hG4bK-refer-2", originated_refer(&call_id));
+        assert!(store.call_id_for_branch("z9hG4bK-refer-2").is_none());
+    }
+
+    #[test]
+    fn originated_refer_is_dropped_when_its_call_goes_away() {
+        // A call that is gone cannot be transferred; leaving the entry would
+        // leak one per abandoned transfer.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.register_originated_refer("z9hG4bK-refer-3", originated_refer(&call_id));
+        store.remove_call(&call_id);
+        assert!(store.lookup_originated_refer("z9hG4bK-refer-3").is_none());
+    }
 
     #[test]
     fn registry_basic() {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -5246,6 +5246,14 @@ fn handle_response(
         }
     };
 
+    // A response to a REFER siphon originated on one of its own legs. Checked
+    // before the leg-branch lookup because this is a non-INVITE transaction that
+    // must not run the INVITE/B-leg response machinery below.
+    if state.call_actors.lookup_originated_refer(&branch).is_some() {
+        handle_originated_refer_response(&branch, &message, status_code, state);
+        return;
+    }
+
     // Check if this response belongs to a B2BUA call
     if let Some(call_id) = state.call_actors.call_id_for_branch(&branch) {
         handle_b2bua_response(&call_id, &branch, &mut message, status_code, inbound.remote_addr, state);
@@ -17271,6 +17279,198 @@ pub fn b2bua_terminate_call(sip_call_id: &str, reason: Option<&str>) -> bool {
 /// referee's `message/sipfrag` NOTIFYs are absorbed (200 OK'd + read) by
 /// [`handle_b2bua_notify`] rather than bridged. Returns `false` if the call or
 /// leg is gone.
+/// Handle the response to a REFER siphon originated on one of its own legs.
+///
+/// A cold transfer off a call siphon answered itself (`call.refer()` /
+/// `b2bua.refer()`) is an in-dialog REFER on a leg that already exists, so the
+/// peer may challenge it, which trunks commonly do. This is the
+/// only place that challenge can be answered: the REFER's branch belongs to no
+/// leg, so nothing else matches its response.
+///
+/// Differences from the B-leg INVITE retry that this deliberately does NOT copy:
+///
+/// * **No ACK.** REFER is a non-INVITE transaction — only an INVITE client
+///   transaction ACKs a non-2xx final (RFC 3261 §17.1.2). ACKing here would put
+///   a stray ACK on the dialog.
+/// * **A fresh CSeq, not a fresh branch on the same one.** §22.2 wants the
+///   credentialed retry to be a new transaction in the dialog.
+fn handle_originated_refer_response(
+    branch: &str,
+    message: &SipMessage,
+    status_code: u16,
+    state: &DispatcherState,
+) {
+    // Provisionals do not end the transaction; keep waiting for the final.
+    if (100..200).contains(&status_code) {
+        return;
+    }
+
+    let Some(pending) = state.call_actors.take_originated_refer(branch) else {
+        return;
+    };
+
+    if (200..300).contains(&status_code) {
+        debug!(
+            call_id = %pending.call_id,
+            status = status_code,
+            "B2BUA: siphon-originated REFER accepted"
+        );
+        return;
+    }
+
+    let challenged = status_code == 401 || status_code == 407;
+    if challenged
+        && pending.auth_retries < MAX_B2BUA_AUTH_RETRIES
+        && retry_originated_refer_with_credentials(&pending, message, status_code, state)
+    {
+        return;
+    }
+
+    // Nothing more to try: no credentials configured, an unparseable challenge,
+    // the retry cap reached, or a plain rejection. Drop the pending subscription
+    // rather than leaving the script waiting on sipfrag NOTIFYs that will never
+    // arrive — a transfer that failed should look failed.
+    if challenged {
+        warn!(
+            call_id = %pending.call_id,
+            status = status_code,
+            retries = pending.auth_retries,
+            "B2BUA: siphon-originated REFER challenged and not retried \
+             (no call.set_credentials(), unparseable challenge, or retry cap reached)"
+        );
+    } else {
+        warn!(
+            call_id = %pending.call_id,
+            status = status_code,
+            "B2BUA: siphon-originated REFER rejected by the peer"
+        );
+    }
+    state
+        .call_actors
+        .clear_refer_subscriptions_on_leg(&pending.call_id, pending.on_a_leg);
+}
+
+/// Re-send a challenged REFER carrying digest credentials. Returns `false` when
+/// the retry could not be built, so the caller can report the failure.
+fn retry_originated_refer_with_credentials(
+    pending: &crate::b2bua::actor::OriginatedRefer,
+    message: &SipMessage,
+    status_code: u16,
+    state: &DispatcherState,
+) -> bool {
+    let Some((username, password)) = state
+        .call_actors
+        .get_call(&pending.call_id)
+        .and_then(|call| call.outbound_credentials.clone())
+    else {
+        return false;
+    };
+
+    let challenge_header = if status_code == 401 {
+        message.headers.get("WWW-Authenticate")
+    } else {
+        message.headers.get("Proxy-Authenticate")
+    };
+    let Some(challenge) = challenge_header.and_then(|value| crate::auth::parse_challenge(value))
+    else {
+        return false;
+    };
+
+    let Some(cseq) = state
+        .call_actors
+        .reserve_leg_cseq(&pending.call_id, pending.on_a_leg)
+    else {
+        return false;
+    };
+    let Some(leg) = state
+        .call_actors
+        .clone_leg(&pending.call_id, pending.on_a_leg)
+    else {
+        return false;
+    };
+
+    // RFC 7616 §3.3: nc starts at 1 for a fresh nonce and increments on reuse.
+    // The per-call counter resets itself when the nonce changes, so this is
+    // right for both a first challenge and a stale-nonce re-challenge.
+    let nc = state
+        .call_actors
+        .get_call(&pending.call_id)
+        .map(|call| call.digest_nc.next_for(&challenge.nonce))
+        .unwrap_or(1);
+
+    let credentials = crate::auth::DigestCredentials { username, password };
+    let auth_value = crate::auth::format_authorization_header(
+        &challenge,
+        &credentials,
+        Method::Refer.as_str(),
+        &pending.target_uri,
+        Some(nc),
+        None,
+    );
+    let auth_header_name = if status_code == 401 {
+        "Authorization"
+    } else {
+        "Proxy-Authorization"
+    };
+
+    let extra_headers = [
+        ("Refer-To", pending.refer_to.to_string()),
+        (auth_header_name, auth_value),
+    ];
+    let Some(retry) = build_b2bua_in_dialog_request(
+        &leg,
+        state,
+        Method::Refer,
+        cseq,
+        &extra_headers,
+        None,
+    ) else {
+        return false;
+    };
+
+    let (destination, transport) = resolve_in_dialog_destination(
+        &leg.dialog.route_set,
+        state,
+        leg.transport.remote_addr,
+        leg.transport.transport,
+    );
+
+    // Track the retry's own branch — a peer may challenge again with a stale
+    // nonce, and the cap is what stops that becoming a loop.
+    if let Some(retry_branch) = retry
+        .headers
+        .get("Via")
+        .and_then(|raw| Via::parse_multi(raw).ok())
+        .and_then(|vias| vias.first().and_then(|via| via.branch.clone()))
+    {
+        state.call_actors.register_originated_refer(
+            &retry_branch,
+            crate::b2bua::actor::OriginatedRefer {
+                auth_retries: pending.auth_retries + 1,
+                ..pending.clone()
+            },
+        );
+    }
+
+    info!(
+        call_id = %pending.call_id,
+        status = status_code,
+        realm = %challenge.realm,
+        attempt = pending.auth_retries + 1,
+        "B2BUA: siphon-originated REFER challenged, retrying with credentials"
+    );
+
+    send_message_from(
+        retry,
+        transport,
+        destination,
+        leg.transport.connection_id,
+        leg.transport.local_addr,
+        state,
+    );
+    true
+}
+
 fn b2bua_send_outbound_refer(
     state: &DispatcherState,
     internal_call_id: &str,
@@ -17304,6 +17504,32 @@ fn b2bua_send_outbound_refer(
         leg.transport.remote_addr,
         leg.transport.transport,
     );
+
+    // Record the transaction before it goes out, so its response can be matched.
+    // Only the A-leg and B-legs are in the branch registry; an in-dialog request
+    // siphon originates carries a fresh branch that belongs to no leg, so without
+    // this its 401/407 matches nothing and the transfer fails in silence.
+    if let Some(branch) = refer
+        .headers
+        .get("Via")
+        .and_then(|raw| Via::parse_multi(raw).ok())
+        .and_then(|vias| vias.first().and_then(|via| via.branch.clone()))
+    {
+        state.call_actors.register_originated_refer(
+            &branch,
+            crate::b2bua::actor::OriginatedRefer {
+                call_id: internal_call_id.to_string(),
+                on_a_leg,
+                target_uri: refer
+                    .request_uri()
+                    .map(|uri| uri.to_string())
+                    .unwrap_or_default(),
+                refer_to: refer_to.clone(),
+                auth_retries: 0,
+            },
+        );
+    }
+
     send_message_from(
         refer,
         transport,


### PR DESCRIPTION
The last code-bearing package of the voice-AI work: the AI decides, and siphon hands the caller to a human.

## The path, and why it is the only one

A call siphon answered itself has no B leg, so a transfer is an in-dialog REFER on the A dialog, sent via the **imperative** `b2bua.refer(call_id, target)`. Not a style choice:

- `call.refer()` is a documented no-op from `@b2bua.on_invite` — the dialog isn't confirmed until the 2xx is out.
- `@b2bua.on_answer` never fires, because that hook is a *B leg's* 2xx arriving.

So the transfer must come from an event context (DTMF, timer, external controller), and those only have the SIP Call-ID — which is exactly what the imperative verb takes. Now documented, because it is not guessable.

## The bug

That path was half-built. A REFER siphon originates gets a fresh Via branch belonging to no leg, while responses are matched to a call **by branch** — so its 202 was dropped on the floor, and a 401/407 with it.

A trunk that challenges an in-dialog REFER killed the transfer in **total silence**: no retry, no error, the script still waiting on sipfrag NOTIFYs that could never arrive. Challenging an in-dialog REFER is common enough in the field that this is a routine failure, not an edge case.

Fixed by tracking such a REFER in its own index, deliberately kept **out** of the leg branch index — registering it there would route the challenge into the INVITE/B-leg response machinery, which ACKs a non-2xx (wrong for a non-INVITE transaction, RFC 3261 §17.1.2) and reasons about legs a single-leg call doesn't have.

The retry uses the credentials `call.set_credentials()` already stored — previously read only by the B-leg INVITE retry — as a new transaction on the same dialog (§22.2), with the same nonce counter and the same cap, so a trunk that challenges unconditionally can't loop. A REFER that can't be retried clears its subscription and logs WARN rather than leaving the transfer pending forever.

## Verification

Two scenarios against the mock control server (no engine needed):

- **plain** — asserts the REFER is in-dialog (carries a To-tag) and has the right `Refer-To`
- **challenged** — answers 407, asserts the retry carries `Proxy-Authorization` for the challenged realm with the configured username, preserves `Refer-To`, and advances the CSeq

**Mutation-checked.** Disabling the retry fails the challenge scenario and leaves the plain one passing — so it gates the new code specifically, rather than passing for unrelated reasons.

Three unit tests on the tracking, one of which caught a leak I'd written: I put the cleanup in `remove_all_for_call`, but `remove_call` cleans per-leg and never calls it, so every abandoned transfer would have leaked an entry.

`cargo clippy --all-targets --all-features -- -D warnings` clean; 3512 + 311 and the rest green; 539 SDK tests green; `--refer-single-leg` green.

## Also

CI job, `--refer-single-leg` mode, and `examples/voice_ai_b2bua.py` wired as "press 0 for an agent" — the example's `@rtpengine.on_dtmf` handler was already there, and DTMF is exactly the event context where only the imperative verb works.

Services use `172.20.0.106–108`, documented alongside the neighbouring allocations.

No perf baseline: control-plane path, no per-message datapath cost.
