### PR TITLE
feat(b2bua): expose the inbound flow on a Call, and make Flow comparable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   and a `reoffer` per re-INVITE. Verified against a reverted fix, where the mock
   sees three offers and no re-offers — while SIPp still exits 0, which is why
   the assertion is on the verbs and not on the call outcome.
+- **`call.flow`, `Flow.connection_id`, and `Flow` equality/hashing.** A B2BUA
+  `Call` exposed no inbound flow at all, so the RFC 5626 authorisation — accept
+  an INVITE that arrived on the connection a registration was made on, rather
+  than challenging every call with a 407 — could not be written, even though
+  `request.flow` and `Contact.flow` both existed. `Flow` also had no `__eq__`,
+  so `call.flow == contact.flow` would have compared object identity and
+  silently always been `False`; it now compares by value and hashes, so a flow
+  works as a dict key or set member too. On a stream transport the comparison is
+  an exact match on one accepted socket, which is what makes it stronger than a
+  source-address check — the latter is worthless behind carrier NAT, where every
+  subscriber shares an address. On UDP a flow is derived from the address pair
+  and carries no more assurance than the address does. `call.flow` is `None` for
+  an internally-originated call, which is distinguishable from a flow that did
+  not match.
 
 ### Fixed
 - **A proxied in-dialog request whose Request-URI addresses the proxy itself is

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -20,7 +20,31 @@ A registered contact binding returned by `registrar.lookup(...)`.
 ## `Flow`
 
 An opaque view of the inbound flow captured at REGISTER time, used for
-Path-token MT routing.
+Path-token MT routing and for RFC 5626 connection reuse.
+
+Flows compare by value and hash, so a call can be authorised by matching it
+against the connection the registration arrived on, rather than by challenging
+every INVITE with a 407:
+
+```python
+@b2bua.on_invite
+def on_invite(call):
+    bindings = registrar.lookup(str(call.from_uri))
+    if any(contact.flow == call.flow for contact in bindings):
+        call.dial(str(call.ruri))       # same connection as the REGISTER
+    else:
+        call.reject(403, "Forbidden")
+```
+
+Equality covers the transport, both addresses and the connection id together.
+On a stream transport (TCP/TLS/WS/WSS) that is an exact match on one accepted
+socket, which is why it is worth doing: a source-address check is worthless
+behind carrier NAT, where every subscriber on the network shares an address. On
+UDP there is no connection, so a flow carries no more assurance than the address
+does — treat it as a hint, not authorisation.
+
+The match survives the UE reusing the connection across many calls: the
+connection id identifies the socket, not the transaction.
 
 ::: siphon_sdk.types.Flow
 

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -70,12 +70,14 @@ class Call:
         refer_replaces: Optional[dict] = None,
         transport: str = "udp",
         active_route: Optional[Route] = None,
+        flow: Optional[Flow] = None,
     ) -> None:
         self._id = call_id or str(uuid.uuid4())
         self._from_uri = _parse_uri(from_uri)
         self._to_uri = _parse_uri(to_uri)
         self._ruri = _parse_uri(ruri)
         self._source_ip = source_ip
+        self._flow = flow
         self._state = state
         # Transport the A-leg arrived on.  Not a public property (the real
         # PyCall does not expose one either) — it exists so cdr.write(call)
@@ -129,6 +131,38 @@ class Call:
     def source_ip(self) -> str:
         """Source IP address of the A-leg caller."""
         return self._source_ip
+
+    @property
+    def flow(self) -> Optional[Flow]:
+        """The inbound flow this call's INVITE arrived on.
+
+        The B2BUA twin of :attr:`Request.flow`.  ``None`` when the dispatcher
+        had no transport binding to build one from (an internally-originated
+        call, or a ``Call`` constructed in a test without ``flow=``).
+
+        The point of it is RFC 5626 connection reuse: a :class:`Contact` saved
+        at REGISTER time carries the flow the registration arrived on, so a
+        call can be authorised by matching the two rather than by challenging
+        every INVITE with a 407::
+
+            @b2bua.on_invite
+            def on_invite(call):
+                bindings = registrar.lookup(str(call.from_uri))
+                if any(c.flow == call.flow for c in bindings):
+                    call.dial(str(call.ruri))
+                else:
+                    call.reject(403, "Forbidden")
+
+        On a stream transport (TCP/TLS/WS/WSS) that comparison is an exact
+        match on one accepted socket — far stronger than a source-address
+        check, which is worthless behind carrier NAT where every subscriber
+        shares an address.  On UDP there is no connection, so the flow carries
+        no more assurance than the address does.
+
+        The match survives the UE reusing the connection across many calls: the
+        connection id identifies the socket, not the transaction.
+        """
+        return self._flow
 
     @property
     def auth_user(self) -> Optional[str]:

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -926,10 +926,17 @@ class MockRegistrar:
                 contact.flow_token = flow_token
                 # Reconstitute the Flow view from request context.
                 from siphon_sdk.types import Flow as _Flow
+                # Carry the connection id through as well: it is what makes
+                # `contact.flow == call.flow` an RFC 5626 connection-reuse test
+                # rather than an address comparison. A request that already
+                # carries a flow contributes its id, so a test can register and
+                # then call on the same (or a different) connection.
+                inbound = getattr(request, "_flow", None)
                 contact.flow = _Flow(
                     transport=request.transport,
                     remote_addr=f"{request.source_ip}:{request.source_port}",
                     local_addr=getattr(request, "_local_addr", "0.0.0.0:0"),
+                    connection_id=getattr(inbound, "connection_id", 0),
                 )
             contacts.append(contact)
             # Index for lookup_by_token.

--- a/sdk/siphon_sdk/types.py
+++ b/sdk/siphon_sdk/types.py
@@ -70,16 +70,34 @@ class SipUri:
         return f"SipUri({self})"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Flow:
     """Opaque view of an inbound flow captured at REGISTER time.
 
-    Returned by :attr:`Contact.flow` and :attr:`Request.flow`.  Pass back
-    to :meth:`Request.relay` (``flow=`` kwarg) to send a request over the
-    same listener that received the REGISTER — bypassing DNS resolution
-    of the Request-URI.  Used by P-CSCF MT routing (RFC 3327 §5 /
-    TS 24.229 §5.2.7.2) where the UE's Contact URI is unreachable
-    (NAT, IPSec) and the only path back is the captured flow.
+    Returned by :attr:`Contact.flow`, :attr:`Request.flow` and
+    :attr:`Call.flow`.  Pass back to :meth:`Request.relay` (``flow=`` kwarg)
+    to send a request over the same listener that received the REGISTER —
+    bypassing DNS resolution of the Request-URI.  Used by P-CSCF MT routing
+    (RFC 3327 §5 / TS 24.229 §5.2.7.2) where the UE's Contact URI is
+    unreachable (NAT, IPSec) and the only path back is the captured flow.
+
+    Flows compare by value and hash, so the RFC 5626 connection-reuse test
+    is written directly::
+
+        @b2bua.on_invite
+        def on_invite(call):
+            bindings = registrar.lookup(str(call.from_uri))
+            if any(c.flow == call.flow for c in bindings):
+                call.dial(str(call.ruri))     # same connection as the REGISTER
+            else:
+                call.reject(403, "Forbidden")
+
+    Equality covers the transport, both addresses and the connection id
+    together.  On a stream transport that makes it an exact match on one
+    accepted socket, which is a far stronger signal than a source-address
+    check — worthless behind carrier NAT, where every subscriber on the
+    network shares an address.  On UDP there is no connection, so the flow
+    carries no more assurance than the address does.
 
     Treat as opaque: scripts read :attr:`is_alive` for defensive checks
     but should not depend on the internal field shapes.
@@ -96,6 +114,21 @@ class Flow:
     """String form of the captured listener local address — load-bearing
     for IPSec sec-agree where the protected port pair must be preserved
     (3GPP TS 33.203 §7.4)."""
+
+    connection_id: int = 0
+    """Identifier of the accepted inbound connection this flow was captured
+    on.
+
+    For a stream transport (TCP/TLS/WS/WSS) this identifies one accepted
+    socket, so it is what distinguishes a UE still on the connection its
+    REGISTER arrived on from one that reconnected.  For UDP it is a
+    deterministic hash of ``(local_addr, remote_addr)`` — there is no
+    connection to speak of.
+
+    Prefer comparing whole flows over reading this: equality covers the
+    transport and both addresses as well, and a connection id is only
+    meaningful alongside them.
+    """
 
     @property
     def is_alive(self) -> bool:

--- a/sdk/tests/test_call_flow.py
+++ b/sdk/tests/test_call_flow.py
@@ -1,0 +1,77 @@
+"""`call.flow` and Flow comparison — RFC 5626 connection reuse.
+
+A Contact saved at REGISTER time carries the flow the registration arrived on.
+`call.flow` is the same view for the INVITE, so a call can be authorised by
+matching the two rather than by challenging every INVITE with a 407.
+
+On a stream transport that comparison is an exact match on one accepted socket.
+That is the whole point over a source-address check, which is worthless behind
+carrier NAT where every subscriber on the network shares an address.
+"""
+
+from siphon_sdk.call import Call
+from siphon_sdk.types import Flow
+
+
+def flow(transport="tls", remote="192.0.2.10:41234", local="198.51.100.1:5061", cid=0xC0FFEE):
+    return Flow(transport=transport, remote_addr=remote, local_addr=local, connection_id=cid)
+
+
+def test_call_flow_is_none_when_no_binding_was_captured():
+    # An internally-originated call has no inbound flow to describe, and a
+    # script must be able to tell that apart from a flow that did not match.
+    assert Call(call_id="c1").flow is None
+
+
+def test_call_flow_exposes_the_captured_flow():
+    call = Call(call_id="c1", flow=flow())
+
+    assert call.flow.transport == "tls"
+    assert call.flow.remote_addr == "192.0.2.10:41234"
+    assert call.flow.local_addr == "198.51.100.1:5061"
+    assert call.flow.connection_id == 0xC0FFEE
+
+
+def test_a_call_on_the_registered_connection_matches_that_binding():
+    registered = flow()
+    call = Call(call_id="c1", flow=flow())
+
+    assert call.flow == registered
+
+
+def test_same_address_on_a_new_connection_does_not_match():
+    registered = flow(cid=0xC0FFEE)
+    reconnected = Call(call_id="c1", flow=flow(cid=0xBEEF))
+
+    assert reconnected.flow != registered
+
+
+def test_a_different_transport_does_not_match():
+    registered = flow(transport="tls")
+    over_tcp = Call(call_id="c1", flow=flow(transport="tcp"))
+
+    assert over_tcp.flow != registered
+
+
+def test_the_match_survives_the_ue_reusing_the_connection():
+    # The connection id identifies the socket, not the transaction.
+    registered = flow()
+
+    for _ in range(3):
+        assert Call(call_id="c1", flow=flow()).flow == registered
+
+
+def test_flow_is_hashable_so_it_works_as_a_set_member_or_dict_key():
+    assert len({flow(), flow(), flow(cid=0xBEEF)}) == 2
+    assert {flow(): "registered"}[flow()] == "registered"
+
+
+def test_authorising_an_invite_against_the_registered_flow():
+    """The shape this exists for."""
+    registered_bindings = [flow(cid=0xC0FFEE), flow(cid=0xAAAA)]
+
+    on_registered_connection = Call(call_id="c1", flow=flow(cid=0xC0FFEE))
+    assert any(binding == on_registered_connection.flow for binding in registered_bindings)
+
+    on_fresh_connection = Call(call_id="c2", flow=flow(cid=0xDEAD))
+    assert not any(binding == on_fresh_connection.flow for binding in registered_bindings)

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11449,6 +11449,7 @@ fn handle_b2bua_cancel(
     let cancel_a_leg_invite = call.a_leg_invite.clone();
     let cancel_a_leg_source_ip = call.a_leg.transport.remote_addr.ip().to_string();
     let cancel_a_leg_transport = format!("{}", call.a_leg.transport.transport).to_lowercase();
+    let cancel_a_leg_flow = py_flow_from_leg(&call.a_leg.transport);
     drop(call);
 
     // Emit the prepared CANCELs after dropping the call lock so the
@@ -11480,6 +11481,7 @@ fn handle_b2bua_cancel(
         cancel_a_leg_invite,
         cancel_a_leg_source_ip,
         cancel_a_leg_transport,
+        cancel_a_leg_flow,
         state,
     );
 
@@ -11524,6 +11526,7 @@ fn run_b2bua_cancel_handlers(
     a_leg_invite: Option<Arc<std::sync::Mutex<SipMessage>>>,
     a_leg_source_ip: String,
     a_leg_transport: String,
+    a_leg_flow: Option<crate::script::api::registrar::PyFlow>,
     state: &DispatcherState,
 ) {
     let engine_state = state.engine.state();
@@ -11540,7 +11543,8 @@ fn run_b2bua_cancel_handlers(
         }
     };
 
-    let py_call = PyCall::new(call_id.to_string(), invite_arc, a_leg_source_ip, a_leg_transport);
+    let py_call = PyCall::new(call_id.to_string(), invite_arc, a_leg_source_ip, a_leg_transport)
+        .with_flow(a_leg_flow);
 
     Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {
@@ -11697,6 +11701,41 @@ fn lcr_injectable_headers(route: &crate::lcr::Route, call_id: &str) -> Vec<(Stri
         })
         .map(|(name, value)| (name.clone(), value.clone()))
         .collect()
+}
+
+/// The inbound flow an INVITE arrived on, for `call.flow`.
+///
+/// Built straight off the transport frame, so the connection id is the accepted
+/// socket the INVITE came in on — which is what makes `call.flow ==
+/// contact.flow` an RFC 5626 connection-reuse test on a stream transport rather
+/// than an address comparison.
+fn py_flow_from_inbound(
+    inbound: &crate::transport::InboundMessage,
+) -> Option<crate::script::api::registrar::PyFlow> {
+    Some(crate::script::api::registrar::PyFlow {
+        transport: format!("{}", inbound.transport).to_ascii_lowercase(),
+        source_addr: inbound.remote_addr,
+        local_addr: inbound.local_addr,
+        connection_id: inbound.connection_id.0,
+    })
+}
+
+/// The same flow, recovered from a leg's stored transport binding for the
+/// handlers that run after the INVITE frame is gone (`on_answer`, `on_bye`,
+/// `on_failure`, `on_cancel`, `on_refer`).
+///
+/// `local_addr` is only recorded for A-legs, so this yields `None` for a B-leg
+/// — which is correct: `call.flow` describes how the caller reached siphon, and
+/// a B-leg has no inbound flow to describe.
+fn py_flow_from_leg(
+    transport: &crate::b2bua::actor::TransportInfo,
+) -> Option<crate::script::api::registrar::PyFlow> {
+    Some(crate::script::api::registrar::PyFlow {
+        transport: format!("{}", transport.transport).to_ascii_lowercase(),
+        source_addr: transport.remote_addr,
+        local_addr: transport.local_addr?,
+        connection_id: transport.connection_id.0,
+    })
 }
 
 /// Build the B-leg R-URI for a carrier route: base is the route's `ruri` (else
@@ -11939,7 +11978,8 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
                 Arc::clone(invite_arc),
                 a_leg.transport.remote_addr.ip().to_string(),
                 format!("{}", a_leg.transport.transport).to_lowercase(),
-            );
+            )
+            .with_flow(py_flow_from_leg(&a_leg.transport));
             Python::attach(|python| {
                 let call_obj = match Py::new(python, py_call) {
                     Ok(obj) => obj,
@@ -12243,7 +12283,8 @@ fn handle_b2bua_invite(
         Arc::clone(&message_arc),
         inbound.remote_addr.ip().to_string(),
         format!("{}", inbound.transport).to_lowercase(),
-    );
+    )
+    .with_flow(py_flow_from_inbound(&inbound));
 
     let engine_state = state.engine.state();
     let handlers = engine_state.handlers_for(&HandlerKind::B2buaInvite);
@@ -15179,7 +15220,8 @@ fn handle_b2bua_response(
                     Arc::clone(invite_arc),
                     a_leg.transport.remote_addr.ip().to_string(),
                     format!("{}", a_leg.transport.transport).to_lowercase(),
-                );
+                )
+                .with_flow(py_flow_from_leg(&a_leg.transport));
                 // LCR: surface the carrier that won as `call.active_route` so the
                 // script can stamp it onto a CDR / charging record.
                 if let Some(route) = state.call_actors.active_route(call_id) {
@@ -15705,7 +15747,8 @@ fn handle_b2bua_response(
                         Arc::clone(invite_arc),
                         a_leg.transport.remote_addr.ip().to_string(),
                         format!("{}", a_leg.transport.transport).to_lowercase(),
-                    );
+                    )
+                    .with_flow(py_flow_from_leg(&a_leg.transport));
                     let py_reply = PyReply::new(Arc::clone(&response_arc))
                         .with_a_leg(Arc::clone(invite_arc))
                         .with_response_source(
@@ -16381,7 +16424,8 @@ fn handle_b2bua_response(
                     Arc::clone(invite_arc),
                     a_leg.transport.remote_addr.ip().to_string(),
                     format!("{}", a_leg.transport.transport).to_lowercase(),
-                );
+                )
+                .with_flow(py_flow_from_leg(&a_leg.transport));
 
                 Python::attach(|python| {
                     let call_obj = match Py::new(python, py_call) {
@@ -16725,13 +16769,14 @@ fn handle_b2bua_bye(
     };
 
     // Extract the rest from the DashMap ref and drop it before entering Python
-    let (a_leg_invite, a_leg_source_ip, a_leg_transport, a_leg_call_id) =
+    let (a_leg_invite, a_leg_source_ip, a_leg_transport, a_leg_call_id, a_leg_flow) =
         match state.call_actors.get_call(&call_id) {
             Some(call) => (
                 call.a_leg_invite.clone(),
                 call.a_leg.transport.remote_addr.ip().to_string(),
                 format!("{}", call.a_leg.transport.transport).to_lowercase(),
                 call.a_leg.dialog.call_id.clone(),
+                py_flow_from_leg(&call.a_leg.transport),
             ),
             None => return,
         };
@@ -16753,7 +16798,8 @@ fn handle_b2bua_bye(
                 Arc::clone(invite_arc),
                 a_leg_source_ip,
                 a_leg_transport,
-            );
+            )
+            .with_flow(a_leg_flow);
             let initiator = PyByeInitiator { side };
 
             Python::attach(|python| {
@@ -19698,7 +19744,8 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
         Arc::new(std::sync::Mutex::new(message.clone())),
         inbound.remote_addr.ip().to_string(),
         format!("{}", inbound.transport).to_lowercase(),
-    );
+    )
+    .with_flow(py_flow_from_inbound(&inbound));
     py_call.set_refer_to(refer_to.uri.clone(), refer_to.replaces.clone());
 
     let action = Python::attach(|python| {

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -280,6 +280,10 @@ pub struct PyCall {
     message: Arc<Mutex<SipMessage>>,
     /// Source IP of the A-leg.
     source_ip: String,
+    /// The inbound flow the A-leg INVITE arrived on, when the dispatcher had
+    /// the A-leg's transport binding to build it from. `None` for a `Call`
+    /// constructed without one (tests, internally-originated calls).
+    flow: Option<super::registrar::PyFlow>,
     /// Transport the A-leg arrived on ("udp"/"tcp"/"tls"/"ws"/"wss"), for CDRs.
     transport_name: String,
     /// Current call state.
@@ -411,6 +415,7 @@ impl PyCall {
             id,
             message,
             source_ip,
+            flow: None,
             transport_name,
             state: "calling".to_string(),
             action: CallAction::None,
@@ -447,6 +452,13 @@ impl PyCall {
     }
 
     /// Record the username verified by `auth.require_*_digest(call, …)`.
+    /// Attach the inbound flow the A-leg INVITE arrived on. Called by the
+    /// dispatcher, which builds it from the A-leg's `TransportInfo`.
+    pub fn with_flow(mut self, flow: Option<super::registrar::PyFlow>) -> Self {
+        self.flow = flow;
+        self
+    }
+
     pub fn set_auth_user(&mut self, username: String) {
         self.auth_user = Some(username);
     }
@@ -956,6 +968,41 @@ impl PyCall {
     #[getter]
     fn source_ip(&self) -> &str {
         &self.source_ip
+    }
+
+    /// The inbound flow this call's INVITE arrived on — the B2BUA twin of
+    /// `request.flow`.
+    ///
+    /// `None` when the dispatcher had no transport binding to build it from
+    /// (an internally-originated call, or a `Call` constructed in a test).
+    ///
+    /// The point of it is RFC 5626 connection reuse: a `Contact` saved at
+    /// REGISTER time carries the flow the registration arrived on, so a call
+    /// can be authorised by matching the two rather than by challenging every
+    /// INVITE with a 407:
+    ///
+    /// ```python
+    /// @b2bua.on_invite
+    /// def on_invite(call):
+    ///     bindings = registrar.lookup(str(call.from_uri))
+    ///     if any(c.flow == call.flow for c in bindings):
+    ///         call.dial(str(call.ruri))      # same connection as the REGISTER
+    ///     else:
+    ///         call.reject(403, "Forbidden")
+    /// ```
+    ///
+    /// On a stream transport (TCP/TLS/WS/WSS) that comparison is an exact match
+    /// on one accepted socket, which is why it is worth doing: a source-address
+    /// check is worthless behind carrier NAT, where every subscriber on the
+    /// network shares an address. On UDP there is no connection, so the flow is
+    /// derived from the address pair and carries no more assurance than the
+    /// address does.
+    ///
+    /// The match survives the UE reusing the connection across many calls —
+    /// the connection id identifies the socket, not the transaction.
+    #[getter]
+    fn flow(&self) -> Option<super::registrar::PyFlow> {
+        self.flow.clone()
     }
 
     /// Username the A-leg authenticated as, or `None` if it was never
@@ -2147,6 +2194,123 @@ mod tests {
             .content_length(0)
             .build()
             .unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // call.flow — RFC 5626 connection reuse
+    // -----------------------------------------------------------------------
+
+    fn test_flow(
+        transport: &str,
+        source: &str,
+        local: &str,
+        connection_id: u64,
+    ) -> super::super::registrar::PyFlow {
+        super::super::registrar::PyFlow {
+            transport: transport.to_string(),
+            source_addr: source.parse().expect("test source addr"),
+            local_addr: local.parse().expect("test local addr"),
+            connection_id,
+        }
+    }
+
+    fn call_on(flow: Option<super::super::registrar::PyFlow>) -> PyCall {
+        PyCall::new(
+            "test-id".to_string(),
+            Arc::new(Mutex::new(make_invite())),
+            "192.0.2.10".to_string(),
+            "tls".to_string(),
+        )
+        .with_flow(flow)
+    }
+
+    #[test]
+    fn call_flow_is_none_when_no_transport_binding_was_captured() {
+        // An internally-originated call has no inbound flow to describe, and a
+        // script must be able to tell that apart from a flow that didn't match.
+        assert!(call_on(None).flow().is_none());
+    }
+
+    #[test]
+    fn call_flow_exposes_the_captured_inbound_flow() {
+        let flow = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xc0ffee);
+        let call = call_on(Some(flow));
+
+        let exposed = call.flow().expect("flow present");
+        assert_eq!(exposed.transport(), "tls");
+        assert_eq!(exposed.remote_addr(), "192.0.2.10:41234");
+        assert_eq!(exposed.local_addr(), "198.51.100.1:5061");
+        assert_eq!(exposed.connection_id(), 0xc0ffee);
+    }
+
+    #[test]
+    fn a_call_on_the_registered_connection_matches_that_binding_flow() {
+        // The authorisation this exists for: the INVITE arrived on the same
+        // accepted socket the REGISTER did, so it is the registered UE.
+        let registered = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xc0ffee);
+        let call = call_on(Some(registered.clone()));
+
+        assert_eq!(call.flow(), Some(registered));
+    }
+
+    #[test]
+    fn a_call_from_the_same_address_on_a_new_connection_does_not_match() {
+        // This is the whole point over a source-address check. Behind carrier
+        // NAT every subscriber shares an address, so the address matching says
+        // nothing; the accepted connection is what carries the assurance.
+        let registered = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xc0ffee);
+        let reconnected = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xbeef);
+
+        assert_ne!(call_on(Some(reconnected)).flow(), Some(registered));
+    }
+
+    #[test]
+    fn a_call_on_a_different_transport_does_not_match() {
+        let registered = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xc0ffee);
+        let over_tcp = test_flow("tcp", "192.0.2.10:41234", "198.51.100.1:5061", 0xc0ffee);
+
+        assert_ne!(call_on(Some(over_tcp)).flow(), Some(registered));
+    }
+
+    #[test]
+    fn the_match_survives_the_ue_reusing_the_connection_across_calls() {
+        // The connection id identifies the socket, not the transaction, so a
+        // second and third call over the same connection still match.
+        let registered = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xc0ffee);
+
+        for _ in 0..3 {
+            assert_eq!(call_on(Some(registered.clone())).flow(), Some(registered.clone()));
+        }
+    }
+
+    #[test]
+    fn call_flow_is_comparable_and_hashable_from_python() {
+        // `call.flow == contact.flow` has to work as an expression in a script,
+        // and a flow has to be usable as a dict key / set member. pyclass needs
+        // `eq` + `hash` for either; a Rust-only PartialEq gives neither.
+        Python::initialize();
+        Python::attach(|py| {
+            let flow = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xc0ffee);
+            let other = test_flow("tls", "192.0.2.10:41234", "198.51.100.1:5061", 0xbeef);
+
+            let same_a = Py::new(py, flow.clone()).expect("flow into Python");
+            let same_b = Py::new(py, flow).expect("flow into Python");
+            let different = Py::new(py, other).expect("flow into Python");
+
+            assert!(same_a
+                .bind(py)
+                .eq(same_b.bind(py))
+                .expect("Flow must support =="));
+            assert!(!same_a
+                .bind(py)
+                .eq(different.bind(py))
+                .expect("Flow must support =="));
+
+            // Hashable, and equal flows hash equal, so a set/dict works.
+            let hash_a = same_a.bind(py).hash().expect("Flow must be hashable");
+            let hash_b = same_b.bind(py).hash().expect("Flow must be hashable");
+            assert_eq!(hash_a, hash_b);
+        });
     }
 
     #[test]

--- a/src/script/api/registrar.rs
+++ b/src/script/api/registrar.rs
@@ -47,8 +47,17 @@ fn repin_protected_sa(request: &PyRequest, granted_expires: u32) {
 /// REGISTER.  Treat as opaque from Python: scripts pass it back to
 /// `request.relay(flow=)` and read `is_alive` to defend against dead
 /// stream connections.
-#[pyclass(name = "Flow", from_py_object)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Flows compare by value and hash, so the natural RFC 5626 test — did this
+/// request arrive on the same connection the registration did? — is written as
+/// `call.flow == contact.flow` (or `request.flow == contact.flow`), and a flow
+/// can be used as a dict key or put in a set.  Equality covers the transport,
+/// both addresses and the connection id together; on a stream transport that
+/// makes it an exact match on one accepted socket, which is a far stronger
+/// signal than a source-address check (worthless behind carrier NAT, where
+/// every subscriber shares an address).
+#[pyclass(name = "Flow", from_py_object, eq, hash, frozen)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PyFlow {
     /// Lowercase transport name ("udp", "tcp", "tls", "ws", "wss").
     pub transport: String,
@@ -68,20 +77,36 @@ pub struct PyFlow {
 impl PyFlow {
     /// Lowercase transport name ("udp", "tcp", "tls", "ws", "wss").
     #[getter]
-    fn transport(&self) -> &str {
+    pub(crate) fn transport(&self) -> &str {
         &self.transport
     }
 
     /// String form of the captured remote (UE) address.
     #[getter]
-    fn remote_addr(&self) -> String {
+    pub(crate) fn remote_addr(&self) -> String {
         self.source_addr.to_string()
     }
 
     /// String form of the captured listener local address.
     #[getter]
-    fn local_addr(&self) -> String {
+    pub(crate) fn local_addr(&self) -> String {
         self.local_addr.to_string()
+    }
+
+    /// Identifier of the accepted inbound connection this flow was captured on.
+    ///
+    /// For a stream transport (TCP/TLS/WS/WSS) this identifies one accepted
+    /// socket, so it is what distinguishes a UE that is still on the connection
+    /// its REGISTER arrived on from one that reconnected. For UDP it is a
+    /// deterministic hash of `(local_addr, remote_addr)`, since there is no
+    /// connection to speak of.
+    ///
+    /// Prefer comparing whole flows (`call.flow == contact.flow`) over reading
+    /// this: equality covers the transport and both addresses as well, and a
+    /// connection id is only meaningful alongside them.
+    #[getter]
+    pub(crate) fn connection_id(&self) -> u64 {
+        self.connection_id
     }
 
     /// Whether the flow is still usable.


### PR DESCRIPTION
`request.flow` and `Contact.flow` both existed, but a B2BUA `Call` exposed no flow at all — and an INVITE on a tracked call arrives as a `Call`. So the RFC 5626 authorisation could not be written: accept a call that arrived on the connection its registration was made on, instead of challenging every INVITE with a 407.

`Flow` also carried `connection_id` on the struct with no `#[getter]`, and had no `__eq__`. `call.flow == contact.flow` would therefore have compared **object identity** and been silently `False` forever — the worst failure mode for an authorisation check, because it fails closed and looks exactly like the subscriber being unregistered.

## What lands

- `Call.flow` — the B2BUA twin of `request.flow`
- `Flow.connection_id` getter
- `Flow` compares by value and hashes (`#[pyclass(eq, hash, frozen)]`), so it also works as a dict key or set member

```python
@b2bua.on_invite
def on_invite(call):
    bindings = registrar.lookup(str(call.from_uri))
    if any(contact.flow == call.flow for contact in bindings):
        call.dial(str(call.ruri))       # same connection as the REGISTER
    else:
        call.reject(403, "Forbidden")
```

## Why the connection, not the address

Equality covers the transport, both addresses **and** the connection id together. On a stream transport that is an exact match on one accepted socket, which is the entire reason this beats a source-address check — the latter is worthless behind carrier NAT, where every subscriber on the network shares an address.

On UDP there is no connection, so the flow is derived from the address pair and carries no more assurance than the address does. Documented as such rather than implying otherwise.

## Wiring

Populated at all 8 `PyCall::new` sites: from the inbound transport frame where the INVITE is still in hand (`on_invite`, `on_refer`), and from the leg's stored `TransportInfo` for the handlers that run after it is gone (`on_answer`, `on_early_media`, `on_failure`, `on_bye`, `on_cancel`).

`py_flow_from_leg` yields `None` for a B-leg, because `local_addr` is only recorded for A-legs — which is correct: `call.flow` describes how the *caller* reached siphon, and a B-leg has no inbound flow to describe. `None` is also what an internally-originated call gets, and a script can tell that apart from a flow that did not match.

## SDK

`Flow` becomes a frozen dataclass so it is hashable like the runtime. It was a plain `@dataclass`, which sets `__hash__ = None` — the same parity gap in the opposite direction. `connection_id` added, and the mock's `contact.flow` now carries it so the comparison is meaningful in tests.

## Tests

- flow exposed, and `None` when no binding was captured
- a call on the registered connection matches that binding
- **same address, new connection does not match** — the case a source-address check gets wrong
- a different transport does not match
- the match survives the UE reusing the connection across calls
- comparable and hashable *through the interpreter*, not just in Rust
- SDK: `sdk/tests/test_call_flow.py`, including the authorise-against-bindings shape

Mutation-checked: dropping `eq` from the pyclass fails the Python comparison test — i.e. it reproduces the always-`False` comparison this prevents.

Rust 3928 passed, SDK 550 passed, clippy clean.