### PR TITLE
fix(proxy): an in-dialog request whose R-URI addresses the proxy itself 482'd as a relay loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Fixed
+- **A proxied in-dialog request whose Request-URI addresses the proxy itself is
+  now forwarded to the dialog's established peer instead of failing as a
+  routing loop.** RFC 3261 §12.2.1.1 has the UAC build a mid-dialog request
+  from the remote target (the peer's Contact) plus the route set, but a common
+  class of UAC keeps the proxy's address in the R-URI — so after the proxy
+  consumed its own Route (§16.4) the computed next hop was the proxy itself,
+  and the request was answered `482 Loop Detected` (re-INVITE/UPDATE/BYE) or
+  silently dropped (the end-to-end 2xx ACK, leaving the UAS retransmitting its
+  200 until Timer H). On a hold/resume pair the resume re-INVITE was the
+  visible casualty: the caller never got its 200 and the call hung. Both paths
+  now fall back to the dialog session's established downstream branch when the
+  resolved next hop is one of our own listeners, and only a session whose
+  branch *also* points at us still draws the loop answer. A completed
+  re-INVITE's per-transaction session teardown also no longer evicts the
+  dialog-establishing INVITE's dialog-key entry (the removal twin of the
+  insert-side first-writer-wins guard), so the *second* and later in-dialog
+  requests of a call still find the dialog. The `--reinvite` SIPp mode now
+  actually gates on this: the runner propagates the UAC's exit code, the UAC
+  fails on the global timeout, and each re-INVITE's 200 is asserted by CSeq so
+  a retransmitted initial-INVITE 200 can no longer mask a lost re-INVITE.
+
 - **`cdr.file.rotate_size_mb` actually rotates.** The value was documented,
   parsed and carried into the file backend, then dropped at the write site — so
   a CDR file configured with `rotate_size_mb: 100` grew without bound. It now

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -219,7 +219,11 @@ if [[ "$RUN_REINVITE" == true ]]; then
   echo "=== SIPp re-INVITE test (hold/resume with RTPEngine media renegotiation) ==="
   # Re-uses the rtpengine profile for siphon-rtpengine + mock-rtpengine + register
   run_sipp docker compose -f "$COMPOSE_FILE" --profile reinvite --profile rtpengine run --rm sipp-rtpengine-register
-  run_sipp docker compose -f "$COMPOSE_FILE" --profile reinvite --profile rtpengine up --abort-on-container-exit sipp-reinvite-uac sipp-reinvite-uas
+  # --exit-code-from is load-bearing: without it the step passed on the compose
+  # exit status regardless of sipp's, and the mode was green while the resume
+  # re-INVITE never completed.
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile reinvite --profile rtpengine up --abort-on-container-exit --exit-code-from sipp-reinvite-uac sipp-reinvite-uac sipp-reinvite-uas
+  docker compose -f "$COMPOSE_FILE" --profile reinvite --profile rtpengine rm -sf sipp-reinvite-uac sipp-reinvite-uas 2>/dev/null || true
 fi
 
 # ── Step 9: B2BUA tests (optional) ──────────────────────────────────────────

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -815,6 +815,10 @@ services:
       - "1"
       - -timeout
       - "30"
+      # An incomplete call must FAIL the run: without this, sipp exits 0 on the
+      # global timeout with "Successful call 0 / Failed call 0" and the mode
+      # passes vacuously while the resume re-INVITE never completes.
+      - -timeout_error
       - -trace_err
     profiles:
       - reinvite

--- a/sipp/reinvite_uac.xml
+++ b/sipp/reinvite_uac.xml
@@ -46,8 +46,15 @@ a=sendrecv
   <label id="1" />
   <recv response="180" optional="true" next="1" />
 
-  <!-- 200 OK for initial INVITE -->
-  <recv response="200" rtd="true" crlf="true" />
+  <!-- 200 OK for initial INVITE — assert it answers CSeq 1, so a
+       retransmitted / stale 200 can never satisfy a later recv. -->
+  <recv response="200" rtd="true" crlf="true">
+    <action>
+      <ereg regexp="1 INVITE" search_in="hdr" header="CSeq:" check_it="true"
+            assign_to="invite_cseq_ok" />
+      <log message="initial 200 CSeq assertion: [$invite_cseq_ok]" />
+    </action>
+  </recv>
 
   <!-- ACK for initial INVITE -->
   <send>
@@ -99,8 +106,20 @@ a=sendonly
 ]]>
   </send>
 
-  <!-- 200 OK for hold re-INVITE -->
-  <recv response="200" rtd="true" crlf="true" />
+  <!-- The proxy answers a relayed INVITE with its own 100 Trying
+       (RFC 3261 §16.2) — absorb it. -->
+  <recv response="100" optional="true" />
+
+  <!-- 200 OK for hold re-INVITE — MUST answer CSeq 2.  Without this check a
+       retransmitted 200 for the initial INVITE (CSeq 1) satisfied this recv
+       and masked a hold re-INVITE that never reached the callee. -->
+  <recv response="200" rtd="true" crlf="true">
+    <action>
+      <ereg regexp="2 INVITE" search_in="hdr" header="CSeq:" check_it="true"
+            assign_to="hold_cseq_ok" />
+      <log message="hold 200 CSeq assertion: [$hold_cseq_ok]" />
+    </action>
+  </recv>
 
   <!-- ACK for hold re-INVITE -->
   <send>
@@ -152,8 +171,20 @@ a=sendrecv
 ]]>
   </send>
 
-  <!-- 200 OK for resume re-INVITE -->
-  <recv response="200" rtd="true" crlf="true" />
+  <!-- The proxy answers a relayed INVITE with its own 100 Trying
+       (RFC 3261 §16.2) — absorb it. -->
+  <recv response="100" optional="true" />
+
+  <!-- 200 OK for resume re-INVITE — MUST answer CSeq 3.  This is the recv
+       that catches the relay-to-self loop: the resume re-INVITE was 482'd
+       instead of being forwarded, so no CSeq-3 200 ever arrives. -->
+  <recv response="200" rtd="true" crlf="true">
+    <action>
+      <ereg regexp="3 INVITE" search_in="hdr" header="CSeq:" check_it="true"
+            assign_to="resume_cseq_ok" />
+      <log message="resume 200 CSeq assertion: [$resume_cseq_ok]" />
+    </action>
+  </recv>
 
   <!-- ACK for resume re-INVITE -->
   <send>

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -3844,28 +3844,48 @@ fn relay_request(
         }
     }
 
-    // Prevent routing loops — don't relay to ourselves
+    // Prevent routing loops — don't relay to ourselves.  Before treating this
+    // as a loop, try the mid-dialog rescue: a UAC that keeps the proxy's
+    // address in the R-URI of its re-INVITE/UPDATE/BYE (instead of the remote
+    // target per RFC 3261 §12.2.1.1) computes a next hop that is us, but the
+    // dialog's session still knows the established downstream branch — forward
+    // there rather than failing a call we can route (§16.5).
     if state.is_own_address(&destination) {
-        // ACK to 2xx is end-to-end and should go to the UAS Contact, not the
-        // proxy. If the R-URI still points at us, silently drop rather than
-        // generating a response (ACK never gets a response per RFC 3261).
-        let is_ack = matches!(
-            &message.start_line,
-            StartLine::Request(rl) if rl.method == crate::sip::message::Method::Ack
-        );
-        if is_ack {
-            debug!(target = %target_uri_string, "ACK to self — silently dropping");
+        if let Some((established_destination, established_transport)) =
+            rescue_in_dialog_self_next_hop(message, &state.session_store, &|address| {
+                state.is_own_address(address)
+            })
+        {
+            debug!(
+                target = %target_uri_string,
+                resolved = %destination,
+                destination = %established_destination,
+                "in-dialog next hop resolves to ourselves — forwarding to the dialog's established branch (RFC 3261 §12.2.1.1)"
+            );
+            destination = established_destination;
+            outbound_transport = established_transport;
+        } else {
+            // ACK to 2xx is end-to-end and should go to the UAS Contact, not the
+            // proxy. If the R-URI still points at us, silently drop rather than
+            // generating a response (ACK never gets a response per RFC 3261).
+            let is_ack = matches!(
+                &message.start_line,
+                StartLine::Request(rl) if rl.method == crate::sip::message::Method::Ack
+            );
+            if is_ack {
+                debug!(target = %target_uri_string, "ACK to self — silently dropping");
+                return;
+            }
+
+            warn!(
+                target = %target_uri_string,
+                destination = %destination,
+                "relay loop detected — destination is ourselves"
+            );
+            let response = build_response(message, 482, "Loop Detected", state.server_header.as_deref(), &[]);
+            send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
             return;
         }
-
-        warn!(
-            target = %target_uri_string,
-            destination = %destination,
-            "relay loop detected — destination is ourselves"
-        );
-        let response = build_response(message, 482, "Loop Detected", state.server_header.as_deref(), &[]);
-        send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
-        return;
     }
 
     // Clone the message for modification
@@ -7580,13 +7600,83 @@ fn in_dialog_reuse_destination(
     message: &SipMessage,
     state: &DispatcherState,
 ) -> Option<(SocketAddr, Transport)> {
+    in_dialog_established_branch(message, &state.session_store)
+}
+
+/// Store-level core of [`in_dialog_reuse_destination`]: the dialog's
+/// established downstream branch, looked up by the dialog key
+/// `(Call-ID, From-tag)`.  Split from `DispatcherState` so the self-next-hop
+/// rescue below is unit-testable against a bare [`ProxySessionStore`].
+fn in_dialog_established_branch(
+    message: &SipMessage,
+    session_store: &ProxySessionStore,
+) -> Option<(SocketAddr, Transport)> {
     let call_id = message.headers.get("Call-ID")?;
     let from_tag = message.typed_from().ok().flatten().and_then(|na| na.tag)?;
-    let session_arc = state.session_store.get_by_dialog_key(call_id, &from_tag)?;
+    let session_arc = session_store.get_by_dialog_key(call_id, &from_tag)?;
     let session = session_arc.read().ok()?;
     let client_key = session.client_keys.first()?;
     let branch = session.get_client_branch(client_key)?;
     Some((branch.destination, branch.transport))
+}
+
+/// Rescue an in-dialog request whose computed next hop resolved to one of OUR
+/// OWN listeners.
+///
+/// RFC 3261 §12.2.1.1 has the UAC build a mid-dialog request from the remote
+/// target (the peer's Contact) and the route set (our Record-Route).  A
+/// non-compliant-but-common UAC instead keeps the proxy's address in the
+/// Request-URI — so after `loose_route()` consumed our Route (§16.4) the
+/// remaining next hop (the R-URI) *is us*, and blindly answering
+/// `482 Loop Detected` fails a request we hold the correct destination for:
+/// the dialog's established downstream branch.  §16.5 makes us responsible
+/// for a Request-URI in our own domain, and for a mid-dialog request the only
+/// consistent target is the dialog peer, so forward there.
+///
+/// Returns `None` — caller keeps its existing drop/482 behaviour — when the
+/// request is not mid-dialog (no To-tag, RFC 3261 §12.2), the dialog is not in
+/// the session store, or the established branch is (also) one of our own
+/// addresses (a genuine loop).
+fn rescue_in_dialog_self_next_hop(
+    message: &SipMessage,
+    session_store: &ProxySessionStore,
+    is_self: &dyn Fn(&SocketAddr) -> bool,
+) -> Option<(SocketAddr, Transport)> {
+    let has_to_tag = message
+        .typed_to()
+        .ok()
+        .flatten()
+        .and_then(|name_addr| name_addr.tag)
+        .is_some();
+    if !has_to_tag {
+        return None;
+    }
+    let (destination, transport) = in_dialog_established_branch(message, session_store)?;
+    if is_self(&destination) {
+        return None;
+    }
+    Some((destination, transport))
+}
+
+/// Decide the forward hop for an end-to-end 2xx ACK after dialog-route-set
+/// resolution: keep the resolved hop unless it is one of our own addresses, in
+/// which case fall back to the dialog's established branch (same
+/// RFC 3261 §12.2.1.1 rescue as [`rescue_in_dialog_self_next_hop`] — the UAC
+/// kept the proxy's address in the R-URI instead of the remote target).  `None`
+/// means both hops point back at us — a genuine loop, drop the ACK silently
+/// (RFC 3261 §17.1.1.3: an ACK never gets a response).
+fn ack_forward_hop(
+    resolved: (SocketAddr, Transport, ConnectionId),
+    established: (SocketAddr, Transport, ConnectionId),
+    is_self: &dyn Fn(&SocketAddr) -> bool,
+) -> Option<(SocketAddr, Transport, ConnectionId)> {
+    if !is_self(&resolved.0) {
+        return Some(resolved);
+    }
+    if is_self(&established.0) {
+        return None;
+    }
+    Some(established)
 }
 
 /// Pin the outbound transport to a matching IPsec SA's protocol
@@ -10919,21 +11009,45 @@ fn handle_ack_via_session(
             );
 
             // Loop guard (RFC 3261 §16.3): never forward an ACK back to one of
-            // our own listen addresses.  A stray/misrouted 2xx ACK whose route
-            // set or R-URI resolves to us (e.g. a non-compliant UAC ACKing a
-            // final whose R-URI is the proxy, matched here by `by_dialog_key`)
-            // would otherwise be re-received and re-relayed, stacking a Via each
-            // hop until the datagram exceeds the UDP recv buffer and is dropped
-            // on a parse error.  ACK gets no response (RFC 3261 §17.1.1.3), so
-            // drop silently — mirroring the relay-path guard in `relay_request`.
-            if state.is_own_address(&destination) {
-                debug!(
-                    client_key = %client_key,
-                    %destination,
-                    "ACK to self via dialog route set — dropping (loop guard)"
-                );
-                continue;
-            }
+            // our own listen addresses.  A next hop that resolves to us means
+            // the UAC kept the proxy's address in the ACK's R-URI instead of
+            // the dialog's remote target (RFC 3261 §12.2.1.1) — but the ACK is
+            // dialog-matched, and the session's established branch IS the
+            // remote target, so fall back to it rather than dropping an ACK we
+            // can deliver (a dropped 2xx ACK leaves the UAS retransmitting its
+            // 200 until Timer H and tearing the dialog down).  Only when the
+            // established branch is *also* one of our own addresses is this a
+            // genuine loop; ACK gets no response (RFC 3261 §17.1.1.3), so drop
+            // silently — mirroring the relay-path guard in `relay_request`.
+            let (destination, out_transport, ack_connection_id) = match ack_forward_hop(
+                (destination, out_transport, ack_connection_id),
+                (
+                    client_branch.destination,
+                    client_branch.transport,
+                    client_branch.connection_id,
+                ),
+                &|address| state.is_own_address(address),
+            ) {
+                Some(hop) => {
+                    if hop.0 != destination {
+                        debug!(
+                            client_key = %client_key,
+                            resolved = %destination,
+                            destination = %hop.0,
+                            "2xx ACK next hop resolves to ourselves — falling back to the dialog's established branch (RFC 3261 §12.2.1.1)"
+                        );
+                    }
+                    hop
+                }
+                None => {
+                    debug!(
+                        client_key = %client_key,
+                        %destination,
+                        "ACK to self via dialog route set — dropping (loop guard)"
+                    );
+                    continue;
+                }
+            };
 
             // Add our Via on top (preserving existing Vias), reflecting the
             // transport we will actually send over.
@@ -24089,6 +24203,276 @@ a=rtpmap:8 PCMA/8000\r\n";
             ConnectionId::default(),
             "fresh resolution must not reuse the established connection_id",
         );
+    }
+
+    // --- Mid-dialog self-next-hop rescue (RFC 3261 §12.2.1.1 / §16.5) ---
+    //
+    // The field case: a UAC keeps the proxy's address in the R-URI of its
+    // in-dialog re-INVITE/ACK ("sip:bob@<proxy>:5060") instead of the remote
+    // target from the 200's Contact.  After loose_route() consumed our Route
+    // the computed next hop resolves to ourselves; the old behaviour answered
+    // 482 Loop Detected (re-INVITE) / silently dropped (ACK), failing the
+    // hold/resume of a call whose correct destination sits in the dialog's
+    // session.  These tests pin the rescue: forward to the established branch.
+
+    const RESCUE_PROXY: &str = "192.0.2.1:5060";
+    const RESCUE_CALLEE: &str = "198.51.100.7:5060";
+
+    fn rescue_is_self(address: &SocketAddr) -> bool {
+        *address == RESCUE_PROXY.parse::<SocketAddr>().unwrap()
+    }
+
+    fn rescue_dialog_invite(call_id: &str) -> SipMessage {
+        // Dialog-establishing INVITE (no To-tag) — the session's original_request.
+        SipMessageBuilder::new()
+            .request(
+                Method::Invite,
+                SipUri::new("192.0.2.1".to_string()).with_user("bob".to_string()),
+            )
+            .via("SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-orig".to_string())
+            .to("<sip:bob@192.0.2.1>".to_string())
+            .from("<sip:alice@203.0.113.9>;tag=alice-tag".to_string())
+            .call_id(call_id.to_string())
+            .cseq("1 INVITE".to_string())
+            .content_length(0)
+            .build()
+            .unwrap()
+    }
+
+    fn rescue_in_dialog_message(method: Method, call_id: &str, cseq: u32, to_tag: bool) -> SipMessage {
+        let to = if to_tag {
+            "<sip:bob@192.0.2.1>;tag=bob-tag".to_string()
+        } else {
+            "<sip:bob@192.0.2.1>".to_string()
+        };
+        let cseq_header = format!("{cseq} {}", method.as_str());
+        SipMessageBuilder::new()
+            .request(
+                method,
+                SipUri::new("192.0.2.1".to_string()).with_user("bob".to_string()),
+            )
+            .via(format!("SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-cseq{cseq}"))
+            .to(to)
+            .from("<sip:alice@203.0.113.9>;tag=alice-tag".to_string())
+            .call_id(call_id.to_string())
+            .cseq(cseq_header)
+            .content_length(0)
+            .build()
+            .unwrap()
+    }
+
+    fn rescue_store_with_dialog(call_id: &str) -> ProxySessionStore {
+        let store = ProxySessionStore::new();
+        let invite_client_key = TransactionKey::new(
+            "z9hG4bK-branch0".to_string(),
+            Method::Invite,
+            RESCUE_PROXY.to_string(),
+        );
+        let mut session = ProxySession::new(
+            TransactionKey::new(
+                "z9hG4bK-orig".to_string(),
+                Method::Invite,
+                "203.0.113.9:5060".to_string(),
+            ),
+            "203.0.113.9:5060".parse().unwrap(),
+            RESCUE_PROXY.parse().unwrap(),
+            ConnectionId::default(),
+            Transport::Udp,
+            rescue_dialog_invite(call_id),
+            true,
+        );
+        session.add_client_key(invite_client_key.clone());
+        session.set_client_branch(
+            invite_client_key,
+            ClientBranch {
+                destination: RESCUE_CALLEE.parse().unwrap(),
+                transport: Transport::Udp,
+                connection_id: ConnectionId::default(),
+            },
+        );
+        store.insert(session);
+        store
+    }
+
+    #[test]
+    fn reinvite_addressed_at_proxy_reroutes_to_established_branch() {
+        // The repro: hold re-INVITE with R-URI sip:bob@<proxy> — the computed
+        // next hop is us, but the dialog's established branch is the callee.
+        let store = rescue_store_with_dialog("rescue-1");
+        let reinvite = rescue_in_dialog_message(Method::Invite, "rescue-1", 2, true);
+        let rescued = rescue_in_dialog_self_next_hop(&reinvite, &store, &rescue_is_self);
+        assert_eq!(
+            rescued,
+            Some((RESCUE_CALLEE.parse().unwrap(), Transport::Udp)),
+            "in-dialog re-INVITE addressed at the proxy must forward to the dialog's established branch"
+        );
+    }
+
+    #[test]
+    fn resume_reinvite_still_reroutes_after_hold_transaction_cleanup() {
+        // The SECOND re-INVITE of a hold/resume pair: the hold's own
+        // per-transaction session was inserted (same dialog key — insert's
+        // or_insert_with keeps the INVITE's entry) and cleaned up when its
+        // transaction completed.  The resume must still find the dialog.
+        let store = rescue_store_with_dialog("rescue-2");
+
+        // Hold re-INVITE relayed: relay_request inserts a per-transaction session.
+        let hold_client_key = TransactionKey::new(
+            "z9hG4bK-hold-branch".to_string(),
+            Method::Invite,
+            RESCUE_PROXY.to_string(),
+        );
+        let mut hold_session = ProxySession::new(
+            TransactionKey::new(
+                "z9hG4bK-cseq2".to_string(),
+                Method::Invite,
+                "203.0.113.9:5060".to_string(),
+            ),
+            "203.0.113.9:5060".parse().unwrap(),
+            RESCUE_PROXY.parse().unwrap(),
+            ConnectionId::default(),
+            Transport::Udp,
+            rescue_in_dialog_message(Method::Invite, "rescue-2", 2, true),
+            false,
+        );
+        hold_session.add_client_key(hold_client_key.clone());
+        hold_session.set_client_branch(
+            hold_client_key.clone(),
+            ClientBranch {
+                destination: RESCUE_CALLEE.parse().unwrap(),
+                transport: Transport::Udp,
+                connection_id: ConnectionId::default(),
+            },
+        );
+        store.insert(hold_session);
+        // Hold's 200 forwarded → its client transaction is cleaned up.
+        store.remove_client_key(&hold_client_key);
+
+        let resume = rescue_in_dialog_message(Method::Invite, "rescue-2", 3, true);
+        let rescued = rescue_in_dialog_self_next_hop(&resume, &store, &rescue_is_self);
+        assert_eq!(
+            rescued,
+            Some((RESCUE_CALLEE.parse().unwrap(), Transport::Udp)),
+            "the resume re-INVITE must still reach the callee after the hold's transaction is cleaned up"
+        );
+    }
+
+    #[test]
+    fn out_of_dialog_request_is_not_rescued() {
+        // No To-tag → not mid-dialog (RFC 3261 §12.2): a genuinely misdirected
+        // initial request must keep drawing 482, never be steered by a session
+        // that happens to share (Call-ID, From-tag).
+        let store = rescue_store_with_dialog("rescue-3");
+        let initial = rescue_in_dialog_message(Method::Invite, "rescue-3", 1, false);
+        assert_eq!(
+            rescue_in_dialog_self_next_hop(&initial, &store, &rescue_is_self),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_dialog_is_not_rescued() {
+        let store = ProxySessionStore::new();
+        let reinvite = rescue_in_dialog_message(Method::Invite, "rescue-4", 2, true);
+        assert_eq!(
+            rescue_in_dialog_self_next_hop(&reinvite, &store, &rescue_is_self),
+            None
+        );
+    }
+
+    #[test]
+    fn rescue_declines_when_established_branch_is_also_ourselves() {
+        // Genuine loop: the session's branch ALSO points at us → keep the 482.
+        let store = ProxySessionStore::new();
+        let invite_client_key = TransactionKey::new(
+            "z9hG4bK-branch0".to_string(),
+            Method::Invite,
+            RESCUE_PROXY.to_string(),
+        );
+        let mut session = ProxySession::new(
+            TransactionKey::new(
+                "z9hG4bK-orig".to_string(),
+                Method::Invite,
+                "203.0.113.9:5060".to_string(),
+            ),
+            "203.0.113.9:5060".parse().unwrap(),
+            RESCUE_PROXY.parse().unwrap(),
+            ConnectionId::default(),
+            Transport::Udp,
+            rescue_dialog_invite("rescue-5"),
+            true,
+        );
+        session.add_client_key(invite_client_key.clone());
+        session.set_client_branch(
+            invite_client_key,
+            ClientBranch {
+                destination: RESCUE_PROXY.parse().unwrap(),
+                transport: Transport::Udp,
+                connection_id: ConnectionId::default(),
+            },
+        );
+        store.insert(session);
+
+        let reinvite = rescue_in_dialog_message(Method::Invite, "rescue-5", 2, true);
+        assert_eq!(
+            rescue_in_dialog_self_next_hop(&reinvite, &store, &rescue_is_self),
+            None
+        );
+    }
+
+    #[test]
+    fn ack_forward_hop_keeps_resolved_hop_when_not_self() {
+        let resolved = (
+            RESCUE_CALLEE.parse::<SocketAddr>().unwrap(),
+            Transport::Udp,
+            ConnectionId(3),
+        );
+        let established = (
+            "198.51.100.9:5060".parse::<SocketAddr>().unwrap(),
+            Transport::Tcp,
+            ConnectionId(4),
+        );
+        assert_eq!(
+            ack_forward_hop(resolved, established, &rescue_is_self),
+            Some(resolved)
+        );
+    }
+
+    #[test]
+    fn ack_forward_hop_falls_back_to_established_branch_when_resolved_is_self() {
+        // The 2xx ACK with R-URI sip:bob@<proxy>: the resolved hop is us, the
+        // established branch is the UAS that answered — deliver the ACK there
+        // instead of dropping it (a dropped 2xx ACK leaves the UAS
+        // retransmitting its 200 until Timer H).
+        let resolved = (
+            RESCUE_PROXY.parse::<SocketAddr>().unwrap(),
+            Transport::Udp,
+            ConnectionId(3),
+        );
+        let established = (
+            RESCUE_CALLEE.parse::<SocketAddr>().unwrap(),
+            Transport::Udp,
+            ConnectionId(4),
+        );
+        assert_eq!(
+            ack_forward_hop(resolved, established, &rescue_is_self),
+            Some(established)
+        );
+    }
+
+    #[test]
+    fn ack_forward_hop_drops_when_both_hops_are_self() {
+        let resolved = (
+            RESCUE_PROXY.parse::<SocketAddr>().unwrap(),
+            Transport::Udp,
+            ConnectionId(3),
+        );
+        let established = (
+            RESCUE_PROXY.parse::<SocketAddr>().unwrap(),
+            Transport::Udp,
+            ConnectionId(4),
+        );
+        assert_eq!(ack_forward_hop(resolved, established, &rescue_is_self), None);
     }
 
     // --- B2BUA 401/407/422 retry connection reuse (RFC 5923) ---

--- a/src/proxy/session.rs
+++ b/src/proxy/session.rs
@@ -444,12 +444,22 @@ impl ProxySessionStore {
     /// Remove a session by its server key, cleaning up all indices.
     pub fn remove_by_server_key(&self, server_key: &TransactionKey) {
         if let Some((_, client_keys)) = self.server_to_clients.remove(server_key) {
-            // Remove dialog key index entry via the session's original request
+            // Remove the dialog-key index entry via the session's original
+            // request — but only when the entry actually points at *this*
+            // session.  A mid-dialog re-INVITE's per-transaction session
+            // computes the SAME dialog key `(Call-ID, From-tag)` as the
+            // dialog-establishing INVITE, and `insert` deliberately does not
+            // let it displace the INVITE's entry (`or_insert_with`); removing
+            // unconditionally here would be the missing twin of that guard —
+            // a failed re-INVITE torn down through this path would erase the
+            // dialog entry the original INVITE still needs for 2xx-ACK routing
+            // and the in-dialog self-next-hop rescue.
             if let Some(first) = client_keys.first() {
                 if let Some(session_ref) = self.by_client_key.get(first) {
                     if let Ok(session) = session_ref.value().read() {
                         if let Some(dk) = Self::invite_dialog_key(&session.original_request) {
-                            self.by_dialog_key.remove(&dk);
+                            self.by_dialog_key
+                                .remove_if(&dk, |_, entry| Arc::ptr_eq(entry, session_ref.value()));
                         }
                     }
                 }
@@ -860,6 +870,48 @@ mod tests {
         assert!(store.get_client_keys_for_server(&server_key()).is_none());
         assert_eq!(store.session_count(), 0);
         assert_eq!(store.client_key_count(), 0);
+    }
+
+    #[test]
+    fn store_remove_by_server_key_keeps_dialog_entry_of_another_session() {
+        // A mid-dialog re-INVITE's per-transaction session shares the dialog
+        // key (Call-ID, From-tag) with the dialog-establishing INVITE, and
+        // insert() deliberately keeps the INVITE's entry (`or_insert_with`).
+        // Tearing the re-INVITE's session down by server key must not rip the
+        // INVITE's dialog entry out from under the live call — that entry
+        // routes the 2xx ACK and the in-dialog self-next-hop rescue for every
+        // LATER mid-dialog request (the resume of a hold/resume pair).
+        let store = ProxySessionStore::new();
+        let invite_arc = store.insert(make_session());
+
+        // Re-INVITE: same Call-ID + From-tag (dummy_request), its own keys.
+        let reinvite_server_key = TransactionKey::new(
+            "z9hG4bK-reinvite".to_string(),
+            Method::Invite,
+            "10.0.0.1:5060".to_string(),
+        );
+        let mut reinvite_session = ProxySession::new(
+            reinvite_server_key.clone(),
+            source_addr(),
+            local_addr(),
+            ConnectionId::default(),
+            Transport::Udp,
+            dummy_request(),
+            false,
+        );
+        reinvite_session.add_client_key(client_key("reinvite"));
+        store.insert(reinvite_session);
+
+        store.remove_by_server_key(&reinvite_server_key);
+
+        let survivor = store
+            .get_by_dialog_key("session-test", "abc")
+            .expect("the INVITE's dialog entry must survive the re-INVITE session's teardown");
+        assert!(Arc::ptr_eq(&survivor, &invite_arc));
+
+        // Removing the INVITE's own server key still cleans its dialog entry.
+        store.remove_by_server_key(&server_key());
+        assert!(store.get_by_dialog_key("session-test", "abc").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Found while trying to SIPp the hold/resume path for #187. It is a real routing bug, and the test
that was supposed to cover it has been passing vacuously.

## Root cause

A UAC that keeps the **proxy's address in the R-URI** of a mid-dialog request — instead of the
remote target per RFC 3261 §12.2.1.1 — is a common real-world shape. After `loose_route()`
correctly consumes our Route (§16.4), the remaining next hop *is us*. siphon then failed the
request two ways:

1. **The end-to-end 2xx ACK was silently dropped.** `handle_ack_via_session` resolved the hop to
   ourselves and hit the loop guard. The UAS never got the ACK and retransmitted its 200 every
   500 ms until Timer H.
2. **The re-INVITE was answered `482 Loop Detected`** — even though the dialog's `ProxySession`
   held the correct destination (the callee's established branch) the entire time.

§16.5 makes the proxy *responsible* for a Request-URI in its own domain, not entitled to 482 it,
and for a mid-dialog request the only consistent target is the dialog peer.

**The "hold works, resume loops" symptom was a masking artifact.** The retransmitted CSeq-1 200
from the un-ACKed initial INVITE satisfied SIPp's unqualified `recv 200` for the hold, so the abort
surfaced one step later at the resume. One defect; timing decided where it showed.

## Fix

- `relay_request`: when the resolved destination is one of our own listeners, `rescue_in_dialog_self_next_hop`
  forwards to the dialog's established branch. Guarded — requires a To-tag (§12.2), requires the
  dialog in the session store, and a branch that *also* points at us still draws 482.
- `handle_ack_via_session`: `ack_forward_hop` keeps the resolved hop unless it is us, then falls
  back to the cached client branch. Dropped only when both point at us (ACK gets no response,
  §17.1.1.3).
- `remove_by_server_key`: `remove_if(..., Arc::ptr_eq)` — a re-INVITE's per-transaction session
  shares the dialog key `(Call-ID, From-tag)` with the dialog-establishing INVITE, and `insert`
  already refuses to let it displace that entry (`or_insert_with`). Removal was the missing twin:
  tearing down a re-INVITE session could rip the live call's dialog entry out.

## The test was passing vacuously

`--reinvite` claims "hold/resume" and only ever covered the hold:

- invoked without `--exit-code-from`, and SIPp exits 0 on an incomplete call
  (`Successful call 0 / Failed call 0`)
- the UAC had no `-timeout_error`
- `recv response="200"` was unqualified, so a retransmitted initial 200 satisfied a re-INVITE's recv

All three fixed: `--exit-code-from sipp-reinvite-uac`, `-timeout_error`, and per-CSeq `check_it`
assertions on each re-INVITE 200 (plus absorbing the proxy's legitimate §16.2 100 Trying).

## Mutation check

- **Fix reverted, hardened test kept:** UAC exits **255**, 0 successful calls, aborts on
  `482 Loop Detected`; siphon logs the relay-loop WARN and the ACK drop.
- **Fix applied:** UAC exits **0**, Successful 1 / Failed 0 on both UAC and UAS, **0 retransmits**,
  full ladder (initial + hold + resume + BYE, ACKs delivered), zero loop/drop lines.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean, **3930 tests pass** — 9 new:
5 covering the rescue path (including the resume-after-hold shape and the no-To-tag / genuine-loop
negatives), 3 on `ack_forward_hop`, 1 store regression guard.
