### PR TITLE
fix(media): renegotiate a live call with reoffer instead of replacing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,39 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   agent", and documented in `docs/cookbook/voice-ai.md`.
 
 ### Fixed
+- **A re-INVITE or UPDATE on a `siphon-rtp`-anchored call replaced its media
+  session instead of renegotiating it.** siphon has only ever had one verb for
+  an SDP offer, and on rtpengine that is correct — a repeat `offer` on a live
+  call-id *is* a re-offer, which is how `rtpengine_manage()` has always done
+  hold and codec renegotiation. siphon-rtp draws the line differently: a repeat
+  `offer` there is a **replacement**, so the engine freed the call and allocated
+  fresh ports. The visible damage was not the ports (siphon answers with the
+  rewritten SDP either way) but everything attached to them — the WebSocket
+  bridge, any `ws_tee`, and any SIPREC subscription were torn down with the old
+  call. So putting a voice-AI call on hold, or any mid-dialog renegotiation,
+  silently killed the audio path to the AI while the call itself carried on,
+  and left a spurious media CDR with reason `replaced` behind. A call this
+  process has already anchored now renegotiates with `siphon-rtp-proto` 0.2.0's
+  `reoffer`, which keeps the ports, the pipeline and the attachments, and
+  carries an RFC 8445 §9 ICE restart when the peer offers new credentials.
+  Covers the framework's re-INVITE and UPDATE paths and the script-facing
+  `rtpengine.offer()`; rtpengine and rtpproxy still send a plain offer, so their
+  wire is byte-identical to before.
+- **A re-offer is addressed by the media session's own engine call-id.**
+  `rtpengine.offer()` used the SIP Call-ID, but a siphon-terminated transfer
+  deliberately re-anchors the surviving pair on a *fresh* engine call-id while
+  the store key stays the SIP one — so a re-INVITE after a transfer addressed a
+  call-id the engine had never heard of. It now uses `rtpengine_id()`, as every
+  other post-offer verb already did, and no longer re-inserts the media session
+  on a re-offer (which reset that id and cleared the `to_tag` the answer set).
+- **The one case a re-offer cannot serve falls back explicitly.** The engine
+  refuses a re-offer that changes the negotiated codec — that needs a pipeline
+  rebuild it will not do on a live call — and its error says to replace the call
+  instead. That refusal, and only that refusal, is retried as a replacement
+  `offer`, which is exactly the behaviour such a re-INVITE had before. It is
+  logged at WARN naming the consequence (ports re-allocated, bridge/tee/SIPREC
+  dropped) rather than performed silently, and the match is deliberately narrow
+  so no other engine error can acquire a call-replacing retry.
 - **A challenged REFER was never retried, and its response was dropped
   entirely.** A REFER siphon originates on one of its own legs is allocated a
   fresh Via branch that belongs to no leg, and responses are matched to a call by

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -18711,7 +18711,7 @@ fn handle_b2bua_reinvite(
                         let offer_flags = profile.offer.clone();
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(
-                                rtpengine_set.offer(session.rtpengine_id(), offer_tag, &forwarded.body, &offer_flags)
+                                rtpengine_set.reoffer(session.rtpengine_id(), offer_tag, &forwarded.body, &offer_flags)
                             )
                         }) {
                             Ok(rewritten_sdp) => {
@@ -19139,7 +19139,7 @@ fn handle_b2bua_update(
                         let offer_flags = profile.offer.clone();
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(
-                                rtpengine_set.offer(session.rtpengine_id(), offer_tag, &forwarded.body, &offer_flags)
+                                rtpengine_set.reoffer(session.rtpengine_id(), offer_tag, &forwarded.body, &offer_flags)
                             )
                         }) {
                             Ok(rewritten_sdp) => {

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -358,6 +358,36 @@ impl MediaBackend {
         }
     }
 
+    /// Renegotiate a **live** call on the ports it already holds — what a SIP
+    /// re-INVITE or UPDATE maps to.
+    ///
+    /// The backends differ in what a repeated offer means, which is the whole
+    /// reason this verb exists:
+    ///
+    /// * **rtpengine / rtpproxy** — a repeat `offer` on a live call-id *is* a
+    ///   re-offer.  That is how `rtpengine_manage()` has always done hold and
+    ///   codec renegotiation, so these delegate to [`Self::offer`] and the wire
+    ///   is byte-identical to before.  Not a degraded path: it is the native
+    ///   semantics.
+    /// * **siphon-rtp** — a repeat `offer` is a *replacement*: the engine frees
+    ///   the old call and allocates fresh ports, which drops the WebSocket
+    ///   bridge, any tee and any SIPREC subscription riding on it, and answers
+    ///   with an address the peer was never told to expect.  So it gets the
+    ///   dedicated `reoffer` command.
+    pub async fn reoffer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        match self {
+            Self::RtpEngine(set) => set.offer(call_id, from_tag, sdp, flags).await,
+            Self::SiphonRtp(client) => client.reoffer(call_id, from_tag, sdp, flags).await,
+            Self::RtpProxy(client) => client.offer(call_id, from_tag, sdp, flags).await,
+        }
+    }
+
     /// Complete a subscription's SDP negotiation.
     pub async fn subscribe_answer(
         &self,
@@ -540,6 +570,57 @@ mod tests {
         let error = backend.echo("call-1", "tag-a", true).await.unwrap_err();
         assert!(matches!(error, RtpEngineError::Protocol(_)));
         assert!(error.to_string().contains("siphon-rtp"));
+    }
+
+    /// rtpengine and rtpproxy must NOT reject a re-offer: a repeat offer is
+    /// their native re-offer, so the verb has to delegate rather than surface
+    /// an `Unsupported` the way the siphon-rtp-only verbs do.  Proven by
+    /// reaching the wire (a timeout against a dead address) instead of a
+    /// synchronous rejection.
+    #[tokio::test]
+    async fn reoffer_delegates_to_offer_on_rtpengine_and_rtpproxy() {
+        let rtpengine = MediaBackend::RtpEngine(Arc::new(
+            RtpEngineSet::new(vec![(dead_address(), 200, 1)]).await.unwrap(),
+        ));
+        let error = rtpengine
+            .reoffer("call-1", "tag-a", b"v=0\r\n", &NgFlags::default())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, RtpEngineError::Timeout { .. }),
+            "rtpengine must send a re-offer as a plain offer, got {error:?}"
+        );
+
+        let rtpproxy = MediaBackend::RtpProxy(
+            RtpProxyClientSet::new(vec![(dead_address(), 200, 1)], 0).await.unwrap(),
+        );
+        // rtpproxy's transport is UDP and it rewrites the SDP itself, so the
+        // delegated offer succeeds rather than timing out — success here is the
+        // same proof: the verb reached the offer path instead of being rejected.
+        assert!(
+            rtpproxy
+                .reoffer("call-1", "tag-a", b"v=0\r\n", &NgFlags::default())
+                .await
+                .is_ok(),
+            "rtpproxy must send a re-offer as a plain offer"
+        );
+    }
+
+    #[tokio::test]
+    async fn reoffer_routes_to_the_native_client_on_siphon_rtp() {
+        let (event_tx, _event_rx) = mpsc::channel::<RtpEngineEvent>(16);
+        let set =
+            SiphonRtpClientSet::new(vec![(dead_address(), 200, 1)], None, 5_000, event_tx).unwrap();
+        let backend = MediaBackend::SiphonRtp(set);
+
+        let error = backend
+            .reoffer("call-1", "tag-a", b"v=0\r\n", &NgFlags::default())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, RtpEngineError::Timeout { .. }),
+            "expected the native client path (Timeout), got {error:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -306,6 +306,38 @@ impl SiphonRtpClient {
         Ok(rewritten)
     }
 
+    /// Send a `reoffer` — renegotiate a **live** call on the ports it already
+    /// holds, returning the rewritten SDP.
+    ///
+    /// This is what a SIP re-INVITE or UPDATE maps to.  A repeated `offer` on a
+    /// live call-id is a *replacement*: the engine tears the old call down and
+    /// allocates fresh ports, which drops everything attached to it — the
+    /// WebSocket bridge, any tee, any SIPREC subscription — and hands the peer
+    /// an address it was never told about.  `reoffer` keeps the ports, the
+    /// pipeline and the attachments, and carries an RFC 8445 §9 ICE restart
+    /// when the peer sends new credentials.
+    ///
+    /// The engine refuses a re-offer that changes the negotiated codec (that
+    /// needs a pipeline rebuild) — see [`RtpEngineSet::reoffer`], which falls
+    /// back to a replacement for exactly that case.
+    pub async fn reoffer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        let result = self
+            .request(Command::Reoffer {
+                call_id: call_id.to_string(),
+                from_tag: from_tag.to_string(),
+                sdp: String::from_utf8_lossy(sdp).into_owned(),
+                profile: profile_flags_from_ng(flags),
+            })
+            .await?;
+        expect_sdp(result)
+    }
+
     /// Send an `answer`, returning the rewritten SDP.
     pub async fn answer(
         &self,
@@ -841,6 +873,41 @@ impl SiphonRtpClientSet {
         Ok(result)
     }
 
+    /// Renegotiate a live call on the affinity-bound instance, keeping its ports
+    /// and everything attached to them.
+    ///
+    /// Falls back to a replacement `offer` for the one case the engine refuses:
+    /// a re-offer that changes the negotiated codec needs a pipeline rebuild the
+    /// engine does not do on a live call, and its own error says to replace the
+    /// call instead.  That fallback is today's behaviour for every re-INVITE, so
+    /// a codec-changing one is no worse than before — but it *does* re-allocate
+    /// ports and drop the call's bridge/tee/SIPREC attachments, so it is logged
+    /// rather than performed silently.
+    pub async fn reoffer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        sdp: &[u8],
+        flags: &NgFlags,
+    ) -> Result<Vec<u8>, RtpEngineError> {
+        match self.select(call_id).reoffer(call_id, from_tag, sdp, flags).await {
+            Ok(rewritten) => Ok(rewritten),
+            Err(error) if is_codec_change_refusal(&error) => {
+                tracing::warn!(
+                    %call_id,
+                    %error,
+                    "re-offer changes the negotiated codec; replacing the media session — its \
+                     ports are re-allocated and any WebSocket bridge, tee or SIPREC subscription \
+                     on it is torn down"
+                );
+                let result = self.select(call_id).offer(call_id, from_tag, sdp, flags).await?;
+                self.bind_affinity(call_id);
+                Ok(result)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Send an `answer` to the affinity-bound instance.
     pub async fn answer(
         &self,
@@ -1068,6 +1135,19 @@ impl SiphonRtpClientSet {
     pub fn instance_addresses(&self) -> Vec<SocketAddr> {
         self.clients.iter().map(|client| client.address()).collect()
     }
+}
+
+/// Whether a `reoffer` failure is the engine's "this changes the codec" refusal
+/// (the one case that has to be retried as a replacement `offer`) rather than a
+/// transport failure, an unknown call, or anything else we must not paper over.
+///
+/// Matched on the reason text because the control protocol carries a string
+/// reason, not a typed error code, for a command-level refusal.  Deliberately
+/// narrow: only a refusal naming the codec qualifies, so a future engine error
+/// cannot silently acquire a call-replacing retry.
+fn is_codec_change_refusal(error: &RtpEngineError) -> bool {
+    let reason = error.to_string();
+    reason.contains("re-offer changes the negotiated codec")
 }
 
 /// Interpret a result that must carry rewritten SDP (offer/answer/subscribe req).
@@ -1628,7 +1708,7 @@ mod tests {
                     while let Some(request) = read_frame_opt::<Request, _>(&mut stream, &mut buffer).await {
                         let result = match request.command {
                             Command::Ping => CmdResult::Pong,
-                            Command::Offer { .. } | Command::Answer { .. } => CmdResult::Ok {
+                            Command::Offer { .. } | Command::Reoffer { .. } | Command::Answer { .. } => CmdResult::Ok {
                                 sdp: Some("v=0\r\nc=IN IP4 203.0.113.1\r\n".to_string()),
                                 duration_ms: None,
                                 to_tag: None,
@@ -1712,6 +1792,7 @@ mod tests {
                         let result = match request.command {
                             Command::Ping => CmdResult::Pong,
                             Command::Offer { .. }
+                            | Command::Reoffer { .. }
                             | Command::Answer { .. }
                             | Command::AnswerLocal { .. } => CmdResult::Ok {
                                 sdp: Some("v=0\r\nc=IN IP4 203.0.113.1\r\n".to_string()),
@@ -1746,6 +1827,121 @@ mod tests {
             .await
             .expect("offer");
         capture_rx.recv().await.expect("captured frame")
+    }
+
+    /// A fake engine that refuses a `reoffer` the way the real one refuses a
+    /// codec change, answers `offer` with SDP, and reports which commands it
+    /// saw — so the fallback can be proven to be a *retry as offer* and not a
+    /// swallowed error.
+    async fn spawn_codec_refusing_server() -> (SocketAddr, mpsc::UnboundedReceiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (seen_tx, seen_rx) = mpsc::unbounded_channel::<String>();
+        tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                let seen_tx = seen_tx.clone();
+                tokio::spawn(async move {
+                    let mut buffer = Vec::new();
+                    while let Some(request) =
+                        read_frame_opt::<Request, _>(&mut stream, &mut buffer).await
+                    {
+                        let result = match request.command {
+                            Command::Reoffer { .. } => {
+                                let _ = seen_tx.send("reoffer".to_string());
+                                CmdResult::Error {
+                                    reason: "re-offer changes the negotiated codec (PCMU → PCMA); \
+                                             not supported on a live call — replace it with a \
+                                             fresh offer instead"
+                                        .to_string(),
+                                }
+                            }
+                            Command::Offer { .. } => {
+                                let _ = seen_tx.send("offer".to_string());
+                                CmdResult::Ok {
+                                    sdp: Some("v=0\r\nc=IN IP4 203.0.113.9\r\n".to_string()),
+                                    duration_ms: None,
+                                    to_tag: None,
+                                    stats: None,
+                                    play_id: None,
+                                }
+                            }
+                            _ => CmdResult::Ok {
+                                sdp: None,
+                                duration_ms: None,
+                                to_tag: None,
+                                stats: None,
+                                play_id: None,
+                            },
+                        };
+                        write_frame(&mut stream, &Response { id: request.id, result }).await;
+                    }
+                });
+            }
+        });
+        (address, seen_rx)
+    }
+
+    /// The whole point of the verb: a re-INVITE must not go out as `offer`,
+    /// which on this backend frees the call's ports and takes its WebSocket
+    /// bridge, tee and SIPREC subscription with them.
+    #[tokio::test]
+    async fn reoffer_emits_the_reoffer_command_not_an_offer() {
+        let (address, mut capture_rx) = spawn_capturing_server().await;
+        let (event_tx, _event_rx) = channel();
+        let client = SiphonRtpClient::new(address, None, 2_000, 5_000, event_tx);
+        client
+            .reoffer("call-1", "tag-a", b"v=0\r\n", &NgFlags::default())
+            .await
+            .expect("reoffer");
+
+        let json = capture_rx.recv().await.expect("captured frame");
+        assert!(json.contains(r#""command":"reoffer""#), "wire frame was: {json}");
+        assert!(!json.contains(r#""command":"offer""#), "wire frame was: {json}");
+        assert!(json.contains(r#""call_id":"call-1""#), "wire frame was: {json}");
+    }
+
+    /// A re-offer that changes the codec is the one case the engine refuses, and
+    /// its own error says to replace the call.  Retrying as `offer` keeps that
+    /// re-INVITE working exactly as it did before this verb existed — but only
+    /// that case: any other failure must propagate, or a transport blip would
+    /// quietly re-allocate a live call's ports.
+    #[tokio::test]
+    async fn reoffer_retries_as_offer_only_on_the_codec_change_refusal() {
+        let (address, mut seen_rx) = spawn_codec_refusing_server().await;
+        let (event_tx, _event_rx) = channel();
+        let set = SiphonRtpClientSet::new(vec![(address, 2_000, 1)], None, 5_000, event_tx)
+            .expect("set");
+
+        let rewritten = set
+            .reoffer("call-1", "tag-a", b"v=0\r\n", &NgFlags::default())
+            .await
+            .expect("falls back to a replacement offer");
+        assert!(String::from_utf8_lossy(&rewritten).contains("203.0.113.9"));
+
+        assert_eq!(seen_rx.recv().await.as_deref(), Some("reoffer"));
+        assert_eq!(seen_rx.recv().await.as_deref(), Some("offer"));
+    }
+
+    /// Narrow by construction: only a refusal naming the codec earns the retry.
+    #[test]
+    fn only_the_codec_refusal_is_treated_as_retryable() {
+        assert!(is_codec_change_refusal(&RtpEngineError::Protocol(
+            "re-offer changes the negotiated codec (PCMU → PCMA)".to_string()
+        )));
+        for other in [
+            "unknown call-id",
+            "node is draining; not accepting new sessions",
+            "re-offer SDP parse failed: no m= line",
+        ] {
+            assert!(
+                !is_codec_change_refusal(&RtpEngineError::Protocol(other.to_string())),
+                "{other} must not earn a call-replacing retry"
+            );
+        }
     }
 
     /// The acceptance criterion for the WebSocket bridge: a profile carrying

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -496,15 +496,41 @@ impl PyRtpEngine {
         let sessions = Arc::clone(&self.sessions);
         let profile_str = profile_name.to_string();
 
+        // A call this process has already anchored is a *re*-offer — a re-INVITE
+        // or an UPDATE, the shape hold/unhold and an ICE restart arrive in. It
+        // has to keep the ports it already holds, so it goes out as `reoffer`;
+        // a plain `offer` on a live call-id replaces it on the siphon-rtp
+        // backend, taking its WebSocket bridge, tee and SIPREC subscription with
+        // it. Address the engine by the session's own id, not the SIP Call-ID:
+        // a siphon-terminated transfer re-anchors the surviving pair on a fresh
+        // engine call-id while the store key stays the SIP one.
+        let existing = sessions.get(&call_id);
+        let engine_call_id = existing
+            .as_ref()
+            .map(|session| session.rtpengine_id().to_string())
+            .unwrap_or_else(|| call_id.clone());
+        let is_reoffer = existing.is_some();
+
         pyo3_async_runtimes::tokio::future_into_py(python, async move {
-            let rewritten_sdp = client
-                .offer(&call_id, &from_tag, &sdp, &flags)
-                .await
-                .map_err(|error| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "rtpengine.offer failed: {error}"
-                    ))
-                })?;
+            let rewritten_sdp = if is_reoffer {
+                client
+                    .reoffer(&engine_call_id, &from_tag, &sdp, &flags)
+                    .await
+                    .map_err(|error| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "rtpengine.offer failed (re-offer): {error}"
+                        ))
+                    })?
+            } else {
+                client
+                    .offer(&engine_call_id, &from_tag, &sdp, &flags)
+                    .await
+                    .map_err(|error| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "rtpengine.offer failed: {error}"
+                        ))
+                    })?
+            };
 
             debug!(
                 call_id = %call_id,
@@ -514,15 +540,22 @@ impl PyRtpEngine {
 
             replace_body(&message, &rewritten_sdp)?;
 
-            sessions.insert(MediaSession {
-                rtpengine_call_id: call_id.clone(),
-                call_id,
-                from_tag,
-                to_tag: None,
-                profile: profile_str,
-                ws_uri: resolved_ws_uri,
-                created_at: std::time::Instant::now(),
-            });
+            // Only an *initial* offer creates the session. Re-inserting on a
+            // re-offer would reset `rtpengine_call_id` to the SIP Call-ID —
+            // stranding a transfer-re-anchored call, whose engine id is
+            // deliberately different — and clear the `to_tag` the answer set,
+            // which is what every later `answer`/`delete` addresses the leg by.
+            if !is_reoffer {
+                sessions.insert(MediaSession {
+                    rtpengine_call_id: call_id.clone(),
+                    call_id,
+                    from_tag,
+                    to_tag: None,
+                    profile: profile_str,
+                    ws_uri: resolved_ws_uri,
+                    created_at: std::time::Instant::now(),
+                });
+            }
 
             Ok(true)
         })


### PR DESCRIPTION
WP-R3's mechanism, and a live bug on the way to it.

## The bug

siphon has only ever had one verb for an SDP offer. On rtpengine that is correct — a repeat
`offer` on a live call-id **is** a re-offer, which is how `rtpengine_manage()` has always done
hold and codec renegotiation.

siphon-rtp draws the line differently. A repeat `offer` there is a **replacement**: the engine
frees the call and allocates fresh ports. The ports themselves are not the damage — siphon answers
with the rewritten SDP either way — it is everything attached to them:

- the WebSocket bridge (`ws_uri`)
- any `ws_tee`
- any SIPREC subscription

all torn down with the old call, plus a spurious media CDR with reason `replaced`.

So putting a voice-AI call on hold, or any mid-dialog renegotiation, silently severed the audio
path to the AI while the call itself carried on. Nothing in the signalling looked wrong.

## The fix

A call this process has already anchored renegotiates with `siphon-rtp-proto` 0.2.0's `reoffer`,
which keeps the ports, the pipeline and the attachments — and carries an RFC 8445 §9 ICE restart
when the peer offers new credentials. Three call sites: the framework's re-INVITE path, its UPDATE
path, and the script-facing `rtpengine.offer()`.

rtpengine and rtpproxy still send a plain `offer`. That is not a degraded path, it is their native
semantics, and their wire is byte-identical to before.

## Two things found while wiring it

**A re-offer was addressed by the wrong call-id.** `rtpengine.offer()` used the SIP Call-ID, but a
siphon-terminated transfer deliberately re-anchors the surviving pair on a *fresh* engine call-id
while the store key stays the SIP one. So a re-INVITE after a transfer addressed a call-id the
engine had never heard of. It now uses `rtpengine_id()`, as every other post-offer verb already
did.

**The session was re-inserted on every offer.** On a re-offer that reset `rtpengine_call_id` back
to the SIP Call-ID (stranding the transfer case above) and cleared the `to_tag` the answer had set
— the tag every later `answer` / `delete` addresses the leg by. The insert is now guarded to the
initial offer.

## The one case re-offer cannot serve

The engine refuses a re-offer that changes the negotiated codec — that needs a pipeline rebuild it
will not do on a live call — and its own error says to replace the call instead. That refusal, and
only that refusal, is retried as a replacement `offer`, which is exactly the behaviour such a
re-INVITE already had. It is logged at WARN naming what it costs (ports re-allocated,
bridge/tee/SIPREC dropped) rather than done silently, and `is_codec_change_refusal` is deliberately
narrow so a transport blip or an unknown-call error can never acquire a call-replacing retry.

Worth an engine-side follow-up: `reoffer` rebuilding the pipeline on a codec change would close
this properly, and a codec-changing re-INVITE on a voice-AI call would stop dropping the bridge.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean, **3922 tests pass** (5 new).

- The wire frame carries `"command":"reoffer"` and not `"command":"offer"` — the assertion that
  fails if the call site regresses.
- The codec-change refusal is retried as `offer`, proven by a fake engine reporting the command
  sequence it saw (`reoffer` then `offer`), not by the call merely succeeding.
- `is_codec_change_refusal` rejects unknown-call, draining and SDP-parse errors.
- rtpengine and rtpproxy reach the offer path rather than returning `Unsupported`.

Not covered here: a live hold/unhold against a running siphon-rtp. The demo box is the place for
that.
