### PR TITLE
feat(media): surface RFC 4103 real-time text from the engine, and move the proto pin to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,34 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   Builds on the single-leg REFER machinery, so a terminate-mode accept on a
   voice-AI / IVR call with no B leg re-dials the target off the A dialog. The SDK
   client facades for the new verbs and event follow separately.
-
+- **RFC 4103 real-time text observability.** A call carrying a plaintext
+  `m=text` stream (RTT / T.140, the accessibility and emergency-calling text
+  channel, and what an NG112 deployment needs alongside audio) can now be
+  observed rather than only relayed. Set `text_events` on a media profile and
+  the engine promotes **only** that low-rate stream to its userspace text
+  processor, which RED-depacketizes (RFC 2198) and reassembles it and reports
+  each recovered increment to a new `@rtpengine.on_text` handler —
+  `fn(call_id, from_tag, to_tag, text, direction)`, with the same optional
+  `call_id` / `from_tag` filters as `@rtpengine.on_dtmf`. Only non-empty
+  increments are reported, so a handler firing always means new characters
+  arrived; a duplicate, a reordered packet or an idle keepalive produces
+  nothing. A `\ufffd` in the text marks a gap RED redundancy could not repair
+  (RFC 4103 §5.3) and is deliberately left in place — a consumer needs to see
+  where loss occurred rather than silently reading a shorter message. The audio
+  relay/transcode path is untouched (text observability never promotes audio),
+  and the flag is inert on a call that negotiated no text. Requires
+  `media.backend: siphon-rtp` (`siphon-rtp-proto` 0.2.0); rtpengine and rtpproxy
+  reject a `text_events` profile at config load rather than accepting a flag
+  they cannot honour and leaving a script waiting on events that can never
+  arrive.
+- **Per-leg text reception counters in the media CDR** — `text_packets`,
+  `text_characters`, `text_missing_markers` and
+  `text_recovered_from_redundancy`, prefixed per leg alongside the existing
+  loss/jitter/MOS fields. A content-level QoS surface distinct from the
+  datapath's packet counters: it reports what the receiver actually recovered,
+  including redundancy repair and unrecoverable-loss markers. Absent, not
+  zeroed, on a call with no observed text stream — `text_packets=0` would read
+  as a text stream that carried nothing, which is a different claim.
 - **Cold transfer off a call siphon answered itself.** A voice-AI or IVR call has
   no B leg, so the only way to hand the caller on is an in-dialog REFER on the A
   dialog via the imperative `b2bua.refer(call_id, target)` — `call.refer()` is a
@@ -262,6 +289,11 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   constructible in a test. Additive, defaulting to `None`.
 
 ### Changed
+- **`siphon-rtp-proto` pinned to 0.2.0** (from 0.1.5). A 0.x minor bump is a
+  semver-breaking range, so it is a deliberate move rather than something
+  `cargo update` performs: the pin is what makes the engine's newer control
+  surface reachable at all. Deployments on `media.backend: siphon-rtp` must run
+  a siphon-rtp built from that contract.
 - **`Contact.received` is a SIP URI, not a bare `host:port` — the doc-comment
   now says so.** The value has always been
   `sip:<ip>:<port>;transport=<proto>` (the OpenSIPS `received_avp` shape),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,9 +3093,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afa6b54b21e7ba5c89a57bda3743ce2d2b829955f454e2663ba4b983f4e134"
+checksum = "592452d239ffe9f9502311773f1d36db56871dbbb27229e6ebf3a0b1b421fb53"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.1.5"
+siphon-rtp-proto = "0.2.0"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -184,7 +184,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.1.5"
+siphon-rtp-proto = "0.2.0"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -2057,6 +2057,7 @@ class MockRtpEngine:
         self._media_timeout_handlers: list[dict[str, Any]] = []
         self._ws_tee_started_handlers: list[dict[str, Any]] = []
         self._ws_tee_ended_handlers: list[dict[str, Any]] = []
+        self._text_handlers: list[dict[str, Any]] = []
 
     @property
     def active_sessions(self) -> int:
@@ -2754,6 +2755,59 @@ class MockRtpEngine:
             fired += 1
         return fired
 
+    def on_text(self, func_or_none: Any = None, *,
+                call_id: Optional[str] = None,
+                from_tag: Optional[str] = None) -> Any:
+        """Register a handler for **RFC 4103 real-time text** (T.140) increments.
+
+        Fires once per increment the engine's text processor recovers on the
+        call's ``m=text`` stream, carrying the UTF-8 text that packet newly
+        delivered. Only non-empty increments are reported — a duplicate, a
+        reordered packet or an idle keepalive produces no event — so the handler
+        firing always means new characters arrived. A ``\ufffd`` in the text is
+        a gap RED redundancy could not repair (RFC 4103 §5.3), left in place so
+        a consumer sees where loss occurred rather than silently reading a
+        shorter message.
+
+        Requires the call's media profile to set ``text_events``. Delivered by
+        the native **siphon-rtp** backend only.
+
+        Usage::
+
+            @rtpengine.on_text
+            def transcript(call_id, from_tag, to_tag, text, direction):
+                log.info(f"[{call_id}] {direction}: {text}")
+
+            @rtpengine.on_text(call_id="abc", from_tag="ftag1")
+            def transcript_specific(call_id, from_tag, to_tag, text, direction):
+                ...
+        """
+        def decorator(fn: Any) -> Any:
+            self._text_handlers.append({
+                "fn": fn,
+                "call_id": call_id,
+                "from_tag": from_tag,
+            })
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
+    def fire_text(self, call_id: str, from_tag: str, text: str,
+                  to_tag: Optional[str] = None,
+                  direction: Optional[str] = "a_to_b") -> int:
+        """Test helper: fire a real-time text event.  Returns the number of
+        handlers that matched (and were invoked)."""
+        fired = 0
+        for entry in self._text_handlers:
+            if entry["call_id"] is not None and entry["call_id"] != call_id:
+                continue
+            if entry["from_tag"] is not None and entry["from_tag"] != from_tag:
+                continue
+            entry["fn"](call_id, from_tag, to_tag, text, direction)
+            fired += 1
+        return fired
+
     def on_ws_tee_started(self, func_or_none: Any = None, *,
                           call_id: Optional[str] = None,
                           from_tag: Optional[str] = None) -> Any:
@@ -2889,6 +2943,7 @@ class MockRtpEngine:
         self._media_timeout_handlers.clear()
         self._ws_tee_started_handlers.clear()
         self._ws_tee_ended_handlers.clear()
+        self._text_handlers.clear()
         self._answer_local_no_codec = False
 
 

--- a/sdk/tests/test_rtpengine_media.py
+++ b/sdk/tests/test_rtpengine_media.py
@@ -589,6 +589,41 @@ class TestWebSocketTee:
         assert harness.rtpengine.fire_ws_tee_ended("abc", "ftag1", "s-3") == 1
         assert hits == ["s-3"]
 
+    def test_text_handler_receives_the_increment_with_its_loss_markers(self, harness):
+        # U+FFFD is how a consumer sees where redundancy could not repair the
+        # stream (RFC 4103 §5.3) — scrubbing it would hide the gap.
+        seen = []
+
+        @harness.rtpengine.on_text
+        def transcript(call_id, from_tag, to_tag, text, direction):
+            seen.append((call_id, from_tag, to_tag, text, direction))
+
+        fired = harness.rtpengine.fire_text(
+            "c", "f", "hel\ufffdo", to_tag="t", direction="a_to_b",
+        )
+        assert fired == 1
+        assert seen == [("c", "f", "t", "hel\ufffdo", "a_to_b")]
+
+    def test_text_handler_filters_on_call_id_and_from_tag(self, harness):
+        hits = []
+
+        @harness.rtpengine.on_text(call_id="abc", from_tag="ftag1")
+        def transcript(call_id, from_tag, to_tag, text, direction):
+            hits.append(text)
+
+        assert harness.rtpengine.fire_text("other", "ftag1", "a") == 0
+        assert harness.rtpengine.fire_text("abc", "wrong", "b") == 0
+        assert harness.rtpengine.fire_text("abc", "ftag1", "c") == 1
+        assert hits == ["c"]
+
+    def test_clear_drops_registered_text_handlers(self, harness):
+        @harness.rtpengine.on_text
+        def transcript(*args):
+            pass
+
+        harness.rtpengine.clear()
+        assert harness.rtpengine.fire_text("c", "f", "x") == 0
+
     def test_clear_drops_registered_tee_handlers(self, harness):
         @harness.rtpengine.on_ws_tee_started
         def tee_up(*args):

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -711,6 +711,17 @@ auth:
 #                       ws_tee_direction: both — a single-leg tee is always mono.
 #                       Unset uses the engine default (2 for both legs, 1 for
 #                       one). Inert without ws_tee.
+#   text_events         Observe RFC 4103 real-time text (T.140) on this call.
+#                       When the call negotiates a plaintext m=text stream the
+#                       engine promotes ONLY that low-rate stream to its
+#                       userspace text processor, which RED-depacketizes and
+#                       reassembles it and reports each recovered increment to
+#                       @rtpengine.on_text, plus per-leg reception counters in
+#                       the media CDR (text_packets / text_characters /
+#                       text_missing_markers / text_recovered_from_redundancy).
+#                       The audio relay/transcode path is untouched — text
+#                       observability never promotes audio — and the flag is
+#                       inert on a call that negotiated no text.
 #   noise_suppression   Single-channel noise suppression on this leg's decoded
 #                       ingress audio. Engaged only on a userspace-transcoded leg
 #                       whose ingress codec runs at 8 or 16 kHz, and forces the

--- a/src/config.rs
+++ b/src/config.rs
@@ -2042,6 +2042,9 @@ impl MediaBackendKind {
             if flags.ws_tee_channels.is_some() {
                 unsupported.push("ws_tee_channels");
             }
+            if flags.text_events {
+                unsupported.push("text_events");
+            }
         }
 
         if matches!(self, Self::Rtpproxy) {
@@ -2505,6 +2508,12 @@ pub struct NgFlagsConfig {
     /// (RFC 5761).  Empty mirrors the offer.  Not honoured by `rtpproxy`.
     #[serde(default, deserialize_with = "deserialize_rtcp_mux")]
     pub rtcp_mux: Vec<String>,
+    /// Observe RFC 4103 real-time text on this call, delivering each recovered
+    /// T.140 increment to `@rtpengine.on_text` and per-leg reception counters in
+    /// the media CDR.  Promotes only the `m=text` stream, never audio, and is
+    /// inert on a call that negotiated no text.  `siphon-rtp` only.
+    #[serde(default)]
+    pub text_events: bool,
 }
 
 /// One or more RTPEngine instances.
@@ -5768,6 +5777,33 @@ script:
                 backend.as_str()
             );
         }
+    }
+
+    /// `text_events` drives the engine's RFC 4103 text processor, which only
+    /// siphon-rtp has.  It must be a hard config error on the other two rather
+    /// than a silent no-op: a script waiting on `@rtpengine.on_text` for events
+    /// that can never arrive looks identical to a caller who typed nothing.
+    #[test]
+    fn unsupported_profile_fields_rejects_text_events_off_siphon_rtp() {
+        let flags = NgFlagsConfig {
+            text_events: true,
+            ..NgFlagsConfig::default()
+        };
+        for backend in [MediaBackendKind::Rtpengine, MediaBackendKind::Rtpproxy] {
+            assert!(
+                backend
+                    .unsupported_profile_fields(&flags)
+                    .contains(&"text_events"),
+                "{} accepted text_events it cannot honour",
+                backend.as_str()
+            );
+        }
+        assert!(
+            MediaBackendKind::SiphonRtp
+                .unsupported_profile_fields(&flags)
+                .is_empty(),
+            "siphon-rtp rejected text_events it supports"
+        );
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1247,6 +1247,59 @@ pub async fn run(
                             crate::cdr::write(media_summary_to_cdr(&summary));
                         }
                     }
+                    crate::rtpengine::events::RtpEngineEvent::Text(text_event) => {
+                        tracing::debug!(
+                            call_id = %text_event.call_id,
+                            from_tag = %text_event.from_tag,
+                            direction = text_event.direction.as_deref().unwrap_or("-"),
+                            characters = text_event.text.chars().count(),
+                            "media engine recovered a real-time text increment"
+                        );
+                        let engine_state = state_for_events.engine.state();
+                        let handlers = engine_state
+                            .text_handlers(&text_event.call_id, &text_event.from_tag);
+                        if handlers.is_empty() {
+                            continue;
+                        }
+                        let state_ref = Arc::clone(&state_for_events);
+                        let text_clone = text_event.clone();
+                        let _ = crate::script::py_executor::try_run(move || {
+                            let engine_state = state_ref.engine.state();
+                            let handlers = engine_state
+                                .text_handlers(&text_clone.call_id, &text_clone.from_tag);
+                            pyo3::Python::attach(|python| {
+                                for handler in handlers {
+                                    let callable = handler.callable.bind(python);
+                                    let result = callable.call1((
+                                        text_clone.call_id.as_str(),
+                                        text_clone.from_tag.as_str(),
+                                        text_clone.to_tag.as_deref(),
+                                        text_clone.text.as_str(),
+                                        text_clone.direction.as_deref(),
+                                    ));
+                                    match result {
+                                        Ok(ret) => {
+                                            if handler.is_async {
+                                                if let Err(error) = run_coroutine(python, &ret) {
+                                                    tracing::error!(
+                                                        %error,
+                                                        "async rtpengine.on_text handler error"
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        Err(error) => {
+                                            tracing::error!(
+                                                %error,
+                                                "rtpengine.on_text handler failed"
+                                            );
+                                        }
+                                    }
+                                }
+                            });
+                        })
+                        .await;
+                    }
                     crate::rtpengine::events::RtpEngineEvent::WsTeeStarted(tee) => {
                         tracing::debug!(
                             call_id = %tee.call_id,
@@ -9398,6 +9451,15 @@ fn media_summary_to_cdr(summary: &crate::rtpengine::events::CallSummary) -> crat
         put("packets_dropped", leg.packets_dropped.to_string());
         if let Some(ssrc) = leg.ssrc {
             put("ssrc", ssrc.to_string());
+        }
+        if let Some(text) = &leg.text {
+            put("text_packets", text.packets.to_string());
+            put("text_characters", text.characters.to_string());
+            put("text_missing_markers", text.missing_markers.to_string());
+            put(
+                "text_recovered_from_redundancy",
+                text.recovered_from_redundancy.to_string(),
+            );
         }
         if let Some(packets_lost) = leg.packets_lost {
             put("packets_lost", packets_lost.to_string());
@@ -21242,6 +21304,7 @@ mod tests {
                 mos_min: Some(3.9),
                 mos_max: Some(4.3),
                 mos_basis: Some("full".to_string()),
+                text: None,
             }
         }
 
@@ -21264,6 +21327,7 @@ mod tests {
             mos_min: None,
             mos_max: None,
             mos_basis: None,
+            text: None,
         };
 
         let summary = CallSummary {
@@ -21325,6 +21389,7 @@ mod tests {
                 mos_min: None,
                 mos_max: None,
                 mos_basis: None,
+                text: None,
             }
         }
 
@@ -21369,6 +21434,7 @@ mod tests {
             mos_min: None,
             mos_max: None,
             mos_basis: Some("loss+jitter".to_string()),
+            text: None,
         };
         let summary = CallSummary {
             call_id: "voice-ai-1".to_string(),

--- a/src/rtpengine/events.rs
+++ b/src/rtpengine/events.rs
@@ -44,6 +44,12 @@ pub enum RtpEngineEvent {
     /// scraping logs.  Emitted by the `siphon-rtp` native backend only; the
     /// rtpengine NG backend does not surface it.
     CallSummary(CallSummary),
+    /// Newly-recovered RFC 4103 real-time text (T.140) on a call's `m=text`
+    /// stream.  Emitted per recovered increment by the engine's userspace text
+    /// processor, which only runs when the profile set `text_events` and the
+    /// call actually negotiated a plaintext text stream.  `siphon-rtp` native
+    /// backend only.
+    Text(TextEvent),
     /// A WebSocket tee started streaming — the engine dialled the server, sent
     /// `start`, and the call's decoded audio is now flowing.  Emitted by the
     /// `siphon-rtp` native backend only.
@@ -133,6 +139,51 @@ pub struct CallLegSummary {
     /// `"full"` (MOS includes the G.107 delay term) or `"loss+jitter"` — how the
     /// MOS was derived.
     pub mos_basis: Option<String>,
+    /// RFC 4103 reception counters for this leg's inbound text stream, present
+    /// only when the call negotiated a plaintext `m=text` stream *and* a text
+    /// observability feature (recording, or `text_events`) promoted it.
+    pub text: Option<TextStreamStats>,
+}
+
+/// One increment of RFC 4103 real-time text (T.140), carried by
+/// [`RtpEngineEvent::Text`].
+///
+/// The engine emits only *non-empty* increments — a duplicate, a reordered
+/// packet or an idle keepalive produces no event — so a handler firing always
+/// means new characters arrived.  Any U+FFFD marker is left in `text` so a
+/// consumer sees where loss occurred (RFC 4103 §5.3) rather than silently
+/// receiving a shorter message.
+#[derive(Debug, Clone)]
+pub struct TextEvent {
+    /// SIP Call-ID the media session is keyed on.
+    pub call_id: String,
+    /// The leg that *sent* the text.
+    pub from_tag: String,
+    /// The peer leg's tag, when the engine reported one.
+    pub to_tag: Option<String>,
+    /// The UTF-8 increment this packet newly delivered.
+    pub text: String,
+    /// The observed direction, `"a_to_b"` or `"b_to_a"`, when reported.
+    pub direction: Option<String>,
+}
+
+/// RFC 4103 reception counters for one leg's inbound T.140 stream, measured by
+/// the engine's userspace text processor.  A content-level QoS surface distinct
+/// from the datapath's packet/byte counters: it reports what the receiver
+/// actually recovered, including redundancy repair and unrecoverable-loss
+/// markers.  `None` on a call with no observed text stream.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TextStreamStats {
+    /// RTP packets accepted on this leg's inbound text stream.
+    pub packets: u64,
+    /// UTF-8 characters delivered after reassembly, including those recovered
+    /// from RED redundancy and the U+FFFD markers.
+    pub characters: u64,
+    /// U+FFFD markers inserted for gaps redundancy could not recover.
+    pub missing_markers: u64,
+    /// Generations recovered from RFC 2198 RED redundancy — loss the redundant
+    /// copies repaired before it reached the receiver.
+    pub recovered_from_redundancy: u64,
 }
 
 /// A WebSocket tee started streaming, carried by

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -343,6 +343,15 @@ pub struct NgFlags {
     pub record_call: bool,
     /// Directory path for RTPEngine to write recording files.
     pub record_path: Option<String>,
+    /// Ask the engine to observe RFC 4103 real-time text on this call
+    /// (`siphon-rtp` only).  When the call negotiates a plaintext `m=text`
+    /// stream, the engine promotes *only* that low-rate stream to its userspace
+    /// text processor, which RED-depacketizes and reassembles it and reports each
+    /// recovered increment as an `@rtpengine.on_text` event plus per-leg counters
+    /// in the end-of-call media summary.  The audio relay/transcode path is
+    /// untouched — text observability never promotes audio — and the flag is
+    /// inert on an audio-only call.
+    pub text_events: bool,
     /// Single-channel noise suppression on this leg's decoded ingress audio,
     /// before it is relayed/transcoded toward the peer.  Engaged only on a
     /// userspace-transcoded leg whose ingress codec runs at 8 or 16 kHz, and
@@ -460,6 +469,7 @@ impl NgFlags {
             direction: config.direction.clone(),
             record_call: config.record_call,
             record_path: config.record_path.clone(),
+            text_events: config.text_events,
             noise_suppression: config.noise_suppression,
             echo_cancellation: config.echo_cancellation,
             ws_uri: config.ws_uri.clone(),

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -41,8 +41,8 @@ use tracing::{debug, info, trace, warn};
 use super::client::PlayMediaSource;
 use super::error::RtpEngineError;
 use super::events::{
-    CallLegSummary, CallSummary, DtmfEvent, RtpEngineEvent, WsTeeEndReason, WsTeeStarted,
-    WsTeeEnded,
+    CallLegSummary, CallSummary, DtmfEvent, RtpEngineEvent, TextEvent, TextStreamStats,
+    WsTeeEndReason, WsTeeStarted, WsTeeEnded,
 };
 use super::profile::{NgFlags, WsTeeDirection};
 
@@ -93,6 +93,7 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         // opted-out profile leaves this `None` and serialises away.
         received_from: flags.received_from,
         rtcp_mux: flags.rtcp_mux.clone(),
+        text_events: flags.text_events,
     }
 }
 
@@ -1163,6 +1164,19 @@ fn convert_event(event: Event) -> RtpEngineEvent {
             duration_ms,
             legs: legs.into_iter().map(convert_leg_summary).collect(),
         }),
+        Event::Text {
+            call_id,
+            from_tag,
+            to_tag,
+            text,
+            direction,
+        } => RtpEngineEvent::Text(TextEvent {
+            call_id,
+            from_tag,
+            to_tag,
+            text,
+            direction,
+        }),
         Event::ActiveSpeaker {
             conference_id,
             from_tag,
@@ -1262,6 +1276,12 @@ fn convert_leg_summary(leg: ProtoLegSummary) -> CallLegSummary {
         mos_min: leg.mos_min,
         mos_max: leg.mos_max,
         mos_basis: leg.mos_basis,
+        text: leg.text.map(|stats| TextStreamStats {
+            packets: stats.packets,
+            characters: stats.characters,
+            missing_markers: stats.missing_markers,
+            recovered_from_redundancy: stats.recovered_from_redundancy,
+        }),
     }
 }
 
@@ -1817,6 +1837,74 @@ mod tests {
     /// tail.  Asserting the whole struct is what makes "every field" mean it —
     /// compare against a fully-populated expected value so a newly-added proto
     /// field cannot pass by being defaulted on both sides.
+    /// The text increment must reach the script byte-for-byte, U+FFFD markers
+    /// included — they are how a consumer sees where loss occurred (RFC 4103
+    /// §5.3), so a conversion that scrubbed them would hide the gap.
+    #[test]
+    fn convert_event_text_is_field_exact() {
+        let event = Event::Text {
+            call_id: "call-77".into(),
+            from_tag: "caller-tag".into(),
+            to_tag: Some("callee-tag".into()),
+            text: "hel\u{fffd}o".into(),
+            direction: Some("a_to_b".into()),
+        };
+        match convert_event(event) {
+            RtpEngineEvent::Text(text_event) => {
+                assert_eq!(text_event.call_id, "call-77");
+                assert_eq!(text_event.from_tag, "caller-tag");
+                assert_eq!(text_event.to_tag.as_deref(), Some("callee-tag"));
+                assert_eq!(text_event.text, "hel\u{fffd}o");
+                assert_eq!(text_event.direction.as_deref(), Some("a_to_b"));
+            }
+            other => panic!("expected a text event, got {other:?}"),
+        }
+    }
+
+    /// An engine that reported no text stream for the leg must leave the field
+    /// absent, not synthesise a zeroed one — a media CDR carrying
+    /// `text_packets=0` for an audio-only call reads as a text stream that
+    /// carried nothing, which is a different claim.
+    #[test]
+    fn convert_leg_summary_carries_text_stats_only_when_measured() {
+        let with_text = ProtoLegSummary {
+            tag: "near".into(),
+            codec: Some("PCMU".into()),
+            packets_in: 10,
+            bytes_in: 100,
+            packets_out: 10,
+            bytes_out: 100,
+            packets_dropped: 0,
+            ssrc: None,
+            packets_lost: None,
+            loss_percent: None,
+            jitter_ms: None,
+            rtt_ms: None,
+            mos_average: None,
+            mos_min: None,
+            mos_max: None,
+            mos_basis: None,
+            text: Some(siphon_rtp_proto::TextStreamStats {
+                packets: 12,
+                characters: 41,
+                missing_markers: 2,
+                recovered_from_redundancy: 3,
+            }),
+        };
+        let converted = convert_leg_summary(with_text.clone());
+        let stats = converted.text.expect("text stats carried");
+        assert_eq!(stats.packets, 12);
+        assert_eq!(stats.characters, 41);
+        assert_eq!(stats.missing_markers, 2);
+        assert_eq!(stats.recovered_from_redundancy, 3);
+
+        let audio_only = ProtoLegSummary {
+            text: None,
+            ..with_text
+        };
+        assert!(convert_leg_summary(audio_only).text.is_none());
+    }
+
     #[test]
     fn profile_flags_from_ng_maps_every_field() {
         let ng = NgFlags {
@@ -1842,6 +1930,7 @@ mod tests {
             carry_received_from: true,
             received_from: Some("198.51.100.7".parse().unwrap()),
             rtcp_mux: vec!["require".into()],
+            text_events: true,
         };
 
         let expected = ProfileFlags {
@@ -1866,6 +1955,7 @@ mod tests {
             ws_tee_channels: Some(1),
             received_from: Some("198.51.100.7".parse().unwrap()),
             rtcp_mux: vec!["require".into()],
+            text_events: true,
         };
 
         assert_eq!(profile_flags_from_ng(&ng), expected);
@@ -2017,6 +2107,7 @@ mod tests {
             mos_min: Some(3.9),
             mos_max: Some(4.3),
             mos_basis: Some("full".into()),
+            text: None,
         };
         let far = ProtoLegSummary {
             tag: "far-tag".into(),
@@ -2035,6 +2126,7 @@ mod tests {
             mos_min: None,
             mos_max: None,
             mos_basis: None,
+            text: None,
         };
         match convert_event(Event::CallSummary {
             call_id: "call-9".into(),

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -1498,6 +1498,68 @@ def make_decorator(call_id, from_tag):
         }
     }
 
+    /// Register a handler for **RFC 4103 real-time text** (T.140) increments.
+    ///
+    /// Fires once per increment the engine's text processor recovers on the
+    /// call's ``m=text`` stream, carrying the UTF-8 text that packet newly
+    /// delivered.  Only non-empty increments are reported — a duplicate, a
+    /// reordered packet or an idle keepalive produces no event — so the handler
+    /// firing always means new characters arrived.  A ``\ufffd`` in the text is
+    /// a gap RED redundancy could not repair (RFC 4103 §5.3), left in place so a
+    /// consumer sees where loss occurred rather than silently reading a shorter
+    /// message.
+    ///
+    /// Requires the call's media profile to set ``text_events``, and a call that
+    /// actually negotiated a plaintext text stream.  Delivered by the native
+    /// **siphon-rtp** backend only.
+    ///
+    /// ```python,ignore
+    /// @rtpengine.on_text
+    /// def transcript(call_id, from_tag, to_tag, text, direction):
+    ///     log.info(f"[{call_id}] {direction}: {text}")
+    /// ```
+    ///
+    /// Args:
+    ///     func_or_none: When applied directly (``@rtpengine.on_text``) this is
+    ///         the function.  When called with keyword filters the return value
+    ///         is a decorator.
+    ///     call_id: Optional engine call-id filter.
+    ///     from_tag: Optional from-tag filter — the leg that *sent* the text.
+    #[pyo3(signature = (func_or_none=None, *, call_id=None, from_tag=None))]
+    fn on_text<'py>(
+        &self,
+        python: Python<'py>,
+        func_or_none: Option<Py<PyAny>>,
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let code = r#"
+def make_decorator(call_id, from_tag):
+    import asyncio
+    import _siphon_registry
+    def decorator(fn):
+        is_async = asyncio.iscoroutinefunction(fn)
+        metadata = {"call_id": call_id, "from_tag": from_tag}
+        _siphon_registry.register("rtpengine.on_text", None, fn, is_async, metadata)
+        return fn
+    return decorator
+"#;
+        let globals = PyDict::new(python);
+        python.run(&std::ffi::CString::new(code).map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("on_text decorator source: {error}"))
+        })?, Some(&globals), None)?;
+        let make_decorator = globals.get_item("make_decorator")?.ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("failed to build on_text decorator")
+        })?;
+        let decorator = make_decorator.call1((call_id, from_tag))?;
+
+        // Support both `@on_text` (bare) and `@on_text(call_id=...)` forms.
+        match func_or_none {
+            Some(func) => decorator.call1((func.bind(python),)),
+            None => Ok(decorator),
+        }
+    }
+
     /// Register a handler for **WebSocket tee started** events.
     ///
     /// Fires once the engine has dialled the tee's WebSocket server, sent its

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -467,6 +467,37 @@ class _RtpEngineNamespace:
             return decorator(func_or_none)
         return decorator
 
+    def on_text(self, func_or_none=None, *, call_id=None, from_tag=None):
+        """Register a handler for RFC 4103 real-time text (T.140) increments.
+
+        Fires once per increment the engine recovers on the call's ``m=text``
+        stream, carrying the text that packet newly delivered.  Only non-empty
+        increments are reported, so the handler firing always means new
+        characters arrived.  A ``\ufffd`` in the text marks a gap RED redundancy
+        could not repair (RFC 4103 §5.3) — it is left in so a consumer sees
+        where loss occurred instead of silently reading a shorter message.
+
+        Requires the call's media profile to set ``text_events``, and the
+        ``siphon-rtp`` media backend.
+
+        Usage:
+            @rtpengine.on_text
+            def handle_any(call_id, from_tag, to_tag, text, direction):
+                ...
+
+            @rtpengine.on_text(call_id="abc")
+            def handle_specific(call_id, from_tag, to_tag, text, direction):
+                ...
+        """
+        def decorator(fn):
+            is_async = _asyncio.iscoroutinefunction(fn)
+            metadata = {"call_id": call_id, "from_tag": from_tag}
+            _registry.register("rtpengine.on_text", None, fn, is_async, metadata)
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
     def on_ws_tee_started(self, func_or_none=None, *, call_id=None, from_tag=None):
         """Register a handler for WebSocket tee started events.
 

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -126,6 +126,15 @@ pub enum HandlerKind {
         call_id: Option<String>,
         from_tag: Option<String>,
     },
+    /// `@rtpengine.on_text` — an RFC 4103 real-time text (T.140) increment was
+    /// recovered on a call's text stream. Fires only for a call whose media
+    /// profile set `text_events`, and only for non-empty increments.
+    ///
+    /// ``call_id`` and ``from_tag`` are optional filters.
+    RtpEngineOnText {
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    },
     /// `@rtpengine.on_ws_tee_started` — a WebSocket tee began streaming a
     /// call's audio. The handler receives the negotiated wire shape so it can
     /// correlate the control event with the media stream.
@@ -252,6 +261,21 @@ impl ScriptState {
             .iter()
             .filter(|h| match &h.kind {
                 HandlerKind::RtpEngineOnMediaTimeout { call_id: filter_cid, from_tag: filter_ftag } => {
+                    filter_cid.as_deref().map_or(true, |v| v == call_id)
+                        && filter_ftag.as_deref().map_or(true, |v| v == from_tag)
+                }
+                _ => false,
+            })
+            .collect()
+    }
+
+    /// Return all `RtpEngineOnText` handlers whose optional call-id/from-tag
+    /// filters match the event.  `None` filters match everything.
+    pub fn text_handlers(&self, call_id: &str, from_tag: &str) -> Vec<&HandlerEntry> {
+        self.handlers
+            .iter()
+            .filter(|h| match &h.kind {
+                HandlerKind::RtpEngineOnText { call_id: filter_cid, from_tag: filter_ftag } => {
                     filter_cid.as_deref().map_or(true, |v| v == call_id)
                         && filter_ftag.as_deref().map_or(true, |v| v == from_tag)
                 }
@@ -1161,6 +1185,17 @@ fn extract_handlers(
                     .and_then(|v| v.extract().ok());
                 HandlerKind::RtpEngineOnWsTeeStarted { call_id, from_tag }
             }
+            "rtpengine.on_text" => {
+                let call_id: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("call_id").ok())
+                    .and_then(|v| v.extract().ok());
+                let from_tag: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("from_tag").ok())
+                    .and_then(|v| v.extract().ok());
+                HandlerKind::RtpEngineOnText { call_id, from_tag }
+            }
             "rtpengine.on_ws_tee_ended" => {
                 let call_id: Option<String> = metadata
                     .as_ref()
@@ -1831,6 +1866,43 @@ async def specific_timeout(call_id, from_tag):
                 HandlerKind::RtpEngineOnMediaTimeout { call_id: Some(c), .. } if c == "abc"
             ))
             .expect("filtered media-timeout handler registered");
+        assert!(specific.is_async);
+    }
+
+    #[test]
+    fn rtpengine_on_text_decorator_registers_and_filters() {
+        // Same (call_id, from_tag) filter shape as the sibling rtpengine hooks;
+        // the from-tag names the leg that *sent* the text.
+        let source = r#"
+from siphon import rtpengine
+
+@rtpengine.on_text
+def any_text(call_id, from_tag, to_tag, text, direction):
+    pass
+
+@rtpengine.on_text(call_id="abc", from_tag="ftag1")
+async def specific_text(call_id, from_tag, to_tag, text, direction):
+    pass
+"#;
+        let state = compile_temp_script(source).unwrap();
+        assert_eq!(state.handlers.len(), 2);
+
+        // Catch-all everywhere, plus the filtered one on an exact match only.
+        assert_eq!(state.text_handlers("xyz", "other").len(), 1);
+        assert_eq!(state.text_handlers("abc", "ftag1").len(), 2);
+        assert_eq!(state.text_handlers("abc", "wrong").len(), 1);
+
+        // A text handler is not picked up by the other rtpengine hooks.
+        assert_eq!(state.ws_tee_started_handlers("abc", "ftag1").len(), 0);
+
+        let specific = state
+            .handlers
+            .iter()
+            .find(|h| matches!(
+                &h.kind,
+                HandlerKind::RtpEngineOnText { call_id: Some(c), .. } if c == "abc"
+            ))
+            .expect("filtered text handler registered");
         assert!(specific.is_async);
     }
 


### PR DESCRIPTION
`siphon-rtp-proto` 0.2.0 added `Event::Text` and the `text_events` profile flag. siphon carried
neither, so a call's `m=text` stream could be anchored and relayed but never **read** — the one
channel an accessibility or NG112 deployment needs alongside the audio. This bumps the pin and
wires the surface.

## The pin

0.1.5 → 0.2.0. A 0.x minor is a semver-breaking range, so this is a deliberate move rather than
something `cargo update` performs — which is the point: the pin is what makes the engine's newer
control surface reachable at all. It broke exactly the two sites built to break it, the exhaustive
`profile_flags_from_ng` and `convert_event`. Nothing else.

`Command::Reoffer` and `Command::IceCandidate` also arrive with 0.2.0. They are send-side, so they
produce no compile pressure and are **not** wired here — `Reoffer` (renegotiation on the existing
ports, what a re-INVITE maps to) deserves its own change.

## What the flag does

Set `text_events` on a media profile and the engine promotes **only** the low-rate `m=text` stream
to its userspace processor, which RED-depacketizes (RFC 2198) and reassembles it. The audio
relay/transcode path is untouched — text observability never promotes audio — and the flag is inert
on a call that negotiated no text.

```yaml
media:
  backend: siphon-rtp
  profiles:
    rtt:
      offer: &rtt { replace: ["origin"], text_events: true }
      answer: *rtt
```

```python
@rtpengine.on_text
def transcript(call_id, from_tag, to_tag, text, direction):
    log.info(f"[{call_id}] {direction}: {text}")
```

Same optional `call_id` / `from_tag` filters as `@rtpengine.on_dtmf`; `from_tag` names the leg that
*sent* the text.

## Three decisions worth reviewing

**Only non-empty increments fire.** The engine reports what a packet newly delivered, so a
duplicate, a reordered packet or an idle keepalive produces nothing. A handler firing therefore
always means characters actually arrived — the alternative would have scripts filtering empty
strings on every keystroke.

**U+FFFD stays in the text.** RFC 4103 §5.3 inserts it where RED redundancy could not repair a gap.
Scrubbing it would hand the script a shorter message with no sign anything was lost, which is worse
than the marker.

**The media-CDR counters are absent, not zeroed, on an audio-only call.** `text_packets=0` claims a
text stream that carried nothing — a different thing from no text stream at all. Per-leg
`text_packets` / `text_characters` / `text_missing_markers` / `text_recovered_from_redundancy` sit
alongside the existing loss/jitter/MOS fields.

## Backend gate

`text_events` is a siphon-rtp extension, so rtpengine and rtpproxy reject it at config load naming
the profile/direction/field — the same treatment `ws_uri` and the tee fields already get, and for
the same reason: a flag the engine never sees leaves a script waiting on events that can never
arrive, which looks exactly like a caller who typed nothing.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean, **3893 tests pass** (4 new),
SDK **542 pass** (3 new). New coverage: the field-exact event conversion including the U+FFFD
round trip, leg-summary stats carried only when measured, the decorator's registration and
filtering, and the config gate on all three backends.

Docs: `siphon.yaml` profile-field reference, SDK mock (`on_text` + `fire_text`), CHANGELOG.

Not covered by CI here: a live text stream end to end against a siphon-rtp built from 0.2.0.
