### PR TITLE
fix(packaging): create missing parent dirs for file sinks, ship a logrotate config that matches the writable dir, and stop the unit restart-looping on a broken config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
             -C target/${{ matrix.target }}/release siphon \
             --transform='s,^,siphon-${{ github.ref_name }}/,' \
             -C "${{ github.workspace }}" siphon.yaml scripts/proxy_default.py scripts/b2bua_default.py \
-            dist/siphon.service LICENSE README.md
+            dist/siphon.service etc/logrotate.d/siphon LICENSE README.md
           echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
       # Stage everything into one flat dir. v1.0.0 lost the deb/rpm because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,33 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   owned by the service user, and pins `WorkingDirectory=/etc/siphon`. It also
   documents, as commented lines, the `CAP_NET_ADMIN` + `AF_NETLINK` an IMS
   P-CSCF needs for `ipsec:` sec-agree.
+- **A log, CDR, audit or event-sink file whose parent directory is missing now
+  creates it.** Opening with `create(true)` creates the file and never the
+  directory holding it, so every default path we ship — all of them inside
+  `/var/log/siphon` — worked only through the packaged unit, where
+  `LogsDirectory=` had already made the directory. Started any other way (a
+  tarball install, `cargo install`, a container, by hand) the same config took
+  `log.file` down with a process exit and logged an error per record for the CDR
+  file, the LI audit log and the Diameter event sink. The directory is created
+  only when the open actually fails with `NotFound`, so the happy path is
+  unchanged and a permission error still reads as a permission error.
+- **The shipped logrotate config is installed, and rotates the paths siphon
+  actually writes.** `etc/logrotate.d/siphon` still named `/var/log/siphon.log`
+  — a path that is not writable under `ProtectSystem=strict` — and was in no
+  package: not the `.deb`, not the `.rpm`, not the release tarball. It now
+  covers `/var/log/siphon/*.log` with `copytruncate` (siphon holds those open
+  for the process lifetime, and `ExecReload` reloads the Python script, not the
+  log file) and rotates `cdr.jsonl` separately *without* `copytruncate`, whose
+  copy-then-truncate race can drop a billing record. `.deb` and `.rpm` also
+  create `/var/log/siphon` at install time for a by-hand first run.
+- **The packaged unit stops restart-looping on a broken config.** siphon exits
+  non-zero on a config or script error, and `RestartSec=5s` puts only two starts
+  inside systemd's default 10 s window, so the default start limit never tripped
+  — a permanently broken config looped forever (a reported install reached
+  restart counter 279) instead of failing visibly. The unit now sets
+  `StartLimitIntervalSec=300` / `StartLimitBurst=10`, so roughly a minute of
+  failed restarts puts the unit in `failed` where `systemctl status` shows it —
+  generous enough that a slow-to-appear address still recovers on its own.
 
 ### Added
 - **In-band DTMF on a controlled call is forwarded to the control plane as a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,10 +280,11 @@ assets = [
     ["scripts/proxy_default.py", "etc/siphon/scripts/proxy_default.py", "644"],
     ["scripts/b2bua_default.py", "etc/siphon/scripts/b2bua_default.py", "644"],
     ["dist/siphon.service", "lib/systemd/system/siphon.service", "644"],
+    ["etc/logrotate.d/siphon", "etc/logrotate.d/siphon", "644"],
     ["README.md", "usr/share/doc/siphon/README.md", "644"],
     ["LICENSE", "usr/share/doc/siphon/LICENSE", "644"],
 ]
-conf-files = ["/etc/siphon/siphon.yaml"]
+conf-files = ["/etc/siphon/siphon.yaml", "/etc/logrotate.d/siphon"]
 maintainer-scripts = "dist/debian/"
 systemd-units = { unit-name = "siphon", enable = false, start = false }
 
@@ -295,6 +296,7 @@ assets = [
     { source = "scripts/proxy_default.py", dest = "/etc/siphon/scripts/proxy_default.py", mode = "644" },
     { source = "scripts/b2bua_default.py", dest = "/etc/siphon/scripts/b2bua_default.py", mode = "644" },
     { source = "dist/siphon.service", dest = "/usr/lib/systemd/system/siphon.service", mode = "644" },
+    { source = "etc/logrotate.d/siphon", dest = "/etc/logrotate.d/siphon", mode = "644", config = true },
     { source = "README.md", dest = "/usr/share/doc/siphon/README.md", mode = "644" },
     { source = "LICENSE", dest = "/usr/share/doc/siphon/LICENSE", mode = "644" },
 ]
@@ -307,8 +309,8 @@ python3 = ">= 3.12"
 pre_install_script = """
 getent group siphon >/dev/null || groupadd -r siphon
 getent passwd siphon >/dev/null || useradd -r -g siphon -d /var/lib/siphon -s /sbin/nologin -c "SIPhon SIP proxy" siphon
-mkdir -p /var/lib/siphon
-chown siphon:siphon /var/lib/siphon
+mkdir -p /var/lib/siphon /var/log/siphon
+chown siphon:siphon /var/lib/siphon /var/log/siphon
 """
 post_install_script = """
 systemctl daemon-reload

--- a/dist/debian/preinst
+++ b/dist/debian/preinst
@@ -11,7 +11,11 @@ if ! getent passwd siphon >/dev/null; then
         --no-create-home --gecos "SIPhon SIP proxy" siphon
 fi
 
-mkdir -p /var/lib/siphon
-chown siphon:siphon /var/lib/siphon
+# systemd creates and owns these through StateDirectory=/LogsDirectory= when
+# the unit starts, but the shipped config points log.file, cdr.file.path and
+# the LI audit log inside them, so create them here too for anyone running the
+# binary by hand before the first `systemctl start`.
+mkdir -p /var/lib/siphon /var/log/siphon
+chown siphon:siphon /var/lib/siphon /var/log/siphon
 
 #DEBHELPER#

--- a/dist/siphon.service
+++ b/dist/siphon.service
@@ -5,6 +5,16 @@ Documentation=https://github.com/siphon-project/siphon-sip
 After=network-online.target
 Wants=network-online.target
 
+# Give up instead of restarting forever. siphon exits non-zero on a config or
+# script error, and RestartSec=5s puts only two starts in systemd's default
+# 10 s window, so a permanently broken config never trips the default limit —
+# it just loops silently until someone reads the journal. The window here is
+# deliberately generous (roughly a minute of retrying before the unit fails):
+# long enough that a slow-to-appear address or a dependency still coming up
+# recovers on its own, short of the endless loop a bad config used to produce.
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
 [Service]
 Type=simple
 # A relative script.path in siphon.yaml is resolved against the config

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,12 +146,14 @@ from-source path, are covered in the
 [README](https://github.com/siphon-project/siphon-sip#installation).
 
 If the unit does not come up, `journalctl -u siphon -n 50` has the reason: siphon
-exits non-zero on a config or script error, so `Restart=on-failure` turns any
-such error into a restart loop rather than a running-but-broken proxy. Two
-things the sandboxed unit imposes that a manual run does not:
+exits non-zero on a config or script error rather than running broken, and the
+unit gives up after about a minute of failed restarts, so `systemctl status
+siphon` reports `failed` instead of restarting forever. Two things the sandboxed unit
+imposes that a manual run does not:
 
 - **Writable paths.** `ProtectSystem=strict` leaves the filesystem read-only
-  apart from `/var/lib/siphon` and `/var/log/siphon`. Point `log.file`,
+  apart from `/var/lib/siphon` and `/var/log/siphon`, which the unit creates
+  itself through `StateDirectory=` / `LogsDirectory=`. Point `log.file`,
   `cdr.file.path`, registrar persistence and recordings inside those.
 - **Capabilities.** The unit grants `CAP_NET_BIND_SERVICE` only. An IMS P-CSCF
   using the `ipsec:` sec-agree block also needs `CAP_NET_ADMIN` and `AF_NETLINK`
@@ -159,6 +161,11 @@ things the sandboxed unit imposes that a manual run does not:
 
 Override either with `systemctl edit siphon` rather than editing the packaged
 unit, which an upgrade replaces.
+
+The packages also install `/etc/logrotate.d/siphon`, which rotates everything
+siphon writes under `/var/log/siphon` — daily, 14 rotations for log files and 30
+for `cdr.jsonl`. Nothing to enable; adjust the retention there if your policy
+differs.
 
 ### Running a native binary directly
 

--- a/etc/logrotate.d/siphon
+++ b/etc/logrotate.d/siphon
@@ -1,4 +1,13 @@
-/var/log/siphon.log {
+# Rotation for the files siphon writes under /var/log/siphon — `log.file`,
+# `lawful_intercept.audit_log` and `cdr.file.path` in /etc/siphon/siphon.yaml.
+# The packaged systemd unit creates that directory, owned by the siphon user,
+# through LogsDirectory=.
+
+# Files siphon holds open for the lifetime of the process (log.file, the LI
+# audit log). copytruncate is load-bearing here: ExecReload sends SIGHUP, which
+# reloads the Python script and not the log file, so a rename-based rotation
+# would leave siphon writing to the unlinked inode until the next restart.
+/var/log/siphon/*.log {
     daily
     rotate 14
     compress
@@ -6,4 +15,20 @@
     missingok
     notifempty
     copytruncate
+    su siphon siphon
+}
+
+# CDRs are appended with a fresh open per record, so they rotate the ordinary
+# way. Deliberately NOT copytruncate: that copies and then truncates, and any
+# record written in between is lost — acceptable for a log line, not for a
+# billing record.
+/var/log/siphon/cdr.jsonl {
+    daily
+    rotate 30
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0640 siphon siphon
+    su siphon siphon
 }

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -1221,9 +1221,11 @@ auth:
 log:
   level: info      # debug | info | warn | error
   format: pretty   # pretty (human-readable) | json (structured, for log aggregators)
-  # Optional: also write logs to a file (for logrotate). The packaged systemd
-  # unit runs with ProtectSystem=strict, so only /var/log/siphon and
-  # /var/lib/siphon are writable — keep this and cdr.file.path inside them.
+  # Optional: also write logs to a file. The packaged systemd unit runs with
+  # ProtectSystem=strict, so only /var/log/siphon and /var/lib/siphon are
+  # writable — keep this and cdr.file.path inside them. A missing directory is
+  # created, and the packaged /etc/logrotate.d/siphon rotates anything named
+  # *.log under /var/log/siphon.
   # file: /var/log/siphon/siphon.log
 
 # External remote-control plane (ARI/ESL-class). A management plane — OFF by

--- a/src/cdr/mod.rs
+++ b/src/cdr/mod.rs
@@ -506,12 +506,7 @@ async fn write_file_cdr(cdr: &Cdr, path: &str) {
     };
 
     use tokio::io::AsyncWriteExt;
-    match tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .await
-    {
+    match crate::file_sink::open_append_async(path).await {
         Ok(mut file) => {
             let line = format!("{json}\n");
             if let Err(error) = file.write_all(line.as_bytes()).await {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3459,8 +3459,10 @@ fn default_srs_rtpengine_profile() -> String { "srs_recording".to_string() }
 pub struct LogConfig {
     pub level: LogLevel,
     pub format: LogFormat,
-    /// Optional path to a log file (e.g. `/var/log/siphon.log`).
-    /// When set, logs are written to both stderr and the file.
+    /// Optional path to a log file (e.g. `/var/log/siphon/siphon.log`).
+    /// When set, logs are written to both stderr and the file. A missing
+    /// parent directory is created; the packaged logrotate config rotates
+    /// anything named `*.log` under `/var/log/siphon`.
     pub file: Option<String>,
 }
 

--- a/src/diameter/event_sink.rs
+++ b/src/diameter/event_sink.rs
@@ -35,11 +35,7 @@ struct FileWriter {
 impl EventSinkWriter for FileWriter {
     fn write_batch(&self, rows: &[String]) {
         use std::io::Write;
-        match std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)
-        {
+        match crate::file_sink::open_append(&self.path) {
             Ok(mut file) => {
                 for row in rows {
                     if let Err(error) = writeln!(file, "{row}") {

--- a/src/file_sink.rs
+++ b/src/file_sink.rs
@@ -1,0 +1,136 @@
+//! Opening append-only file sinks (log file, CDR file, LI audit log, Diameter
+//! event sink).
+//!
+//! Every one of these paths is operator-configured and every default we ship
+//! points inside `/var/log/siphon` or `/var/lib/siphon` — directories the
+//! packaged systemd unit materialises through `LogsDirectory=` /
+//! `StateDirectory=`, and that nothing creates when siphon is started any other
+//! way (a tarball install, `cargo install`, a container, a by-hand run). Opening
+//! with `create(true)` creates the *file*, never the directory holding it, so
+//! the shipped default failed for everyone not going through the unit: the log
+//! file exits the process, the other three log an error per write.
+//!
+//! So a missing parent directory is created on demand. The directory is only
+//! touched when the open actually fails with `NotFound`, which is the sole
+//! reason a `create(true).append(true)` open reports it — the happy path stays
+//! at one syscall, and a permission error still surfaces as a permission error
+//! rather than as a confusing `mkdir` failure.
+
+use std::io;
+use std::path::Path;
+
+/// Open `path` for append, creating the file and any missing parent directory.
+pub fn open_append(path: impl AsRef<Path>) -> io::Result<std::fs::File> {
+    let path = path.as_ref();
+    match std::fs::OpenOptions::new().create(true).append(true).open(path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::OpenOptions::new().create(true).append(true).open(path)
+        }
+        result => result,
+    }
+}
+
+/// [`open_append`] for the async runtime.
+pub async fn open_append_async(path: impl AsRef<Path>) -> io::Result<tokio::fs::File> {
+    let path = path.as_ref();
+    match tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+    {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .await
+        }
+        result => result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+
+    #[test]
+    fn creates_missing_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("var/log/siphon/siphon.log");
+
+        let mut file = open_append(&path).unwrap();
+        file.write_all(b"line\n").unwrap();
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn appends_to_an_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cdr.jsonl");
+        std::fs::write(&path, "first\n").unwrap();
+
+        let mut file = open_append(&path).unwrap();
+        file.write_all(b"second\n").unwrap();
+        drop(file);
+
+        let mut contents = String::new();
+        std::fs::File::open(&path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+        assert_eq!(contents, "first\nsecond\n");
+    }
+
+    /// A parent that exists as a *file* is a real operator error — it must
+    /// surface, not be papered over.
+    #[test]
+    fn parent_that_is_a_file_still_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let not_a_directory = dir.path().join("siphon");
+        std::fs::write(&not_a_directory, "").unwrap();
+
+        let result = open_append(not_a_directory.join("siphon.log"));
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn async_creates_missing_parent_directories() {
+        use tokio::io::AsyncWriteExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("var/log/siphon/cdr.jsonl");
+
+        let mut file = open_append_async(&path).await.unwrap();
+        file.write_all(b"{}\n").await.unwrap();
+
+        assert!(path.exists());
+    }
+
+    #[tokio::test]
+    async fn async_appends_to_an_existing_file() {
+        use tokio::io::AsyncWriteExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        tokio::fs::write(&path, "first\n").await.unwrap();
+
+        let mut file = open_append_async(&path).await.unwrap();
+        file.write_all(b"second\n").await.unwrap();
+        drop(file);
+
+        assert_eq!(
+            tokio::fs::read_to_string(&path).await.unwrap(),
+            "first\nsecond\n"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod uac;
 pub mod metrics;
 pub mod admin;
 pub mod cdr;
+pub mod file_sink;
 pub mod shutdown;
 pub mod media;
 pub mod ifc;

--- a/src/server.rs
+++ b/src/server.rs
@@ -2361,14 +2361,10 @@ fn init_logging(
     };
 
     let (file_layer, guard) = if let Some(ref path) = log_config.file {
-        let file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .unwrap_or_else(|error| {
-                eprintln!("Failed to open log file {path}: {error}");
-                std::process::exit(1);
-            });
+        let file = crate::file_sink::open_append(path).unwrap_or_else(|error| {
+            eprintln!("Failed to open log file {path}: {error}");
+            std::process::exit(1);
+        });
         let (non_blocking, guard) = tracing_appender::non_blocking(file);
 
         let layer = if is_json {
@@ -3138,12 +3134,7 @@ fn spawn_li_tasks(
     tokio::spawn(async move {
         let mut receiver = audit_rx;
         let mut file = if let Some(ref path) = audit_log_path {
-            match tokio::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(path)
-                .await
-            {
+            match crate::file_sink::open_append_async(path).await {
                 Ok(file) => Some(file),
                 Err(error) => {
                     error!("failed to open LI audit log {path}: {error}");

--- a/tests/integration/packaging_tests.rs
+++ b/tests/integration/packaging_tests.rs
@@ -1,0 +1,156 @@
+//! Packaging guards for the files the `.deb` / `.rpm` install alongside the
+//! binary.
+//!
+//! The asset lists in `Cargo.toml` are hand-maintained, so a file added under
+//! `dist/` or `etc/` only ships if someone remembers to list it — twice, once
+//! per package format. Nobody did for `etc/logrotate.d/siphon`: it sat in the
+//! tree rotating `/var/log/siphon.log`, a path the sandboxed unit cannot write,
+//! while being installed by no package at all. These tests fail the next time
+//! the tree and the asset lists drift apart.
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read(relative: &str) -> String {
+    std::fs::read_to_string(repo_root().join(relative))
+        .unwrap_or_else(|error| panic!("cannot read {relative}: {error}"))
+}
+
+/// Text of the `[package.metadata.deb]` and `[package.metadata.generate-rpm]`
+/// asset declarations.
+fn package_asset_sections() -> (String, String) {
+    let manifest = read("Cargo.toml");
+    let deb_start = manifest
+        .find("[package.metadata.deb]")
+        .expect("Cargo.toml has no [package.metadata.deb]");
+    let rpm_start = manifest
+        .find("[package.metadata.generate-rpm]")
+        .expect("Cargo.toml has no [package.metadata.generate-rpm]");
+    let rpm_end = manifest
+        .find("[package.metadata.generate-rpm.requires]")
+        .expect("Cargo.toml has no [package.metadata.generate-rpm.requires]");
+
+    (
+        manifest[deb_start..rpm_start].to_string(),
+        manifest[rpm_start..rpm_end].to_string(),
+    )
+}
+
+/// Every packaged support file in the tree, relative to the repo root.
+/// `dist/debian/` is excluded: cargo-deb picks those up through
+/// `maintainer-scripts`, not through `assets`.
+fn packaged_support_files() -> Vec<String> {
+    fn walk(directory: &Path, root: &Path, found: &mut Vec<String>) {
+        let entries = std::fs::read_dir(directory)
+            .unwrap_or_else(|error| panic!("cannot list {}: {error}", directory.display()));
+        for entry in entries {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                walk(&path, root, found);
+            } else if let Ok(relative) = path.strip_prefix(root) {
+                found.push(relative.to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    let root = repo_root();
+    let mut found = Vec::new();
+    walk(&root.join("dist"), &root, &mut found);
+    walk(&root.join("etc"), &root, &mut found);
+    found.retain(|path| !path.starts_with("dist/debian/"));
+    found.sort();
+    found
+}
+
+#[test]
+fn every_support_file_ships_in_both_packages() {
+    let (deb, rpm) = package_asset_sections();
+    let files = packaged_support_files();
+    assert!(
+        files.contains(&"etc/logrotate.d/siphon".to_string()),
+        "the walk found no logrotate config — did the tree move? found: {files:?}"
+    );
+
+    for file in files {
+        // Match the asset entry itself, not any mention of the path: the deb
+        // section also lists `/etc/logrotate.d/siphon` under `conf-files`, and
+        // a conffile declaration for a file the package never installs is
+        // exactly the drift this test exists to catch.
+        assert!(
+            deb.contains(&format!("[\"{file}\",")),
+            "{file} is in the tree but not in the .deb assets in Cargo.toml"
+        );
+        assert!(
+            rpm.contains(&format!("source = \"{file}\"")),
+            "{file} is in the tree but not in the .rpm assets in Cargo.toml"
+        );
+    }
+}
+
+/// The release tarball is assembled by hand in the workflow, so it drifts the
+/// same way the asset lists do.
+#[test]
+fn every_support_file_ships_in_the_release_tarball() {
+    let workflow = read(".github/workflows/release.yaml");
+    for file in packaged_support_files() {
+        assert!(
+            workflow.contains(&file),
+            "{file} is in the tree but not in the release tarball built by release.yaml"
+        );
+    }
+}
+
+/// The sandboxed unit makes exactly one log directory writable. Rotation has
+/// to name that directory, or it rotates nothing siphon ever writes.
+#[test]
+fn logrotate_targets_the_directory_the_unit_makes_writable() {
+    let unit = read("dist/siphon.service");
+    let logrotate = read("etc/logrotate.d/siphon");
+
+    assert!(
+        unit.contains("LogsDirectory=siphon"),
+        "the unit no longer declares LogsDirectory=siphon"
+    );
+    assert!(
+        logrotate.contains("/var/log/siphon/"),
+        "logrotate does not rotate anything under /var/log/siphon"
+    );
+    for line in logrotate.lines() {
+        let line = line.trim();
+        if line.starts_with('/') {
+            assert!(
+                line.starts_with("/var/log/siphon/"),
+                "logrotate rotates {line}, which is outside the only writable log \
+                 directory the unit creates (/var/log/siphon)"
+            );
+        }
+    }
+}
+
+/// CDRs are billing records: `copytruncate` copies and then truncates, and
+/// anything written in between is gone. The CDR backend opens the file per
+/// record, so it does not need `copytruncate` and must not get it.
+#[test]
+fn cdr_rotation_does_not_use_copytruncate() {
+    let logrotate = read("etc/logrotate.d/siphon");
+    let cdr_stanza = logrotate
+        .split("/var/log/siphon/cdr.jsonl")
+        .nth(1)
+        .expect("logrotate has no cdr.jsonl stanza");
+    let cdr_stanza = cdr_stanza
+        .split('}')
+        .next()
+        .expect("cdr.jsonl stanza is not closed");
+
+    assert!(
+        !cdr_stanza.contains("copytruncate"),
+        "the cdr.jsonl stanza uses copytruncate, which can drop a billing record"
+    );
+    assert!(
+        cdr_stanza.contains("create "),
+        "the cdr.jsonl stanza rotates by rename but does not re-create the file"
+    );
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -39,6 +39,9 @@ mod li_tests;
 #[path = "integration/admin_tests.rs"]
 mod admin_tests;
 
+#[path = "integration/packaging_tests.rs"]
+mod packaging_tests;
+
 #[path = "integration/nat_tests.rs"]
 mod nat_tests;
 


### PR DESCRIPTION
Follow-up to #177, from the same report ([discussion #175](https://github.com/siphon-project/siphon-sip/discussions/175)). #177 made the packaged unit able to write `/var/log/siphon` and `/var/lib/siphon`; three things around that were still wrong.

## 1. Nothing creates the parent directory of a log / CDR / audit file

Opening with `create(true)` creates the *file*, never the directory holding it. Every default write path we ship lives under `/var/log/siphon`, which only exists because the packaged unit declares `LogsDirectory=`. Started any other way — tarball, `cargo install`, container, plain `siphon --config …` as root — the same config fails:

```
$ siphon --config /etc/siphon/siphon.yaml
Failed to open log file /var/log/siphon/siphon.log: No such file or directory
exit=1
```

and the CDR file, the LI audit log and the Diameter event sink log an error per record instead.

New `src/file_sink.rs` (`open_append` / `open_append_async`) is now used by all four sinks. The directory is created **only** when the open actually fails with `NotFound`, which is the sole reason a `create(true).append(true)` open reports it, so the happy path stays at one syscall and a permission error still surfaces as a permission error rather than as a confusing `mkdir` failure.

## 2. The logrotate config rotated a path siphon cannot write, and shipped nowhere

`etc/logrotate.d/siphon` still named `/var/log/siphon.log` — read-only under `ProtectSystem=strict` — and was in no package: not the `.deb`, not the `.rpm`, not the release tarball. Meanwhile the feature matrix advertises "with logrotate support".

It now covers the paths siphon actually writes, in two stanzas:

- `/var/log/siphon/*.log` with `copytruncate`. Load-bearing: siphon holds those files open for the lifetime of the process, and `ExecReload` reloads the Python script, not the log file, so a rename-based rotation would leave it writing to the unlinked inode.
- `/var/log/siphon/cdr.jsonl` with `create 0640 siphon siphon` and deliberately **no** `copytruncate`. The CDR backend opens the file per record, so it rotates cleanly by rename; `copytruncate` copies and then truncates, and anything written in between is gone — acceptable for a log line, not for a billing record.

Added to the deb assets + `conf-files`, the rpm assets, and the tarball the release workflow builds. The deb `preinst` and the rpm scriptlet also create `/var/log/siphon` so a by-hand first run before `systemctl start` has somewhere to write.

## 3. The unit restart-looped forever on a broken config

siphon exits non-zero on a config or script error, and `RestartSec=5s` puts only two starts inside systemd's default 10 s window, so the default start limit never tripped. A permanently broken config just looped, silently — the reported install reached restart counter 279 — instead of failing where `systemctl status` shows it.

`StartLimitIntervalSec=300` / `StartLimitBurst=10`: roughly a minute of retrying before the unit fails. Deliberately wider than the default so an address that is slow to appear still recovers on its own.

## Guards

`tests/integration/packaging_tests.rs` — the asset lists are hand-maintained in two places plus the workflow, which is how the logrotate file rotted unnoticed:

- every file under `dist/` and `etc/` appears in the deb assets, the rpm assets, and the release tarball (matching the asset entry itself, not any mention of the path — the deb section also names the logrotate file under `conf-files`)
- logrotate only names paths under the one directory the unit makes writable
- the `cdr.jsonl` stanza never gets `copytruncate`

Mutation-checked: restoring the old `/var/log/siphon.log` path fails the third, deleting the deb asset line fails the first.

## Testing

- `cargo test` — 3517 lib + 315 integration, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `systemd-analyze verify dist/siphon.service` — clean
- `logrotate -d etc/logrotate.d/siphon` — parses (the only complaint is the `siphon` user missing on the dev box; the packages create it before unpacking)

Not perf-affecting: no per-message path is touched.

## Left out

`cdr.file.rotate_size_mb` is documented, parsed, and plumbed into `CdrBackendType::File` — then dropped at the write site (`File { path, .. }`), so it rotates nothing. Out of scope here; it wants either a real implementation (containers have neither systemd nor logrotate, so it would earn its keep) or removal.
