### PR TITLE
fix(cdr): honour cdr.file.rotate_size_mb instead of dropping it at the write site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Fixed
+- **`cdr.file.rotate_size_mb` actually rotates.** The value was documented,
+  parsed and carried into the file backend, then dropped at the write site — so
+  a CDR file configured with `rotate_size_mb: 100` grew without bound. It now
+  renames the file to `<path>.<UTC timestamp>` once a record takes it past the
+  limit, and the next record starts a fresh one; the rename happens after the
+  write, never mid-record. `0` disables rotation. Rotated files are kept, never
+  deleted: retention belongs to logrotate or whatever ships them, and dropping
+  billing records to enforce a size cap would be worse than the unbounded file
+  this replaces. The packaged logrotate config names `cdr.jsonl` only, so it
+  does not re-rotate the size-rotated siblings.
+
 ### Added
 - **Inbound REFER on a controlled call is surfaced to the control app as a
   `TransferRequested` event.** When a B2BUA call has been handed to an external

--- a/etc/logrotate.d/siphon
+++ b/etc/logrotate.d/siphon
@@ -19,7 +19,10 @@
 }
 
 # CDRs are appended with a fresh open per record, so they rotate the ordinary
-# way. Deliberately NOT copytruncate: that copies and then truncates, and any
+# way. Only cdr.jsonl is named here, deliberately: siphon's own
+# cdr.file.rotate_size_mb renames oversized files to cdr.jsonl.<timestamp>, and
+# rotating an already-rotated file again would compress the same records twice.
+# Deliberately NOT copytruncate: that copies and then truncates, and any
 # record written in between is lost — acceptable for a log line, not for a
 # billing record.
 /var/log/siphon/cdr.jsonl {

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -924,6 +924,11 @@ auth:
 #   backend: file
 #   file:
 #     path: "/var/log/siphon/cdr.jsonl"
+#     # Rename the file to <path>.<UTC timestamp> once it reaches this many MB,
+#     # so the next record starts a fresh one. Rotated files are kept, never
+#     # deleted — retention is logrotate's job (the packaged config rotates
+#     # cdr.jsonl daily and leaves the size-rotated siblings alone). Set 0 to
+#     # disable and let logrotate do all of it.
 #     rotate_size_mb: 100
 #
 # HTTP webhook (POST JSON to a collector):

--- a/src/cdr/mod.rs
+++ b/src/cdr/mod.rs
@@ -474,8 +474,11 @@ pub async fn writer_task(mut receiver: mpsc::Receiver<Cdr>, config: CdrConfig) {
 
     while let Some(cdr) = receiver.recv().await {
         match &config.backend {
-            CdrBackendType::File { path, .. } => {
-                write_file_cdr(&cdr, path).await;
+            CdrBackendType::File {
+                path,
+                rotate_size_mb,
+            } => {
+                write_file_cdr(&cdr, path, *rotate_size_mb).await;
             }
             CdrBackendType::Syslog { target } => {
                 write_syslog_cdr(&cdr, target).await;
@@ -495,8 +498,9 @@ pub async fn writer_task(mut receiver: mpsc::Receiver<Cdr>, config: CdrConfig) {
 // File backend
 // ---------------------------------------------------------------------------
 
-/// Write a CDR as JSON to a file (append mode, one JSON object per line).
-async fn write_file_cdr(cdr: &Cdr, path: &str) {
+/// Write a CDR as JSON to a file (append mode, one JSON object per line),
+/// rotating the file once it reaches `rotate_size_mb` (0 disables rotation).
+async fn write_file_cdr(cdr: &Cdr, path: &str, rotate_size_mb: u64) {
     let json = match serde_json::to_string(cdr) {
         Ok(json) => json,
         Err(error) => {
@@ -511,9 +515,54 @@ async fn write_file_cdr(cdr: &Cdr, path: &str) {
             let line = format!("{json}\n");
             if let Err(error) = file.write_all(line.as_bytes()).await {
                 error!("CDR file write error: {error}");
+                return;
+            }
+            // Rotate *after* the write, never mid-record: a CDR split across
+            // two files is worse than a file a few hundred bytes over.
+            if rotate_size_mb > 0 {
+                match file.metadata().await {
+                    Ok(metadata) if metadata.len() >= rotate_size_mb * 1024 * 1024 => {
+                        rotate_file_cdr(path).await;
+                    }
+                    Ok(_) => {}
+                    Err(error) => error!("CDR file size check error: {error}"),
+                }
             }
         }
         Err(error) => error!("CDR file open error: {error}"),
+    }
+}
+
+/// Rename the CDR file out of the way so the next record starts a fresh one.
+///
+/// The writer task is the only writer of this path and opens it per record, so
+/// a plain rename is enough — nothing holds a descriptor that would keep
+/// writing into the rotated inode. Rotated files are never deleted: retention
+/// is the operator's (the packaged logrotate config, a shipper, a cron), and
+/// silently dropping billing records to enforce a size limit would be worse
+/// than the unbounded file this replaces.
+async fn rotate_file_cdr(path: &str) {
+    // Reuse the CDR timestamp so there is one date implementation, minus the
+    // separators that make a filename awkward: 2026-08-20T11:22:33.042Z
+    // becomes 20260820T112233042Z.
+    let stamp: String = format_timestamp(SystemTime::now())
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .collect();
+
+    let mut target = format!("{path}.{stamp}");
+    // A same-millisecond collision needs a full rotation between two records,
+    // which the size threshold makes all but impossible — but overwriting a
+    // file full of billing records is not a risk worth leaving open.
+    let mut attempt = 1;
+    while tokio::fs::try_exists(&target).await.unwrap_or(false) {
+        target = format!("{path}.{stamp}-{attempt}");
+        attempt += 1;
+    }
+
+    match tokio::fs::rename(path, &target).await {
+        Ok(()) => debug!("CDR file rotated: {path} -> {target}"),
+        Err(error) => error!("CDR file rotation error ({path} -> {target}): {error}"),
     }
 }
 
@@ -1032,5 +1081,98 @@ mod tests {
         assert_eq!(parsed["disconnect_initiator"], "caller");
         assert_eq!(parsed["billing_id"], "B-12345"); // flattened extra
         assert_eq!(parsed["transport"], "udp");
+    }
+
+    // --- file backend rotation (cdr.file.rotate_size_mb) ---
+
+    /// Sibling files the rotation left next to `path`.
+    fn rotated_siblings(path: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let directory = path.parent().unwrap();
+        let prefix = format!("{}.", path.file_name().unwrap().to_string_lossy());
+        let mut found: Vec<_> = std::fs::read_dir(directory)
+            .unwrap()
+            .filter_map(|entry| {
+                let entry = entry.unwrap().path();
+                let name = entry.file_name()?.to_string_lossy().into_owned();
+                name.starts_with(&prefix).then_some(entry)
+            })
+            .collect();
+        found.sort();
+        found
+    }
+
+    #[tokio::test]
+    async fn file_backend_rotates_once_over_the_limit() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cdr.jsonl");
+        let path_str = path.to_string_lossy().into_owned();
+        // One byte short of 1 MB, so the next record tips it over.
+        std::fs::write(&path, vec![b'x'; 1024 * 1024 - 1]).unwrap();
+
+        write_file_cdr(&sample_cdr(), &path_str, 1).await;
+
+        let siblings = rotated_siblings(&path);
+        assert_eq!(siblings.len(), 1, "expected exactly one rotated file");
+        let rotated = std::fs::read_to_string(&siblings[0]).unwrap();
+        assert!(
+            rotated.contains("a84b4c76e66710@192.168.1.100"),
+            "the record that tipped the limit belongs in the rotated file, not lost"
+        );
+        assert!(
+            !path.exists(),
+            "the live path is renamed away; the next record re-creates it"
+        );
+
+        // And the next record starts a fresh file rather than appending to the
+        // rotated one.
+        write_file_cdr(&sample_cdr(), &path_str, 1).await;
+        assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 1);
+        assert_eq!(rotated_siblings(&path).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn file_backend_does_not_rotate_below_the_limit() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cdr.jsonl");
+        let path_str = path.to_string_lossy().into_owned();
+
+        write_file_cdr(&sample_cdr(), &path_str, 1).await;
+
+        assert!(rotated_siblings(&path).is_empty());
+        assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 1);
+    }
+
+    /// `rotate_size_mb: 0` is the documented "never rotate" setting.
+    #[tokio::test]
+    async fn zero_disables_rotation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cdr.jsonl");
+        let path_str = path.to_string_lossy().into_owned();
+        std::fs::write(&path, vec![b'x'; 2 * 1024 * 1024]).unwrap();
+
+        write_file_cdr(&sample_cdr(), &path_str, 0).await;
+
+        assert!(rotated_siblings(&path).is_empty());
+        assert!(path.exists());
+    }
+
+    /// Two rotations in the same millisecond must not overwrite each other —
+    /// the first rotated file is full of billing records.
+    #[tokio::test]
+    async fn repeated_rotation_never_overwrites_a_rotated_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cdr.jsonl");
+        let path_str = path.to_string_lossy().into_owned();
+
+        for _ in 0..2 {
+            std::fs::write(&path, vec![b'x'; 1024 * 1024]).unwrap();
+            write_file_cdr(&sample_cdr(), &path_str, 1).await;
+        }
+
+        let siblings = rotated_siblings(&path);
+        assert_eq!(siblings.len(), 2, "second rotation clobbered the first");
+        for sibling in siblings {
+            assert!(std::fs::metadata(sibling).unwrap().len() > 1024 * 1024);
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3025,7 +3025,11 @@ pub struct CdrFileConfig {
     /// Path to the JSON-lines CDR file.
     #[serde(default = "default_cdr_file_path")]
     pub path: String,
-    /// Rotate when file exceeds this size (MB). Default: 100.
+    /// Rename the file out of the way once it reaches this size, in MB, so
+    /// the next record starts a fresh one. Rotated files are named
+    /// `<path>.<UTC timestamp>` and are never deleted — retention belongs to
+    /// logrotate or whatever ships them. `0` disables rotation entirely.
+    /// Default: 100.
     #[serde(default = "default_cdr_rotate_size")]
     pub rotate_size_mb: u64,
 }


### PR DESCRIPTION
The follow-up flagged at the bottom of #183.

## The gap

`cdr.file.rotate_size_mb` is documented in `siphon.yaml`, parsed into `CdrFileConfig`, and carried into `CdrBackendType::File { path, rotate_size_mb }` — then dropped at the write site:

```rust
CdrBackendType::File { path, .. } => {
    write_file_cdr(&cdr, path).await;
}
```

So a CDR file configured with `rotate_size_mb: 100` grew without bound, and the only thing between a busy proxy and a full disk was a logrotate config that — until #183 — shipped in no package at all.

## The fix

A record that takes the file past the limit rotates it: the file is renamed to `<path>.<UTC timestamp>` and the next record starts a fresh one.

- **After the write, never mid-record.** A CDR split across two files is worse than a file a few hundred bytes over the limit.
- **A rename is enough, no locking.** The writer task is the single writer of this path and opens it per record, so nothing holds a descriptor that would keep writing into the rotated inode.
- **A numeric suffix if the target name already exists.** Two rotations inside one millisecond is all but impossible at any sane threshold, but overwriting a file full of billing records is not a risk worth leaving open.
- **`0` disables rotation**, as the config comment now says.
- **Rotated files are never deleted.** Retention belongs to logrotate or whatever ships them; dropping billing records to enforce a size cap would be worse than the unbounded file this replaces.
- The packaged logrotate config names `cdr.jsonl` only, so it does not re-rotate and re-compress the size-rotated siblings. Noted in the file itself.

The timestamp reuses the existing `format_timestamp` with the separators stripped (`20260820T112233042Z`), so there is still one date implementation in this module.

## Testing

Four tests in `src/cdr/mod.rs`: rotates once over the limit (and the tipping record lands in the rotated file, not lost), does not rotate below it, `0` means off, and two rotations do not clobber each other. Mutation-checked — disabling the rotation call fails the first and last, and leaves the other two passing.

- `cargo test` — 3536 lib + 315 integration, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean

No per-message path is touched; the added cost is one `fstat` per CDR, on a path that already does an open + write + close per record.
