### PR TITLE
fix(lcr): stop a routing answer forging a dialog header on the B-leg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   fails on the global timeout, and each re-INVITE's 200 is asserted by CSeq so
   a retransmitted initial-INVITE 200 can no longer mask a lost re-INVITE.
 
+- **An LCR route's `headers` can no longer forge a dialog header.** Per-route
+  `headers` from the routing answer were injected onto the B-leg INVITE
+  verbatim, last (after both the header policy and the number policy) and with
+  no guard on the name — so a backend naming `From` overwrote the header
+  *including its dialog tag*. That failed silently: the INVITE went out fine and
+  the breakage surfaced later as ACKs and BYEs that no longer matched the
+  dialog. `To`, `Call-ID`, `CSeq`, `Via`, `Contact`, `Route`, `Record-Route`,
+  `Max-Forwards` and `Content-Length` were exposed the same way. The injection
+  now skips exactly the set no header policy may touch either, and logs at warn
+  naming the carrier and the header. `Proxy-Authorization` stays injectable — a
+  per-carrier trunk credential is a legitimate use of it. Use `number_policy` to
+  reshape identity headers per carrier.
 - **`cdr.file.rotate_size_mb` actually rotates.** The value was documented,
   parsed and carried into the file backend, then dropped at the write site — so
   a CDR file configured with `rotate_size_mb: 100` grew without bound. It now

--- a/docs/reference/lcr-api.md
+++ b/docs/reference/lcr-api.md
@@ -75,7 +75,7 @@ one of `gateway_group` / `next_hop` / `ruri`.
 | `billing_increment` | int? | Seconds (60 = per-minute, 1 = per-second). |
 | `min_duration` | int? | Minimum billable seconds. |
 | `timeout_secs` | int? | Per-attempt ring timeout (else the call-level default). |
-| `headers` | object? | Headers to inject on this carrier's B-leg INVITE (applied after the header policy). |
+| `headers` | object? | Headers to inject on this carrier's B-leg INVITE (applied after the header policy). Dialog headers are refused — see below. |
 | `cdr_fields` | object? | Fields siphon auto-stamps onto the CDR when this carrier wins (no per-field script). |
 | `reroute_causes` | int[]? | SIP codes from this carrier that fail over to the next (overrides per-gateway + global). |
 
@@ -100,6 +100,16 @@ Top-level:
   `gateway.groups[].reroute_causes` > global `lcr.reroute_causes`, default
   `[408, 500, 502, 503, 504]`). A definitive response (486, 603) is forwarded to
   the caller.
+- **`headers` cannot forge a dialog header** — siphon owns the B-leg dialog, so
+  `Via`, `Call-ID`, `CSeq`, `Max-Forwards`, `Content-Length`, `From`, `To`,
+  `Contact`, `Record-Route` and `Route` are refused from a route's `headers` and
+  logged at warn naming the carrier and the header. This is the same set no
+  header policy may touch. Overwriting one would not fail visibly — a `From`
+  from a route replaces the header *including its dialog tag*, the INVITE still
+  goes out, and the breakage surfaces later as ACKs and BYEs that no longer
+  match. Use `number_policy` to reshape the From/To identity per carrier.
+  `Proxy-Authorization` is **not** refused, so a per-carrier trunk credential
+  still works.
 - **Forward-compatibility** — unknown response fields are ignored; new optional
   fields can be added without a version bump. Bump `version` only on a breaking
   change.

--- a/src/b2bua/header_policy/mod.rs
+++ b/src/b2bua/header_policy/mod.rs
@@ -238,7 +238,7 @@ pub struct PolicyContext<'a> {
 /// strips them by default (the spec-correct posture), but a script can
 /// opt in via `call.dial(copy=["Proxy-Authenticate"])` for the rare
 /// transparent-proxy B2BUA case.
-fn is_framework_auto(name: &str) -> bool {
+pub(crate) fn is_framework_auto(name: &str) -> bool {
     matches!(
         name.to_ascii_lowercase().as_str(),
         "via"

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11648,6 +11648,45 @@ fn b2bua_status_reroutes(call_id: &str, status: u16, state: &DispatcherState) ->
     crate::lcr::global_reroute_contains(status)
 }
 
+/// The per-route `headers` from an LCR answer that may be injected onto the
+/// B-leg INVITE, with the dialog-defining headers filtered out.
+///
+/// The answer comes from an external routing backend, and the injection runs
+/// last — after the header policy and the number policy — so an unfiltered
+/// `From` in a route's `headers` overwrote the B-leg From *including its tag*.
+/// That doesn't fail visibly: the INVITE goes out, and the damage surfaces
+/// later as ACKs and BYEs that no longer match the dialog. `To`, `Call-ID`,
+/// `CSeq`, `Via` and `Contact` are exposed the same way.
+///
+/// The names filtered here are exactly
+/// [`crate::b2bua::header_policy::is_framework_auto`] — the set no header
+/// policy is allowed to touch either, for the same reason. `Proxy-Authorization`
+/// is deliberately *not* in that set and stays injectable, since a per-carrier
+/// trunk credential is a legitimate use of this field.
+///
+/// A refused header is logged at warn naming the carrier and the header, so a
+/// backend sending one finds out rather than debugging dropped mid-dialog
+/// requests.
+fn lcr_injectable_headers(route: &crate::lcr::Route, call_id: &str) -> Vec<(String, String)> {
+    route
+        .headers
+        .iter()
+        .filter(|(name, _)| {
+            if crate::b2bua::header_policy::is_framework_auto(name) {
+                warn!(
+                    call_id = %call_id,
+                    carrier = %route.carrier_id,
+                    header = %name,
+                    "LCR: refusing to inject a dialog header from a route, ignoring it",
+                );
+                return false;
+            }
+            true
+        })
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect()
+}
+
 /// Build the B-leg R-URI for a carrier route: base is the route's `ruri` (else
 /// the A-leg R-URI), with the carrier's tech-prefix prepended to the userpart.
 /// For a bare dialed-number route (no `ruri`) dialed via a carrier next-hop, the
@@ -11735,11 +11774,7 @@ fn b2bua_advance_route(
             continue;
         }
         let target = b2bua_carrier_ruri(&route, &a_leg_ruri, next_hop.as_deref());
-        let extra_headers: Vec<(String, String)> = route
-            .headers
-            .iter()
-            .map(|(name, value)| (name.clone(), value.clone()))
-            .collect();
+        let extra_headers = lcr_injectable_headers(&route, call_id);
         let timeout = route.timeout_secs.unwrap_or(30);
         debug!(
             call_id = %call_id,
@@ -12944,6 +12979,10 @@ fn b2bua_send_b_leg_invite(
     forced_call_id: Option<&str>,
     original_request: &SipMessage,
     number_policy: Option<&str>,
+    // Injected verbatim onto the B-leg INVITE, last, after both the header
+    // policy and the number policy. Callers must not put a dialog-defining
+    // header in here — see [`lcr_injectable_headers`], which is where the one
+    // caller with externally-supplied headers filters them.
     extra_headers: &[(String, String)],
     state: &DispatcherState,
 ) {
@@ -21308,6 +21347,94 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    // -----------------------------------------------------------------------
+    // LCR per-route header injection must not forge dialog headers
+    // -----------------------------------------------------------------------
+
+    /// A route carrying `headers`, everything else defaulted.
+    fn route_with_headers(pairs: &[(&str, &str)]) -> crate::lcr::Route {
+        crate::lcr::Route {
+            carrier_id: "carrier-a".to_string(),
+            headers: pairs
+                .iter()
+                .map(|(name, value)| ((*name).to_string(), (*value).to_string()))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn injected_names(route: &crate::lcr::Route) -> Vec<String> {
+        let mut names: Vec<String> = lcr_injectable_headers(route, "call-id@host")
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn lcr_headers_pass_through_an_ordinary_carrier_header() {
+        let route = route_with_headers(&[("X-Account", "42"), ("X-Route-Tag", "gold")]);
+        assert_eq!(injected_names(&route), vec!["X-Account", "X-Route-Tag"]);
+    }
+
+    #[test]
+    fn lcr_headers_refuse_from_so_the_dialog_tag_survives() {
+        // The bug this closes: an unfiltered `From` overwrote the B-leg From
+        // including its tag, which doesn't fail at INVITE time — it surfaces
+        // later as ACKs and BYEs that no longer match the dialog.
+        let route = route_with_headers(&[("From", "<sip:spoofed@example.net>"), ("X-Account", "42")]);
+        assert_eq!(injected_names(&route), vec!["X-Account"]);
+    }
+
+    #[test]
+    fn lcr_headers_refuse_every_dialog_header() {
+        for name in [
+            "Via",
+            "Call-ID",
+            "CSeq",
+            "Max-Forwards",
+            "Content-Length",
+            "From",
+            "To",
+            "Contact",
+            "Record-Route",
+            "Route",
+        ] {
+            let route = route_with_headers(&[(name, "forged"), ("X-Account", "42")]);
+            assert_eq!(
+                injected_names(&route),
+                vec!["X-Account"],
+                "{name} must not be injectable from an LCR route",
+            );
+        }
+    }
+
+    #[test]
+    fn lcr_headers_refuse_dialog_headers_case_insensitively() {
+        // RFC 3261 §7.3.1 makes field names case-insensitive, so a lower-cased
+        // or mixed-case spelling must not slip past the guard.
+        let route = route_with_headers(&[
+            ("from", "<sip:spoofed@example.net>"),
+            ("cAlL-Id", "forged@host"),
+            ("X-Account", "42"),
+        ]);
+        assert_eq!(injected_names(&route), vec!["X-Account"]);
+    }
+
+    #[test]
+    fn lcr_headers_still_allow_a_per_carrier_trunk_credential() {
+        // Proxy-Authorization is deliberately outside the framework-auto set:
+        // a per-carrier trunk credential is a legitimate use of this field.
+        let route = route_with_headers(&[("Proxy-Authorization", "Digest username=\"trunk\"")]);
+        assert_eq!(injected_names(&route), vec!["Proxy-Authorization"]);
+    }
+
+    #[test]
+    fn lcr_headers_on_a_route_with_none_inject_nothing() {
+        assert!(lcr_injectable_headers(&route_with_headers(&[]), "call-id@host").is_empty());
+    }
 
     #[test]
     fn b2bua_media_target_is_none_without_dispatcher() {

--- a/src/lcr/mod.rs
+++ b/src/lcr/mod.rs
@@ -177,6 +177,15 @@ pub struct Route {
     /// Headers to inject on this carrier's B-leg INVITE (e.g. a carrier account
     /// token or routing tag). Applied after the header policy, so they always
     /// land on the wire.
+    ///
+    /// Dialog-defining headers are refused and logged: `Via`, `Call-ID`,
+    /// `CSeq`, `Max-Forwards`, `Content-Length`, `From`, `To`, `Contact`,
+    /// `Record-Route`, `Route`. siphon owns those on the B-leg, and overwriting
+    /// one — `From`, say, which carries the dialog tag — doesn't fail visibly:
+    /// the INVITE goes out and the damage surfaces later as ACKs and BYEs that
+    /// no longer match. Use `number_policy` (per-carrier identity reshaping) for
+    /// the From/To shape. `Proxy-Authorization` is *not* refused, so a
+    /// per-carrier trunk credential still works.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub headers: HashMap<String, String>,
     /// Fields siphon auto-stamps onto the CDR when this carrier wins — the API


### PR DESCRIPTION
Per-route `headers` from an LCR answer were injected onto the B-leg INVITE as a bare `headers.set(name, value)` loop over whatever the backend sent — applied last, after both the header policy and the number policy, and with no guard on the name.

So a backend naming `From` overwrote the B-leg From **including its dialog tag**. Nothing fails at that point: the INVITE goes out clean, the callee answers, and the breakage surfaces later as ACKs and BYEs that no longer match the dialog. `To`, `Call-ID`, `CSeq`, `Via`, `Contact`, `Route`, `Record-Route`, `Max-Forwards` and `Content-Length` were exposed the same way.

## Fix

The right list already existed one layer up. `b2bua::header_policy::is_framework_auto` covers exactly those names and short-circuits them so no header policy can touch them, for exactly this reason — the LCR injection just never consulted it.

The injection now filters that set and logs at warn naming the carrier and the header, so a backend sending one finds out instead of debugging dropped mid-dialog requests.

`Proxy-Authorization` is deliberately **not** in `is_framework_auto` and stays injectable: a per-carrier trunk credential is a legitimate use of this field. `number_policy` remains the supported way to reshape identity headers per carrier.

## Where the guard sits

Filtered at the LCR site, where the externally-supplied answer enters and `carrier_id` is in scope for the log, rather than inside the shared injection loop. One guard, not two, and no duplicated logic. The loop keeps three other callers, all of which pass an empty slice; its parameter now documents the invariant.

## Tests

- ordinary carrier headers pass through
- `From` is refused, the rest of the route still injects
- every name in the framework-auto set is refused, checked one at a time
- refused case-insensitively (`from`, `cAlL-Id`) per RFC 3261 §7.3.1
- `Proxy-Authorization` still injects
- a route with no headers injects nothing

Mutation-checked: disabling the guard fails three of them.

Full suite 3927 passed, clippy clean.