### PR TITLE
feat(control): inbound REFER on a controlled call → TransferRequested + accept_refer/reject_refer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **Inbound REFER on a controlled call is surfaced to the control app as a
+  `TransferRequested` event.** When a B2BUA call has been handed to an external
+  control app, an in-dialog REFER on that call is no longer run through the
+  in-process `@b2bua.on_refer` path — the app owns the transfer decision. siphon
+  holds the REFER un-answered, emits `TransferRequested` (payload
+  `{refer_to, replaces?, from_tag}` plus the stable id triple) to the owning
+  connection, and waits for the app's decision via two new SIP-adapter verbs:
+  `accept_refer` (`{target?, next_hop?, mode?}`, `mode` ∈ `terminate` /
+  `transparent`) drives the same shipped transfer machinery the script accept path
+  uses, and `reject_refer` (`{code?, reason?}`) declines with a final non-2xx. If
+  the app never decides, a decision-deadline sweep answers `603 Decline` (the same
+  default as no `@b2bua.on_refer` handler) so a REFER is never left pending. An
+  uncontrolled call's REFER still runs the Python `@b2bua.on_refer` path unchanged.
+  Builds on the single-leg REFER machinery, so a terminate-mode accept on a
+  voice-AI / IVR call with no B leg re-dials the target off the A dialog. The SDK
+  client facades for the new verbs and event follow separately.
+
 - **Cold transfer off a call siphon answered itself.** A voice-AI or IVR call has
   no B leg, so the only way to hand the caller on is an in-dialog REFER on the A
   dialog via the imperative `b2bua.refer(call_id, target)` — `call.refer()` is a

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -211,6 +211,8 @@ chunk, so logs join Homer and billing with no mapping table.
 | `reject` | sip | `{code, reason?}` | final non-2xx + tear down |
 | `hangup` | sip | `{reason?}` | BYE an answered call, or reject an unanswered one |
 | `refer` | sip | `{to, replaces?}` | in-dialog REFER on the A-leg |
+| `accept_refer` | sip | `{target?, next_hop?, mode?}` | accept a pending inbound REFER (from a `TransferRequested` event) and run the transfer |
+| `reject_refer` | sip | `{code?, reason?}` | reject a pending inbound REFER with a final non-2xx (default `603 Decline`) |
 | `route` | sip | `{targets, strategy?, headers?}` | return control to siphon: un-park the call and dial the B-leg via LCR sequential failover |
 | `set_header` / `remove_header` / `get_header` | sip | `{name, value?}` | on the stored A-leg INVITE |
 | `play` | sip | `{file\|db_id\|blob, repeat?, start_ms?, duration_ms?, to_tag?}` | play an announcement on the A-leg media (fire-and-forget) |
@@ -269,9 +271,33 @@ additive to the in-process `@rtpengine.on_dtmf` dispatch: the digit fires both,
 and it needs no extra configuration beyond the DTMF-log wiring the media engine
 already uses.
 
+An **inbound REFER on a controlled call** (a party asking to be transferred) is
+handed to the owning app rather than the in-process `@b2bua.on_refer` path: siphon
+holds the REFER un-answered and pushes a `TransferRequested` event, payload
+`{refer_to, replaces?, from_tag}` (`replaces` present for an attended transfer;
+`from_tag` identifies the referring party). The app decides with:
+
+- `accept_refer` `{target?, next_hop?, mode?}` — run the transfer through siphon's
+  shipped machinery. `target` overrides the Refer-To URI, `next_hop` steers egress
+  without reshaping the R-URI, and `mode` is `terminate` (siphon-terminated: 202 +
+  sipfrag NOTIFYs + re-dial the target as a new leg — the default, from
+  `b2bua.default_refer_mode`) or `transparent` (forward the REFER on the far leg's
+  own dialog). On a single-leg call (a voice-AI / IVR call siphon answered itself,
+  no B leg) terminate mode re-dials the target off the A dialog.
+- `reject_refer` `{code?, reason?}` — decline with a final non-2xx (default
+  `603 Decline`).
+
+If the app never decides, a decision deadline answers `603 Decline` (the same
+default as when no `@b2bua.on_refer` handler is registered), so a REFER is never
+left pending — the referrer is always answered (RFC 3515 §2.4.2). A bad `mode`
+answers `bad_request`; a decision for a call with no pending REFER (already
+decided, timed out, or gone) answers `not_found`. A REFER on an **uncontrolled**
+call is unaffected — it still runs the Python `@b2bua.on_refer` path.
+
 `bridge` / `originate` verbs arrive in later phases over the same envelope. The
-client SDK facade methods for the media verbs land alongside them (until then,
-reach the verbs through the generic `command(verb, args)` escape hatch).
+client SDK facade methods for the media verbs and the transfer verbs land
+alongside them (until then, reach the verbs through the generic
+`command(verb, args)` escape hatch).
 
 The complete wire reference, both connection modes end to end, and two
 low-level example clients (one Python, one TypeScript) that drive calls with no

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -800,6 +800,62 @@ impl ControlBus {
         pushed
     }
 
+    /// Surface an inbound REFER on a *controlled* call to the owning control
+    /// connection as a `TransferRequested` event, so the app owns the transfer
+    /// decision (`accept_refer` / `reject_refer`) instead of the in-process
+    /// `@b2bua.on_refer` path. The dispatcher holds the REFER un-answered until
+    /// the app decides or the decision deadline applies the 603 default — this
+    /// method only emits the event; the pending REFER (and its deadline) live in
+    /// the dispatcher's store, so this adds and removes **no** per-call state of
+    /// its own and needs no leak coverage here.
+    ///
+    /// `channel_id` is the caller-resolved owner
+    /// ([`channel_id_for_sip_call_id`](Self::channel_id_for_sip_call_id));
+    /// `from_tag` identifies the referring party. The payload is
+    /// `{refer_to, replaces?, from_tag}` alongside the stable id triple. Returns
+    /// whether the event was pushed (idempotent no-op / `false` when the channel
+    /// is unknown or its connection is gone).
+    pub fn forward_transfer_requested(
+        &self,
+        channel_id: &str,
+        sip_call_id: &str,
+        refer_to: &crate::sip::headers::refer::ReferTo,
+        from_tag: Option<&str>,
+    ) -> bool {
+        let (app, call_actor_id) = match self.channels.get(channel_id) {
+            Some(entry) => (entry.app.clone(), entry.call_actor_id.clone()),
+            None => return false,
+        };
+        let replaces = refer_to.replaces.as_ref().map(|replaces| {
+            serde_json::json!({
+                "call_id": replaces.call_id,
+                "from_tag": replaces.from_tag,
+                "to_tag": replaces.to_tag,
+                "early_only": replaces.early_only,
+            })
+        });
+        let payload = serde_json::json!({
+            "refer_to": refer_to.uri,
+            "replaces": replaces,
+            "from_tag": from_tag,
+        });
+        let pushed = self.publish_to_channel(
+            channel_id,
+            EventFrame::new(
+                "TransferRequested",
+                channel_id,
+                &app,
+                &call_actor_id,
+                sip_call_id,
+                payload,
+            ),
+        );
+        if pushed {
+            debug!(%channel_id, %sip_call_id, target = %refer_to.uri, "control plane: TransferRequested forwarded");
+        }
+        pushed
+    }
+
     /// Offer a handed-over call to an app: assign a persistent owner (round
     /// robin) and push `StasisStart`, or launch a per-call-connect dial. Returns
     /// the outcome so the dispatcher knows whether to arm the handoff deadline
@@ -1276,6 +1332,71 @@ mod tests {
         let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
         let conn = bus.register_connection("ivr-app");
         assert!(!bus.forward_dtmf("unknown-cid", "1", 100, 0, "ftag"));
+        assert_eq!(conn.events.depth(), 0, "no event for an uncontrolled call");
+        assert_eq!(bus.channel_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn forward_transfer_requested_pushes_event_to_owning_connection() {
+        // An inbound REFER on a controlled call reaches the owning connection as a
+        // TransferRequested event carrying the Refer-To target, embedded Replaces,
+        // and the referring party's from_tag — the app owns the decision.
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid@h",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+
+        let refer_to = crate::sip::headers::refer::ReferTo {
+            uri: "sip:carol@example.com".to_string(),
+            replaces: Some(crate::sip::headers::refer::Replaces {
+                call_id: "xfer-dialog".to_string(),
+                from_tag: "peer-ft".to_string(),
+                to_tag: "peer-tt".to_string(),
+                early_only: false,
+            }),
+        };
+        assert!(bus.forward_transfer_requested("ch1", "sipcid@h", &refer_to, Some("alice-tag")));
+
+        let frames = conn.events.recv_many().await;
+        let transfer = frames
+            .iter()
+            .find_map(|frame| match frame {
+                OutboundFrame::Event(event) if event.event == "TransferRequested" => Some(event),
+                _ => None,
+            })
+            .expect("owning app must receive TransferRequested");
+        assert_eq!(transfer.channel.as_deref(), Some("ch1"));
+        assert_eq!(transfer.call_id.as_deref(), Some("call-uuid"));
+        assert_eq!(transfer.sip_call_id.as_deref(), Some("sipcid@h"));
+        assert_eq!(transfer.payload["refer_to"], "sip:carol@example.com");
+        assert_eq!(transfer.payload["from_tag"], "alice-tag");
+        assert_eq!(transfer.payload["replaces"]["call_id"], "xfer-dialog");
+        assert_eq!(transfer.payload["replaces"]["to_tag"], "peer-tt");
+        assert_eq!(transfer.payload["replaces"]["early_only"], false);
+
+        // Emitting the event neither creates nor removes per-call state (the
+        // pending REFER lives in the dispatcher's store, not here).
+        assert_eq!(bus.channel_count(), 1, "forward_transfer_requested must not touch channel state");
+    }
+
+    #[test]
+    fn forward_transfer_requested_on_uncontrolled_call_is_clean_noop() {
+        // A REFER for a call no control app owns is a silent no-op — nothing
+        // pushed, no state change (the dispatcher then runs the Python path).
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        let refer_to = crate::sip::headers::refer::ReferTo {
+            uri: "sip:carol@example.com".to_string(),
+            replaces: None,
+        };
+        assert!(!bus.forward_transfer_requested("unknown-ch", "unknown-cid", &refer_to, None));
         assert_eq!(conn.events.depth(), 0, "no event for an uncontrolled call");
         assert_eq!(bus.channel_count(), 0);
     }

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -51,6 +51,8 @@ impl ControlAdapter for SipControlAdapter {
                 verb("reject", "Send a final non-2xx and tear the call down (args: code, reason)"),
                 verb("hangup", "BYE an answered call, or reject an unanswered one (args: reason)"),
                 verb("refer", "Send an in-dialog REFER on the A-leg (args: to, replaces)"),
+                verb("accept_refer", "Accept a pending inbound REFER (from a TransferRequested event) and run the transfer (args: target, next_hop, mode)"),
+                verb("reject_refer", "Reject a pending inbound REFER with a final non-2xx (args: code, reason)"),
                 verb("route", "Return control to siphon with a routing decision: un-park the call and dial the B-leg via LCR sequential failover (args: targets, strategy, headers)"),
                 verb("set_header", "Set a header on the stored A-leg INVITE (args: name, value)"),
                 verb("remove_header", "Remove a header from the stored A-leg INVITE (args: name)"),
@@ -69,6 +71,7 @@ impl ControlAdapter for SipControlAdapter {
                 "ChannelStateChange".to_string(),
                 "ChannelHangupRequest".to_string(),
                 "ChannelDtmfReceived".to_string(),
+                "TransferRequested".to_string(),
             ],
         }
     }
@@ -127,6 +130,8 @@ fn apply_sip(command: AdapterCommand) -> ControlResult {
         "reject" => reject(&channel, &command.args),
         "hangup" => hangup(&channel, &command.args),
         "refer" => refer(&channel, &command.args),
+        "accept_refer" => accept_refer(&channel, &command.args),
+        "reject_refer" => reject_refer(&channel, &command.args),
         "route" => route(&channel, &command.args),
         "set_header" => set_header(&channel, &command.args),
         "remove_header" => remove_header(&channel, &command.args),
@@ -569,6 +574,88 @@ fn refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
     }
 }
 
+/// `accept_refer` — accept a *controlled* call's pending inbound REFER (surfaced
+/// as a `TransferRequested` event). Drives siphon's shipped transfer machinery in
+/// the resolved mode. Optional `target` overrides the Refer-To URI, `next_hop`
+/// steers egress, and `mode` (`"terminate"` / `"transparent"`) overrides the
+/// configured `b2bua.default_refer_mode`. No pending REFER (already decided,
+/// timed out, or the call is gone) → `not_found`.
+fn accept_refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let target = args.get("target").and_then(|v| v.as_str());
+    if let Some(target) = target {
+        if let Err(error) = crate::sip::parser::parse_uri_standalone(target) {
+            return ControlResult::error(
+                ControlErrorCode::BadRequest,
+                format!("invalid refer target: {error}"),
+            );
+        }
+    }
+    let next_hop = args.get("next_hop").and_then(|v| v.as_str());
+    if let Some(next_hop) = next_hop {
+        if let Err(error) = crate::sip::parser::parse_uri_standalone(next_hop) {
+            return ControlResult::error(
+                ControlErrorCode::BadRequest,
+                format!("invalid next_hop: {error}"),
+            );
+        }
+    }
+    let mode = match parse_refer_mode(args.get("mode")) {
+        Ok(mode) => mode,
+        Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
+    };
+
+    if crate::dispatcher::b2bua_accept_refer_call(
+        &channel.sip_call_id,
+        target.map(|s| s.to_string()),
+        next_hop.map(|s| s.to_string()),
+        mode,
+    ) {
+        ControlResult::Ok(
+            serde_json::json!({ "channel": channel.channel_id, "transfer": "accepted" }),
+        )
+    } else {
+        ControlResult::error(ControlErrorCode::NotFound, "no pending transfer for this call")
+    }
+}
+
+/// `reject_refer` — decline a *controlled* call's pending inbound REFER with a
+/// final non-2xx (default `603 Decline`). No pending REFER → `not_found`.
+fn reject_refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
+    let (code, reason, _, _) = response_args(args, 603, "Decline");
+    if !(300..700).contains(&code) {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "reject_refer requires a 3xx-6xx code",
+        );
+    }
+    if crate::dispatcher::b2bua_reject_refer_call(&channel.sip_call_id, code, &reason) {
+        ControlResult::Ok(
+            serde_json::json!({ "channel": channel.channel_id, "transfer": "rejected", "code": code }),
+        )
+    } else {
+        ControlResult::error(ControlErrorCode::NotFound, "no pending transfer for this call")
+    }
+}
+
+/// Parse an optional `mode` arg for `accept_refer` into a
+/// [`crate::script::api::call::ReferMode`]. Absent / null → `None` (the rail then
+/// applies the configured `b2bua.default_refer_mode`); an unrecognized value is a
+/// typed `bad_request`, never a silent default.
+fn parse_refer_mode(
+    value: Option<&serde_json::Value>,
+) -> Result<Option<crate::script::api::call::ReferMode>, String> {
+    use crate::script::api::call::ReferMode;
+    match value {
+        None => Ok(None),
+        Some(value) if value.is_null() => Ok(None),
+        Some(value) => match value.as_str() {
+            Some("terminate") => Ok(Some(ReferMode::Terminate)),
+            Some("transparent") => Ok(Some(ReferMode::Transparent)),
+            _ => Err("accept_refer args.mode must be \"terminate\" or \"transparent\"".to_string()),
+        },
+    }
+}
+
 /// Parse an optional `replaces` arg (`{call_id, from_tag, to_tag, early_only?}`).
 fn parse_replaces_arg(
     value: Option<&serde_json::Value>,
@@ -779,6 +866,8 @@ mod tests {
             "reject",
             "hangup",
             "refer",
+            "accept_refer",
+            "reject_refer",
             "route",
             "set_header",
             "remove_header",
@@ -800,6 +889,7 @@ mod tests {
             "ChannelStateChange",
             "ChannelHangupRequest",
             "ChannelDtmfReceived",
+            "TransferRequested",
         ] {
             assert!(events.contains(&expected), "missing event {expected}");
         }
@@ -836,7 +926,7 @@ mod tests {
         for verb in ["play", "stop", "dtmf", "hold", "unhold", "stream_start", "stream_stop"] {
             assert!(is_media_verb(verb), "{verb} should route to the async media path");
         }
-        for verb in ["answer", "progress", "reject", "hangup", "refer", "route", "set_header", "remove_header", "get_header", "collect_dtmf", "teleport"] {
+        for verb in ["answer", "progress", "reject", "hangup", "refer", "accept_refer", "reject_refer", "route", "set_header", "remove_header", "get_header", "collect_dtmf", "teleport"] {
             assert!(!is_media_verb(verb), "{verb} should NOT route to the async media path");
         }
     }
@@ -1233,5 +1323,99 @@ mod tests {
         assert!(replaces.early_only);
         assert!(parse_replaces_arg(None).unwrap().is_none());
         assert!(parse_replaces_arg(Some(&serde_json::Value::Null)).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_refer_mode_variants() {
+        use crate::script::api::call::ReferMode;
+        assert_eq!(parse_refer_mode(None), Ok(None));
+        assert_eq!(parse_refer_mode(Some(&serde_json::Value::Null)), Ok(None));
+        assert_eq!(
+            parse_refer_mode(Some(&serde_json::json!("terminate"))),
+            Ok(Some(ReferMode::Terminate))
+        );
+        assert_eq!(
+            parse_refer_mode(Some(&serde_json::json!("transparent"))),
+            Ok(Some(ReferMode::Transparent))
+        );
+        // An unrecognized mode is a typed error, never a silent default.
+        assert!(parse_refer_mode(Some(&serde_json::json!("sideways"))).is_err());
+        assert!(parse_refer_mode(Some(&serde_json::json!(42))).is_err());
+    }
+
+    #[test]
+    fn accept_refer_bad_mode_is_bad_request() {
+        // Parsed before touching the rail, so it holds with no dispatcher.
+        let result = accept_refer(&channel(), &serde_json::json!({ "mode": "sideways" }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn accept_refer_bad_target_is_bad_request() {
+        let result = accept_refer(&channel(), &serde_json::json!({ "target": "not a uri" }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn accept_refer_without_pending_is_not_found() {
+        // No B2BUA_CONTROL installed (unit context) → b2bua_accept_refer_call is
+        // false (no pending REFER), mapped to not_found — never a hang.
+        let result = accept_refer(&channel(), &serde_json::json!({}));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[test]
+    fn accept_refer_dispatches_through_apply_sip() {
+        // Prove the "accept_refer" arm is wired in apply_sip (reaches the rail →
+        // not_found with no dispatcher, rather than the unsupported_verb catch-all).
+        let result = apply_sip(AdapterCommand {
+            verb: "accept_refer".to_string(),
+            args: serde_json::json!({}),
+            target: ResolvedTarget::Channel(channel()),
+        });
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[test]
+    fn reject_refer_bad_code_is_bad_request() {
+        let result = reject_refer(&channel(), &serde_json::json!({ "code": 200 }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn reject_refer_without_pending_is_not_found() {
+        let result = reject_refer(&channel(), &serde_json::json!({ "code": 486, "reason": "Busy" }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+    }
+
+    #[test]
+    fn reject_refer_dispatches_through_apply_sip() {
+        let result = apply_sip(AdapterCommand {
+            verb: "reject_refer".to_string(),
+            args: serde_json::json!({}),
+            target: ResolvedTarget::Channel(channel()),
+        });
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
     }
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -282,6 +282,12 @@ struct DispatcherState {
     /// `cdr.auto_emit` is off; the orphan sweep reaps any entry whose teardown
     /// never reached the dispatcher.
     cdr_sessions: Arc<DashMap<String, crate::cdr::CdrSession>>,
+    /// Inbound REFERs on *controlled* B2BUA calls held un-answered while the
+    /// owning control app decides (`accept_refer` / `reject_refer`). Populated by
+    /// [`handle_b2bua_refer`] only when the call is controlled; drained on accept
+    /// / reject / the decision-deadline sweep. Empty and cheaply skipped when no
+    /// control plane is configured (no call is ever controlled).
+    pending_inbound_refer: Arc<PendingInboundReferStore>,
 }
 
 /// Bundle held in `DispatcherState::rf_sessions` so ACR-STOP can reuse
@@ -728,6 +734,7 @@ pub async fn run(
         ro_charger,
         ro_sessions: Arc::new(DashMap::new()),
         cdr_sessions: Arc::new(DashMap::new()),
+        pending_inbound_refer: Arc::new(PendingInboundReferStore::default()),
     });
 
     // Hand the freshly-constructed manager handles to the drain coordinator
@@ -826,6 +833,7 @@ pub async fn run(
                     }
                     _ = answer_timeout_interval.tick() => {
                         check_b2bua_answer_timeouts(&state);
+                        check_pending_inbound_refer_timeouts(&state);
                     }
                     _ = cleanup_interval.tick() => {
                         sweep_stale_entries(&state).await;
@@ -11401,6 +11409,26 @@ fn check_b2bua_answer_timeouts(state: &DispatcherState) {
     }
 }
 
+/// Answer every controlled call's inbound REFER whose decision deadline passed
+/// without the owning control app calling `accept_refer` / `reject_refer` — a
+/// `603 Decline`, matching the no-`@b2bua.on_refer`-handler default. Drains the
+/// pending entry so the store returns to baseline (a REFER held forever would
+/// strand the referrer). Modelled on [`check_b2bua_answer_timeouts`]; runs on the
+/// same fast dispatcher-loop interval.
+fn check_pending_inbound_refer_timeouts(state: &DispatcherState) {
+    let now = std::time::Instant::now();
+    for pending in state.pending_inbound_refer.take_expired(now) {
+        let sip_call_id = pending
+            .message
+            .headers
+            .get("Call-ID")
+            .map(|value| value.to_string())
+            .unwrap_or_default();
+        warn!(%sip_call_id, "control plane: inbound REFER decision deadline — no accept_refer/reject_refer, applying default (603 Decline)");
+        b2bua_refer_send_final(&pending.inbound, &pending.message, 603, "Decline", state);
+    }
+}
+
 /// Resolve a gateway group to a healthy member's next-hop URI (LCR carrier
 /// pools). `None` when the group is unknown or entirely down — the caller skips
 /// that carrier. The transport is baked into the URI so a TLS/TCP carrier pool
@@ -17579,6 +17607,81 @@ pub fn b2bua_refer_call(
     b2bua_send_outbound_refer(&control.state, &internal_call_id, /*on_a_leg=*/ true, &refer_to)
 }
 
+/// Accept a *controlled* call's pending inbound REFER — the control-plane
+/// `accept_refer` verb. Pops the REFER held by [`handle_b2bua_refer`] for a
+/// controlled call and drives the shipped [`b2bua_refer_accept`] transfer in the
+/// resolved mode (terminate = siphon-terminated 202 + NOTIFY + re-dial;
+/// transparent = forward on the far leg), reusing the exact same machinery the
+/// `@b2bua.on_refer` accept path uses — including #181's single-leg behaviour
+/// (a voice-ai / IVR call with no B leg re-dials the target off the A dialog,
+/// falling back to the referrer's SDP when there is no surviving leg to bridge).
+///
+/// `target` overrides the Refer-To URI, `next_hop` steers egress without
+/// reshaping the R-URI, and `mode` overrides the configured
+/// `b2bua.default_refer_mode`. Returns `false` (never panics) when no REFER is
+/// pending for this call (already decided, timed out, or the call is gone),
+/// which the adapter maps to `not_found`. Safe from any thread (enters the
+/// dispatcher runtime), mirroring [`b2bua_refer_call`].
+pub fn b2bua_accept_refer_call(
+    sip_call_id: &str,
+    target: Option<String>,
+    next_hop: Option<String>,
+    mode: Option<crate::script::api::call::ReferMode>,
+) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let state = &control.state;
+    let Some(pending) = state.pending_inbound_refer.take(sip_call_id) else {
+        return false;
+    };
+    let Some(internal_call_id) = state.call_actors.find_by_sip_call_id(sip_call_id) else {
+        // The call vanished between the REFER and the decision — the referrer's
+        // transaction is gone too. The pending entry is already removed (no leak).
+        warn!(%sip_call_id, "b2bua_accept_refer_call: call gone before accept — dropping pending REFER");
+        return false;
+    };
+
+    // The send path re-anchors media (block_in_place) and may spawn (TCP/TLS
+    // connect); the caller may be on a non-tokio thread (control apply task) —
+    // establish the runtime, mirroring b2bua_route_call / b2bua_refer_call.
+    let _enter = control.runtime.enter();
+
+    let mode = mode.unwrap_or(state.default_refer_mode);
+    let target_uri = target.unwrap_or_else(|| pending.refer_to.uri.clone());
+    b2bua_refer_accept(
+        pending.inbound,
+        pending.message,
+        &internal_call_id,
+        pending.from_a_leg,
+        &target_uri,
+        next_hop.as_deref(),
+        pending.refer_to.replaces.clone(),
+        mode,
+        state,
+    );
+    true
+}
+
+/// Reject a *controlled* call's pending inbound REFER — the control-plane
+/// `reject_refer` verb. Pops the REFER held by [`handle_b2bua_refer`] and sends
+/// the given final non-2xx to the referrer on the flow it arrived on (the same
+/// builder the no-handler / deadline paths use, so the referrer is always
+/// answered per RFC 3515 §2.4.2). Returns `false` (mapped to `not_found` by the
+/// adapter) when no REFER is pending for this call. Safe from any thread.
+pub fn b2bua_reject_refer_call(sip_call_id: &str, code: u16, reason: &str) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let state = &control.state;
+    let Some(pending) = state.pending_inbound_refer.take(sip_call_id) else {
+        return false;
+    };
+    let _enter = control.runtime.enter();
+    b2bua_refer_send_final(&pending.inbound, &pending.message, code, reason, state);
+    true
+}
+
 /// One routing target for [`b2bua_route_call`]. Built by the control adapter from
 /// the `route` verb's `targets[]` — a bare URI (`ruri` only) or an object
 /// carrying a per-target `next_hop` / `headers` / ring `timeout`.
@@ -19086,6 +19189,126 @@ fn build_b2bua_in_dialog_request(
     }
 }
 
+/// A REFER received on a *controlled* B2BUA call, held un-answered while the
+/// owning control app decides via `accept_refer` / `reject_refer`.
+///
+/// The inbound datagram + parsed message are owned here so the deferred decision
+/// can drive [`b2bua_refer_accept`] (accept) or build the final SIP response
+/// (reject / deadline) — both need the original request to route the answer back
+/// on the flow the REFER arrived on. The entry is removed on accept, reject, OR
+/// the decision deadline (a `603 Decline`, matching the no-`@b2bua.on_refer`
+/// -handler default). A REFER left pending forever would strand the referrer's
+/// transaction, so the deadline is a hard backstop, never optional.
+struct PendingInboundRefer {
+    /// The inbound datagram (transport + flow) the REFER arrived on.
+    inbound: InboundMessage,
+    /// The parsed REFER request.
+    message: SipMessage,
+    /// Parsed Refer-To — target URI + any embedded Replaces (attended transfer).
+    refer_to: crate::sip::headers::refer::ReferTo,
+    /// Whether the REFER arrived on the A-leg dialog (drives survivor selection in
+    /// terminate mode — see [`b2bua_refer_accept`]).
+    from_a_leg: bool,
+    /// When the decision deadline expires and the sweep applies the 603 default.
+    deadline: std::time::Instant,
+}
+
+/// Per-call store of inbound REFERs on *controlled* calls awaiting a control-app
+/// decision, keyed by the REFER's SIP Call-ID (byte-identical to the control
+/// channel's `sip_call_id` for a controlled single-`CallActor` call).
+///
+/// New per-call state: every entry is removed on accept, reject, or the decision
+/// deadline, so the store drains back to baseline under a completed workload (the
+/// classic never-evicted-per-call-entry leak). Covered by the co-located
+/// steady-state leak test `pending_inbound_refer_store_drains_to_baseline`.
+#[derive(Default)]
+struct PendingInboundReferStore {
+    entries: DashMap<String, PendingInboundRefer>,
+}
+
+impl PendingInboundReferStore {
+    /// Record a pending REFER. Returns `false` (dropping `pending`) when an entry
+    /// already exists for this call — a REFER retransmit is absorbed rather than
+    /// pushing a duplicate `TransferRequested` to the app or resetting the
+    /// deadline. Race-safe via the map entry API (the junction is not guaranteed
+    /// serialized per Call-ID across workers).
+    fn insert(&self, sip_call_id: &str, pending: PendingInboundRefer) -> bool {
+        use dashmap::mapref::entry::Entry;
+        match self.entries.entry(sip_call_id.to_string()) {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(slot) => {
+                slot.insert(pending);
+                true
+            }
+        }
+    }
+
+    /// Remove + return the pending REFER for a call (accept / reject path). `None`
+    /// when nothing is pending (already decided, timed out, or never controlled).
+    fn take(&self, sip_call_id: &str) -> Option<PendingInboundRefer> {
+        self.entries.remove(sip_call_id).map(|(_, pending)| pending)
+    }
+
+    /// Drain every entry whose decision deadline has passed; the sweep applies the
+    /// 603 default to each drained REFER.
+    fn take_expired(&self, now: std::time::Instant) -> Vec<PendingInboundRefer> {
+        let expired: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|entry| entry.value().deadline <= now)
+            .map(|entry| entry.key().clone())
+            .collect();
+        expired
+            .into_iter()
+            .filter_map(|key| self.entries.remove(&key).map(|(_, pending)| pending))
+            .collect()
+    }
+
+    /// The number of pending REFERs (leak-test + observability accessor).
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Send the final SIP response to an inbound REFER on the flow it arrived on.
+///
+/// The single builder every "answer the REFER now" path funnels through — the
+/// no-`@b2bua.on_refer`-handler and script-reject arms of [`handle_b2bua_refer`],
+/// the control-plane `reject_refer` verb, and the decision-deadline 603 default.
+/// RFC 3515 §2.4.2: a REFER is always answered, never silently dropped.
+fn b2bua_refer_send_final(
+    inbound: &InboundMessage,
+    message: &SipMessage,
+    code: u16,
+    reason: &str,
+    state: &DispatcherState,
+) {
+    let response = build_response(message, code, reason, state.server_header.as_deref(), &[]);
+    send_message_from(
+        response,
+        inbound.transport,
+        inbound.remote_addr,
+        inbound.connection_id,
+        Some(inbound.local_addr),
+        state,
+    );
+}
+
+/// The window a controlled call's inbound REFER waits for an `accept_refer` /
+/// `reject_refer` decision before the sweep applies the 603 default.
+///
+/// Reuses the control app's handoff-deadline knob (the same "how long to wait for
+/// the controller to act" budget), flooring a disabled (`0`) value at 30 s so the
+/// REFER is always answered inside the referrer's transaction (RFC 3261 Timer F =
+/// 64·T1 ≈ 32 s) — a REFER left pending forever would strand the referrer.
+fn refer_decision_deadline(bus: &crate::control::ControlBus) -> std::time::Duration {
+    match bus.handoff_deadline_ms() {
+        0 => std::time::Duration::from_secs(30),
+        ms => std::time::Duration::from_millis(ms),
+    }
+}
+
 /// Handle an in-dialog REFER (RFC 3515) belonging to a tracked B2BUA call.
 ///
 /// This is the intercept that stops the REFER loop: without it, an in-dialog
@@ -19095,12 +19318,19 @@ fn build_b2bua_in_dialog_request(
 ///
 /// Flow: resolve the dialog leg the REFER arrived on (by dialog identity, never
 /// source socket — Teams reconnects per transaction over TLS), parse Refer-To,
-/// fire `@b2bua.on_refer(call)`, then act on the deferred action:
-///   - no `@b2bua.on_refer` handler registered → local `603 Decline` (siphon
-///     *does* implement REFER, so `501 Not Implemented` would be untruthful),
-///   - `reject_refer(code, reason)` → that final response,
-///   - `accept_refer(...)` → run the transfer in the resolved mode
-///     (siphon-terminated by default, transparent forward when selected).
+/// then split on ownership:
+///   - **Controlled call** (handed to an external control app): hold the REFER
+///     un-answered, emit a `TransferRequested` event to the owning connection,
+///     and arm the decision deadline. The app decides via `accept_refer` /
+///     `reject_refer`; a missed deadline applies the 603 default. The in-process
+///     `@b2bua.on_refer` path does NOT run.
+///   - **Uncontrolled call**: fire `@b2bua.on_refer(call)`, then act on the
+///     deferred action:
+///     - no `@b2bua.on_refer` handler registered → local `603 Decline` (siphon
+///       *does* implement REFER, so `501 Not Implemented` would be untruthful),
+///     - `reject_refer(code, reason)` → that final response,
+///     - `accept_refer(...)` → run the transfer in the resolved mode
+///       (siphon-terminated by default, transparent forward when selected).
 ///
 /// Every path answers the REFER — never a silent drop, never a proxy relay.
 fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &DispatcherState) {
@@ -19177,24 +19407,54 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
         Some(Ok(refer_to)) => refer_to,
         _ => {
             warn!(call_id = %call_id, "B2BUA REFER: missing or malformed Refer-To — 400");
-            let response = build_response(
-                &message,
-                400,
-                "Bad Request",
-                state.server_header.as_deref(),
-                &[],
-            );
-            send_message_from(
-                response,
-                inbound.transport,
-                inbound.remote_addr,
-                inbound.connection_id,
-                Some(inbound.local_addr),
-                state,
-            );
+            b2bua_refer_send_final(&inbound, &message, 400, "Bad Request", state);
             return;
         }
     };
+
+    // Control-plane interception (RFC 3515 on a *controlled* call): when the call
+    // has been handed to an external control app, that app owns the transfer
+    // decision — NOT the in-process `@b2bua.on_refer` path. Hold the REFER
+    // un-answered, surface it as a `TransferRequested` event on the owning
+    // connection, and arm the decision deadline (603 Decline default on timeout,
+    // matching the no-handler default below). An UNCONTROLLED call falls through
+    // to the Python path unchanged — the control interception is only for
+    // controlled calls.
+    if let Some(bus) = crate::control::ControlBus::global() {
+        if let Some(channel_id) = bus.channel_id_for_sip_call_id(&sip_call_id) {
+            let emitted = state.pending_inbound_refer.insert(
+                &sip_call_id,
+                PendingInboundRefer {
+                    inbound,
+                    message,
+                    refer_to: refer_to.clone(),
+                    from_a_leg,
+                    deadline: std::time::Instant::now() + refer_decision_deadline(&bus),
+                },
+            );
+            if emitted {
+                bus.forward_transfer_requested(
+                    &channel_id,
+                    &sip_call_id,
+                    &refer_to,
+                    from_tag.as_deref(),
+                );
+                info!(
+                    call_id = %call_id,
+                    %sip_call_id,
+                    channel = %channel_id,
+                    target = %refer_to.uri,
+                    "B2BUA REFER: controlled call — TransferRequested, awaiting accept/reject"
+                );
+            } else {
+                // A REFER retransmit (non-INVITE over UDP retransmits to Timer F):
+                // a decision is already pending, so absorb it rather than emit a
+                // duplicate event or reset the deadline.
+                debug!(call_id = %call_id, %sip_call_id, "B2BUA REFER: retransmit for a pending controlled transfer — absorbed");
+            }
+            return;
+        }
+    }
 
     // Fire @b2bua.on_refer(call). No handler → local 603 Decline (loop killer for
     // scripts that don't handle REFER at all).
@@ -19202,21 +19462,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
     let handlers = engine_state.handlers_for(&HandlerKind::B2buaRefer);
     if handlers.is_empty() {
         debug!(call_id = %call_id, "B2BUA REFER: no @b2bua.on_refer handler — 603 Decline");
-        let response = build_response(
-            &message,
-            603,
-            "Decline",
-            state.server_header.as_deref(),
-            &[],
-        );
-        send_message_from(
-            response,
-            inbound.transport,
-            inbound.remote_addr,
-            inbound.connection_id,
-            Some(inbound.local_addr),
-            state,
-        );
+        b2bua_refer_send_final(&inbound, &message, 603, "Decline", state);
         return;
     }
 
@@ -19269,16 +19515,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
     match action {
         CallAction::RejectRefer { code, reason } => {
             debug!(call_id = %call_id, code, "B2BUA REFER: script rejected");
-            let response =
-                build_response(&message, code, &reason, state.server_header.as_deref(), &[]);
-            send_message_from(
-                response,
-                inbound.transport,
-                inbound.remote_addr,
-                inbound.connection_id,
-                Some(inbound.local_addr),
-                state,
-            );
+            b2bua_refer_send_final(&inbound, &message, code, &reason, state);
         }
         CallAction::AcceptRefer {
             target,
@@ -19304,21 +19541,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
         // fall through to a relay (RFC 3515 — the recipient must answer).
         other => {
             debug!(call_id = %call_id, ?other, "B2BUA REFER: handler took no accept/reject action — 603 Decline");
-            let response = build_response(
-                &message,
-                603,
-                "Decline",
-                state.server_header.as_deref(),
-                &[],
-            );
-            send_message_from(
-                response,
-                inbound.transport,
-                inbound.remote_addr,
-                inbound.connection_id,
-                Some(inbound.local_addr),
-                state,
-            );
+            b2bua_refer_send_final(&inbound, &message, 603, "Decline", state);
         }
     }
 }
@@ -25203,6 +25426,171 @@ a=rtpmap:8 PCMA/8000\r\n";
         assert!(
             rf_reserve_start(&pending, key).is_some(),
             "the key is claimable again once the in-flight START resolved"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Pending-inbound-REFER store (controlled-call transfer decision)
+    // -----------------------------------------------------------------------
+
+    /// Build a parseable in-dialog REFER whose Refer-To targets `sip:carol@…`.
+    fn sample_refer() -> SipMessage {
+        let raw = concat!(
+            "REFER sip:proxy@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/UDP 192.0.2.1:5060;branch=z9hG4bKrefer\r\n",
+            "From: <sip:alice@example.com>;tag=alicetag\r\n",
+            "To: <sip:proxy@example.com>;tag=proxytag\r\n",
+            "Call-ID: refer-call@example.com\r\n",
+            "CSeq: 2 REFER\r\n",
+            "Refer-To: <sip:carol@example.com>\r\n",
+            "Max-Forwards: 70\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        );
+        parse_sip_message(raw).expect("REFER fixture must parse").1
+    }
+
+    /// Build a `PendingInboundRefer` with the given decision deadline. The
+    /// inbound flow is a minimal UDP datagram (the store just moves it around).
+    fn sample_pending_refer(deadline: std::time::Instant) -> PendingInboundRefer {
+        let addr: SocketAddr = "192.0.2.1:5060".parse().unwrap();
+        let local: SocketAddr = "192.0.2.100:5060".parse().unwrap();
+        PendingInboundRefer {
+            inbound: InboundMessage {
+                connection_id: ConnectionId::default(),
+                transport: Transport::Udp,
+                local_addr: local,
+                remote_addr: addr,
+                data: Bytes::new(),
+            },
+            message: sample_refer(),
+            refer_to: crate::sip::headers::refer::ReferTo {
+                uri: "sip:carol@example.com".to_string(),
+                replaces: None,
+            },
+            from_a_leg: true,
+            deadline,
+        }
+    }
+
+    #[test]
+    fn pending_inbound_refer_store_drains_to_baseline() {
+        // THE leak gate: N controlled calls each get a pending REFER, then each is
+        // drained via one of the three exit paths (accept → take, reject → take,
+        // deadline → take_expired). The store MUST return to its baseline len() —
+        // a per-call entry that is never evicted is the exact leak this catches.
+        let store = PendingInboundReferStore::default();
+        let baseline = store.len();
+        assert_eq!(baseline, 0);
+
+        let now = std::time::Instant::now();
+        let future = now + std::time::Duration::from_secs(30);
+        let past = now - std::time::Duration::from_secs(1);
+
+        for cycle in 0..64 {
+            let accept_key = format!("accept-{cycle}@host");
+            let reject_key = format!("reject-{cycle}@host");
+            let timeout_key = format!("timeout-{cycle}@host");
+
+            assert!(store.insert(&accept_key, sample_pending_refer(future)));
+            assert!(store.insert(&reject_key, sample_pending_refer(future)));
+            assert!(store.insert(&timeout_key, sample_pending_refer(past)));
+            assert_eq!(store.len(), baseline + 3);
+
+            // Accept path drains its entry.
+            assert!(store.take(&accept_key).is_some());
+            // Reject path drains its entry.
+            assert!(store.take(&reject_key).is_some());
+            // Deadline sweep drains the expired one (only the past-deadline entry).
+            let expired = store.take_expired(now);
+            assert_eq!(expired.len(), 1);
+
+            assert_eq!(
+                store.len(),
+                baseline,
+                "store must drain to baseline after cycle {cycle}"
+            );
+        }
+        assert_eq!(store.len(), baseline);
+    }
+
+    #[test]
+    fn pending_inbound_refer_absorbs_retransmit() {
+        // A second insert for the same call (a REFER retransmit) is absorbed —
+        // returns false and does not add a duplicate entry or reset the deadline.
+        let store = PendingInboundReferStore::default();
+        let now = std::time::Instant::now();
+        let future = now + std::time::Duration::from_secs(30);
+
+        assert!(store.insert("cid@host", sample_pending_refer(future)));
+        assert!(
+            !store.insert("cid@host", sample_pending_refer(future)),
+            "a retransmit must be absorbed, not duplicated"
+        );
+        assert_eq!(store.len(), 1);
+
+        assert!(store.take("cid@host").is_some());
+        assert_eq!(store.len(), 0);
+        // A decision after the entry is gone (raced timeout) is a clean no-op.
+        assert!(store.take("cid@host").is_none());
+    }
+
+    #[test]
+    fn pending_inbound_refer_take_expired_only_past_deadline() {
+        let store = PendingInboundReferStore::default();
+        let now = std::time::Instant::now();
+
+        assert!(store.insert(
+            "past@host",
+            sample_pending_refer(now - std::time::Duration::from_millis(1))
+        ));
+        assert!(store.insert(
+            "future@host",
+            sample_pending_refer(now + std::time::Duration::from_secs(30))
+        ));
+
+        let expired = store.take_expired(now);
+        assert_eq!(expired.len(), 1, "only the past-deadline entry is swept");
+        // The future entry survives the sweep.
+        assert_eq!(store.len(), 1);
+        assert!(store.take("future@host").is_some());
+    }
+
+    #[test]
+    fn pending_inbound_refer_preserves_accept_inputs() {
+        // The stored entry preserves exactly what the accept path feeds
+        // b2bua_refer_accept: the Refer-To target + the resolved leg direction.
+        let store = PendingInboundReferStore::default();
+        let now = std::time::Instant::now();
+        store.insert("cid@host", sample_pending_refer(now + std::time::Duration::from_secs(30)));
+
+        let pending = store.take("cid@host").expect("entry present");
+        assert_eq!(pending.refer_to.uri, "sip:carol@example.com");
+        assert!(pending.from_a_leg);
+    }
+
+    #[test]
+    fn expired_pending_refer_answers_603_decline() {
+        // On the decision deadline the sweep answers the referrer 603 Decline
+        // (matching the no-@b2bua.on_refer-handler default). Prove the drained
+        // entry's REFER maps to a well-formed 603 final response — the wire action
+        // the sweep applies via b2bua_refer_send_final.
+        let store = PendingInboundReferStore::default();
+        let now = std::time::Instant::now();
+        store.insert(
+            "cid@host",
+            sample_pending_refer(now - std::time::Duration::from_millis(1)),
+        );
+
+        let expired = store.take_expired(now);
+        assert_eq!(expired.len(), 1);
+        let response = build_response(&expired[0].message, 603, "Decline", None, &[]);
+        assert!(response.is_response());
+        assert_eq!(response.status_code(), Some(603));
+        // Answered on the referrer's dialog — the REFER's Via/From/To/Call-ID.
+        assert_eq!(
+            response.headers.call_id().unwrap(),
+            "refer-call@example.com"
         );
     }
 }


### PR DESCRIPTION
## What

Surfaces an in-dialog REFER received on a **controlled** B2BUA call to the owning external control app as a `TransferRequested` event, and lets the app decide via two new SIP-adapter verbs (`accept_refer` / `reject_refer`) through a deferred-decision store.

Today an in-dialog REFER on a tracked B2BUA call runs the in-process `@b2bua.on_refer` path (or 603 if no handler). When the call has been handed to a control app, that app must own the transfer decision instead.

## How

- **Junction** (`handle_b2bua_refer`, `src/dispatcher.rs`): after resolving the call + parsing Refer-To, it checks `ControlBus::channel_id_for_sip_call_id`. If the call is controlled it stores the inbound REFER in a per-call pending store, arms a decision deadline, emits `TransferRequested` (payload `{refer_to, replaces?, from_tag}` plus the stable id triple) to the owning connection, and returns **without** running the Python path or answering. An uncontrolled call falls through to the existing `@b2bua.on_refer` path unchanged. A REFER retransmit for a pending decision is absorbed (no duplicate event).
- **Pending store** (`PendingInboundReferStore`, a `DashMap` on `DispatcherState`): a new per-call structure inserted on interception and removed on accept, reject, **or** the decision-deadline sweep — with a co-located steady-state leak test asserting it drains to baseline across accept/reject/timeout cycles.
- **Accept reuses the shipped transfer machinery**: `b2bua_accept_refer_call` pops the pending REFER and drives the existing `b2bua_refer_accept(...)` with the same args the script accept path uses (terminate / transparent mode, target/next_hop overrides). This builds on the single-leg REFER machinery from #181, so a terminate-mode accept on a voice-AI / IVR call with no B leg re-dials the target off the A dialog.
- **Reject / deadline** send a real final SIP response through one `b2bua_refer_send_final` builder (the four "answer the REFER" arms are folded through it). A missed deadline answers `603 Decline` — the same default as no `@b2bua.on_refer` handler — so a REFER is never left pending. The deadline sweep runs on the existing fast dispatcher-loop interval, modelled on the answer/handoff sweep.
- **Adapter verbs** (`src/control/sip_adapter.rs`): `accept_refer{target?, next_hop?, mode?}` (mode ∈ `terminate` / `transparent`, bad mode → `bad_request`, default from config) and `reject_refer{code?, reason?}`. `Ok(false)` from the rail (no pending REFER) → `not_found`. Both added to `describe()` verbs, `TransferRequested` added to `describe()` events, parity test extended.

## Tests

TDD, all green. Unit coverage for the pending-store insert/take/expire + retransmit absorb, the **co-located steady-state leak test** (drains to baseline after accept/reject/timeout), the `TransferRequested` emit path (registry), the 603 deadline default, and adapter arg parsing (bad mode → `bad_request`, missing pending → `not_found`, dispatch wiring). `cargo test` and `cargo clippy --all-targets --all-features -D warnings` both clean.

## Not in scope

SDK client facades for the new verbs / event and the release are a follow-up (server-only here).