### PR TITLE
test(ci): cover re-INVITE renegotiation on the siphon-rtp backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -697,6 +697,59 @@ jobs:
             siphon-voice-ai.log
             mock-siphon-rtp.log
 
+  # ── Re-INVITE renegotiation on the siphon-rtp backend ──────────────────
+  sipp-reoffer:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-reoffer image
+        run: docker compose -f sipp/docker-compose.yaml --profile reoffer build siphon-reoffer
+
+      - name: Start mock siphon-rtp + siphon
+        run: docker compose -f sipp/docker-compose.yaml --profile reoffer up -d --wait mock-siphon-rtp-reoffer siphon-reoffer
+
+      - name: Register bob
+        run: docker compose -f sipp/docker-compose.yaml --profile reoffer run --rm sipp-reoffer-register
+
+      - name: Call, hold, resume, hang up
+        run: docker compose -f sipp/docker-compose.yaml --profile reoffer up --abort-on-container-exit --exit-code-from sipp-reoffer-uac sipp-reoffer-uac sipp-reoffer-uas
+
+      - name: Assert the re-INVITEs renegotiated in place
+        # SIPp cannot tell the two apart — a replacement answers the re-INVITE
+        # with a 200 just as a renegotiation does. The difference is the verb on
+        # the control channel, and a second `offer` means the media session was
+        # replaced: fresh ports, and any WebSocket bridge, tee or SIPREC fork on
+        # it torn down while the call carried on.
+        run: |
+          verbs="$(docker compose -f sipp/docker-compose.yaml --profile reoffer logs --no-log-prefix mock-siphon-rtp-reoffer \
+            | grep -oE '"command": ?"[a-z_]+"' | sed -E 's/"command": ?"//; s/"//' | grep -E '^(offer|reoffer)$' || true)"
+          offers="$(printf '%s\n' "$verbs" | grep -c '^offer$' || true)"
+          reoffers="$(printf '%s\n' "$verbs" | grep -c '^reoffer$' || true)"
+          echo "control verbs: offer=$offers reoffer=$reoffers"
+          test "$offers" -eq 1 || { echo "::error::expected 1 offer, got $offers — a re-INVITE replaced the media session"; exit 1; }
+          test "$reoffers" -ge 2 || { echo "::error::expected >=2 reoffers (hold + resume), got $reoffers"; exit 1; }
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-reoffer > siphon-reoffer.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs mock-siphon-rtp-reoffer > mock-siphon-rtp-reoffer.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile reoffer down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-reoffer-logs
+          path: |
+            siphon-reoffer.log
+            mock-siphon-rtp-reoffer.log
+
   # ── Cold transfer off a single-leg answered call ───────────────────────
   sipp-refer-single-leg:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **CI covers re-INVITE renegotiation on the `siphon-rtp` backend** (`--reoffer`).
+  The existing `--reinvite` mode runs the same hold/resume flow against
+  rtpengine, where a repeat `offer` on a live call-id *is* the re-offer — so it
+  cannot tell a renegotiation from a replacement, which is why the media session
+  being replaced on every re-INVITE went unseen. The mock engine now models the
+  distinction (an `offer` on a new call-id allocates a port, a repeat `offer`
+  replaces the call and allocates a *new* one, a `reoffer` renegotiates in place
+  and keeps it, an unknown call-id errors rather than implicitly creating, and a
+  codec change is refused the way the real engine refuses it), and the job
+  asserts the control verbs the engine actually received: exactly one `offer`
+  and a `reoffer` per re-INVITE. Verified against a reverted fix, where the mock
+  sees three offers and no re-offers — while SIPp still exits 0, which is why
+  the assertion is on the verbs and not on the call outcome.
+
 ### Fixed
 - **A proxied in-dialog request whose Request-URI addresses the proxy itself is
   now forwarded to the dialog's established peer instead of failing as a

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -35,6 +35,7 @@ RUN_RTPPROXY=false
 RUN_VOICE_AI=false
 RUN_REFER_SINGLE_LEG=false
 RUN_REINVITE=false
+RUN_REOFFER=false
 RUN_B2BUA=false
 RUN_B2BUA_AUTH=false
 RUN_B2BUA_INVITE_AUTH=false
@@ -63,6 +64,7 @@ for arg in "$@"; do
     --voice-ai)   RUN_VOICE_AI=true;   SELECTED_MODES+=("$arg") ;;
     --refer-single-leg) RUN_REFER_SINGLE_LEG=true; SELECTED_MODES+=("$arg") ;;
     --reinvite)   RUN_REINVITE=true;   SELECTED_MODES+=("$arg") ;;
+    --reoffer)    RUN_REOFFER=true;    SELECTED_MODES+=("$arg") ;;
     --b2bua)      RUN_B2BUA=true;      SELECTED_MODES+=("$arg") ;;
     --b2bua-auth) RUN_B2BUA_AUTH=true; SELECTED_MODES+=("$arg") ;;
     --b2bua-invite-auth) RUN_B2BUA_INVITE_AUTH=true; SELECTED_MODES+=("$arg") ;;
@@ -80,7 +82,7 @@ for arg in "$@"; do
       echo
       echo "Scenario modes (pick at most ONE per run):"
       echo "  --ipsec --charging --call --presence --rtpengine --rtpproxy --reinvite"
-      echo "  --voice-ai --refer-single-leg"
+      echo "  --voice-ai --refer-single-leg --reoffer"
       echo "  --b2bua --b2bua-auth --b2bua-invite-auth --gateway --auto100 --http-auth"
       echo "  --wedge --banscan"
       echo "  --security --rfc4475 --webrtc"
@@ -224,6 +226,40 @@ if [[ "$RUN_REINVITE" == true ]]; then
   # re-INVITE never completed.
   run_sipp docker compose -f "$COMPOSE_FILE" --profile reinvite --profile rtpengine up --abort-on-container-exit --exit-code-from sipp-reinvite-uac sipp-reinvite-uac sipp-reinvite-uas
   docker compose -f "$COMPOSE_FILE" --profile reinvite --profile rtpengine rm -sf sipp-reinvite-uac sipp-reinvite-uas 2>/dev/null || true
+fi
+
+# ── Step 8b: Re-INVITE renegotiation on the siphon-rtp backend (optional) ──
+if [[ "$RUN_REOFFER" == true ]]; then
+  echo "=== SIPp re-offer test (hold/resume renegotiates in place on siphon-rtp) ==="
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile reoffer run --rm sipp-reoffer-register
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile reoffer up \
+    --abort-on-container-exit --exit-code-from sipp-reoffer-uac sipp-reoffer-uac sipp-reoffer-uas
+
+  # The SIPp side alone cannot tell a renegotiation from a replacement — both
+  # answer the re-INVITE with a 200. What separates them is the verb siphon put
+  # on the control channel, so assert on what the engine actually received.
+  echo "--- asserting the control verbs the engine saw ---"
+  verbs="$(docker compose -f "$COMPOSE_FILE" --profile reoffer logs --no-log-prefix mock-siphon-rtp-reoffer 2>/dev/null \
+    | grep -oE '"command": ?"[a-z_]+"' | sed -E 's/"command": ?"//; s/"//' | grep -E '^(offer|reoffer)$' || true)"
+  offers="$(printf '%s\n' "$verbs" | grep -c '^offer$' || true)"
+  reoffers="$(printf '%s\n' "$verbs" | grep -c '^reoffer$' || true)"
+  echo "control verbs: offer=$offers reoffer=$reoffers"
+
+  if [[ "$offers" -ne 1 ]]; then
+    echo "FAIL: expected exactly 1 offer (the initial INVITE), got $offers." >&2
+    echo "      A second offer means a re-INVITE replaced the media session:" >&2
+    echo "      fresh ports, and any WebSocket bridge, tee or SIPREC fork gone." >&2
+    docker compose -f "$COMPOSE_FILE" --profile reoffer logs --no-log-prefix mock-siphon-rtp-reoffer >&2 || true
+    exit 1
+  fi
+  if [[ "$reoffers" -lt 2 ]]; then
+    echo "FAIL: expected at least 2 reoffers (hold + resume), got $reoffers." >&2
+    docker compose -f "$COMPOSE_FILE" --profile reoffer logs --no-log-prefix mock-siphon-rtp-reoffer >&2 || true
+    exit 1
+  fi
+  echo "OK: the re-INVITEs renegotiated in place; the media session was never replaced."
+
+  docker compose -f "$COMPOSE_FILE" --profile reoffer rm -sf sipp-reoffer-uac sipp-reoffer-uas 2>/dev/null || true
 fi
 
 # ── Step 9: B2BUA tests (optional) ──────────────────────────────────────────

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -4324,6 +4324,152 @@ services:
     profiles:
       - refer-single-leg
 
+  # ── Re-INVITE renegotiation on the siphon-rtp backend ─────────────────────
+  # Requires the "reoffer" profile.
+  #
+  # The same hold/resume flow the --reinvite mode runs, pointed at the native
+  # backend. That mode runs against rtpengine, where a repeat `offer` on a live
+  # call-id IS the re-offer — so it cannot tell a renegotiation from a
+  # replacement. siphon-rtp draws the line differently: a repeat offer frees the
+  # call and re-allocates, taking any WebSocket bridge, tee or SIPREC
+  # subscription with it. The mock models both, so a regression shows up twice:
+  # in the verb it logs and in the media port the caller is answered with.
+  #
+  # IP assignments:
+  #   172.20.0.109 — mock siphon-rtp control server
+  #   172.20.0.110 — siphon (proxy, media.backend: siphon-rtp)
+  #   172.20.0.112 — registration helper (bob), then the B-leg UAS
+  #   172.20.0.113 — A-leg UAC (INVITE, hold, resume, BYE)
+
+  mock-siphon-rtp-reoffer:
+    image: python:3.12-slim
+    container_name: mock-siphon-rtp-reoffer
+    volumes:
+      - ./siphon-rtp:/app:ro
+    working_dir: /app
+    command: ["python3", "mock_siphon_rtp.py"]
+    environment:
+      SIPHON_RTP_PORT: "8080"
+      MOCK_MEDIA_IP: "203.0.113.1"
+      MOCK_MEDIA_PORT: "30000"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.109
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket,struct,json; s=socket.create_connection(('127.0.0.1',8080),2); b=json.dumps({'id':1,'command':'ping'}).encode(); s.sendall(struct.pack('!I',len(b))+b); h=s.recv(4); n=struct.unpack('!I',h)[0]; d=s.recv(n); s.close(); exit(0 if b'pong' in d else 1)\""]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+    profiles:
+      - reoffer
+
+  siphon-reoffer:
+    build:
+      context: ..
+    container_name: siphon-reoffer-test
+    depends_on:
+      mock-siphon-rtp-reoffer:
+        condition: service_healthy
+    volumes:
+      - ./siphon-rtp/siphon-reoffer.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.110
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - reoffer
+
+  sipp-reoffer-register:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-reoffer:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        # Same address as the UAS below, and deliberately so: the registrar
+        # binds bob to the source address the REGISTER arrived from, so the
+        # contact only points at the UAS if they share an IP. They never run at
+        # the same time — the UAS waits for this to complete.
+        ipv4_address: 172.20.0.112
+    entrypoint:
+      - sipp
+      - "172.20.0.110:5060"
+      - -sf
+      - /sipp/scenarios/register.xml
+      - -s
+      - bob
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -timeout
+      - "20"
+      - -trace_err
+    profiles:
+      - reoffer
+
+  sipp-reoffer-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-reoffer-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.112
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/reinvite_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - reoffer
+
+  sipp-reoffer-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-reoffer:
+        condition: service_healthy
+      sipp-reoffer-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.113
+    entrypoint:
+      - sipp
+      - "172.20.0.110:5060"
+      - -sf
+      - /sipp/scenarios/reinvite_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - reoffer
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:

--- a/sipp/siphon-rtp/mock_siphon_rtp.py
+++ b/sipp/siphon-rtp/mock_siphon_rtp.py
@@ -15,7 +15,21 @@ SIPHON_RTP_BIN (see tests/integration/siphon_rtp_tests.rs) because CI does not
 build the engine.
 
 For offer / answer / answer_local it returns SDP with the c-line rewritten to
-MOCK_MEDIA_IP and the audio port to MOCK_MEDIA_PORT, simulating anchoring.
+MOCK_MEDIA_IP and the audio port to the one allocated for that call, simulating
+anchoring.
+
+Port allocation models the real engine's distinction between the two ways an SDP
+offer can arrive on a live call, which is the whole reason `reoffer` exists:
+
+  * `offer` on a NEW call-id allocates a port.
+  * `offer` on a LIVE call-id is a REPLACEMENT — the old call is freed and a
+    NEW port allocated, so a caller is handed an address it was never told
+    about and everything attached to the old ports is gone.
+  * `reoffer` on a live call-id renegotiates in place and returns the SAME
+    port. On an unknown call-id it is an error, never an implicit create.
+
+A test therefore sees a regression twice over: in the verb the mock logs, and in
+the media port the caller is answered with.
 
 Every command received is echoed to stdout as one JSON line, so a scenario can
 assert on what siphon actually sent — in particular that `profile.ws_uri` is
@@ -39,14 +53,14 @@ MOCK_MEDIA_PORT = os.environ.get("MOCK_MEDIA_PORT", "30000")
 HEADER = struct.Struct("!I")
 
 
-def rewrite_sdp(sdp: str) -> str:
-    """Point the SDP at the mock's media address, as an anchoring engine would."""
+def rewrite_sdp(sdp: str, port: int) -> str:
+    """Point the SDP at the mock's media address and this call's allocated port."""
     sdp = re.sub(r"c=IN IP4 [\d.]+", f"c=IN IP4 {MOCK_MEDIA_IP}", sdp)
-    sdp = re.sub(r"m=audio \d+", f"m=audio {MOCK_MEDIA_PORT}", sdp)
+    sdp = re.sub(r"m=audio \d+", f"m=audio {port}", sdp)
     return sdp
 
 
-def answer_sdp_for(offer: str) -> str:
+def answer_sdp_for(offer: str, port: int) -> str:
     """Synthesise a single-codec answer, the way answer_local does.
 
     RFC 3264 §6.1: the answer selects from the offered formats. Take the first
@@ -63,21 +77,83 @@ def answer_sdp_for(offer: str) -> str:
         "s=-\r\n"
         f"c=IN IP4 {MOCK_MEDIA_IP}\r\n"
         "t=0 0\r\n"
-        f"m=audio {MOCK_MEDIA_PORT} RTP/AVP {payload}\r\n"
+        f"m=audio {port} RTP/AVP {payload}\r\n"
         f"a=rtpmap:{payload} {codec}\r\n"
         "a=ptime:20\r\n"
     )
 
 
+# call-id -> {"port": int, "codec": str}. Guarded by `CALLS_LOCK` because the
+# server is threaded (one thread per control connection).
+CALLS: dict = {}
+CALLS_LOCK = threading.Lock()
+NEXT_PORT = [int(MOCK_MEDIA_PORT)]
+
+
+def allocate_port() -> int:
+    """Hand out the next even media port, as an engine allocating a pair does."""
+    port = NEXT_PORT[0]
+    NEXT_PORT[0] += 2
+    return port
+
+
+def primary_codec(sdp: str) -> str:
+    """The first codec name in the offer, for the codec-change refusal below."""
+    match = re.search(r"m=audio \d+ RTP/AVP ([\d ]+)", sdp)
+    payload = match.group(1).split()[0] if match else "0"
+    rtpmap = re.search(rf"a=rtpmap:{payload} ([^/\s]+)", sdp)
+    return rtpmap.group(1).upper() if rtpmap else f"PT{payload}"
+
+
 def handle_command(command: dict) -> dict:
     verb = command.get("command")
+    call_id = command.get("call_id", "")
     if verb == "ping":
         return {"result": "pong"}
-    if verb in ("offer", "answer"):
-        return {"result": "ok", "sdp": rewrite_sdp(command.get("sdp", ""))}
+    if verb == "offer":
+        sdp = command.get("sdp", "")
+        with CALLS_LOCK:
+            # A repeat offer on a live call-id is a replacement: fresh ports, and
+            # whatever was attached to the old ones is gone.
+            port = allocate_port()
+            CALLS[call_id] = {"port": port, "codec": primary_codec(sdp)}
+        return {"result": "ok", "sdp": rewrite_sdp(sdp, port)}
+    if verb == "reoffer":
+        sdp = command.get("sdp", "")
+        with CALLS_LOCK:
+            call = CALLS.get(call_id)
+            if call is None:
+                # Never an implicit create — that would hide the very bug a
+                # re-offer addressed to the wrong call-id causes.
+                return {"result": "error", "reason": f"unknown call-id {call_id!r}"}
+            offered = primary_codec(sdp)
+            if offered != call["codec"]:
+                # The real engine refuses this: changing the negotiated codec
+                # needs a pipeline rebuild it will not do on a live call.
+                return {
+                    "result": "error",
+                    "reason": (
+                        f"re-offer changes the negotiated codec ({call['codec']} -> {offered}); "
+                        "not supported on a live call - replace it with a fresh offer instead"
+                    ),
+                }
+            port = call["port"]
+        return {"result": "ok", "sdp": rewrite_sdp(sdp, port)}
+    if verb == "answer":
+        with CALLS_LOCK:
+            call = CALLS.get(call_id)
+            port = call["port"] if call else allocate_port()
+        return {"result": "ok", "sdp": rewrite_sdp(command.get("sdp", ""), port)}
     if verb == "answer_local":
-        return {"result": "ok", "sdp": answer_sdp_for(command.get("sdp", ""))}
-    if verb in ("delete", "attach_ws_tee", "detach_ws_tee", "play_media", "stop_media"):
+        with CALLS_LOCK:
+            port = allocate_port()
+            CALLS[call_id] = {"port": port, "codec": primary_codec(command.get("sdp", ""))}
+        return {"result": "ok", "sdp": answer_sdp_for(command.get("sdp", ""), port)}
+    if verb == "delete":
+        with CALLS_LOCK:
+            CALLS.pop(call_id, None)
+        return {"result": "ok"}
+    if verb in ("attach_ws_tee", "detach_ws_tee", "play_media", "stop_media"):
         return {"result": "ok"}
     # Unknown verbs are an explicit error, never a silent ok — a mock that
     # answers ok to everything hides exactly the bugs this exists to catch.

--- a/sipp/siphon-rtp/siphon-reoffer.yaml
+++ b/sipp/siphon-rtp/siphon-reoffer.yaml
@@ -1,0 +1,48 @@
+# siphon config for the re-INVITE renegotiation test on the siphon-rtp backend.
+#
+# Used with: sipp/docker-compose.yaml (reoffer profile)
+# Script:    examples/proxy_rtpengine.py — its in-dialog branch calls
+#            rtpengine.offer() on a re-INVITE, which is the script-facing site
+#            that must go out as `reoffer` once the call is anchored.
+#
+# The sibling rtpengine-backed run (sipp/rtpengine/siphon-rtpengine.yaml, the
+# --reinvite mode) exercises the same scenario against a backend where a repeat
+# offer IS the re-offer, so it cannot see the difference. This one can.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+advertised_address: "172.20.0.110"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.110"
+    - "127.0.0.1"
+
+script:
+  path: "examples/proxy_rtpengine.py"
+  reload: auto
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "172.20.0.109:8080"
+    timeout_ms: 2000
+
+log:
+  level: debug
+  format: pretty


### PR DESCRIPTION
The test that would have caught #187. Nothing in CI drove the `siphon-rtp` backend through a
mid-dialog offer at all.

## Why the existing coverage was blind to it

`--reinvite` runs the same hold/resume scenario, but against **rtpengine** — where a repeat `offer`
on a live call-id *is* the re-offer (it's how `rtpengine_manage()` has always done hold). So it
cannot distinguish a renegotiation from a replacement. The one backend where the difference is
observable had no re-INVITE coverage.

## What the mock now models

It answered `offer` with a fixed port and didn't know `reoffer` at all (it would have returned
`error: unsupported verb`). It now mirrors the real engine:

| | |
|---|---|
| `offer`, new call-id | allocates a port |
| `offer`, **live** call-id | **replacement** — frees the call, allocates a **new** port |
| `reoffer`, live call-id | renegotiates in place, **same** port |
| `reoffer`, unknown call-id | error — never an implicit create |
| `reoffer`, changed codec | refused, in the engine's own wording, so the replacement fallback is exercisable |

So a regression shows up twice: in the verb the mock logs, and in the media port the caller is
answered with.

## The assertion

SIPp cannot tell the two apart — a replacement answers the re-INVITE with a 200 exactly as a
renegotiation does. So the job asserts the **control verbs the engine actually received**: exactly
one `offer`, and a `reoffer` per re-INVITE.

## Mutation check

Routing the backend verb back to `offer`:

```
MUTANT: offer=3 reoffer=0   → assertion FAILS
FIXED:  offer=1 reoffer=2   → assertion PASSES
```

**The UAC exits 0 in both cases.** That is the whole point of asserting on the verbs rather than
the call outcome — the call looks fine while its media session is being torn down and re-allocated
underneath it, taking any WebSocket bridge, tee or SIPREC subscription with it.

Both runs done live against the built stack, with the fix reverted and restored.

## Note

This depends on #191 for the resume leg to complete at all — before that fix, the second re-INVITE
was 482'd as a relay loop and only one `reoffer` was ever observable.
