### PR TITLE
chore(control-sdk): bump to 0.1.2

### DIFF
--- a/siphon-control-sdk/Cargo.lock
+++ b/siphon-control-sdk/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "base64",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control-proto"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/siphon-control-sdk/Cargo.toml
+++ b/siphon-control-sdk/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/siphon-control-sdk/siphon-control-client/Cargo.toml
+++ b/siphon-control-sdk/siphon-control-client/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 readme = "README.md"
 
 [dependencies]
-siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.1" }
+siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.2" }
 base64 = "0.22"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/siphon-control-sdk/siphon-control/Cargo.toml
+++ b/siphon-control-sdk/siphon-control/Cargo.toml
@@ -20,8 +20,8 @@ name = "siphon_control"
 crate-type = ["cdylib"]
 
 [dependencies]
-siphon-control-client = { path = "../siphon-control-client", version = "0.1.1" }
-siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.1" }
+siphon-control-client = { path = "../siphon-control-client", version = "0.1.2" }
+siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.2" }
 # No abi3: the target interpreter is free-threaded CPython 3.14t (the SIPhon
 # runtime), and the stable ABI (abi3) is not available on free-threaded builds.
 # A standard version-tagged wheel loads on both GIL and free-threaded 3.14.

--- a/siphon-control-sdk/typescript/package-lock.json
+++ b/siphon-control-sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siphon-project/control",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siphon-project/control",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/siphon-control-sdk/typescript/package.json
+++ b/siphon-control-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siphon-project/control",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TypeScript client for the SIPhon external control plane (siphon-control.v1) — an ARI/ESL-class rail for driving handed-over calls out of process.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Cuts the control-plane SDK 0.1.2 release. Bumps `[workspace.package]` 0.1.1→0.1.2 (+ the inter-crate path pins, the TS package.json/lock, and the workspace Cargo.lock) so the tag `control-sdk-v0.1.2` passes the version gate and publishes the media/header/DTMF/REFER verb facade (#186) to PyPI, crates.io and npm. No code change.