### PR TITLE
feat(control-sdk): media/header/REFER verbs + ChannelDtmfReceived/TransferRequested events on the sip facade in all three bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,28 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   including redundancy repair and unrecoverable-loss markers. Absent, not
   zeroed, on a call with no observed text stream — `text_packets=0` would read
   as a text stream that carried nothing, which is a different claim.
+
+- **Media / header / REFER verbs + the two events on the control-plane SDK's
+  `sip` facade — all three bindings.** Wraps the SIP-adapter verbs that shipped
+  server-side, mirroring the `route()` facade: `play` (one of `file` / `db_id` /
+  `blob`, the blob base64-encoded on the wire, plus `repeat` / `start_ms` /
+  `duration_ms` / `to_tag`), `stop`, `dtmf` (`digits` plus `duration_ms` /
+  `volume_dbm0` / `pause_ms` / `to_tag`), `hold` / `unhold`, `stream_start`
+  (`ws_uri`, `direction` ∈ `both` / `caller` / `callee`, `channels` — siphon-rtp
+  only, so other backends answer `unsupported_verb`) / `stream_stop`,
+  `remove_header`, and `accept_refer` (`{target?, next_hop?, mode?}`) /
+  `reject_refer` (`{code, reason?}`). The inbound `ChannelDtmfReceived`
+  (`{digit, duration_ms, volume, from_tag}`) and `TransferRequested`
+  (`{refer_to, replaces?, from_tag}`) events are added to the client event enums
+  with typed payload views so a consumer can match and decode them. Method names
+  follow the verbs (`play` / `stop` / `dtmf` / `hold` / `unhold` /
+  `streamStart`/`stream_start` / `streamStop`/`stream_stop` /
+  `removeHeader`/`remove_header` / `acceptRefer`/`accept_refer` /
+  `rejectRefer`/`reject_refer`), idiomatically cased per language. Errors surface
+  as the same typed `unsupported_verb` / `bad_request` / `not_found` as the
+  sibling verbs. The control SDK version is unchanged (its own `control-sdk-v*`
+  train cuts the release).
+
 - **Cold transfer off a call siphon answered itself.** A voice-AI or IVR call has
   no B leg, so the only way to hand the caller on is an in-dialog REFER on the A
   dialog via the imperative `b2bua.refer(call_id, target)` — `call.refer()` is a

--- a/siphon-control-sdk/Cargo.lock
+++ b/siphon-control-sdk/Cargo.lock
@@ -885,6 +885,7 @@ name = "siphon-control-client"
 version = "0.1.1"
 dependencies = [
  "axum",
+ "base64",
  "futures-util",
  "serde",
  "serde_json",

--- a/siphon-control-sdk/siphon-control-client/Cargo.toml
+++ b/siphon-control-sdk/siphon-control-client/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.1" }
+base64 = "0.22"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/siphon-control-sdk/siphon-control-client/README.md
+++ b/siphon-control-sdk/siphon-control-client/README.md
@@ -43,8 +43,9 @@ client
 ```
 
 A rejected command maps to `ControlError::Command` carrying the stable
-`ControlErrorCode`. Media verbs (`play_file`/`dtmf`) resolve to
-`unsupported_verb` until the server implements them.
+`ControlErrorCode`. The WebSocket-tee verbs (`stream_start`/`stream_stop`) are
+siphon-rtp-only, so a non-siphon-rtp backend answers `unsupported_verb`
+(`ControlError::is_unsupported_verb`).
 
 ## License
 

--- a/siphon-control-sdk/siphon-control-client/src/lib.rs
+++ b/siphon-control-sdk/siphon-control-client/src/lib.rs
@@ -62,7 +62,10 @@ pub use error::ControlError;
 pub use server::{ControlServer, ServerConfig};
 
 // Ergonomic top-level re-exports of the common SIP facade.
-pub use sip::{Call, CallEvent, CallStream, RouteTarget, SipClient, SipServer};
+pub use sip::{
+    Call, CallEvent, CallStream, DtmfOptions, PlayOptions, PlaySource, RouteTarget, SipClient,
+    SipServer,
+};
 
 // Re-export the wire contract so downstreams need only depend on this crate.
 pub use siphon_control_proto::{self as proto, ControlErrorCode};

--- a/siphon-control-sdk/siphon-control-client/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-client/src/sip.rs
@@ -16,7 +16,9 @@ use serde_json::json;
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tracing::{debug, warn};
 
-use siphon_control_proto::sip::{SipEvent, SipVerb};
+use siphon_control_proto::sip::{
+    ChannelDtmfPayload, SipEvent, SipVerb, TransferRequestedPayload,
+};
 use siphon_control_proto::verbs::MODULE_SIP;
 use siphon_control_proto::{ChannelSnapshot, EventFrame};
 
@@ -108,6 +110,120 @@ fn headers_to_json(headers: &[(String, String)]) -> serde_json::Value {
 }
 
 // ---------------------------------------------------------------------------
+// play() source + options
+// ---------------------------------------------------------------------------
+
+/// The audio source for [`Call::play`]: exactly one of a server-side file path,
+/// an rtpengine media-DB id, or an inline blob.
+///
+/// A `Blob` is base64-encoded on the wire (the control rail is JSON text), so the
+/// caller passes raw bytes and this handle does the encoding — mirroring the
+/// in-process `rtpengine.play_media(file=…|db_id=…|blob=…)` mutual exclusion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlaySource {
+    /// A file path readable by the media engine.
+    File(String),
+    /// An id of a prompt in rtpengine's media DB.
+    DbId(u64),
+    /// Raw audio bytes played inline (base64-encoded on the wire).
+    Blob(Vec<u8>),
+}
+
+impl PlaySource {
+    /// Play a server-side file by path.
+    pub fn file(path: impl Into<String>) -> Self {
+        Self::File(path.into())
+    }
+
+    /// Play a prompt by its rtpengine media-DB id.
+    pub fn db_id(id: u64) -> Self {
+        Self::DbId(id)
+    }
+
+    /// Play raw audio bytes inline (base64-encoded on the wire).
+    pub fn blob(bytes: impl Into<Vec<u8>>) -> Self {
+        Self::Blob(bytes.into())
+    }
+
+    /// Insert the one source arg (`file` / `db_id` / `blob`) into a play args map.
+    fn insert_into(&self, args: &mut serde_json::Map<String, serde_json::Value>) {
+        match self {
+            PlaySource::File(path) => {
+                args.insert("file".to_string(), json!(path));
+            }
+            PlaySource::DbId(id) => {
+                args.insert("db_id".to_string(), json!(id));
+            }
+            PlaySource::Blob(bytes) => {
+                use base64::Engine as _;
+                let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+                args.insert("blob".to_string(), json!(encoded));
+            }
+        }
+    }
+}
+
+/// Optional shaping for [`Call::play`] (all default to the engine's behaviour).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PlayOptions {
+    /// Repeat the prompt this many times (0/None → play once).
+    pub repeat: Option<u64>,
+    /// Start playback at this offset into the source, in milliseconds.
+    pub start_ms: Option<u64>,
+    /// Cap playback to this duration, in milliseconds.
+    pub duration_ms: Option<u64>,
+    /// Scope the prompt to one peer of an MPTY bridge (its To-tag).
+    pub to_tag: Option<String>,
+}
+
+impl PlayOptions {
+    fn insert_into(&self, args: &mut serde_json::Map<String, serde_json::Value>) {
+        if let Some(repeat) = self.repeat {
+            args.insert("repeat".to_string(), json!(repeat));
+        }
+        if let Some(start_ms) = self.start_ms {
+            args.insert("start_ms".to_string(), json!(start_ms));
+        }
+        if let Some(duration_ms) = self.duration_ms {
+            args.insert("duration_ms".to_string(), json!(duration_ms));
+        }
+        if let Some(to_tag) = &self.to_tag {
+            args.insert("to_tag".to_string(), json!(to_tag));
+        }
+    }
+}
+
+/// Optional shaping for [`Call::dtmf`] (all default to the engine's behaviour).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DtmfOptions {
+    /// Per-digit tone duration, in milliseconds.
+    pub duration_ms: Option<u64>,
+    /// Tone volume in dBm0 (negative).
+    pub volume_dbm0: Option<i64>,
+    /// Inter-digit pause, in milliseconds.
+    pub pause_ms: Option<u64>,
+    /// Scope the tones to one peer of an MPTY bridge (its To-tag).
+    pub to_tag: Option<String>,
+}
+
+impl DtmfOptions {
+    fn insert_into(&self, args: &mut serde_json::Map<String, serde_json::Value>) {
+        if let Some(duration_ms) = self.duration_ms {
+            args.insert("duration_ms".to_string(), json!(duration_ms));
+        }
+        if let Some(volume_dbm0) = self.volume_dbm0 {
+            args.insert("volume_dbm0".to_string(), json!(volume_dbm0));
+        }
+        if let Some(pause_ms) = self.pause_ms {
+            args.insert("pause_ms".to_string(), json!(pause_ms));
+        }
+        if let Some(to_tag) = &self.to_tag {
+            args.insert("to_tag".to_string(), json!(to_tag));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Call handle
 // ---------------------------------------------------------------------------
 
@@ -130,6 +246,24 @@ impl CallEvent {
             payload: frame.payload.clone(),
             frame,
         }
+    }
+
+    /// The typed [`ChannelDtmfPayload`] when this is a
+    /// [`SipEvent::ChannelDtmfReceived`] event, else `None`.
+    pub fn dtmf(&self) -> Option<ChannelDtmfPayload> {
+        if self.kind != SipEvent::ChannelDtmfReceived {
+            return None;
+        }
+        serde_json::from_value(self.payload.clone()).ok()
+    }
+
+    /// The typed [`TransferRequestedPayload`] when this is a
+    /// [`SipEvent::TransferRequested`] event, else `None`.
+    pub fn transfer_requested(&self) -> Option<TransferRequestedPayload> {
+        if self.kind != SipEvent::TransferRequested {
+            return None;
+        }
+        serde_json::from_value(self.payload.clone()).ok()
     }
 }
 
@@ -318,6 +452,45 @@ impl Call {
         self.sip(SipVerb::Refer, args).await.map(drop)
     }
 
+    /// Accept a *pending inbound* REFER (surfaced as a
+    /// [`SipEvent::TransferRequested`] event) and run the transfer.
+    ///
+    /// `target` overrides the Refer-To URI (default: the event's target),
+    /// `next_hop` steers egress without changing the URI shape, and `mode`
+    /// (`"terminate"` / `"transparent"`) overrides `b2bua.default_refer_mode`.
+    /// No pending REFER (already decided, timed out, or the call is gone) →
+    /// [`ControlError`] with `code == "not_found"`.
+    pub async fn accept_refer(
+        &self,
+        target: Option<&str>,
+        next_hop: Option<&str>,
+        mode: Option<&str>,
+    ) -> Result<(), ControlError> {
+        let mut args = serde_json::Map::new();
+        if let Some(target) = target {
+            args.insert("target".to_string(), json!(target));
+        }
+        if let Some(next_hop) = next_hop {
+            args.insert("next_hop".to_string(), json!(next_hop));
+        }
+        if let Some(mode) = mode {
+            args.insert("mode".to_string(), json!(mode));
+        }
+        self.sip(SipVerb::AcceptRefer, serde_json::Value::Object(args))
+            .await
+            .map(drop)
+    }
+
+    /// Reject a *pending inbound* REFER with a final non-2xx (default
+    /// `603 Decline`). No pending REFER → `code == "not_found"`.
+    pub async fn reject_refer(&self, code: u16, reason: Option<&str>) -> Result<(), ControlError> {
+        let mut args = json!({ "code": code });
+        if let Some(reason) = reason {
+            args["reason"] = json!(reason);
+        }
+        self.sip(SipVerb::RejectRefer, args).await.map(drop)
+    }
+
     /// Un-park this controlled call and dial the B-leg via siphon's LCR
     /// sequential-failover engine, returning control to siphon.
     ///
@@ -365,6 +538,13 @@ impl Call {
         Ok(string_value(&result))
     }
 
+    /// Remove a header from the stored A-leg INVITE.
+    pub async fn remove_header(&self, name: &str) -> Result<(), ControlError> {
+        self.sip(SipVerb::RemoveHeader, json!({ "name": name }))
+            .await
+            .map(drop)
+    }
+
     // --- per-call variables (substrate verbs, no module) -------------------
 
     /// Set a per-call variable (survives a reconnect via `resync`).
@@ -386,17 +566,86 @@ impl Call {
         Ok(string_value(&result))
     }
 
-    // --- media (server answers `unsupported_verb` today) -------------------
+    // --- media -------------------------------------------------------------
 
-    /// Play an announcement. **Not yet implemented server-side** — resolves to
-    /// [`ControlError::is_unsupported_verb`] until the media backend lands.
-    pub async fn play_file(&self, file: &str) -> Result<(), ControlError> {
-        self.command("play", json!({ "file": file })).await.map(drop)
+    /// Play an announcement on the A-leg media (fire-and-forget).
+    ///
+    /// `source` is one of [`PlaySource::file`] / [`PlaySource::db_id`] /
+    /// [`PlaySource::blob`] (a blob is base64-encoded on the wire); `options`
+    /// carries the optional `repeat` / `start_ms` / `duration_ms` / `to_tag`
+    /// shaping. Resolves once the media backend *accepts* the command; the far-end
+    /// playback outcome is not the reply. A call with no anchored media session →
+    /// [`ControlError`] with `code == "not_found"`.
+    pub async fn play(
+        &self,
+        source: PlaySource,
+        options: PlayOptions,
+    ) -> Result<(), ControlError> {
+        let mut args = serde_json::Map::new();
+        source.insert_into(&mut args);
+        options.insert_into(&mut args);
+        self.sip(SipVerb::Play, serde_json::Value::Object(args))
+            .await
+            .map(drop)
     }
 
-    /// Send DTMF. **Not yet implemented server-side** — see [`Call::play_file`].
-    pub async fn dtmf(&self, digits: &str) -> Result<(), ControlError> {
-        self.command("dtmf", json!({ "digits": digits })).await.map(drop)
+    /// Convenience for [`Call::play`] of a server-side file with default options.
+    pub async fn play_file(&self, file: &str) -> Result<(), ControlError> {
+        self.play(PlaySource::file(file), PlayOptions::default()).await
+    }
+
+    /// Stop the announcement currently playing on the A-leg media.
+    pub async fn stop(&self) -> Result<(), ControlError> {
+        self.sip(SipVerb::Stop, json!({})).await.map(drop)
+    }
+
+    /// Inject DTMF digits toward the A-leg (fire-and-forget). `options` carries
+    /// the optional `duration_ms` / `volume_dbm0` / `pause_ms` / `to_tag` shaping.
+    pub async fn dtmf(&self, digits: &str, options: DtmfOptions) -> Result<(), ControlError> {
+        let mut args = serde_json::Map::new();
+        args.insert("digits".to_string(), json!(digits));
+        options.insert_into(&mut args);
+        self.sip(SipVerb::Dtmf, serde_json::Value::Object(args))
+            .await
+            .map(drop)
+    }
+
+    /// Hold the A-leg media via silence.
+    pub async fn hold(&self) -> Result<(), ControlError> {
+        self.sip(SipVerb::Hold, json!({})).await.map(drop)
+    }
+
+    /// Resume the A-leg media after a [`Call::hold`].
+    pub async fn unhold(&self) -> Result<(), ControlError> {
+        self.sip(SipVerb::Unhold, json!({})).await.map(drop)
+    }
+
+    /// Attach a WebSocket audio tee — stream a copy of the call's decoded audio
+    /// to `ws_uri` while the call keeps relaying.
+    ///
+    /// `direction` is one of `"both"` (default) / `"caller"` / `"callee"`;
+    /// `channels` is `1` (mixed mono) or `2` (caller/callee stereo, only
+    /// meaningful with `"both"`). siphon-rtp backend only: rtpengine / rtpproxy
+    /// answer [`ControlError::is_unsupported_verb`].
+    pub async fn stream_start(
+        &self,
+        ws_uri: &str,
+        direction: Option<&str>,
+        channels: Option<u8>,
+    ) -> Result<(), ControlError> {
+        let mut args = json!({ "ws_uri": ws_uri });
+        if let Some(direction) = direction {
+            args["direction"] = json!(direction);
+        }
+        if let Some(channels) = channels {
+            args["channels"] = json!(channels);
+        }
+        self.sip(SipVerb::StreamStart, args).await.map(drop)
+    }
+
+    /// Detach the WebSocket audio tee (idempotent on siphon-rtp).
+    pub async fn stream_stop(&self) -> Result<(), ControlError> {
+        self.sip(SipVerb::StreamStop, json!({})).await.map(drop)
     }
 
     // --- escape hatch + events --------------------------------------------
@@ -414,7 +663,9 @@ impl Call {
     }
 
     /// Await the next event for this call (`ChannelStateChange`,
-    /// `ChannelHangupRequest`, `StasisEnd`). `None` once the stream closes.
+    /// `ChannelHangupRequest`, `ChannelDtmfReceived`, `TransferRequested`,
+    /// `StasisEnd`). `None` once the stream closes. Use [`CallEvent::dtmf`] /
+    /// [`CallEvent::transfer_requested`] to decode the payload.
     pub async fn next_event(&self) -> Option<CallEvent> {
         self.inner.events.lock().await.recv().await
     }
@@ -867,5 +1118,128 @@ mod tests {
 
         let recorded = lock(&recorder.calls).clone();
         assert_eq!(recorded[0].args, json!({ "targets": ["sip:only@gw"] }));
+    }
+
+    #[tokio::test]
+    async fn media_verbs_emit_expected_frames() {
+        let recorder = Arc::new(RecordingTransport {
+            calls: Mutex::new(Vec::new()),
+            result: json!({ "channel": "ch1", "state": "playing" }),
+        });
+        let call = make_call(recorder.clone());
+
+        call.play(PlaySource::file("/prompts/welcome.wav"), PlayOptions::default())
+            .await
+            .expect("play file ok");
+        call.play(
+            PlaySource::blob(b"hi".to_vec()),
+            PlayOptions { repeat: Some(2), duration_ms: Some(10_000), ..Default::default() },
+        )
+        .await
+        .expect("play blob ok");
+        call.stop().await.expect("stop ok");
+        call.dtmf(
+            "123#",
+            DtmfOptions { duration_ms: Some(100), volume_dbm0: Some(-8), ..Default::default() },
+        )
+        .await
+        .expect("dtmf ok");
+        call.hold().await.expect("hold ok");
+        call.unhold().await.expect("unhold ok");
+        call.stream_start("ws://ai:9000/stream", Some("both"), Some(2))
+            .await
+            .expect("stream_start ok");
+        call.stream_stop().await.expect("stream_stop ok");
+
+        let recorded = lock(&recorder.calls).clone();
+        let by_verb = |verb: &str| -> serde_json::Value {
+            recorded.iter().find(|call| call.verb == verb).expect("verb recorded").args.clone()
+        };
+        // Every media verb rides the sip module against this channel.
+        for call in &recorded {
+            assert_eq!(call.module.as_deref(), Some("sip"));
+            assert_eq!(call.target, json!({ "channel": "ch1" }));
+        }
+        assert_eq!(by_verb("play").get("file").and_then(|v| v.as_str()), Some("/prompts/welcome.wav"));
+        // A blob is base64-encoded on the wire ("hi" → "aGk=").
+        let blob_args: Vec<&serde_json::Value> = recorded
+            .iter()
+            .filter(|call| call.verb == "play")
+            .map(|call| &call.args)
+            .collect();
+        assert_eq!(blob_args[1], &json!({ "blob": "aGk=", "repeat": 2, "duration_ms": 10_000 }));
+        assert_eq!(by_verb("stop"), json!({}));
+        assert_eq!(by_verb("dtmf"), json!({ "digits": "123#", "duration_ms": 100, "volume_dbm0": -8 }));
+        assert_eq!(by_verb("hold"), json!({}));
+        assert_eq!(by_verb("unhold"), json!({}));
+        assert_eq!(
+            by_verb("stream_start"),
+            json!({ "ws_uri": "ws://ai:9000/stream", "direction": "both", "channels": 2 })
+        );
+        assert_eq!(by_verb("stream_stop"), json!({}));
+    }
+
+    #[tokio::test]
+    async fn header_and_refer_verbs_emit_expected_frames() {
+        let recorder = Arc::new(RecordingTransport {
+            calls: Mutex::new(Vec::new()),
+            result: json!({ "channel": "ch1" }),
+        });
+        let call = make_call(recorder.clone());
+
+        call.remove_header("X-Foo").await.expect("remove_header ok");
+        call.accept_refer(Some("sip:c@pbx"), Some("sip:sbc"), Some("terminate"))
+            .await
+            .expect("accept_refer ok");
+        call.reject_refer(603, Some("Decline")).await.expect("reject_refer ok");
+
+        let recorded = lock(&recorder.calls).clone();
+        assert_eq!(recorded[0].verb, "remove_header");
+        assert_eq!(recorded[0].args, json!({ "name": "X-Foo" }));
+        assert_eq!(recorded[1].verb, "accept_refer");
+        assert_eq!(
+            recorded[1].args,
+            json!({ "target": "sip:c@pbx", "next_hop": "sip:sbc", "mode": "terminate" })
+        );
+        assert_eq!(recorded[2].verb, "reject_refer");
+        assert_eq!(recorded[2].args, json!({ "code": 603, "reason": "Decline" }));
+    }
+
+    #[test]
+    fn dtmf_and_transfer_events_parse_from_frames() {
+        let dtmf = CallEvent::from_frame(EventFrame::new(
+            "ChannelDtmfReceived",
+            "ch1",
+            "ivr-app",
+            "call-uuid",
+            "sip@host",
+            json!({ "digit": "5", "duration_ms": 100, "volume": -8, "from_tag": "alice-tag" }),
+        ));
+        assert_eq!(dtmf.kind, SipEvent::ChannelDtmfReceived);
+        let payload = dtmf.dtmf().expect("dtmf payload");
+        assert_eq!(payload.digit, "5");
+        assert_eq!(payload.volume, -8);
+        assert_eq!(payload.from_tag, "alice-tag");
+        // Wrong-kind accessor returns None.
+        assert!(dtmf.transfer_requested().is_none());
+
+        let transfer = CallEvent::from_frame(EventFrame::new(
+            "TransferRequested",
+            "ch1",
+            "ivr-app",
+            "call-uuid",
+            "sip@host",
+            json!({
+                "refer_to": "sip:carol@example.com",
+                "replaces": { "call_id": "abc", "from_tag": "ft", "to_tag": "tt", "early_only": false },
+                "from_tag": "referrer-tag"
+            }),
+        ));
+        assert_eq!(transfer.kind, SipEvent::TransferRequested);
+        let payload = transfer.transfer_requested().expect("transfer payload");
+        assert_eq!(payload.refer_to, "sip:carol@example.com");
+        assert_eq!(payload.replaces.expect("replaces").call_id, "abc");
+        assert_eq!(payload.from_tag.as_deref(), Some("referrer-tag"));
+        assert!(transfer.dtmf().is_none());
     }
 }

--- a/siphon-control-sdk/siphon-control-client/tests/integration.rs
+++ b/siphon-control-sdk/siphon-control-client/tests/integration.rs
@@ -135,13 +135,14 @@ async fn drive_stub(mut socket: WebSocket, stub: Arc<Stub>) {
                 let _ = socket.send(Message::Text(event.to_string().into())).await;
                 send_ok(&mut socket, &id, serde_json::json!({})).await;
             }
-            // Media verbs the server does not implement yet.
-            "play" | "dtmf" => {
+            // The WebSocket-tee verbs are siphon-rtp-only; a non-siphon-rtp
+            // backend answers unsupported_verb (the stub plays that backend).
+            "stream_start" | "stream_stop" => {
                 send_error(
                     &mut socket,
                     &id,
                     "unsupported_verb",
-                    "sip adapter does not implement this verb in this build",
+                    "ws_tee is only supported by the siphon-rtp backend",
                 )
                 .await;
             }
@@ -258,10 +259,11 @@ async fn stasis_start_dispatches_a_call_and_verbs_round_trip() {
     assert_eq!(call.get_header("P-Asserted-Identity").await.unwrap().as_deref(), Some("203.0.113.7"));
     call.transfer("sip:agent@pbx").await.expect("refer ok");
 
-    // A media verb surfaces the server's unsupported_verb as a typed error.
-    match call.dtmf("123#").await {
+    // A backend-gated verb (ws_tee is siphon-rtp-only) surfaces the server's
+    // unsupported_verb as a typed error.
+    match call.stream_start("ws://ai:9000/stream", None, None).await {
         Err(error) => assert!(error.is_unsupported_verb(), "expected unsupported_verb, got {error:?}"),
-        Ok(()) => panic!("dtmf should be unsupported today"),
+        Ok(()) => panic!("stream_start should be unsupported on a non-siphon-rtp backend"),
     }
 }
 

--- a/siphon-control-sdk/siphon-control-proto/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-proto/src/sip.rs
@@ -10,9 +10,10 @@ use serde::{Deserialize, Serialize};
 
 /// A verb the built-in SIP adapter (`module = "sip"`) accepts.
 ///
-/// `as_str()` yields the exact wire token; media verbs (`play`/`dtmf`/…) are
-/// deliberately absent — the server answers them `unsupported_verb` today, so a
-/// client models them as ad-hoc verbs the enum does not promote.
+/// `as_str()` yields the exact wire token. The media verbs
+/// (`play`/`stop`/`dtmf`/`hold`/`unhold`/`stream_start`/`stream_stop`) are
+/// dispatched against the configured media backend; the WebSocket-tee pair is
+/// siphon-rtp-only, so a non-siphon-rtp backend answers them `unsupported_verb`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SipVerb {
     /// Send a UAS 2xx to the parked A-leg.
@@ -25,12 +26,32 @@ pub enum SipVerb {
     Hangup,
     /// Send an in-dialog REFER on the A-leg.
     Refer,
+    /// Accept a pending inbound REFER (from a `TransferRequested` event).
+    AcceptRefer,
+    /// Reject a pending inbound REFER with a final non-2xx.
+    RejectRefer,
     /// Un-park the call and dial the B-leg via LCR sequential failover.
     Route,
     /// Set a header on the stored A-leg INVITE.
     SetHeader,
+    /// Remove a header from the stored A-leg INVITE.
+    RemoveHeader,
     /// Read a header from the stored A-leg INVITE.
     GetHeader,
+    /// Play an announcement on the A-leg media (fire-and-forget).
+    Play,
+    /// Stop the announcement currently playing on the A-leg media.
+    Stop,
+    /// Inject DTMF digits toward the A-leg.
+    Dtmf,
+    /// Hold the A-leg media via silence.
+    Hold,
+    /// Resume the A-leg media after a hold.
+    Unhold,
+    /// Attach a WebSocket audio tee (siphon-rtp backend only).
+    StreamStart,
+    /// Detach the WebSocket audio tee.
+    StreamStop,
 }
 
 impl SipVerb {
@@ -42,9 +63,19 @@ impl SipVerb {
             SipVerb::Reject => "reject",
             SipVerb::Hangup => "hangup",
             SipVerb::Refer => "refer",
+            SipVerb::AcceptRefer => "accept_refer",
+            SipVerb::RejectRefer => "reject_refer",
             SipVerb::Route => "route",
             SipVerb::SetHeader => "set_header",
+            SipVerb::RemoveHeader => "remove_header",
             SipVerb::GetHeader => "get_header",
+            SipVerb::Play => "play",
+            SipVerb::Stop => "stop",
+            SipVerb::Dtmf => "dtmf",
+            SipVerb::Hold => "hold",
+            SipVerb::Unhold => "unhold",
+            SipVerb::StreamStart => "stream_start",
+            SipVerb::StreamStop => "stream_stop",
         }
     }
 }
@@ -71,6 +102,12 @@ pub enum SipEvent {
     ChannelStateChange,
     /// The far end asked to hang up (a BYE arrived).
     ChannelHangupRequest,
+    /// An in-band DTMF digit was detected on the call's media
+    /// ([`ChannelDtmfPayload`]).
+    ChannelDtmfReceived,
+    /// An inbound REFER on a controlled call is asking the app to own the
+    /// transfer decision ([`TransferRequestedPayload`]).
+    TransferRequested,
     /// Any other event name (forward-compatible catch-all).
     Other(String),
 }
@@ -83,6 +120,8 @@ impl SipEvent {
             SipEvent::StasisEnd => "StasisEnd",
             SipEvent::ChannelStateChange => "ChannelStateChange",
             SipEvent::ChannelHangupRequest => "ChannelHangupRequest",
+            SipEvent::ChannelDtmfReceived => "ChannelDtmfReceived",
+            SipEvent::TransferRequested => "TransferRequested",
             SipEvent::Other(name) => name.as_str(),
         }
     }
@@ -95,6 +134,8 @@ impl From<&str> for SipEvent {
             "StasisEnd" => SipEvent::StasisEnd,
             "ChannelStateChange" => SipEvent::ChannelStateChange,
             "ChannelHangupRequest" => SipEvent::ChannelHangupRequest,
+            "ChannelDtmfReceived" => SipEvent::ChannelDtmfReceived,
+            "TransferRequested" => SipEvent::TransferRequested,
             other => SipEvent::Other(other.to_string()),
         }
     }
@@ -118,6 +159,59 @@ impl std::fmt::Display for SipEvent {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Additive typed views over well-known SIP-adapter event payloads. The server
+// emits these shapes as the `payload` object of an [`crate::EventFrame`]; a
+// client deserializes them for ergonomics. Purely additive (the server need not
+// adopt them for the wire to stay identical).
+// ---------------------------------------------------------------------------
+
+/// The `payload` of a [`SipEvent::ChannelDtmfReceived`] event: an in-band DTMF
+/// digit the media engine detected on a controlled call's leg.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelDtmfPayload {
+    /// The single detected digit (`0`–`9`, `*`, `#`, `A`–`D`).
+    pub digit: String,
+    /// The tone duration in milliseconds.
+    #[serde(default)]
+    pub duration_ms: u32,
+    /// The tone volume in dBm0 (negative).
+    #[serde(default)]
+    pub volume: i32,
+    /// The From-tag of the leg the digit came from.
+    #[serde(default)]
+    pub from_tag: String,
+}
+
+/// The RFC 3891 `Replaces` triple embedded in a [`TransferRequestedPayload`]
+/// (an attended-transfer REFER).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferReplaces {
+    /// The Call-ID of the dialog being replaced.
+    pub call_id: String,
+    /// The From-tag of the dialog being replaced.
+    pub from_tag: String,
+    /// The To-tag of the dialog being replaced.
+    pub to_tag: String,
+    /// Whether the REFER was `early-only`.
+    #[serde(default)]
+    pub early_only: bool,
+}
+
+/// The `payload` of a [`SipEvent::TransferRequested`] event: an inbound REFER on
+/// a controlled call, handed to the app to accept / reject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferRequestedPayload {
+    /// The Refer-To URI (the transfer target).
+    pub refer_to: String,
+    /// The embedded `Replaces` triple for an attended transfer, if present.
+    #[serde(default)]
+    pub replaces: Option<TransferReplaces>,
+    /// The From-tag of the referring party, if known.
+    #[serde(default)]
+    pub from_tag: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,6 +222,17 @@ mod tests {
         assert_eq!(SipVerb::Route.as_str(), "route");
         assert_eq!(SipVerb::SetHeader.as_str(), "set_header");
         assert_eq!(SipVerb::GetHeader.to_string(), "get_header");
+        // The media / header / REFER verbs that shipped server-side.
+        assert_eq!(SipVerb::RemoveHeader.as_str(), "remove_header");
+        assert_eq!(SipVerb::AcceptRefer.as_str(), "accept_refer");
+        assert_eq!(SipVerb::RejectRefer.as_str(), "reject_refer");
+        assert_eq!(SipVerb::Play.as_str(), "play");
+        assert_eq!(SipVerb::Stop.as_str(), "stop");
+        assert_eq!(SipVerb::Dtmf.as_str(), "dtmf");
+        assert_eq!(SipVerb::Hold.as_str(), "hold");
+        assert_eq!(SipVerb::Unhold.as_str(), "unhold");
+        assert_eq!(SipVerb::StreamStart.as_str(), "stream_start");
+        assert_eq!(SipVerb::StreamStop.to_string(), "stream_stop");
     }
 
     #[test]
@@ -138,12 +243,61 @@ mod tests {
             SipEvent::ChannelHangupRequest
         );
         assert_eq!(
+            SipEvent::from("ChannelDtmfReceived"),
+            SipEvent::ChannelDtmfReceived
+        );
+        assert_eq!(
+            SipEvent::from("TransferRequested"),
+            SipEvent::TransferRequested
+        );
+        assert_eq!(
             SipEvent::from("SomethingNew"),
             SipEvent::Other("SomethingNew".to_string())
         );
         let json = serde_json::to_string(&SipEvent::StasisEnd).unwrap();
         assert_eq!(json, "\"StasisEnd\"");
+        assert_eq!(
+            serde_json::to_string(&SipEvent::ChannelDtmfReceived).unwrap(),
+            "\"ChannelDtmfReceived\""
+        );
         let parsed: SipEvent = serde_json::from_str("\"NovelEvent\"").unwrap();
         assert_eq!(parsed, SipEvent::Other("NovelEvent".to_string()));
+    }
+
+    #[test]
+    fn channel_dtmf_payload_parses() {
+        // Byte-identical to the server's ChannelDtmfReceived payload.
+        let value = serde_json::json!({
+            "digit": "5", "duration_ms": 100, "volume": -8, "from_tag": "alice-tag"
+        });
+        let parsed: ChannelDtmfPayload = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.digit, "5");
+        assert_eq!(parsed.duration_ms, 100);
+        assert_eq!(parsed.volume, -8);
+        assert_eq!(parsed.from_tag, "alice-tag");
+    }
+
+    #[test]
+    fn transfer_requested_payload_parses_with_and_without_replaces() {
+        // Blind transfer: replaces + from_tag null.
+        let blind = serde_json::json!({
+            "refer_to": "sip:carol@example.com", "replaces": null, "from_tag": null
+        });
+        let parsed: TransferRequestedPayload = serde_json::from_value(blind).unwrap();
+        assert_eq!(parsed.refer_to, "sip:carol@example.com");
+        assert!(parsed.replaces.is_none());
+        assert!(parsed.from_tag.is_none());
+
+        // Attended transfer: an embedded Replaces triple + a referrer from_tag.
+        let attended = serde_json::json!({
+            "refer_to": "sip:dave@example.com",
+            "replaces": { "call_id": "abc", "from_tag": "ft", "to_tag": "tt", "early_only": true },
+            "from_tag": "referrer-tag"
+        });
+        let parsed: TransferRequestedPayload = serde_json::from_value(attended).unwrap();
+        let replaces = parsed.replaces.expect("replaces present");
+        assert_eq!(replaces.call_id, "abc");
+        assert!(replaces.early_only);
+        assert_eq!(parsed.from_tag.as_deref(), Some("referrer-tag"));
     }
 }

--- a/siphon-control-sdk/siphon-control/src/lib.rs
+++ b/siphon-control-sdk/siphon-control/src/lib.rs
@@ -60,7 +60,9 @@ use pyo3::types::PyList;
 use pyo3_async_runtimes::TaskLocals;
 
 use siphon_control_client::proto::ControlErrorCode;
-use siphon_control_client::sip::{Call as RustCall, RouteTarget, SipClient, SipServer};
+use siphon_control_client::sip::{
+    Call as RustCall, DtmfOptions, PlayOptions, PlaySource, RouteTarget, SipClient, SipServer,
+};
 use siphon_control_client::{ClientConfig, ControlError as ClientError, ServerConfig};
 
 pyo3::create_exception!(
@@ -147,6 +149,23 @@ fn extract_route_target(item: &Bound<'_, PyAny>) -> PyResult<RouteTarget> {
         headers,
         timeout_secs,
     })
+}
+
+/// Build a [`PlaySource`] from the mutually-exclusive `file` / `db_id` / `blob`
+/// kwargs (exactly one must be set — mirrors the in-process `play_media`).
+fn build_play_source(
+    file: Option<String>,
+    db_id: Option<u64>,
+    blob: Option<Vec<u8>>,
+) -> PyResult<PlaySource> {
+    match (file, db_id, blob) {
+        (Some(file), None, None) => Ok(PlaySource::file(file)),
+        (None, Some(db_id), None) => Ok(PlaySource::db_id(db_id)),
+        (None, None, Some(blob)) => Ok(PlaySource::blob(blob)),
+        _ => Err(PyValueError::new_err(
+            "play requires exactly one of file (str), db_id (int), or blob (bytes)",
+        )),
+    }
 }
 
 /// Extract a `{name: value}` header dict into ordered string pairs.
@@ -271,6 +290,41 @@ impl Call {
         self.refer(py, to)
     }
 
+    /// Accept a pending inbound REFER (surfaced as a `TransferRequested` event)
+    /// and run the transfer. `target` overrides the Refer-To URI, `next_hop`
+    /// steers egress, and `mode` is `"terminate"` / `"transparent"`. No pending
+    /// REFER raises `ControlError` with `code == "not_found"`.
+    #[pyo3(signature = (target=None, next_hop=None, mode=None))]
+    fn accept_refer<'py>(
+        &self,
+        py: Python<'py>,
+        target: Option<String>,
+        next_hop: Option<String>,
+        mode: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.accept_refer(target.as_deref(), next_hop.as_deref(), mode.as_deref())
+                .await
+                .map_err(to_pyerr)
+        })
+    }
+
+    /// Reject a pending inbound REFER with a final non-2xx (default
+    /// `603 Decline`). No pending REFER raises `code == "not_found"`.
+    #[pyo3(signature = (code, reason=None))]
+    fn reject_refer<'py>(
+        &self,
+        py: Python<'py>,
+        code: u16,
+        reason: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.reject_refer(code, reason.as_deref()).await.map_err(to_pyerr)
+        })
+    }
+
     /// Un-park this controlled call and dial the B-leg via siphon's LCR
     /// sequential-failover engine, returning control to siphon.
     ///
@@ -328,6 +382,14 @@ impl Call {
         })
     }
 
+    /// Remove a header from the stored A-leg INVITE.
+    fn remove_header<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.remove_header(&name).await.map_err(to_pyerr)
+        })
+    }
+
     fn set_var<'py>(
         &self,
         py: Python<'py>,
@@ -347,8 +409,37 @@ impl Call {
         })
     }
 
-    /// Play an announcement — raises `ControlError` (`code == "unsupported_verb"`)
-    /// until the server implements media.
+    /// Play an announcement on the A-leg media (fire-and-forget). Pass exactly one
+    /// of `file` (str), `db_id` (int), or `blob` (bytes, base64-encoded on the
+    /// wire); the rest shape playback. A call with no anchored media session
+    /// raises `ControlError` with `code == "not_found"`.
+    #[pyo3(signature = (file=None, db_id=None, blob=None, repeat=None, start_ms=None, duration_ms=None, to_tag=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn play<'py>(
+        &self,
+        py: Python<'py>,
+        file: Option<String>,
+        db_id: Option<u64>,
+        blob: Option<Vec<u8>>,
+        repeat: Option<u64>,
+        start_ms: Option<u64>,
+        duration_ms: Option<u64>,
+        to_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let source = build_play_source(file, db_id, blob)?;
+        let options = PlayOptions {
+            repeat,
+            start_ms,
+            duration_ms,
+            to_tag,
+        };
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.play(source, options).await.map_err(to_pyerr)
+        })
+    }
+
+    /// Convenience for `play(file=...)` with default options.
     fn play_file<'py>(&self, py: Python<'py>, file: String) -> PyResult<Bound<'py, PyAny>> {
         let call = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -356,11 +447,79 @@ impl Call {
         })
     }
 
-    /// Send DTMF — raises `ControlError` (`code == "unsupported_verb"`) today.
-    fn dtmf<'py>(&self, py: Python<'py>, digits: String) -> PyResult<Bound<'py, PyAny>> {
+    /// Stop the announcement currently playing on the A-leg media.
+    fn stop<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let call = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            call.dtmf(&digits).await.map_err(to_pyerr)
+            call.stop().await.map_err(to_pyerr)
+        })
+    }
+
+    /// Inject DTMF digits toward the A-leg (fire-and-forget). The optional
+    /// `duration_ms` / `volume_dbm0` / `pause_ms` / `to_tag` shape the tones.
+    #[pyo3(signature = (digits, duration_ms=None, volume_dbm0=None, pause_ms=None, to_tag=None))]
+    fn dtmf<'py>(
+        &self,
+        py: Python<'py>,
+        digits: String,
+        duration_ms: Option<u64>,
+        volume_dbm0: Option<i64>,
+        pause_ms: Option<u64>,
+        to_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let options = DtmfOptions {
+            duration_ms,
+            volume_dbm0,
+            pause_ms,
+            to_tag,
+        };
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.dtmf(&digits, options).await.map_err(to_pyerr)
+        })
+    }
+
+    /// Hold the A-leg media via silence.
+    fn hold<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.hold().await.map_err(to_pyerr)
+        })
+    }
+
+    /// Resume the A-leg media after a `hold`.
+    fn unhold<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.unhold().await.map_err(to_pyerr)
+        })
+    }
+
+    /// Attach a WebSocket audio tee streaming a copy of the call's audio to
+    /// `ws_uri`. `direction` is `"both"` (default) / `"caller"` / `"callee"`;
+    /// `channels` is `1` (mono) or `2` (stereo). siphon-rtp backend only:
+    /// rtpengine / rtpproxy raise `ControlError` (`code == "unsupported_verb"`).
+    #[pyo3(signature = (ws_uri, direction=None, channels=None))]
+    fn stream_start<'py>(
+        &self,
+        py: Python<'py>,
+        ws_uri: String,
+        direction: Option<String>,
+        channels: Option<u8>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.stream_start(&ws_uri, direction.as_deref(), channels)
+                .await
+                .map_err(to_pyerr)
+        })
+    }
+
+    /// Detach the WebSocket audio tee (idempotent on siphon-rtp).
+    fn stream_stop<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let call = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            call.stream_stop().await.map_err(to_pyerr)
         })
     }
 

--- a/siphon-control-sdk/siphon-control/tests/test_smoke.py
+++ b/siphon-control-sdk/siphon-control/tests/test_smoke.py
@@ -78,9 +78,12 @@ async def _stub_handler(websocket):
             )
         elif verb == "boom":
             await _reply_error(websocket, frame_id, "not_found", "no such channel")
-        elif verb in ("play", "dtmf"):
+        elif verb in ("stream_start", "stream_stop"):
             await _reply_error(
-                websocket, frame_id, "unsupported_verb", "not implemented in this build"
+                websocket,
+                frame_id,
+                "unsupported_verb",
+                "ws_tee is only supported by the siphon-rtp backend",
             )
         elif verb in ("get_header", "get_var"):
             await _reply_ok(websocket, frame_id, {"value": "203.0.113.7"})
@@ -119,6 +122,20 @@ def test_module_surface():
     assert hasattr(ControlServer, "run")
     assert hasattr(Call, "answer")
     assert hasattr(Call, "route")
+    # The media / header / REFER verbs that shipped server-side.
+    for verb in (
+        "play",
+        "stop",
+        "dtmf",
+        "hold",
+        "unhold",
+        "stream_start",
+        "stream_stop",
+        "remove_header",
+        "accept_refer",
+        "reject_refer",
+    ):
+        assert hasattr(Call, verb), f"Call is missing {verb}"
     assert issubclass(ControlError, Exception)
 
 
@@ -270,6 +287,207 @@ def test_route_verb_roundtrip():
                 ],
                 "strategy": "sequential",
                 "headers": {"X-Trace": "abc"},
+            }
+
+            client.shutdown()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(run_task, timeout=5)
+
+    asyncio.run(scenario())
+
+
+def test_media_header_refer_verbs_roundtrip():
+    """The new media / header / REFER verbs emit the exact server-side frames."""
+
+    async def scenario():
+        recorded = []
+
+        async def verb_stub(websocket):
+            auth = websocket.request.headers.get("Authorization", "")
+            if auth != f"Bearer {TOKEN}":
+                await websocket.close(code=1008, reason="unauthorized")
+                return
+            said_hello = False
+            async for message in websocket:
+                frame = json.loads(message)
+                frame_id = frame.get("id")
+                verb = frame.get("verb")
+                if not said_hello:
+                    await _reply_ok(
+                        websocket,
+                        frame_id,
+                        {"app": APP, "protocol": 1, "subprotocol": SUBPROTOCOL},
+                    )
+                    said_hello = True
+                elif verb == "test_push_stasis":
+                    await websocket.send(
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": "StasisStart",
+                                "channel": "ch1",
+                                "app": APP,
+                                "call_id": "call-uuid",
+                                "sip_call_id": "sipcid@host",
+                                "payload": {},
+                            }
+                        )
+                    )
+                    await _reply_ok(websocket, frame_id, {})
+                else:
+                    recorded.append(frame)
+                    await _reply_ok(websocket, frame_id, {"channel": "ch1"})
+
+        async with websockets.serve(
+            verb_stub, "127.0.0.1", 0, subprotocols=[SUBPROTOCOL]
+        ) as server:
+            port = server.sockets[0].getsockname()[1]
+            url = f"ws://127.0.0.1:{port}/control/ws"
+            client = ControlClient(app=APP, token=TOKEN, url=url)
+            done = asyncio.get_event_loop().create_future()
+
+            @client.on_call
+            async def handle(call):
+                await call.play(file="/prompts/welcome.wav", repeat=2)
+                await call.play(blob=b"hi", duration_ms=5000)
+                await call.stop()
+                await call.dtmf("123#", duration_ms=100, volume_dbm0=-8)
+                await call.hold()
+                await call.unhold()
+                await call.remove_header("X-Foo")
+                await call.accept_refer(
+                    target="sip:c@pbx", next_hop="sip:sbc", mode="terminate"
+                )
+                await call.reject_refer(603, "Decline")
+                if not done.done():
+                    done.set_result(True)
+
+            await client.connect()
+            run_task = asyncio.ensure_future(client.run())
+            await asyncio.sleep(0.3)
+            await client.command("test_push_stasis")
+
+            await asyncio.wait_for(done, timeout=5)
+
+            by_verb = {frame["verb"]: frame["args"] for frame in recorded}
+            assert by_verb["play"] in (
+                {"file": "/prompts/welcome.wav", "repeat": 2},
+                {"blob": "aGk=", "duration_ms": 5000},
+            )
+            # Both play frames were sent (file first, blob second).
+            play_args = [frame["args"] for frame in recorded if frame["verb"] == "play"]
+            assert play_args[0] == {"file": "/prompts/welcome.wav", "repeat": 2}
+            assert play_args[1] == {"blob": "aGk=", "duration_ms": 5000}
+            assert by_verb["stop"] == {}
+            assert by_verb["dtmf"] == {
+                "digits": "123#",
+                "duration_ms": 100,
+                "volume_dbm0": -8,
+            }
+            assert by_verb["hold"] == {}
+            assert by_verb["unhold"] == {}
+            assert by_verb["remove_header"] == {"name": "X-Foo"}
+            assert by_verb["accept_refer"] == {
+                "target": "sip:c@pbx",
+                "next_hop": "sip:sbc",
+                "mode": "terminate",
+            }
+            assert by_verb["reject_refer"] == {"code": 603, "reason": "Decline"}
+            for frame in recorded:
+                assert frame["module"] == "sip"
+                assert frame["target"]["channel"] == "ch1"
+
+            client.shutdown()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(run_task, timeout=5)
+
+    asyncio.run(scenario())
+
+
+def test_dtmf_event_delivered_to_call():
+    """A pushed ChannelDtmfReceived event surfaces via `call.next_event()`."""
+
+    async def scenario():
+        async def dtmf_stub(websocket):
+            auth = websocket.request.headers.get("Authorization", "")
+            if auth != f"Bearer {TOKEN}":
+                await websocket.close(code=1008, reason="unauthorized")
+                return
+            said_hello = False
+            async for message in websocket:
+                frame = json.loads(message)
+                frame_id = frame.get("id")
+                verb = frame.get("verb")
+                if not said_hello:
+                    await _reply_ok(
+                        websocket,
+                        frame_id,
+                        {"app": APP, "protocol": 1, "subprotocol": SUBPROTOCOL},
+                    )
+                    said_hello = True
+                elif verb == "test_push_stasis":
+                    await websocket.send(
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": "StasisStart",
+                                "channel": "ch1",
+                                "app": APP,
+                                "call_id": "call-uuid",
+                                "sip_call_id": "sipcid@host",
+                                "payload": {},
+                            }
+                        )
+                    )
+                    # Immediately follow with a DTMF event for the same channel.
+                    await websocket.send(
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": "ChannelDtmfReceived",
+                                "channel": "ch1",
+                                "app": APP,
+                                "call_id": "call-uuid",
+                                "sip_call_id": "sipcid@host",
+                                "payload": {
+                                    "digit": "5",
+                                    "duration_ms": 100,
+                                    "volume": -8,
+                                    "from_tag": "alice-tag",
+                                },
+                            }
+                        )
+                    )
+                    await _reply_ok(websocket, frame_id, {})
+                else:
+                    await _reply_ok(websocket, frame_id, {})
+
+        async with websockets.serve(
+            dtmf_stub, "127.0.0.1", 0, subprotocols=[SUBPROTOCOL]
+        ) as server:
+            port = server.sockets[0].getsockname()[1]
+            url = f"ws://127.0.0.1:{port}/control/ws"
+            client = ControlClient(app=APP, token=TOKEN, url=url)
+            got = asyncio.get_event_loop().create_future()
+
+            @client.on_call
+            async def handle(call):
+                event = await call.next_event()
+                if not got.done():
+                    got.set_result(event)
+
+            await client.connect()
+            run_task = asyncio.ensure_future(client.run())
+            await asyncio.sleep(0.3)
+            await client.command("test_push_stasis")
+
+            event = await asyncio.wait_for(got, timeout=5)
+            assert event["kind"] == "ChannelDtmfReceived"
+            assert event["payload"] == {
+                "digit": "5",
+                "duration_ms": 100,
+                "volume": -8,
+                "from_tag": "alice-tag",
             }
 
             client.shutdown()

--- a/siphon-control-sdk/typescript/src/index.ts
+++ b/siphon-control-sdk/typescript/src/index.ts
@@ -39,9 +39,10 @@
  * ## Errors
  *
  * A `status:"error"` reply throws a {@link ControlError} carrying the stable
- * {@link ControlErrorCode} in `.code`. Media verbs ({@link Call.playFile} /
- * {@link Call.dtmf}) throw `code === "unsupported_verb"` until the server
- * implements them (`error.isUnsupportedVerb()`).
+ * {@link ControlErrorCode} in `.code`. The WebSocket-tee verbs
+ * ({@link Call.streamStart} / {@link Call.streamStop}) are siphon-rtp-only, so a
+ * non-siphon-rtp backend throws `code === "unsupported_verb"`
+ * (`error.isUnsupportedVerb()`).
  */
 
 export { ControlError } from "./errors";
@@ -75,6 +76,9 @@ export type {
   ResyncResult,
   SipVerbToken,
   SipEventKind,
+  ChannelDtmfPayload,
+  TransferReplaces,
+  TransferRequestedPayload,
 } from "./protocol";
 
 export { ControlClient, EventStream } from "./client";
@@ -94,4 +98,8 @@ export type {
   AcceptReferOptions,
   RouteTarget,
   RouteTargetObject,
+  PlaySource,
+  PlayOptions,
+  DtmfOptions,
+  StreamOptions,
 } from "./sip";

--- a/siphon-control-sdk/typescript/src/protocol.ts
+++ b/siphon-control-sdk/typescript/src/protocol.ts
@@ -165,11 +165,10 @@ export function parseInboundFrame(text: string): ReplyFrame | EventFrame | null 
 /**
  * The verbs the built-in SIP adapter accepts (`module = "sip"`).
  *
- * These are the exact wire tokens. The server implements
- * `answer`/`progress`/`reject`/`hangup`/`refer`/`route`/`set_header`/`get_header`;
- * the rest (`remove_header`, `accept_refer`, `reject_refer`, `play`, `dtmf`)
- * are accepted names the server answers `unsupported_verb` until it implements
- * them.
+ * These are the exact wire tokens. The media verbs
+ * (`play`/`stop`/`dtmf`/`hold`/`unhold`/`stream_start`/`stream_stop`) dispatch
+ * against the configured media backend; the WebSocket-tee pair is
+ * siphon-rtp-only, so a non-siphon-rtp backend answers them `unsupported_verb`.
  */
 export const SipVerb = {
   Answer: "answer",
@@ -184,7 +183,12 @@ export const SipVerb = {
   AcceptRefer: "accept_refer",
   RejectRefer: "reject_refer",
   Play: "play",
+  Stop: "stop",
   Dtmf: "dtmf",
+  Hold: "hold",
+  Unhold: "unhold",
+  StreamStart: "stream_start",
+  StreamStop: "stream_stop",
 } as const;
 
 /** A value of {@link SipVerb}. */
@@ -196,9 +200,51 @@ export type SipEventKind =
   | "StasisEnd"
   | "ChannelStateChange"
   | "ChannelHangupRequest"
+  | "ChannelDtmfReceived"
+  | "TransferRequested"
   | (string & {});
 
 /** Parse a wire event name; unknown names pass through verbatim (forward-compatible). */
 export function sipEventKind(name: string): SipEventKind {
   return name as SipEventKind;
+}
+
+/**
+ * The `payload` of a `ChannelDtmfReceived` event — an in-band DTMF digit the
+ * media engine detected on a controlled call's leg. Cast a
+ * {@link import("./sip").CallEvent}'s `payload` to this when
+ * `kind === "ChannelDtmfReceived"`.
+ */
+export interface ChannelDtmfPayload {
+  /** The single detected digit (`0`–`9`, `*`, `#`, `A`–`D`). */
+  digit: string;
+  /** The tone duration in milliseconds. */
+  duration_ms: number;
+  /** The tone volume in dBm0 (negative). */
+  volume: number;
+  /** The From-tag of the leg the digit came from. */
+  from_tag: string;
+}
+
+/** The RFC 3891 `Replaces` triple embedded in a {@link TransferRequestedPayload}. */
+export interface TransferReplaces {
+  call_id: string;
+  from_tag: string;
+  to_tag: string;
+  early_only: boolean;
+}
+
+/**
+ * The `payload` of a `TransferRequested` event — an inbound REFER on a
+ * controlled call, handed to the app to accept / reject. Cast a
+ * {@link import("./sip").CallEvent}'s `payload` to this when
+ * `kind === "TransferRequested"`.
+ */
+export interface TransferRequestedPayload {
+  /** The Refer-To URI (the transfer target). */
+  refer_to: string;
+  /** The embedded `Replaces` triple for an attended transfer, if present. */
+  replaces?: TransferReplaces | null;
+  /** The From-tag of the referring party, if known. */
+  from_tag?: string | null;
 }

--- a/siphon-control-sdk/typescript/src/sip.ts
+++ b/siphon-control-sdk/typescript/src/sip.ts
@@ -36,7 +36,10 @@ import type { CommandTransport } from "./session";
 // ---------------------------------------------------------------------------
 
 /** One event delivered to a call's stream (`ChannelStateChange`,
- * `ChannelHangupRequest`, `StasisEnd`, …). */
+ * `ChannelHangupRequest`, `ChannelDtmfReceived`, `TransferRequested`,
+ * `StasisEnd`, …). Cast `payload` to
+ * {@link import("./protocol").ChannelDtmfPayload} /
+ * {@link import("./protocol").TransferRequestedPayload} by `kind`. */
 export interface CallEvent {
   /** The parsed event kind. */
   kind: SipEventKind;
@@ -133,6 +136,93 @@ function stringValue(result: unknown): string | null {
     }
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// play() / dtmf() / streamStart() args
+// ---------------------------------------------------------------------------
+
+/**
+ * The audio source for {@link Call.play}: exactly one of a server-side file
+ * path, an rtpengine media-DB id, or an inline blob. A blob is base64-encoded on
+ * the wire (the control rail is JSON text).
+ */
+export type PlaySource =
+  | { file: string }
+  | { dbId: number }
+  | { blob: Uint8Array };
+
+/** Optional shaping for {@link Call.play}. */
+export interface PlayOptions {
+  /** Repeat the prompt this many times (0/undefined → play once). */
+  repeat?: number;
+  /** Start playback at this offset into the source, in milliseconds. */
+  startMs?: number;
+  /** Cap playback to this duration, in milliseconds. */
+  durationMs?: number;
+  /** Scope the prompt to one peer of an MPTY bridge (its To-tag). */
+  toTag?: string;
+}
+
+/** Optional shaping for {@link Call.dtmf}. */
+export interface DtmfOptions {
+  /** Per-digit tone duration, in milliseconds. */
+  durationMs?: number;
+  /** Tone volume in dBm0 (negative). */
+  volumeDbm0?: number;
+  /** Inter-digit pause, in milliseconds. */
+  pauseMs?: number;
+  /** Scope the tones to one peer of an MPTY bridge (its To-tag). */
+  toTag?: string;
+}
+
+/** Options for {@link Call.streamStart} (the WebSocket audio tee). */
+export interface StreamOptions {
+  /** Which leg(s) to tee — `"both"` (default), `"caller"`, or `"callee"`. */
+  direction?: "both" | "caller" | "callee";
+  /** `1` = mixed mono, `2` = caller/callee stereo (only with `"both"`). */
+  channels?: 1 | 2;
+}
+
+function playArgs(source: PlaySource, options?: PlayOptions): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  if ("file" in source) {
+    args.file = source.file;
+  } else if ("dbId" in source) {
+    args.db_id = source.dbId;
+  } else {
+    args.blob = Buffer.from(source.blob).toString("base64");
+  }
+  if (options?.repeat !== undefined) {
+    args.repeat = options.repeat;
+  }
+  if (options?.startMs !== undefined) {
+    args.start_ms = options.startMs;
+  }
+  if (options?.durationMs !== undefined) {
+    args.duration_ms = options.durationMs;
+  }
+  if (options?.toTag !== undefined) {
+    args.to_tag = options.toTag;
+  }
+  return args;
+}
+
+function dtmfArgs(digits: string, options?: DtmfOptions): Record<string, unknown> {
+  const args: Record<string, unknown> = { digits };
+  if (options?.durationMs !== undefined) {
+    args.duration_ms = options.durationMs;
+  }
+  if (options?.volumeDbm0 !== undefined) {
+    args.volume_dbm0 = options.volumeDbm0;
+  }
+  if (options?.pauseMs !== undefined) {
+    args.pause_ms = options.pauseMs;
+  }
+  if (options?.toTag !== undefined) {
+    args.to_tag = options.toTag;
+  }
+  return args;
 }
 
 /**
@@ -257,9 +347,11 @@ export class Call {
   }
 
   /**
-   * Accept an inbound REFER on this tracked call. **Not implemented server-side
-   * in Phase 1** — resolves to a {@link ControlError} with `code ===
-   * "unsupported_verb"` until the server adds it.
+   * Accept a *pending inbound* REFER (surfaced as a `TransferRequested` event)
+   * and run the transfer. `target` overrides the Refer-To URI, `nextHop` steers
+   * egress, and `mode` (`"terminate"` / `"transparent"`) overrides
+   * `b2bua.default_refer_mode`. No pending REFER (already decided, timed out, or
+   * the call is gone) rejects with `code === "not_found"`.
    */
   async acceptRefer(options?: AcceptReferOptions): Promise<void> {
     const args: Record<string, unknown> = {};
@@ -276,8 +368,8 @@ export class Call {
   }
 
   /**
-   * Reject an inbound REFER on this tracked call. **Not implemented server-side
-   * in Phase 1** — see {@link Call.acceptRefer}.
+   * Reject a *pending inbound* REFER with a final non-2xx (default
+   * `603 Decline`). No pending REFER rejects with `code === "not_found"`.
    */
   async rejectRefer(code: number, reason?: string): Promise<void> {
     const args: Record<string, unknown> = { code };
@@ -298,11 +390,7 @@ export class Call {
     return stringValue(result);
   }
 
-  /**
-   * Remove a header from the stored A-leg INVITE. **Not implemented server-side
-   * in Phase 1** — resolves to a {@link ControlError} with `code ===
-   * "unsupported_verb"` until the server adds it.
-   */
+  /** Remove a header from the stored A-leg INVITE. */
   async removeHeader(name: string): Promise<void> {
     await this.sip(SipVerb.RemoveHeader, { name });
   }
@@ -320,20 +408,65 @@ export class Call {
     return stringValue(result);
   }
 
-  // --- media (server answers `unsupported_verb` today) -------------------
+  // --- media -------------------------------------------------------------
 
   /**
-   * Play an announcement. **Not yet implemented server-side** — resolves to a
-   * {@link ControlError} with `code === "unsupported_verb"` until the media
-   * backend lands.
+   * Play an announcement on the A-leg media (fire-and-forget). `source` is a
+   * {@link PlaySource} (a blob is base64-encoded on the wire); `options` shapes
+   * playback. A call with no anchored media session rejects with
+   * `code === "not_found"`.
    */
-  async playFile(file: string): Promise<void> {
-    await this.sip(SipVerb.Play, { file });
+  async play(source: PlaySource, options?: PlayOptions): Promise<void> {
+    await this.sip(SipVerb.Play, playArgs(source, options));
   }
 
-  /** Send DTMF. **Not yet implemented server-side** — see {@link Call.playFile}. */
-  async dtmf(digits: string): Promise<void> {
-    await this.sip(SipVerb.Dtmf, { digits });
+  /** Convenience for {@link Call.play} of a server-side file with default options. */
+  async playFile(file: string): Promise<void> {
+    await this.play({ file });
+  }
+
+  /** Stop the announcement currently playing on the A-leg media. */
+  async stop(): Promise<void> {
+    await this.sip(SipVerb.Stop, {});
+  }
+
+  /**
+   * Inject DTMF digits toward the A-leg (fire-and-forget). `options` carries the
+   * optional `durationMs` / `volumeDbm0` / `pauseMs` / `toTag` shaping.
+   */
+  async dtmf(digits: string, options?: DtmfOptions): Promise<void> {
+    await this.sip(SipVerb.Dtmf, dtmfArgs(digits, options));
+  }
+
+  /** Hold the A-leg media via silence. */
+  async hold(): Promise<void> {
+    await this.sip(SipVerb.Hold, {});
+  }
+
+  /** Resume the A-leg media after a {@link Call.hold}. */
+  async unhold(): Promise<void> {
+    await this.sip(SipVerb.Unhold, {});
+  }
+
+  /**
+   * Attach a WebSocket audio tee — stream a copy of the call's decoded audio to
+   * `wsUri` while the call keeps relaying. siphon-rtp backend only: rtpengine /
+   * rtpproxy reject with `code === "unsupported_verb"` (`error.isUnsupportedVerb()`).
+   */
+  async streamStart(wsUri: string, options?: StreamOptions): Promise<void> {
+    const args: Record<string, unknown> = { ws_uri: wsUri };
+    if (options?.direction !== undefined) {
+      args.direction = options.direction;
+    }
+    if (options?.channels !== undefined) {
+      args.channels = options.channels;
+    }
+    await this.sip(SipVerb.StreamStart, args);
+  }
+
+  /** Detach the WebSocket audio tee (idempotent on siphon-rtp). */
+  async streamStop(): Promise<void> {
+    await this.sip(SipVerb.StreamStop, {});
   }
 
   // --- escape hatch + events --------------------------------------------

--- a/siphon-control-sdk/typescript/test/wire.test.ts
+++ b/siphon-control-sdk/typescript/test/wire.test.ts
@@ -53,11 +53,18 @@ describe("SipVerb wire tokens + event names", () => {
     expect(SipVerb.AcceptRefer).toBe("accept_refer");
     expect(SipVerb.RejectRefer).toBe("reject_refer");
     expect(SipVerb.Play).toBe("play");
+    expect(SipVerb.Stop).toBe("stop");
     expect(SipVerb.Dtmf).toBe("dtmf");
+    expect(SipVerb.Hold).toBe("hold");
+    expect(SipVerb.Unhold).toBe("unhold");
+    expect(SipVerb.StreamStart).toBe("stream_start");
+    expect(SipVerb.StreamStop).toBe("stream_stop");
   });
 
-  it("passes unknown event names through (forward-compatible)", () => {
+  it("passes unknown + new event names through (forward-compatible)", () => {
     expect(sipEventKind("StasisStart")).toBe("StasisStart");
+    expect(sipEventKind("ChannelDtmfReceived")).toBe("ChannelDtmfReceived");
+    expect(sipEventKind("TransferRequested")).toBe("TransferRequested");
     expect(sipEventKind("SomethingNew")).toBe("SomethingNew");
   });
 });
@@ -206,13 +213,11 @@ describe("Call verbs map to the in-process-mirrored wire verbs", () => {
     ]);
   });
 
-  it("acceptRefer / rejectRefer / media verbs", async () => {
+  it("acceptRefer / rejectRefer", async () => {
     const transport = new RecordingTransport();
     const call = makeCall(transport);
     await call.acceptRefer({ target: "sip:c@pbx", nextHop: "sip:sbc", mode: "terminate" });
     await call.rejectRefer(603, "Decline");
-    await call.playFile("/prompts/welcome.wav");
-    await call.dtmf("123#");
     expect(transport.calls).toEqual([
       {
         module: MODULE_SIP,
@@ -221,8 +226,43 @@ describe("Call verbs map to the in-process-mirrored wire verbs", () => {
         args: { target: "sip:c@pbx", next_hop: "sip:sbc", mode: "terminate" },
       },
       { module: MODULE_SIP, verb: "reject_refer", target: { channel: "ch1" }, args: { code: 603, reason: "Decline" } },
-      { module: MODULE_SIP, verb: "play", target: { channel: "ch1" }, args: { file: "/prompts/welcome.wav" } },
-      { module: MODULE_SIP, verb: "dtmf", target: { channel: "ch1" }, args: { digits: "123#" } },
+    ]);
+  });
+
+  it("media verbs — play (file/dbId/blob), stop, dtmf, hold, unhold, stream", async () => {
+    const transport = new RecordingTransport();
+    const call = makeCall(transport);
+    await call.play({ file: "/prompts/welcome.wav" }, { repeat: 2 });
+    await call.play({ dbId: 42 });
+    // "hi" → base64 "aGk=".
+    await call.play({ blob: new Uint8Array([104, 105]) }, { durationMs: 5000 });
+    await call.playFile("/prompts/bye.wav");
+    await call.stop();
+    await call.dtmf("123#", { durationMs: 100, volumeDbm0: -8 });
+    await call.hold();
+    await call.unhold();
+    await call.streamStart("ws://ai:9000/stream", { direction: "both", channels: 2 });
+    await call.streamStop();
+    expect(transport.calls).toEqual([
+      { module: MODULE_SIP, verb: "play", target: { channel: "ch1" }, args: { file: "/prompts/welcome.wav", repeat: 2 } },
+      { module: MODULE_SIP, verb: "play", target: { channel: "ch1" }, args: { db_id: 42 } },
+      { module: MODULE_SIP, verb: "play", target: { channel: "ch1" }, args: { blob: "aGk=", duration_ms: 5000 } },
+      { module: MODULE_SIP, verb: "play", target: { channel: "ch1" }, args: { file: "/prompts/bye.wav" } },
+      { module: MODULE_SIP, verb: "stop", target: { channel: "ch1" }, args: {} },
+      { module: MODULE_SIP, verb: "dtmf", target: { channel: "ch1" }, args: { digits: "123#", duration_ms: 100, volume_dbm0: -8 } },
+      { module: MODULE_SIP, verb: "hold", target: { channel: "ch1" }, args: {} },
+      { module: MODULE_SIP, verb: "unhold", target: { channel: "ch1" }, args: {} },
+      { module: MODULE_SIP, verb: "stream_start", target: { channel: "ch1" }, args: { ws_uri: "ws://ai:9000/stream", direction: "both", channels: 2 } },
+      { module: MODULE_SIP, verb: "stream_stop", target: { channel: "ch1" }, args: {} },
+    ]);
+  });
+
+  it("removeHeader emits the remove_header verb", async () => {
+    const transport = new RecordingTransport();
+    const call = makeCall(transport);
+    await call.removeHeader("X-Foo");
+    expect(transport.calls).toEqual([
+      { module: MODULE_SIP, verb: "remove_header", target: { channel: "ch1" }, args: { name: "X-Foo" } },
     ]);
   });
 });


### PR DESCRIPTION
Adds the media / header / DTMF / REFER verbs plus the `ChannelDtmfReceived` and `TransferRequested` events to the control-plane SDK's `sip` facade in all three bindings (proto, Rust client, Python/PyO3, TypeScript), mirroring the shipped `route()` facade and wrapping the SIP-adapter verbs that landed server-side in `src/control/sip_adapter.rs`.

## Verbs (method on the `Call` handle)
- `remove_header` — `{name}`
- `play` — one of `file` / `db_id` / `blob` (blob base64-encoded on the wire) plus optional `repeat` / `start_ms` / `duration_ms` / `to_tag`
- `stop`, `hold`, `unhold` — no args
- `dtmf` — `digits` plus optional `duration_ms` / `volume_dbm0` / `pause_ms` / `to_tag`
- `stream_start` — `{ws_uri, direction?, channels?}` (siphon-rtp-only server-side; a typed `unsupported_verb` surfaces like any other error) / `stream_stop` — no args
- `accept_refer` — `{target?, next_hop?, mode?}` / `reject_refer` — `{code, reason?}`

## Events
- `ChannelDtmfReceived` — `{digit, duration_ms, volume, from_tag}`
- `TransferRequested` — `{refer_to, replaces?, from_tag}`

Both added to the proto `SipEvent` enum (+ parsing) with typed payload views, and surfaced through each binding's event stream.

## No version bump
`[workspace.package]` stays `0.1.1`; the `control-sdk-v0.1.2` release is a separate maintainer step. Adds a root `CHANGELOG.md` `[Unreleased]` entry.

## Gates
- Rust: `cargo test` green (proto 18, client 6 unit + 9 integration + 2 doctests), `cargo clippy --all-targets --all-features -- -D warnings` clean across the workspace.
- Python: built via maturin, `pytest` 8/8 green.
- TypeScript: `npm run build`, `npm run typecheck`, `npm test` (19) all green.
