### PR TITLE
fix(security): honour trusted_cidrs on the apiban feed, and expire its entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   actually gates on this: the runner propagates the UAC's exit code, the UAC
   fails on the global timeout, and each re-INVITE's 200 is asserted by CSeq so
   a retransmitted initial-INVITE 200 can no longer mask a lost re-INVITE.
+- **`security.trusted_cidrs` now covers the APIBAN blocklist.** The transport
+  ACL consulted the fetched set directly, before the deny/allow lists and with
+  no trusted check, and the kernel-firewall path had none either — so a trusted
+  source that landed on the community feed was dropped anyway and no config
+  could save it. Since the kernel drop is port-agnostic, a listed management
+  address took ssh down with the trunk. Trusted addresses are now filtered as
+  the feed is ingested, ahead of both the userspace store and the kernel set,
+  which is what `docs/kernel-firewall.md` already claimed.
 
 - **`cdr.file.rotate_size_mb` actually rotates.** The value was documented,
   parsed and carried into the file backend, then dropped at the write site — so
@@ -55,6 +63,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   does not re-rotate the size-rotated siblings.
 
 ### Added
+- **`security.apiban.ban_ttl_secs` expires blocklist entries** (default `604800`,
+  7 days, matching the interval after which APIBAN itself releases an address).
+  Entries used to be inserted permanently and the poll only ever fetched
+  forward, so the set grew for the life of the process and a false positive
+  stayed blocked until a restart — which drops every registration — or until it
+  was lifted one address at a time. The TTL is applied as a per-element kernel
+  timeout, so nf_tables expires entries without siphon acting, and the userspace
+  store enforces the deadline on read as well as sweeping on the poll cycle.
+  `0` restores the previous never-expire behaviour. Note the poll still only
+  fetches forward from the last seen id: an address whose TTL expires while it
+  is still abusive returns when the feed re-lists it, not immediately.
 - **Inbound REFER on a controlled call is surfaced to the control app as a
   `TransferRequested` event.** When a B2BUA call has been handed to an external
   control app, an in-dialog REFER on that call is no longer run through the

--- a/docs/cookbook/security.md
+++ b/docs/cookbook/security.md
@@ -29,7 +29,16 @@ security:
   apiban:                       # optional: APIBAN community blocklist
     api_key: "your-api-key"
     interval_secs: 300
+    ban_ttl_secs: 604800        # 7 days, matching the feed's own release
+                                # policy. 0 = never expire.
 ```
+
+`trusted_cidrs` covers the feed too: an address listed by APIBAN that matches a
+trusted CIDR is dropped as the feed is ingested, so it reaches neither the
+userspace ACL nor the kernel set. Put your own trunks, monitoring and management
+addresses there — a community blocklist has no way to know they're yours, and
+the kernel drop is port-agnostic, so a listed management address would cost you
+ssh along with the trunk.
 
 ### How the scoring works
 

--- a/docs/kernel-firewall.md
+++ b/docs/kernel-firewall.md
@@ -18,9 +18,22 @@ The same sources SIPhon already bans, now enforced in the kernel:
   store. Each ban is pushed to the kernel with the **same TTL** as the in-memory
   ban, so both expire in lockstep.
 - **APIBAN** — every IP from the [APIBAN](https://apiban.org) community blocklist,
-  added permanently (the blocklist carries no per-IP lifetime).
+  added with the `apiban.ban_ttl_secs` TTL (default 7 days, matching the interval
+  after which the feed itself releases an address) as a per-element timeout, so
+  the kernel expires them without SIPhon acting. Set `ban_ttl_secs: 0` to add
+  them permanently instead.
 
-`trusted_cidrs` are never banned, so they're never in the set.
+`trusted_cidrs` are never banned, so they're never in the set. That applies to
+both sources: the auto-ban store exempts trusted sources before scoring, and
+APIBAN drops trusted addresses as the feed is ingested, before either the
+userspace ACL or the kernel set sees them. This matters more for the feed than
+it looks — the kernel drop is port-agnostic, so a management address that landed
+on a community blocklist would take ssh down with the trunk.
+
+Because the poll only fetches *forward* from the last seen id, an address whose
+TTL expires while it is still abusive returns to the set when the feed re-lists
+it, not immediately. That is how the feed publishes; it isn't a full
+re-synchronisation.
 
 ## Enable it
 
@@ -117,8 +130,9 @@ SIPhon only ever **creates** its objects — it never deletes a table or chain i
 finds, because it can't know the objects aren't yours. So if you rename `table`
 / `chain` in the config, flip `manage_rule` off, or remove `firewall:` entirely,
 the previously created table (and its drop rules) stays in the kernel and keeps
-dropping whatever is still in its sets — including permanent APIBAN entries that
-never expire. Remove it explicitly:
+dropping whatever is still in its sets until each element's timeout runs out —
+and indefinitely for any element added with `ban_ttl_secs: 0`. Remove it
+explicitly:
 
 ```bash
 nft delete table inet siphon

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -421,6 +421,16 @@ auth:
 #   apiban:                     # APIBAN community blocklist (apiban.org)
 #     api_key: "your-api-key"   # get a free key at apiban.org
 #     interval_secs: 300        # poll interval (default: 300 = 5 min)
+#     ban_ttl_secs: 604800      # how long a fetched entry stays blocked
+#                               # (default: 604800 = 7 days, the interval after
+#                               # which apiban itself releases an address).
+#                               # Applied as a per-element kernel timeout, so
+#                               # the kernel expires it without siphon acting.
+#                               # 0 = never expire (pre-TTL behaviour).
+#                               # trusted_cidrs are dropped as the feed is
+#                               # ingested, so a listed trunk or management
+#                               # address reaches neither the ACL nor the
+#                               # kernel set.
 #
 #   firewall: {}                # kernel firewall: mirror bans (failed_auth_ban +
 #                               # apiban) into a kernel nf_tables set so banned

--- a/src/apiban/mod.rs
+++ b/src/apiban/mod.rs
@@ -3,13 +3,32 @@
 //! Periodically polls the APIBAN REST API to fetch IPs known for SIP abuse
 //! (scanners, brute-forcers, toll fraud) and feeds them into the transport ACL.
 //!
+//! Two properties the feed itself dictates, and which the store below
+//! implements:
+//!
+//! - **Trusted sources are never blocked.** A carrier trunk or a management
+//!   address that lands on a community feed would otherwise lose its trunk (or
+//!   its ssh, since the kernel drop is port-agnostic) with no config able to
+//!   save it. `security.trusted_cidrs` is applied at insert, so neither the
+//!   userspace set nor the kernel set ever receives a trusted address.
+//! - **Entries expire.** APIBAN releases an address after 7 days; siphon used
+//!   to insert permanently, so a false positive stayed blocked for the life of
+//!   the process and the only levers were a restart (which drops every
+//!   registration) or lifting one address at a time. Entries now carry a TTL.
+//!
+//! Known limit: the poll only fetches *forward* from `last_id`, so an address
+//! whose TTL expired while it is still abusive returns to the set only when the
+//! feed re-lists it under a new id. That matches how the feed publishes; it is
+//! not a full re-synchronisation.
+//!
 //! API docs: <https://apiban.org/doc.html>
 
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use dashmap::DashSet;
+use dashmap::DashMap;
+use ipnet::IpNet;
 use serde::Deserialize;
 use tracing::{debug, error, info, warn};
 
@@ -24,6 +43,79 @@ const INITIAL_ID: &str = "100";
 /// Base URL for the APIBAN API.
 const APIBAN_BASE_URL: &str = "https://apiban.org/api";
 
+/// Blocklist entries fetched from the feed, each with an expiry deadline.
+///
+/// `None` as a deadline means the entry never expires — reachable only by
+/// configuring `ban_ttl_secs: 0`, which restores the pre-TTL behaviour for an
+/// operator who wants it.
+///
+/// Expiry is enforced on read as well as by the periodic sweep, so an entry is
+/// never honoured past its deadline just because no sweep has run yet.
+#[derive(Debug, Default)]
+pub struct ApiBanStore {
+    entries: DashMap<IpAddr, Option<Instant>>,
+}
+
+impl ApiBanStore {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: DashMap::new(),
+        }
+    }
+
+    /// Whether `source` is currently blocked. An entry past its deadline
+    /// reports `false` even before the sweep removes it.
+    pub fn contains(&self, source: &IpAddr) -> bool {
+        self.contains_at(source, Instant::now())
+    }
+
+    fn contains_at(&self, source: &IpAddr, now: Instant) -> bool {
+        match self.entries.get(source) {
+            Some(entry) => match *entry {
+                Some(deadline) => deadline > now,
+                None => true,
+            },
+            None => false,
+        }
+    }
+
+    /// Insert `source` with `ttl` (`None` = never expires). Returns `true` when
+    /// the address was not already present, so the caller can count genuinely
+    /// new entries and program the kernel set once.
+    pub(crate) fn insert(&self, source: IpAddr, ttl: Option<Duration>) -> bool {
+        let deadline = ttl.map(|ttl| Instant::now() + ttl);
+        self.entries.insert(source, deadline).is_none()
+    }
+
+    /// Drop every entry past its deadline. Returns how many were removed.
+    fn sweep(&self) -> usize {
+        self.sweep_at(Instant::now())
+    }
+
+    fn sweep_at(&self, now: Instant) -> usize {
+        let before = self.entries.len();
+        // Explicit match rather than `is_none_or`, which is newer than the
+        // crate's MSRV.
+        self.entries.retain(|_, deadline| match deadline {
+            Some(deadline) => *deadline > now,
+            None => true,
+        });
+        before - self.entries.len()
+    }
+
+    /// Number of entries held, including any past their deadline but not yet
+    /// swept. Used only for logging and the ACL's cheap "any rules at all"
+    /// check, both of which tolerate the imprecision.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the store holds no entries at all.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 /// JSON response from the APIBAN `/banned` endpoint.
 #[derive(Debug, Deserialize)]
 struct ApiBanResponse {
@@ -36,32 +128,50 @@ struct ApiBanResponse {
 pub struct ApiBanClient {
     api_key: String,
     interval: Duration,
-    banned: Arc<DashSet<IpAddr>>,
+    /// How long a fetched entry stays blocked. `None` = never expires.
+    ban_ttl: Option<Duration>,
+    /// Sources that must never be blocked no matter what the feed says
+    /// (`security.trusted_cidrs`): own trunks, monitoring, management.
+    trusted: Vec<IpNet>,
+    banned: Arc<ApiBanStore>,
     client: reqwest::Client,
     /// Optional kernel-firewall handle — fetched IPs are also pushed to the
-    /// nf_tables set (permanently; the blocklist carries no per-IP TTL).
+    /// nf_tables set, with the same TTL so the kernel expires them in lockstep.
     firewall: Option<crate::firewall::KernelFirewall>,
 }
 
 impl ApiBanClient {
-    /// Create a new client from config. The banned set is empty until `start()` is called.
-    pub fn new(config: &ApiBanConfig) -> Result<Self, reqwest::Error> {
+    /// Create a new client from config. The banned set is empty until `start()`
+    /// is called. `trusted_cidrs` comes from the enclosing `security` block;
+    /// unparseable entries are ignored (the caller logs them).
+    pub fn new(config: &ApiBanConfig, trusted_cidrs: &[String]) -> Result<Self, reqwest::Error> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .connect_timeout(Duration::from_secs(10))
             .build()?;
 
+        let trusted = trusted_cidrs
+            .iter()
+            .filter_map(|cidr| cidr.parse::<IpNet>().ok())
+            .collect();
+
         Ok(Self {
             api_key: config.api_key.clone(),
             interval: Duration::from_secs(config.interval_secs),
-            banned: Arc::new(DashSet::new()),
+            // 0 means "never expire" — the pre-TTL behaviour, kept reachable.
+            ban_ttl: match config.ban_ttl_secs {
+                0 => None,
+                secs => Some(Duration::from_secs(secs)),
+            },
+            trusted,
+            banned: Arc::new(ApiBanStore::new()),
             client,
             firewall: None,
         })
     }
 
-    /// Returns the shared banned IP set for ACL integration.
-    pub fn banned(&self) -> Arc<DashSet<IpAddr>> {
+    /// Returns the shared banned IP store for ACL integration.
+    pub fn banned(&self) -> Arc<ApiBanStore> {
         Arc::clone(&self.banned)
     }
 
@@ -70,6 +180,11 @@ impl ApiBanClient {
     pub fn with_firewall(mut self, firewall: Option<crate::firewall::KernelFirewall>) -> Self {
         self.firewall = firewall;
         self
+    }
+
+    /// Whether `source` is exempt from the feed.
+    fn is_trusted(&self, source: IpAddr) -> bool {
+        self.trusted.iter().any(|net| net.contains(&source))
     }
 
     /// Spawn the background polling task. Returns a `JoinHandle` for the poll loop.
@@ -84,6 +199,8 @@ impl ApiBanClient {
 
         info!(
             interval_secs = self.interval.as_secs(),
+            ban_ttl_secs = self.ban_ttl.map(|ttl| ttl.as_secs()).unwrap_or(0),
+            trusted_cidrs = self.trusted.len(),
             "APIBAN client started"
         );
 
@@ -105,8 +222,56 @@ impl ApiBanClient {
                 }
             }
 
+            // Drop entries past their TTL. The kernel set expires its own
+            // elements, so this only keeps the userspace store in step.
+            let expired = self.banned.sweep();
+            if expired > 0 {
+                info!(expired, total = self.banned.len(), "APIBAN entries expired");
+            }
+
             tokio::time::sleep(self.interval).await;
         }
+    }
+
+    /// Add one batch of feed addresses to the store, dropping trusted and
+    /// unparseable ones, and program each newly-added address into the kernel
+    /// set with the same TTL. Returns how many were genuinely new.
+    ///
+    /// Split out of [`Self::fetch_all`] so the trusted filter and the TTL are
+    /// exercised on the path that actually runs, not on a re-creation of it.
+    fn ingest(&self, addresses: &[String]) -> usize {
+        let mut added = 0;
+
+        for ip_str in addresses {
+            let Ok(ip_address) = ip_str.parse::<IpAddr>() else {
+                warn!(ip = %ip_str, "APIBAN: skipping invalid IP address");
+                continue;
+            };
+
+            // Trusted sources are dropped here, before both the userspace store
+            // and the kernel set, so a listed trunk or management address is
+            // never dropped anywhere. Doing it at the ACL alone would still
+            // leave the kernel set blackholing the address on every port.
+            if self.is_trusted(ip_address) {
+                warn!(
+                    ip = %ip_address,
+                    "APIBAN: listed address is in trusted_cidrs, not banning"
+                );
+                continue;
+            }
+
+            if self.banned.insert(ip_address, self.ban_ttl) {
+                added += 1;
+                if let Some(firewall) = &self.firewall {
+                    match self.ban_ttl {
+                        Some(ttl) => firewall.ban(ip_address, ttl),
+                        None => firewall.ban_permanent(ip_address),
+                    }
+                }
+            }
+        }
+
+        added
     }
 
     /// Fetch all new entries since `last_id`, paginating in batches of 250.
@@ -116,10 +281,7 @@ impl ApiBanClient {
         let mut total_added = 0;
 
         loop {
-            let url = format!(
-                "{}/{}/banned/{}",
-                APIBAN_BASE_URL, self.api_key, last_id
-            );
+            let url = format!("{}/{}/banned/{}", APIBAN_BASE_URL, self.api_key, last_id);
 
             let response = self
                 .client
@@ -144,27 +306,12 @@ impl ApiBanClient {
                 return Err(ApiBanError::BadStatus(status.as_u16(), body));
             }
 
-            let parsed: ApiBanResponse =
-                serde_json::from_str(&body).map_err(ApiBanError::Json)?;
+            let parsed: ApiBanResponse = serde_json::from_str(&body).map_err(ApiBanError::Json)?;
 
             let addresses = parsed.ipaddress.unwrap_or_default();
             let batch_size = addresses.len();
 
-            for ip_str in &addresses {
-                match ip_str.parse::<IpAddr>() {
-                    Ok(ip_address) => {
-                        if self.banned.insert(ip_address) {
-                            total_added += 1;
-                            if let Some(firewall) = &self.firewall {
-                                firewall.ban_permanent(ip_address);
-                            }
-                        }
-                    }
-                    Err(_) => {
-                        warn!(ip = %ip_str, "APIBAN: skipping invalid IP address");
-                    }
-                }
-            }
+            total_added += self.ingest(&addresses);
 
             *last_id = parsed.id;
 
@@ -194,6 +341,20 @@ pub enum ApiBanError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ip(value: &str) -> IpAddr {
+        value.parse().expect("test IP literal")
+    }
+
+    fn client_with(trusted: &[&str], ban_ttl_secs: u64) -> ApiBanClient {
+        let config = ApiBanConfig {
+            api_key: "test-key".to_string(),
+            interval_secs: 300,
+            ban_ttl_secs,
+        };
+        let trusted: Vec<String> = trusted.iter().map(|cidr| (*cidr).to_string()).collect();
+        ApiBanClient::new(&config, &trusted).expect("client builds")
+    }
 
     #[test]
     fn parse_valid_response() {
@@ -227,60 +388,6 @@ mod tests {
     }
 
     #[test]
-    fn ip_parsing_valid_v4_and_v6() {
-        let banned = DashSet::new();
-
-        let addresses = vec![
-            "192.168.1.1".to_string(),
-            "10.0.0.1".to_string(),
-            "2001:db8::1".to_string(),
-        ];
-
-        for ip_str in &addresses {
-            if let Ok(ip_address) = ip_str.parse::<IpAddr>() {
-                banned.insert(ip_address);
-            }
-        }
-
-        assert_eq!(banned.len(), 3);
-        assert!(banned.contains(&"192.168.1.1".parse::<IpAddr>().unwrap()));
-        assert!(banned.contains(&"10.0.0.1".parse::<IpAddr>().unwrap()));
-        assert!(banned.contains(&"2001:db8::1".parse::<IpAddr>().unwrap()));
-    }
-
-    #[test]
-    fn ip_parsing_skips_invalid() {
-        let banned = DashSet::new();
-
-        let addresses = vec![
-            "1.2.3.4".to_string(),
-            "not-an-ip".to_string(),
-            "999.999.999.999".to_string(),
-            "5.6.7.8".to_string(),
-        ];
-
-        for ip_str in &addresses {
-            if let Ok(ip_address) = ip_str.parse::<IpAddr>() {
-                banned.insert(ip_address);
-            }
-        }
-
-        assert_eq!(banned.len(), 2);
-        assert!(banned.contains(&"1.2.3.4".parse::<IpAddr>().unwrap()));
-        assert!(banned.contains(&"5.6.7.8".parse::<IpAddr>().unwrap()));
-    }
-
-    #[test]
-    fn duplicate_ips_not_counted() {
-        let banned = DashSet::new();
-        let ip: IpAddr = "1.2.3.4".parse().unwrap();
-
-        assert!(banned.insert(ip)); // first insert → true
-        assert!(!banned.insert(ip)); // duplicate → false
-        assert_eq!(banned.len(), 1);
-    }
-
-    #[test]
     fn no_new_bans_detection() {
         // The actual APIBAN response when there are no new bans
         let body = r#"{"ID":"none","ipaddress":"no new bans"}"#;
@@ -289,5 +396,179 @@ mod tests {
         // Normal response with IPs should not trigger the check
         let body = r#"{"ID":"12345","ipaddress":["1.2.3.4"]}"#;
         assert!(!body.contains("no new bans"));
+    }
+
+    #[test]
+    fn store_reports_inserted_address_as_banned() {
+        let store = ApiBanStore::new();
+        assert!(store.insert(ip("192.0.2.10"), Some(Duration::from_secs(60))));
+        assert!(store.contains(&ip("192.0.2.10")));
+        assert!(!store.contains(&ip("192.0.2.11")));
+    }
+
+    #[test]
+    fn store_duplicate_insert_reports_not_new() {
+        let store = ApiBanStore::new();
+        let ttl = Some(Duration::from_secs(60));
+        assert!(store.insert(ip("192.0.2.10"), ttl));
+        assert!(!store.insert(ip("192.0.2.10"), ttl));
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn store_entry_stops_matching_once_past_its_deadline() {
+        // Expiry is enforced on read, so a false positive stops being blocked
+        // at its deadline rather than at the next sweep.
+        let store = ApiBanStore::new();
+        let now = Instant::now();
+        store.insert(ip("192.0.2.10"), Some(Duration::from_millis(1)));
+
+        assert!(store.contains_at(&ip("192.0.2.10"), now));
+        assert!(!store.contains_at(&ip("192.0.2.10"), now + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn store_sweep_drops_only_expired_entries() {
+        let store = ApiBanStore::new();
+        let now = Instant::now();
+        store.insert(ip("192.0.2.10"), Some(Duration::from_secs(1)));
+        store.insert(ip("192.0.2.11"), Some(Duration::from_secs(3600)));
+        assert_eq!(store.len(), 2);
+
+        assert_eq!(store.sweep_at(now + Duration::from_secs(60)), 1);
+        assert_eq!(store.len(), 1);
+        assert!(!store.contains_at(&ip("192.0.2.10"), now));
+        assert!(store.contains_at(&ip("192.0.2.11"), now));
+    }
+
+    #[test]
+    fn store_sweep_leaves_the_store_empty_after_every_entry_expires() {
+        // The store grew without bound before entries carried a TTL; a batch of
+        // entries whose TTL has passed must drain it back to zero.
+        let store = ApiBanStore::new();
+        let now = Instant::now();
+        for octet in 0..50u8 {
+            store.insert(
+                ip(&format!("192.0.2.{octet}")),
+                Some(Duration::from_secs(60)),
+            );
+        }
+        assert_eq!(store.len(), 50);
+
+        assert_eq!(store.sweep_at(now + Duration::from_secs(120)), 50);
+        assert_eq!(store.len(), 0);
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn store_permanent_entry_never_expires() {
+        // ban_ttl_secs: 0 restores the pre-TTL behaviour.
+        let store = ApiBanStore::new();
+        let now = Instant::now();
+        store.insert(ip("192.0.2.10"), None);
+
+        assert!(store.contains_at(&ip("192.0.2.10"), now + Duration::from_secs(86_400 * 365)));
+        assert_eq!(store.sweep_at(now + Duration::from_secs(86_400 * 365)), 0);
+    }
+
+    #[test]
+    fn trusted_cidr_matches_v4_and_v6_sources() {
+        let client = client_with(&["203.0.113.0/24", "2001:db8::/32"], 604_800);
+
+        assert!(client.is_trusted(ip("203.0.113.7")));
+        assert!(client.is_trusted(ip("2001:db8::1")));
+        assert!(!client.is_trusted(ip("198.51.100.7")));
+    }
+
+    #[test]
+    fn untrusted_client_treats_every_source_as_bannable() {
+        let client = client_with(&[], 604_800);
+        assert!(!client.is_trusted(ip("203.0.113.7")));
+    }
+
+    #[test]
+    fn invalid_trusted_cidr_is_ignored_and_the_rest_still_apply() {
+        let client = client_with(&["not-a-cidr", "203.0.113.0/24"], 604_800);
+
+        assert!(client.is_trusted(ip("203.0.113.7")));
+        assert!(!client.is_trusted(ip("198.51.100.7")));
+    }
+
+    #[test]
+    fn ban_ttl_secs_zero_means_permanent() {
+        assert_eq!(client_with(&[], 0).ban_ttl, None);
+        assert_eq!(
+            client_with(&[], 604_800).ban_ttl,
+            Some(Duration::from_secs(604_800))
+        );
+    }
+
+    fn feed(addresses: &[&str]) -> Vec<String> {
+        addresses.iter().map(|a| (*a).to_string()).collect()
+    }
+
+    #[test]
+    fn ingest_bans_an_untrusted_listed_address() {
+        let client = client_with(&["203.0.113.0/24"], 604_800);
+
+        assert_eq!(client.ingest(&feed(&["198.51.100.7"])), 1);
+        assert!(client.banned.contains(&ip("198.51.100.7")));
+    }
+
+    #[test]
+    fn ingest_never_bans_a_trusted_address() {
+        // The regression this closes: a carrier trunk or a management address
+        // that lands on the feed used to lose its trunk (and, because the
+        // kernel drop is port-agnostic, its ssh) with no config able to save it.
+        let client = client_with(&["203.0.113.0/24"], 604_800);
+
+        assert_eq!(client.ingest(&feed(&["203.0.113.7"])), 0);
+        assert!(!client.banned.contains(&ip("203.0.113.7")));
+        assert!(client.banned.is_empty());
+    }
+
+    #[test]
+    fn ingest_bans_the_untrusted_addresses_of_a_mixed_batch() {
+        let client = client_with(&["203.0.113.0/24"], 604_800);
+
+        let added = client.ingest(&feed(&[
+            "198.51.100.7",  // untrusted -> banned
+            "203.0.113.7",   // trusted -> skipped
+            "not-an-ip",     // unparseable -> skipped
+            "198.51.100.8",  // untrusted -> banned
+            "198.51.100.7",  // duplicate -> not counted again
+        ]));
+
+        assert_eq!(added, 2);
+        assert!(client.banned.contains(&ip("198.51.100.7")));
+        assert!(client.banned.contains(&ip("198.51.100.8")));
+        assert!(!client.banned.contains(&ip("203.0.113.7")));
+        assert_eq!(client.banned.len(), 2);
+    }
+
+    #[test]
+    fn ingest_applies_the_configured_ttl_so_entries_do_not_accumulate() {
+        // Entries used to be inserted permanently, so the store grew for the
+        // life of the process. Ingest a batch, then step past the TTL.
+        let client = client_with(&[], 1);
+        let now = Instant::now();
+
+        assert_eq!(client.ingest(&feed(&["198.51.100.7", "198.51.100.8"])), 2);
+        assert!(client.banned.contains_at(&ip("198.51.100.7"), now));
+
+        assert_eq!(client.banned.sweep_at(now + Duration::from_secs(60)), 2);
+        assert!(client.banned.is_empty());
+    }
+
+    #[test]
+    fn ingest_with_ttl_disabled_keeps_entries_forever() {
+        let client = client_with(&[], 0);
+        let now = Instant::now();
+
+        client.ingest(&feed(&["198.51.100.7"]));
+
+        let far_future = now + Duration::from_secs(86_400 * 365);
+        assert!(client.banned.contains_at(&ip("198.51.100.7"), far_future));
+        assert_eq!(client.banned.sweep_at(far_future), 0);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1455,10 +1455,23 @@ pub struct ApiBanConfig {
     /// Poll interval in seconds (default: 300).
     #[serde(default = "default_apiban_interval_secs")]
     pub interval_secs: u64,
+    /// How long a fetched entry stays blocked, in seconds (default: 604800, 7
+    /// days — the feed's own release policy). Applied as a per-element timeout
+    /// in the kernel set, so the kernel expires it without siphon acting.
+    ///
+    /// `0` disables expiry and restores the pre-TTL behaviour, where an entry
+    /// stayed blocked for the life of the process.
+    #[serde(default = "default_apiban_ban_ttl_secs")]
+    pub ban_ttl_secs: u64,
 }
 
 fn default_apiban_interval_secs() -> u64 {
     300
+}
+
+/// 7 days, matching the interval after which APIBAN itself releases an address.
+fn default_apiban_ban_ttl_secs() -> u64 {
+    604_800
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -3169,7 +3169,10 @@ fn build_transport_acl(
 
     if let Some(ref sec) = config.security {
         let apiban_set = if let Some(ref apiban_config) = sec.apiban {
-            match crate::apiban::ApiBanClient::new(apiban_config) {
+            // trusted_cidrs is applied inside the client, at insert, so a
+            // trusted source reaches neither the userspace store nor the
+            // kernel set. Doing it here would only cover the former.
+            match crate::apiban::ApiBanClient::new(apiban_config, &sec.trusted_cidrs) {
                 Ok(client) => {
                     let client = client.with_firewall(firewall.clone());
                     let banned = client.banned();

--- a/src/transport/acl.rs
+++ b/src/transport/acl.rs
@@ -6,8 +6,9 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use dashmap::DashSet;
 use ipnet::IpNet;
+
+use crate::apiban::ApiBanStore;
 
 /// Transport-level ACL.
 ///
@@ -16,11 +17,13 @@ use ipnet::IpNet;
 /// If both are empty (and no APIBAN set), all traffic is allowed.
 ///
 /// When an APIBAN deny set is attached, IPs in that set are blocked before
-/// static deny/allow checks.
+/// static deny/allow checks. The store filters `security.trusted_cidrs` at
+/// insert and expires entries on its own TTL, so this check needs no trusted
+/// test of its own.
 pub struct TransportAcl {
     deny: Vec<IpNet>,
     allow: Vec<IpNet>,
-    apiban_deny: Option<Arc<DashSet<IpAddr>>>,
+    apiban_deny: Option<Arc<ApiBanStore>>,
 }
 
 impl TransportAcl {
@@ -44,7 +47,7 @@ impl TransportAcl {
     pub fn with_apiban(
         deny_cidrs: Vec<String>,
         allow_cidrs: Vec<String>,
-        apiban_deny: Arc<DashSet<IpAddr>>,
+        apiban_deny: Arc<ApiBanStore>,
     ) -> Self {
         let mut acl = Self::new(deny_cidrs, allow_cidrs);
         acl.apiban_deny = Some(apiban_deny);
@@ -172,13 +175,22 @@ mod tests {
         assert!(acl.is_allowed("8.8.8.8".parse().unwrap()));
     }
 
+    /// A store holding `addresses`, each with a long TTL so nothing expires
+    /// mid-test.
+    fn apiban_store(addresses: &[&str]) -> Arc<ApiBanStore> {
+        let store = ApiBanStore::new();
+        for address in addresses {
+            store.insert(
+                address.parse::<IpAddr>().unwrap(),
+                Some(std::time::Duration::from_secs(3600)),
+            );
+        }
+        Arc::new(store)
+    }
+
     #[test]
     fn apiban_blocks_listed_ips() {
-        let apiban_set = Arc::new(DashSet::new());
-        apiban_set.insert("1.2.3.4".parse::<IpAddr>().unwrap());
-        apiban_set.insert("5.6.7.8".parse::<IpAddr>().unwrap());
-
-        let acl = TransportAcl::with_apiban(vec![], vec![], apiban_set);
+        let acl = TransportAcl::with_apiban(vec![], vec![], apiban_store(&["1.2.3.4", "5.6.7.8"]));
 
         assert!(!acl.is_allowed("1.2.3.4".parse().unwrap()));
         assert!(!acl.is_allowed("5.6.7.8".parse().unwrap()));
@@ -188,8 +200,7 @@ mod tests {
 
     #[test]
     fn apiban_empty_set_allows_all() {
-        let apiban_set = Arc::new(DashSet::new());
-        let acl = TransportAcl::with_apiban(vec![], vec![], apiban_set);
+        let acl = TransportAcl::with_apiban(vec![], vec![], apiban_store(&[]));
 
         assert!(acl.is_allowed("1.2.3.4".parse().unwrap()));
         assert!(!acl.has_rules()); // empty set means no active rules
@@ -197,13 +208,10 @@ mod tests {
 
     #[test]
     fn apiban_combined_with_static_deny() {
-        let apiban_set = Arc::new(DashSet::new());
-        apiban_set.insert("1.2.3.4".parse::<IpAddr>().unwrap());
-
         let acl = TransportAcl::with_apiban(
             vec!["10.0.0.0/8".to_string()],
             vec![],
-            apiban_set,
+            apiban_store(&["1.2.3.4"]),
         );
 
         // Blocked by APIBAN
@@ -212,5 +220,22 @@ mod tests {
         assert!(!acl.is_allowed("10.0.0.1".parse().unwrap()));
         // Allowed (neither list)
         assert!(acl.is_allowed("8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn apiban_entry_stops_blocking_once_its_ttl_passes() {
+        // The ACL reads through the store, so an entry past its deadline is
+        // allowed again without waiting for the poll loop's sweep.
+        let store = ApiBanStore::new();
+        store.insert(
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(std::time::Duration::from_millis(1)),
+        );
+        let acl = TransportAcl::with_apiban(vec![], vec![], Arc::new(store));
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        assert!(acl.is_allowed("1.2.3.4".parse().unwrap()));
+        // The entry is still held (nothing swept it), it just no longer matches.
+        assert!(acl.has_rules());
     }
 }


### PR DESCRIPTION
The APIBAN blocklist bypassed `security.trusted_cidrs` entirely, and its entries never expired. Two independent lockout paths, same file, so they land together.

## `trusted_cidrs` did not cover the feed

`TransportAcl::is_allowed` consulted the fetched set directly, before the deny and allow lists and with no trusted test. The kernel-firewall path had none either, so the nftables set was unfiltered too. A carrier trunk or a management address that appeared on the community feed was therefore dropped anyway, and no config could save it. Because the kernel drop is port-agnostic, a listed management address cost ssh along with the trunk.

`docs/kernel-firewall.md` claimed the opposite. That was only ever true of auto-ban, which exempts trusted sources internally.

Trusted addresses are now filtered as the feed is ingested, ahead of both the userspace store and the kernel set, so the claim in the doc holds for both ban sources.

## Entries never expired

`ApiBanClient` only ever inserted, and the poll loop only fetches forward from `last_id`, so the set grew monotonically and a false positive stayed blocked for the life of the process. APIBAN itself releases an address after 7 days. The only clearing levers were a restart, which drops every registration, or lifting one address at a time.

New `security.apiban.ban_ttl_secs`, default `604800` to match the feed:

- applied as a per-element nftables timeout, so the kernel expires entries without siphon acting;
- enforced on read in the userspace store as well as swept on the poll cycle, so an entry is never honoured past its deadline just because no sweep has run yet;
- `0` restores the previous never-expire behaviour.

The store moves from `DashSet<IpAddr>` to a small `ApiBanStore` over `DashMap<IpAddr, Option<Instant>>` (`None` = permanent), which is what carries the deadline through to the ACL.

### Known limit, stated rather than papered over

The poll still only fetches forward from the last seen id. An address whose TTL expires while it is still abusive returns to the set when the feed re-lists it under a new id, not immediately. That matches how the feed publishes; this is not a full re-synchronisation, and the docs now say so.

## Tests

The per-address ingest is split out of `fetch_all` so the trusted filter and the TTL are exercised on the path that actually runs, not on a re-creation of it in the test.

- trusted address on the feed is never banned, in the store or the kernel set
- mixed batch bans only the untrusted, parseable, non-duplicate addresses
- entries stop matching at their deadline, and sweep drains the store to zero
- `ban_ttl_secs: 0` never expires
- ACL reads through the store, so an expired entry is allowed again without a sweep
- invalid `trusted_cidrs` ignored, the rest still apply

Mutation-checked: disabling the trusted guard fails `ingest_never_bans_a_trusted_address` and `ingest_bans_the_untrusted_addresses_of_a_mixed_batch`.

Full suite 3934 passed, clippy clean.