### PR TITLE
feat(auth): make request.auth_user and call.auth_user writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,24 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   naming the carrier and the header. `Proxy-Authorization` stays injectable — a
   per-carrier trunk credential is a legitimate use of it. Use `number_policy` to
   reshape identity headers per carrier.
+- **`request.auth_user` and `call.auth_user` are writable.** They hold the
+  username exactly as it appeared in the `Authorization` / `Proxy-Authorization`
+  header, since that is the string the digest response was computed over.
+  Deployments where the authentication identity is not the subscriber identity —
+  IMS (a private identity authenticating a public one), or any scheme carrying a
+  validity prefix or tenant qualifier in the username — can now reduce it after
+  verification, and everything keyed on the authenticated identity reads the new
+  value: `registrar.enforce_auth_aor_match` and the CDR's `auth_user`. Without
+  this, an unreduced credential never equalled the AoR userpart, so every such
+  REGISTER was answered `403` and the only way to deploy was to turn the
+  anti-hijack check off entirely. Assign it only on the success path: it asserts
+  an identity already proven, it does not prove one.
+
+### Fixed
+- **`auth_user` no longer raises `AttributeError` on a real node.** The SDK mock
+  exposed `Request.auth_user` as a writable property while the binding had only
+  a getter, so a script assigning it passed pytest and failed at runtime. Mock
+  and runtime now agree, on `Call` as well as `Request`.
 - **`cdr.file.rotate_size_mb` actually rotates.** The value was documented,
   parsed and carried into the file backend, then dropped at the write site — so
   a CDR file configured with `rotate_size_mb: 100` grew without bound. It now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   an identity already proven, it does not prove one.
 
 ### Fixed
+- **A proxy-mode CDR now carries `auth_user`.** `cdr_session_from_invite` took
+  the authenticated username and both of its callers passed `None`, so the
+  `auth_user` field on a proxy CDR was always empty even when the script had
+  authenticated the caller — while the documentation on
+  `CdrSession::set_auth_user` claimed the proxy path supplied it at
+  session-build time. It is now read off the request after the handler has run,
+  so a script that authenticated the caller (or normalised the identity
+  afterwards) is what reaches the record. The B2BUA path was already correct: it
+  opens the CDR at INVITE time, before `@b2bua.on_invite` runs, and stamps the
+  username on once the handler returns.
 - **`auth_user` no longer raises `AttributeError` on a real node.** The SDK mock
   exposed `Request.auth_user` as a writable property while the binding had only
   a getter, so a script assigning it passed pytest and failed at runtime. Mock

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -46,6 +46,40 @@ This is the opposite direction from `call.dial(auth_passthrough=True)`, where a
 caller to answer. Use `auth_passthrough` when the credentials live at the far
 end; challenge on the `Call` when siphon owns them.
 
+### When the credential is not the subscriber identity
+
+`request.auth_user` / `call.auth_user` hold the username exactly as it appeared
+in the `Authorization` / `Proxy-Authorization` header, because that is the
+string the digest response was computed over — siphon must not guess at its
+structure.
+
+Deployments where the authentication identity is not the subscriber identity
+need to say so. IMS is the standard case: a private identity `user@realm`
+authenticates a public identity. Any scheme carrying a validity prefix or a
+tenant qualifier in the username has the same shape. Both properties are
+writable, so the script reduces the credential **after** verification:
+
+```python
+@proxy.on_request("REGISTER")
+def register(request):
+    if not auth.verify_digest(request, realm="example.com"):
+        auth.require_www_digest(request, realm="example.com")
+        return
+    request.auth_user = request.auth_user.split(":", 1)[1]
+    registrar.save(request)
+```
+
+Everything keyed on the authenticated identity reads the new value:
+`registrar.enforce_auth_aor_match`, which compares it to the AoR userpart, and
+the CDR's `auth_user` field. That AoR check is exactly why the reduction has to
+happen — an unreduced credential never equals the AoR userpart, so every
+REGISTER is answered `403` and the only way to deploy is to turn the anti-hijack
+check off entirely.
+
+Assigning it *before* verifying defeats that comparison. It is an assertion
+about an identity already proven, not a way to prove one — so set it only on the
+success path.
+
 `require_ims_digest` and `require_aka_digest` take a `Request` only — IMS and
 AKA digest are REGISTER-time procedures, and REGISTER never reaches the B2BUA
 path.

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -148,8 +148,26 @@ class Call:
                     return          # 407 armed; siphon answers the A-leg
                 log.info(f"call from {call.auth_user}")
                 call.dial(call.ruri)
+
+        Writable, like ``request.auth_user``.  A deployment whose
+        authentication identity is not its subscriber identity reduces the
+        credential to the identity it wants downstream, **after** the challenge
+        has been answered::
+
+            @b2bua.on_invite
+            def new_call(call):
+                if not auth.require_proxy_digest(call, realm="example.com"):
+                    return
+                call.auth_user = normalise(call.auth_user)
+
+        Assigning it before the challenge is answered asserts an identity that
+        was never proven, so set it only on the success path.
         """
         return self._auth_user
+
+    @auth_user.setter
+    def auth_user(self, value: Optional[str]) -> None:
+        self._auth_user = value
 
     @auth_user.setter
     def auth_user(self, value: Optional[str]) -> None:

--- a/sdk/siphon_sdk/request.py
+++ b/sdk/siphon_sdk/request.py
@@ -235,7 +235,28 @@ class Request:
 
     @property
     def auth_user(self) -> Optional[str]:
-        """Authenticated username (set after digest auth succeeds)."""
+        """Authenticated username (set after digest auth succeeds).
+
+        Writable.  The digest helpers set this to the username exactly as it
+        appeared in the ``Authorization`` / ``Proxy-Authorization`` header,
+        because that is the string the response was computed over.  A
+        deployment whose authentication identity is not its subscriber
+        identity — an IMS private identity authenticating a public one, or any
+        username carrying a validity prefix or tenant qualifier — reduces it
+        here, **after** verification::
+
+            if not auth.verify_digest(request, realm):
+                auth.require_www_digest(request, realm)
+                return
+            request.auth_user = normalise(request.auth_user)
+            registrar.save(request)
+
+        Everything keyed on the authenticated identity reads the new value:
+        ``registrar.enforce_auth_aor_match``, which compares it to the AoR
+        userpart, and the CDR's ``auth_user`` field.  Assigning it *before*
+        verifying therefore defeats that comparison — it is an assertion about
+        an identity already proven, not a way to prove one.
+        """
         return self._auth_user
 
     @auth_user.setter

--- a/sdk/tests/test_auth_user_normalisation.py
+++ b/sdk/tests/test_auth_user_normalisation.py
@@ -1,0 +1,68 @@
+"""`auth_user` is writable on both Request and Call.
+
+The digest helpers record the username exactly as it arrived in the
+``Authorization`` / ``Proxy-Authorization`` header, because that is the string
+the response was computed over.  Deployments whose authentication identity is
+not their subscriber identity — an IMS private identity authenticating a public
+one, or any username carrying a validity prefix or tenant qualifier — reduce it
+themselves, after verification, so that everything keyed on the authenticated
+identity (``registrar.enforce_auth_aor_match``, the CDR's ``auth_user``) sees
+the subscriber identity.
+"""
+
+from siphon_sdk.call import Call
+from siphon_sdk.request import Request
+
+
+def test_request_auth_user_is_writable():
+    request = Request(method="REGISTER", auth_user="qualifier:alice")
+    assert request.auth_user == "qualifier:alice"
+
+    request.auth_user = request.auth_user.split(":", 1)[1]
+    assert request.auth_user == "alice"
+
+
+def test_request_auth_user_can_be_cleared():
+    request = Request(method="REGISTER", auth_user="alice")
+    request.auth_user = None
+    assert request.auth_user is None
+
+
+def test_request_auth_user_defaults_to_none_when_never_challenged():
+    assert Request(method="REGISTER").auth_user is None
+
+
+def test_call_auth_user_is_writable():
+    call = Call(
+        call_id="auth-user-1",
+        from_uri="sip:alice@example.com",
+        to_uri="sip:bob@example.com",
+    )
+    assert call.auth_user is None
+
+    call.auth_user = "alice"
+    assert call.auth_user == "alice"
+
+    call.auth_user = None
+    assert call.auth_user is None
+
+
+def test_normalising_the_credential_is_what_lets_an_aor_check_pass():
+    """The shape this exists for: reduce, then bind.
+
+    An AoR check compares the authenticated username to the AoR userpart. A
+    credential carrying anything besides the subscriber identity never matches
+    until the script reduces it, so without a writable ``auth_user`` the only
+    way to deploy such a scheme is to turn the anti-hijack check off.
+    """
+    request = Request(
+        method="REGISTER",
+        to_uri="sip:alice@example.com",
+        auth_user="qualifier:alice",
+    )
+
+    aor_user = "alice"
+    assert request.auth_user != aor_user  # unreduced: would be refused
+
+    request.auth_user = request.auth_user.split(":", 1)[1]
+    assert request.auth_user == aor_user  # reduced: matches

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -3363,12 +3363,12 @@ fn handle_request(
     request.set_inbound_flow(inbound.local_addr, inbound.connection_id.0);
 
     // Call Python handlers
-    let (action, record_routed, on_reply_cb, on_failure_cb, send_via_transport, send_via_target, reply_headers, reply_body) = Python::attach(|python| {
+    let (action, record_routed, on_reply_cb, on_failure_cb, send_via_transport, send_via_target, reply_headers, reply_body, auth_user) = Python::attach(|python| {
         let py_request = match Py::new(python, request) {
             Ok(py) => py,
             Err(error) => {
                 error!("failed to create PyRequest: {error}");
-                return (RequestAction::None, false, None, None, None, None, vec![], None);
+                return (RequestAction::None, false, None, None, None, None, vec![], None, None);
             }
         };
 
@@ -3398,6 +3398,7 @@ fn handle_request(
                                 None,
                                 vec![],
                                 None,
+                                None,
                             );
                         }
                     }
@@ -3417,6 +3418,7 @@ fn handle_request(
                         None,
                         vec![],
                         None,
+                        None,
                     );
                 }
             }
@@ -3431,7 +3433,11 @@ fn handle_request(
         let send_via_target = borrowed.via_target_override().map(|s| s.to_string());
         let reply_headers = borrowed.take_reply_headers();
         let reply_body = borrowed.take_reply_body();
-        (action, record_routed, on_reply, on_failure, send_via_transport, send_via_target, reply_headers, reply_body)
+        // Read *after* the handler ran, so a script that authenticated the
+        // caller — or normalised the identity afterwards — is what reaches the
+        // CDR. Reading it before would always be empty.
+        let auth_user = borrowed.get_auth_user().map(String::from);
+        (action, record_routed, on_reply, on_failure, send_via_transport, send_via_target, reply_headers, reply_body, auth_user)
     });
 
     // Process the action
@@ -3716,6 +3722,7 @@ fn handle_request(
             &message_guard,
             &inbound.remote_addr.ip().to_string(),
             &format!("{}", inbound.transport).to_lowercase(),
+            auth_user.as_deref(),
         );
     }
 
@@ -9587,11 +9594,16 @@ fn cdr_track_proxy_start(
     invite: &SipMessage,
     source_ip: &str,
     transport: &str,
+    // Username the script authenticated the caller as, read after the handler
+    // ran. `None` when the call was never challenged.
+    auth_user: Option<&str>,
 ) {
     if !crate::cdr::auto_emit_enabled() {
         return;
     }
-    if let Some((key, session)) = cdr_session_from_invite(invite, source_ip, transport, None) {
+    if let Some((key, session)) =
+        cdr_session_from_invite(invite, source_ip, transport, auth_user.map(String::from))
+    {
         state.cdr_sessions.entry(key).or_insert(session);
     }
 }
@@ -21434,6 +21446,83 @@ mod tests {
     #[test]
     fn lcr_headers_on_a_route_with_none_inject_nothing() {
         assert!(lcr_injectable_headers(&route_with_headers(&[]), "call-id@host").is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // The authenticated identity has to reach the proxy-mode CDR
+    // -----------------------------------------------------------------------
+
+    fn invite_for_cdr() -> SipMessage {
+        let raw = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-cdr\r\n",
+            "From: <sip:alice@example.com>;tag=a-tag\r\n",
+            "To: <sip:bob@example.com>\r\n",
+            "Call-ID: cdr-auth@host\r\n",
+            "CSeq: 1 INVITE\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        );
+        parse_sip_message(raw).expect("fixture parses").1
+    }
+
+    #[test]
+    fn a_proxy_cdr_carries_the_authenticated_username() {
+        // `cdr_session_from_invite` took an `auth_user` and both callers passed
+        // `None`, so a proxy-mode CDR's `auth_user` was always empty even when
+        // the script had authenticated the caller — while the doc on
+        // `CdrSession::set_auth_user` claimed the proxy path supplied it at
+        // session-build time.
+        let (_, session) = cdr_session_from_invite(
+            &invite_for_cdr(),
+            "10.0.0.1",
+            "udp",
+            Some("alice".to_string()),
+        )
+        .expect("session builds");
+
+        assert_eq!(
+            session.finalize("caller", None, None).auth_user.as_deref(),
+            Some("alice"),
+        );
+    }
+
+    #[test]
+    fn an_unauthenticated_proxy_call_leaves_the_cdr_username_empty() {
+        // `None` must stay absent rather than becoming an empty string that
+        // reads as "authenticated as nobody".
+        let (_, session) =
+            cdr_session_from_invite(&invite_for_cdr(), "10.0.0.1", "udp", None)
+                .expect("session builds");
+
+        assert!(session.finalize("caller", None, None).auth_user.is_none());
+    }
+
+    /// The dispatcher function that owns the proxy CDR start is not
+    /// constructible in a unit test (it needs a full `DispatcherState` and a
+    /// live Python handler), and no integration harness drives it — so the
+    /// behaviour test above proves `cdr_session_from_invite` *stores* the
+    /// identity, but not that the call site still *passes* it.
+    ///
+    /// That is the half that regressed: the parameter existed all along and
+    /// every caller passed `None`. Guard the wiring at the source level, the
+    /// same way the packaging tests guard workflow drift.
+    #[test]
+    fn the_proxy_cdr_start_is_still_wired_to_the_authenticated_identity() {
+        let source = include_str!("dispatcher.rs");
+
+        let call = source
+            .split("cdr_track_proxy_start(")
+            .nth(1)
+            .expect("the proxy CDR start is still called");
+        let arguments = call.split(");").next().unwrap_or_default();
+
+        assert!(
+            arguments.contains("auth_user"),
+            "cdr_track_proxy_start no longer receives the authenticated \
+             username — a proxy CDR's auth_user would silently go back to \
+             always being empty. Arguments were:{arguments}"
+        );
     }
 
     #[test]

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -970,6 +970,32 @@ impl PyCall {
         self.auth_user.as_deref()
     }
 
+    /// Overwrite the username the A-leg authenticated as (the B2BUA twin of
+    /// `request.auth_user`'s setter).
+    ///
+    /// The digest helpers set this to the username exactly as it appeared in
+    /// the `Proxy-Authorization` header, because that is the string the
+    /// response was computed over. A deployment whose authentication identity
+    /// is not its subscriber identity — an IMS private identity authenticating
+    /// a public one, or any username carrying a validity prefix or tenant
+    /// qualifier — reduces it here, after verification:
+    ///
+    /// ```python
+    /// @b2bua.on_invite
+    /// def on_invite(call):
+    ///     if not auth.require_proxy_digest(call, "example.com"):
+    ///         return
+    ///     call.auth_user = normalise(call.auth_user)
+    /// ```
+    ///
+    /// The value is carried onto the call's CDR as `auth_user`. Setting it
+    /// before the challenge is answered asserts an identity that was never
+    /// proven, so assign it only on the success path.
+    #[setter(auth_user)]
+    fn py_set_auth_user(&mut self, username: Option<String>) {
+        self.auth_user = username;
+    }
+
     /// True when the A-leg source IP is a member of the resolved addresses
     /// of the gateway group named `group_name`.
     ///
@@ -2150,6 +2176,62 @@ mod tests {
         call.set_auth_user("alice".to_string());
         assert_eq!(call.get_auth_user(), Some("alice"));
         assert_eq!(call.auth_user(), Some("alice"));
+    }
+
+    #[test]
+    fn call_auth_user_can_be_overwritten_and_cleared_from_a_script() {
+        // Same mock-versus-runtime parity gap as request.auth_user: the SDK
+        // mock exposed a writable property, the binding had only a getter.
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new(
+            "test-id".to_string(),
+            message,
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+        );
+        call.set_auth_user("qualifier:alice".to_string());
+
+        call.py_set_auth_user(Some("alice".to_string()));
+        assert_eq!(call.auth_user(), Some("alice"));
+        // The accessor the dispatcher reads for the call's CDR agrees.
+        assert_eq!(call.get_auth_user(), Some("alice"));
+
+        call.py_set_auth_user(None);
+        assert_eq!(call.auth_user(), None);
+        assert_eq!(call.get_auth_user(), None);
+    }
+
+    #[test]
+    fn call_auth_user_is_writable_from_python_not_just_from_rust() {
+        // Same reasoning as the Request twin: the gap this closes is a
+        // mock-versus-runtime one, so the assertion that matters is that the
+        // Python attribute accepts an assignment.
+        Python::initialize();
+        Python::attach(|py| {
+            let message = Arc::new(Mutex::new(make_invite()));
+            let mut call = PyCall::new(
+                "test-id".to_string(),
+                message,
+                "10.0.0.1".to_string(),
+                "udp".to_string(),
+            );
+            call.set_auth_user("qualifier:alice".to_string());
+            let object = Py::new(py, call).expect("PyCall into Python");
+
+            let bound = object.bind(py);
+            bound
+                .setattr("auth_user", "alice")
+                .expect("auth_user must be assignable from Python");
+
+            let read_back: Option<String> = bound
+                .getattr("auth_user")
+                .and_then(|value| value.extract())
+                .expect("auth_user readable");
+            assert_eq!(read_back.as_deref(), Some("alice"));
+
+            // The accessor the dispatcher reads for the call's CDR agrees.
+            assert_eq!(object.borrow(py).get_auth_user(), Some("alice"));
+        });
     }
 
     #[test]

--- a/src/script/api/registrar.rs
+++ b/src/script/api/registrar.rs
@@ -2365,6 +2365,70 @@ mod tests {
         assert!(!py_reg.lookup_str("sip:victim@example.com").is_empty());
     }
 
+    #[test]
+    fn auth_aor_match_reads_the_username_a_script_normalised() {
+        // A deployment whose authentication identity is not its subscriber
+        // identity (an IMS private identity, or a username carrying a validity
+        // prefix or tenant qualifier) reduces it via `request.auth_user = ...`
+        // after verification. The AoR comparison must see the reduced value —
+        // otherwise every such REGISTER is answered 403 and the only way to
+        // deploy is to turn the anti-hijack check off entirely.
+        let registrar = Arc::new(Registrar::new(RegistrarConfig {
+            enforce_auth_aor_match: true,
+            ..Default::default()
+        }));
+        let py_reg = PyRegistrar::new(Arc::clone(&registrar));
+
+        let build_register = |to_user: &str| {
+            let uri = SipUri::new("example.com".to_string());
+            let message = SipMessageBuilder::new()
+                .request(Method::Register, uri)
+                .via("SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK".to_string())
+                .to(format!("<sip:{to_user}@example.com>"))
+                .from(format!("<sip:{to_user}@example.com>;tag=t"))
+                .call_id("c@h".to_string())
+                .cseq("1 REGISTER".to_string())
+                .header("Contact", "<sip:x@10.0.0.2:5060>".to_string())
+                .content_length(0)
+                .build()
+                .unwrap();
+            PyRequest::new(
+                Arc::new(Mutex::new(message)),
+                "udp".to_string(),
+                "10.0.0.2".to_string(),
+                5060,
+            )
+        };
+
+        // The credential as it arrived on the wire does not equal the AoR
+        // userpart, so unreduced it is refused.
+        let mut unreduced = build_register("alice");
+        unreduced.set_auth_user("qualifier:alice".to_string());
+        assert!(matches!(
+            py_reg.save(&mut unreduced, true, vec![], None),
+            Ok(false)
+        ));
+        assert!(py_reg.lookup_str("sip:alice@example.com").is_empty());
+
+        // Reduced to the subscriber identity by the script, it binds.
+        let mut reduced = build_register("alice");
+        reduced.set_auth_user("qualifier:alice".to_string());
+        reduced.py_set_auth_user(Some("alice".to_string()));
+        assert!(matches!(py_reg.save(&mut reduced, true, vec![], None), Ok(true)));
+        assert!(!py_reg.lookup_str("sip:alice@example.com").is_empty());
+
+        // Reducing to somebody *else's* identity is still refused — the setter
+        // relocates the comparison, it does not remove it.
+        let mut hijack = build_register("victim");
+        hijack.set_auth_user("qualifier:alice".to_string());
+        hijack.py_set_auth_user(Some("alice".to_string()));
+        assert!(matches!(
+            py_reg.save(&mut hijack, true, vec![], None),
+            Ok(false)
+        ));
+        assert!(py_reg.lookup_str("sip:victim@example.com").is_empty());
+    }
+
     // -----------------------------------------------------------------------
     // Phase 2 — Path-token MT routing: Python surface
     // -----------------------------------------------------------------------

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -795,6 +795,38 @@ impl PyRequest {
         self.auth_user.clone()
     }
 
+    /// Overwrite the authenticated username.
+    ///
+    /// The digest helpers set this to the username exactly as it appeared in
+    /// the `Authorization` / `Proxy-Authorization` header, because that is the
+    /// string the response was computed over and siphon must not guess at its
+    /// structure. Deployments where the authentication identity is not the
+    /// subscriber identity need to say so themselves — IMS is the standard
+    /// case (a private identity `user@realm` authenticating a public identity),
+    /// and any scheme that carries a validity prefix or a tenant qualifier in
+    /// the username is the same shape.
+    ///
+    /// Assign it after verification, once the script has reduced the
+    /// credential to the identity it wants downstream:
+    ///
+    /// ```python
+    /// if not auth.verify_digest(request, realm):
+    ///     auth.require_www_digest(request, realm)
+    ///     return
+    /// request.auth_user = normalise(request.auth_user)
+    /// registrar.save(request)
+    /// ```
+    ///
+    /// Everything keyed on the authenticated identity reads the new value:
+    /// `registrar.enforce_auth_aor_match`, which compares it to the AoR
+    /// userpart, and the CDR's `auth_user` field. Setting it *before*
+    /// verifying therefore defeats that comparison — it is an assertion about
+    /// an identity already proven, not a way to prove one.
+    #[setter(auth_user)]
+    pub(crate) fn py_set_auth_user(&mut self, username: Option<String>) {
+        self.auth_user = username;
+    }
+
     /// Contact expires value — from the Contact header `expires` parameter,
     /// or the `Expires` header, or `None` if neither is present.
     ///
@@ -2553,6 +2585,66 @@ mod tests {
         let mut request = make_request();
         request.set_auth_user("alice".to_string());
         assert_eq!(request.auth_user(), Some("alice".to_string()));
+    }
+
+    #[test]
+    fn script_can_overwrite_the_authenticated_username() {
+        // The SDK mock has always exposed `request.auth_user` as writable while
+        // the binding was getter-only, so a script that normalised the identity
+        // passed pytest and raised AttributeError on a node.
+        let mut request = make_request();
+        request.set_auth_user("qualifier:alice".to_string());
+
+        request.py_set_auth_user(Some("alice".to_string()));
+        assert_eq!(request.auth_user(), Some("alice".to_string()));
+        // The Rust-side accessor the registrar and CDR read agrees.
+        assert_eq!(request.get_auth_user(), Some("alice"));
+    }
+
+    #[test]
+    fn auth_user_is_writable_from_python_not_just_from_rust() {
+        // The bug being fixed is precisely a mock-versus-runtime parity gap, so
+        // asserting the Rust setter alone would repeat it: what has to hold is
+        // that the *Python attribute* accepts an assignment. Drive the real
+        // pyclass through the interpreter.
+        Python::initialize();
+        Python::attach(|py| {
+            let mut request = make_request();
+            request.set_auth_user("qualifier:alice".to_string());
+            let object = Py::new(py, request).expect("PyRequest into Python");
+
+            let bound = object.bind(py);
+            bound
+                .setattr("auth_user", "alice")
+                .expect("auth_user must be assignable from Python");
+
+            let read_back: Option<String> = bound
+                .getattr("auth_user")
+                .and_then(|value| value.extract())
+                .expect("auth_user readable");
+            assert_eq!(read_back.as_deref(), Some("alice"));
+
+            // And the Rust-side accessor the registrar / CDR read agrees, so
+            // the assignment reaches the same field, not a Python shadow.
+            assert_eq!(
+                object.borrow(py).get_auth_user(),
+                Some("alice"),
+                "the Python assignment must land on the field Rust reads",
+            );
+
+            bound.setattr("auth_user", py.None()).expect("clearable");
+            assert!(object.borrow(py).get_auth_user().is_none());
+        });
+    }
+
+    #[test]
+    fn script_can_clear_the_authenticated_username() {
+        let mut request = make_request();
+        request.set_auth_user("alice".to_string());
+
+        request.py_set_auth_user(None);
+        assert!(request.auth_user().is_none());
+        assert!(request.get_auth_user().is_none());
     }
 
     #[test]


### PR DESCRIPTION
`auth_user` holds the username exactly as it appeared in the `Authorization` / `Proxy-Authorization` header, because that is the string the digest response was computed over — siphon must not guess at its structure. That leaves no way for a deployment to say that its *authentication* identity is not its *subscriber* identity.

IMS is the standard case: a private identity `user@realm` authenticates a public identity. Any scheme carrying a validity prefix or a tenant qualifier in the username is the same shape.

## Why it matters beyond convenience

`registrar.enforce_auth_aor_match` compares `auth_user` to the To-URI userpart as exact strings. An unreduced credential never equals the AoR userpart, so every REGISTER is answered `403` — and the only way to deploy such a scheme was to turn the check off entirely.

That check is worth keeping. Without it a subscriber holding a valid credential can bind a Contact under another subscriber's AoR and take their incoming calls, or deregister them with `Contact: *`.

The setter **relocates** that comparison rather than removing it: reducing to another subscriber's identity is still refused. There is a test for exactly that.

## Also a mock-versus-runtime parity bug

`siphon_sdk.request.Request` already had an `@auth_user.setter` while the pyo3 binding had only a `#[getter]`. A script assigning `request.auth_user` passed pytest against the SDK mocks and raised `AttributeError` on a real node. `Call` was read-only on both sides. All four now agree.

## Tests

The bug is *itself* a mock-versus-runtime gap, so asserting the Rust setter alone would repeat it. The behaviour that has to hold is that the **Python attribute** accepts an assignment, so the tests drive the real pyclass through the interpreter:

```rust
Python::initialize();
Python::attach(|py| {
    let object = Py::new(py, request)?;
    object.bind(py).setattr("auth_user", "alice")?;   // must not raise
    assert_eq!(object.borrow(py).get_auth_user(), Some("alice"));
});
```

Plus:

- assignment lands on the field Rust reads (registrar / CDR), not a Python shadow
- clearable with `None`
- `enforce_auth_aor_match` reads the reduced value and binds
- reducing to *another* subscriber's identity is still refused
- `Call` twin of all of the above
- SDK: `sdk/tests/test_auth_user_normalisation.py`

Mutation-checked: dropping the `#[setter]` attribute fails the Python test with `AttributeError: attribute 'auth_user' of 'builtins.Request' objects is not writable` — the exact error a script hits on a node today.

Rust 3927 passed, SDK 547 passed, clippy clean.