### PR TITLE
feat(ro): anchor the chargeable clock at the answer, and report it with a CCR-UPDATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,35 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Changed
+- **Ro no longer bills ring time.** The usage clock was stamped at
+  CCR-INITIAL — which `call.ro_authorize()` fires *before* any carrier is
+  dialled — and every reported figure was measured from there, so ring time was
+  charged and a call that was never answered could report a full grant of used
+  seconds. With two carriers at `timeout_secs: 12`, 24 seconds of a 30-second
+  grant could be gone before the callee picked up, and it got worse the longer
+  the carrier list. The clock now starts at the 200 OK, which is what TS 32.260
+  §5 means by chargeable duration. **This changes billed duration on upgrade for
+  any existing Ro deployment**; set the new `ro.charge_from: invite` to keep the
+  previous behaviour. Only the clock moved — the reservation still happens at
+  INVITE, since reserve-before-connect is the point of the prepaid gate.
+
+### Added
+- **A CCR-UPDATE at answer, carrying `Time-Stamps`** (TS 32.299 §7.2.97). There
+  was no credit-control request at the 200 OK, so an OCS could not tell when
+  charging actually started and a Diameter-to-HTTP bridge had nothing to
+  translate into a connect event. `SIP-Request-Timestamp` is the INVITE that
+  triggered the reservation, `SIP-Response-Timestamp` is the answer;
+  `ImsChargingData.response_timestamp` already existed and was never set,
+  because at CCR-INITIAL there is no answer yet. Idempotent — a retransmitted
+  200 OK neither restarts the clock nor sends a second record.
+- **`ro.charge_from`** (`answer` | `invite`, default `answer`) — see above.
+
 ### Fixed
+- **Ro usage is reported as a delta, not per-interval.** A CCR-UPDATE that fails
+  now leaves its seconds unreported, so the next record — or the
+  CCR-TERMINATION — still covers them exactly once, instead of the interval
+  being lost.
 - **Ro CCR-UPDATE and CCR-TERMINATION now carry Service-Information.** Both were
   built with `ims_data: None`, so only the Session-Id, the subscriber and the
   units reached the OCS. Nothing after the initial request named the carrier,

--- a/docs/cookbook/online-charging-ocs.md
+++ b/docs/cookbook/online-charging-ocs.md
@@ -54,6 +54,8 @@ ro:
   sms_service_context_id: "32274@3gpp.org"    # SMS / RCS
   node_functionality: as       # AS/MMTel-AS is the standard Ro trigger
   charge: orig                 # orig | term | both
+  charge_from: answer          # answer (default) | invite — where the chargeable
+                               # clock starts. See "What gets billed" below.
   on_ocs_failure: terminate    # fail-closed; `continue` = fail-open (allow, uncharged)
   credit_denied_status: 402    # SIP status a script returns when denied at setup
   rating_group: 100            # optional; its presence selects the MSCC (multi-service) shape
@@ -192,6 +194,38 @@ curl -s http://cgrates:2080/jsonrpc -d '{"method":"ApierV2.SetBalance",
   "params":[{"Tenant":"cgrates.org","Account":"sip:alice@ims.example.org",
   "BalanceType":"*voice","Value":30000000000}],"id":1}'
 ```
+
+## What gets billed
+
+`charge_from` decides where the chargeable clock starts.
+
+| | Clock starts | Ring time billed? |
+|---|---|---|
+| `answer` *(default)* | the 200 OK | no |
+| `invite` | the CCR-INITIAL | yes |
+
+`answer` is what TS 32.260 §5 means by chargeable duration: a call that rings
+and is never answered has none, and reports `0` used seconds.
+
+`invite` counts from the reservation — which happens *before* any carrier is
+dialled — so ring time is billed. With two carriers at `timeout_secs: 12`, 24
+seconds of a 30-second grant can be gone before the callee picks up, and it gets
+worse the longer the carrier list. This was the only behaviour before
+`charge_from` existed; it is kept for anyone who depended on it.
+
+Only the clock moves. The reservation still happens at INVITE either way,
+because reserve-before-connect is the whole point of the prepaid gate.
+
+When the call is answered siphon sends a CCR-UPDATE carrying `Time-Stamps`
+(TS 32.299 §7.2.97) — `SIP-Request-Timestamp` is the INVITE that triggered the
+reservation, `SIP-Response-Timestamp` is the answer — so the OCS can see when
+charging began, and a Diameter-to-HTTP bridge has a connect event to translate.
+It is idempotent: a retransmitted 200 OK neither restarts the clock nor sends a
+second record.
+
+Usage is reported as a delta against what the OCS has already acknowledged, so a
+CCR-UPDATE that fails leaves its seconds unreported and the next record — or the
+CCR-TERMINATION — still covers them exactly once.
 
 ## Why a call ended
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2926,6 +2926,19 @@ pub struct RoConfig {
     /// Which party to charge: ``"orig"`` | ``"term"`` | ``"both"``. Default ``"orig"``.
     #[serde(default = "default_ro_charge")]
     pub charge: String,
+    /// When the chargeable clock starts: ``"answer"`` | ``"invite"``.
+    /// Default ``"answer"``.
+    ///
+    /// ``answer`` counts reported usage from the 200 OK, which is what
+    /// TS 32.260 means by chargeable duration. ``invite`` counts from the
+    /// CCR-INITIAL — i.e. from the reservation, before any carrier was dialled
+    /// — so ring time is billed. That was the only behaviour before this
+    /// setting existed; it is kept for anyone who depended on it.
+    ///
+    /// Only the clock moves. The reservation still happens at INVITE, because
+    /// reserve-before-connect is the entire point of the prepaid gate.
+    #[serde(default = "default_ro_charge_from")]
+    pub charge_from: String,
     /// One-shot IEC charging on SIP MESSAGE (SMS/RCS). Default: true.
     #[serde(default = "default_true")]
     pub charge_message: bool,
@@ -2956,6 +2969,7 @@ impl Default for RoConfig {
             service_context_id: default_rf_service_context_id(),
             sms_service_context_id: default_ro_sms_service_context_id(),
             charge: default_ro_charge(),
+            charge_from: default_ro_charge_from(),
             charge_message: true,
             on_ocs_failure: default_ro_ocs_failure(),
             credit_denied_status: default_ro_denied_status(),
@@ -2969,6 +2983,12 @@ impl Default for RoConfig {
 fn default_ro_interval() -> u32 { 30 }
 fn default_ro_node_functionality() -> String { "pcscf".to_string() }
 fn default_ro_sms_service_context_id() -> String { "32274@3gpp.org".to_string() }
+/// Chargeable duration runs from the answer (TS 32.260 §5): a call that rings
+/// and is never answered has no chargeable duration at all.
+fn default_ro_charge_from() -> String {
+    "answer".to_string()
+}
+
 fn default_ro_charge() -> String { "orig".to_string() }
 fn default_ro_ocs_failure() -> String { "terminate".to_string() }
 fn default_ro_denied_status() -> u16 { 402 }

--- a/src/diameter/ro_service.rs
+++ b/src/diameter/ro_service.rs
@@ -41,6 +41,35 @@ const DIAMETER_CREDIT_LIMIT_REACHED: u32 = 4012;
 /// Final-Unit-Action TERMINATE (RFC 8506 §8.35).
 const FINAL_UNIT_ACTION_TERMINATE: u32 = 0;
 
+/// When the chargeable clock starts (`ro.charge_from`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChargeFrom {
+    /// From the 200 OK. TS 32.260 §5: chargeable duration is the answered
+    /// duration, so a call that rings and is never answered has none.
+    Answer,
+    /// From the CCR-INITIAL — the reservation, before any carrier was dialled —
+    /// so ring time is billed. The behaviour before `charge_from` existed.
+    Invite,
+}
+
+impl ChargeFrom {
+    /// Parse the config string. Anything unrecognised falls back to `Answer`
+    /// with a warning rather than silently billing ring time.
+    fn from_config(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "invite" => ChargeFrom::Invite,
+            "answer" => ChargeFrom::Answer,
+            other => {
+                warn!(
+                    charge_from = %other,
+                    "ro: unknown charge_from, using \"answer\""
+                );
+                ChargeFrom::Answer
+            }
+        }
+    }
+}
+
 /// IMS-Information `Cause-Code` (TS 32.299 §7.2.35) for a call siphon cut
 /// because the OCS refused further credit.
 ///
@@ -120,7 +149,19 @@ struct CcSessionInner {
     /// A `std::sync::Mutex` rather than a `tokio` one: it is only ever held to
     /// clone the value out, never across an await.
     ims_data: std::sync::Mutex<ImsChargingData>,
+    /// Where the chargeable clock starts for this session.
+    charge_from: ChargeFrom,
+    /// When the reservation was made (CCR-INITIAL). Always the session's own
+    /// age, whatever `charge_from` says — the max-lifetime backstop measures
+    /// from here, because an abandoned reservation has to be released whether
+    /// or not the call was ever answered.
     started_at: Instant,
+    /// Wall-clock instant of the same moment, for `SIP-Request-Timestamp`
+    /// (TS 32.299 §7.2.183) — `Instant` is monotonic and cannot be formatted
+    /// as a date.
+    requested_at: std::time::SystemTime,
+    /// Set once when the call is answered. `None` while it is still ringing.
+    answered_at: std::sync::Mutex<Option<Instant>>,
     /// The OCS's first-grant CC-Time (seconds) — surfaced to the script gate as
     /// `granted_time` so it can log / decide on the reserved quota.
     initial_grant: u32,
@@ -177,6 +218,71 @@ impl CcCreditSession {
         Some(data)
     }
 
+    /// Seconds of *chargeable* time elapsed so far.
+    ///
+    /// Under `charge_from: answer` this is zero until the call is answered and
+    /// counts from the 200 OK thereafter — so ring time is never billed, and a
+    /// call that is never answered reports nothing. Under `charge_from: invite`
+    /// it is the whole session age, the pre-`charge_from` behaviour.
+    fn chargeable_secs(&self) -> u32 {
+        match self.inner.charge_from {
+            ChargeFrom::Invite => self.inner.started_at.elapsed().as_secs() as u32,
+            ChargeFrom::Answer => match self.answered_at() {
+                Some(answered_at) => answered_at.elapsed().as_secs() as u32,
+                None => 0,
+            },
+        }
+    }
+
+    fn answered_at(&self) -> Option<Instant> {
+        match self.inner.answered_at.lock() {
+            Ok(guard) => *guard,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
+    }
+
+    /// Usage not yet reported to the OCS, and therefore what the next
+    /// Used-Service-Unit must carry (RFC 8506 §5.6).
+    ///
+    /// Reporting the delta rather than the interval just slept also means a
+    /// CCR-UPDATE that fails leaves its seconds unreported, so the next
+    /// successful report — or the CCR-TERMINATION — still covers them exactly
+    /// once.
+    fn unreported_secs(&self) -> u32 {
+        self.chargeable_secs()
+            .saturating_sub(self.inner.reported_secs.load(Ordering::Relaxed))
+    }
+
+    /// Mark the call answered, starting the chargeable clock under
+    /// `charge_from: answer`. Idempotent — a retransmitted 200 OK must not
+    /// restart it.
+    fn mark_answered(&self) -> bool {
+        let mut guard = match self.inner.answered_at.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if guard.is_some() {
+            return false;
+        }
+        *guard = Some(Instant::now());
+        true
+    }
+
+    /// The `ImsChargingData` for the answer-time CCR-UPDATE, carrying the real
+    /// `Time-Stamps` pair: the INVITE that triggered the reservation, and the
+    /// answer now.
+    fn answer_charging_data(&self) -> Option<ImsChargingData> {
+        let mut data = match self.inner.ims_data.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        };
+        data.sip_method = Some("INVITE".to_string());
+        data.cause_code = None;
+        data.request_timestamp = Some(self.inner.requested_at);
+        data.response_timestamp = Some(std::time::SystemTime::now());
+        Some(data)
+    }
+
     /// Record the carrier that actually carried the call, as
     /// `Outgoing-Trunk-Group-Id` (TS 32.299 §7.2.71).
     ///
@@ -204,6 +310,9 @@ pub struct RoChargingService {
     manager: Arc<DiameterManager>,
     config: RoConfig,
     node_functionality: Option<NodeFunctionality>,
+    /// Resolved `ro.charge_from`, parsed once at construction rather than per
+    /// call.
+    charge_from: ChargeFrom,
     active_sessions: Arc<AtomicUsize>,
     teardown_hook: StdMutex<Option<RoTeardownHook>>,
 }
@@ -217,10 +326,12 @@ impl RoChargingService {
                 "ro: unrecognized node_functionality, will be omitted from CCRs"
             );
         }
+        let charge_from = ChargeFrom::from_config(&config.charge_from);
         Arc::new(Self {
             manager,
             config,
             node_functionality,
+            charge_from,
             active_sessions: Arc::new(AtomicUsize::new(0)),
             teardown_hook: StdMutex::new(None),
         })
@@ -391,7 +502,10 @@ impl RoChargingService {
                 service_identifier: self.config.service_identifier,
                 requested_seconds: self.config.requested_seconds,
                 ims_data: std::sync::Mutex::new(ims_data),
+                charge_from: self.charge_from,
                 started_at: Instant::now(),
+                requested_at: std::time::SystemTime::now(),
+                answered_at: std::sync::Mutex::new(None),
                 initial_grant: grant_secs,
                 reported_secs: AtomicU32::new(0),
             }),
@@ -465,6 +579,87 @@ impl RoChargingService {
         }
     }
 
+    /// Report that the call was answered: start the chargeable clock (under
+    /// `charge_from: answer`) and tell the OCS, with a CCR-UPDATE carrying
+    /// `Time-Stamps` (TS 32.299 §7.2.97).
+    ///
+    /// Without this there was no credit-control request at the 200 OK at all,
+    /// so an OCS could not tell when charging actually started and a
+    /// Diameter-to-HTTP bridge had nothing to translate into a connect event.
+    /// TS 32.299 has the place for it already: `SIP-Request-Timestamp` (834) is
+    /// when the INVITE triggered the reservation and `SIP-Response-Timestamp`
+    /// (835) is the answer — `ImsChargingData.response_timestamp` existed and
+    /// was never set, because at CCR-INITIAL there is no answer yet.
+    ///
+    /// Idempotent: a retransmitted 200 OK does not restart the clock or send a
+    /// second request. A no-op on a session already stopped.
+    pub async fn report_answer(&self, session: &CcCreditSession) {
+        if session.inner.stopped.load(Ordering::Relaxed) != 0 {
+            return;
+        }
+        if !session.mark_answered() {
+            return;
+        }
+
+        // Whatever is chargeable at this instant — zero under
+        // `charge_from: answer` (the clock has only just started), the ring
+        // time under `charge_from: invite`.
+        let unreported = session.unreported_secs();
+        let used = ServiceUnit {
+            time_seconds: Some(unreported),
+            ..Default::default()
+        };
+        let requested = (session.inner.requested_seconds > 0).then(|| ServiceUnit {
+            time_seconds: Some(session.inner.requested_seconds),
+            ..Default::default()
+        });
+        let ims_data = session.answer_charging_data();
+        let record_number = session.next_cc_request_number();
+        let params = CreditControlParams {
+            request_type: CcRequestType::Update,
+            request_number: record_number,
+            subscriber: &session.inner.subscriber,
+            service_context_id: &session.inner.service_context_id,
+            session_id: Some(&session.inner.session_id),
+            ims_data: ims_data.as_ref(),
+            sms_data: None,
+            requested_units: requested.as_ref(),
+            used_units: Some(&used),
+            rating_group: session.inner.rating_group,
+            service_identifier: session.inner.service_identifier,
+            requested_action: None,
+            multiple_services_indicator: false,
+        };
+
+        match ro::send_ccr(&session.inner.peer, &params).await {
+            Ok(answer) => {
+                session
+                    .inner
+                    .last_result_code
+                    .store(answer.result_code, Ordering::Relaxed);
+                if unreported > 0 {
+                    session
+                        .inner
+                        .reported_secs
+                        .fetch_add(unreported, Ordering::Relaxed);
+                }
+                info!(
+                    session_id = %session.inner.session_id,
+                    result_code = answer.result_code,
+                    "ro: CCR-UPDATE sent at answer, charging clock started"
+                );
+            }
+            // The clock has already started locally, so a failed report costs
+            // one record, not the call's chargeable duration — the seconds stay
+            // unreported and the next CCR covers them.
+            Err(error) => warn!(
+                session_id = %session.inner.session_id,
+                error = %error,
+                "ro: CCR-UPDATE at answer failed"
+            ),
+        }
+    }
+
     /// Send CCR-TERMINATION for a session (BYE path). Idempotent — a session
     /// already stopped by the enforced-teardown path is a no-op.
     /// `cause_code` is the IMS-Information `Cause-Code` for the record
@@ -487,10 +682,8 @@ impl RoChargingService {
     /// (`elapsed - already-reported`, RFC 8506 §5.6). Does not touch the stopped
     /// flag (callers use `claim_stop` first).
     async fn send_terminate(&self, session: &CcCreditSession, cause_code: Option<i32>) {
-        let elapsed = session.inner.started_at.elapsed().as_secs() as u32;
-        let reported = session.inner.reported_secs.load(Ordering::Relaxed);
         let used = ServiceUnit {
-            time_seconds: Some(elapsed.saturating_sub(reported)),
+            time_seconds: Some(session.unreported_secs()),
             ..Default::default()
         };
         let record_number = session.next_cc_request_number();
@@ -587,8 +780,12 @@ impl RoChargingService {
                 return;
             }
 
+            // Report what is chargeable and not yet reported, not the interval
+            // just slept: under `charge_from: answer` the intervals before the
+            // 200 OK are ring time and carry zero.
+            let unreported = session.unreported_secs();
             let used = ServiceUnit {
-                time_seconds: Some(sleep_secs),
+                time_seconds: Some(unreported),
                 ..Default::default()
             };
             let requested = (session.inner.requested_seconds > 0).then(|| ServiceUnit {
@@ -618,13 +815,13 @@ impl RoChargingService {
 
             let result = ro::send_ccr(&session.inner.peer, &params).await;
             if result.is_ok() {
-                // The Used-Service-Unit for this interval was answered by the
-                // OCS, so it's now reported — the eventual CCR-TERMINATION
-                // reports only what happened after it (avoids double-counting).
+                // The Used-Service-Unit was answered by the OCS, so it is now
+                // reported — the eventual CCR-TERMINATION reports only what
+                // happened after it (avoids double-counting).
                 session
                     .inner
                     .reported_secs
-                    .fetch_add(sleep_secs, Ordering::Relaxed);
+                    .fetch_add(unreported, Ordering::Relaxed);
             }
             match result {
                 Ok(answer) if answer.is_success() => {
@@ -1336,5 +1533,233 @@ mod tests {
         // `None` means "no cause to report" and must not be encoded as a 0 that
         // claims the call ended normally.
         assert_eq!(cause_code_on_the_wire(None).await, None);
+    }
+    // -----------------------------------------------------------------------
+    // charge_from: the chargeable clock, and the answer-time CCR-UPDATE
+    // -----------------------------------------------------------------------
+
+    fn config_charging_from(charge_from: &str) -> RoConfig {
+        RoConfig {
+            charge_from: charge_from.to_string(),
+            ..enabled_config()
+        }
+    }
+
+    async fn granted_session(
+        service: &Arc<RoChargingService>,
+    ) -> CcCreditSession {
+        match service
+            .authorize_call(
+                SubscriberId::msisdn("+310000000001"),
+                call_charging_data(),
+                "c1".to_string(),
+            )
+            .await
+        {
+            ChargeDecision::Granted(Some(session)) => session,
+            other => panic!("expected Granted, got {}", decision_label(&other)),
+        }
+    }
+
+    #[test]
+    fn charge_from_parses_and_defaults_to_answer() {
+        assert_eq!(ChargeFrom::from_config("answer"), ChargeFrom::Answer);
+        assert_eq!(ChargeFrom::from_config("invite"), ChargeFrom::Invite);
+        assert_eq!(ChargeFrom::from_config("ANSWER"), ChargeFrom::Answer);
+        assert_eq!(ChargeFrom::from_config(" invite "), ChargeFrom::Invite);
+        // An unrecognised value must not silently start billing ring time.
+        assert_eq!(ChargeFrom::from_config("nonsense"), ChargeFrom::Answer);
+        assert_eq!(ChargeFrom::from_config(""), ChargeFrom::Answer);
+        // And the config default is the spec-correct one.
+        assert_eq!(
+            ChargeFrom::from_config(&RoConfig::default().charge_from),
+            ChargeFrom::Answer
+        );
+    }
+
+    #[tokio::test]
+    async fn a_call_that_rings_and_is_never_answered_reports_zero_usage() {
+        // The defect this closes: `started_at` was stamped at the reservation,
+        // before any carrier was dialled, and every reported figure was
+        // `started_at.elapsed()`. With two carriers at timeout_secs: 12, 24
+        // seconds of a 30-second grant could be gone before the callee picked
+        // up — and an unanswered call could report a full grant of used time.
+        let (manager, _rx, captured) = mock_ocs_manager(2001, Some(30), 2001, None).await;
+        let service = RoChargingService::new(manager, config_charging_from("answer"));
+        let session = granted_session(&service).await;
+
+        // Ring for a while. `report_answer` is never called.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert_eq!(session.chargeable_secs(), 0, "ring time is not chargeable");
+
+        service.terminate_call(&session, Some(0)).await;
+
+        let terminate = ccr_of_type(&captured.lock().unwrap().clone(), 3);
+        assert_eq!(
+            terminate
+                .get("Multiple-Services-Credit-Control")
+                .and_then(|m| m.get("Used-Service-Unit"))
+                .and_then(|u| u.get("CC-Time"))
+                .and_then(|v| v.as_u64()),
+            Some(0),
+            "an unanswered call has no chargeable duration",
+        );
+    }
+
+    #[tokio::test]
+    async fn charge_from_answer_counts_from_the_answer_not_the_reservation() {
+        let (manager, _rx, captured) = mock_ocs_manager(2001, Some(30), 2001, None).await;
+        let service = RoChargingService::new(manager, config_charging_from("answer"));
+        let session = granted_session(&service).await;
+
+        // Ring, then answer, then talk.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        service.report_answer(&session).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let chargeable = session.chargeable_secs();
+        assert!(
+            chargeable <= 1,
+            "only the answered span is chargeable, got {chargeable}s after 2s ringing + 1s talking",
+        );
+
+        service.terminate_call(&session, Some(0)).await;
+        let terminate = ccr_of_type(&captured.lock().unwrap().clone(), 3);
+        let reported = terminate
+            .get("Multiple-Services-Credit-Control")
+            .and_then(|m| m.get("Used-Service-Unit"))
+            .and_then(|u| u.get("CC-Time"))
+            .and_then(|v| v.as_u64())
+            .expect("CCR-T reports a CC-Time");
+        assert!(reported <= 1, "reported {reported}s, expected only the talk time");
+    }
+
+    #[tokio::test]
+    async fn charge_from_invite_preserves_the_previous_behaviour() {
+        let (manager, _rx, _captured) = mock_ocs_manager(2001, Some(30), 2001, None).await;
+        let service = RoChargingService::new(manager, config_charging_from("invite"));
+        let session = granted_session(&service).await;
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert!(
+            session.chargeable_secs() >= 2,
+            "charge_from: invite bills from the reservation, ring time included",
+        );
+
+        service.terminate_call(&session, Some(0)).await;
+    }
+
+    #[tokio::test]
+    async fn answer_sends_a_ccr_update_carrying_both_timestamps() {
+        // TS 32.299 §7.2.97: Time-Stamps with SIP-Request-Timestamp (the
+        // INVITE) and SIP-Response-Timestamp (the answer). Without a request at
+        // the 200 OK an OCS cannot tell when charging started at all.
+        let (manager, _rx, captured) = mock_ocs_manager(2001, Some(300), 2001, None).await;
+        let service = RoChargingService::new(manager, config_charging_from("answer"));
+        let session = granted_session(&service).await;
+
+        service.report_answer(&session).await;
+
+        let ccrs = captured.lock().unwrap().clone();
+        let update = ccr_of_type(&ccrs, 2);
+        let timestamps = ims_information(&update)
+            .and_then(|i| i.get("Time-Stamps"))
+            .expect("the answer CCR-UPDATE must carry Time-Stamps");
+
+        assert!(
+            timestamps.get("SIP-Request-Timestamp").is_some(),
+            "SIP-Request-Timestamp missing: {timestamps}",
+        );
+        assert!(
+            timestamps.get("SIP-Response-Timestamp").is_some(),
+            "SIP-Response-Timestamp missing: {timestamps}",
+        );
+
+        service.terminate_call(&session, Some(0)).await;
+    }
+
+    #[tokio::test]
+    async fn a_retransmitted_answer_neither_restarts_the_clock_nor_resends() {
+        let (manager, _rx, captured) = mock_ocs_manager(2001, Some(300), 2001, None).await;
+        let service = RoChargingService::new(manager, config_charging_from("answer"));
+        let session = granted_session(&service).await;
+
+        service.report_answer(&session).await;
+        let first = session.answered_at();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        service.report_answer(&session).await;
+        service.report_answer(&session).await;
+
+        assert_eq!(
+            session.answered_at(),
+            first,
+            "a retransmitted 200 OK must not restart the chargeable clock",
+        );
+        let updates = captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|c| c.get("CC-Request-Type").and_then(|v| v.as_u64()) == Some(2))
+            .count();
+        assert_eq!(updates, 1, "exactly one answer CCR-UPDATE, got {updates}");
+
+        service.terminate_call(&session, Some(0)).await;
+    }
+
+    #[tokio::test]
+    async fn answer_on_an_already_stopped_session_is_a_no_op() {
+        // A 2xx racing a teardown must not reopen charging on a closed session.
+        let (manager, _rx, captured) = mock_ocs_manager(2001, Some(300), 2001, None).await;
+        let service = RoChargingService::new(manager, config_charging_from("answer"));
+        let session = granted_session(&service).await;
+
+        service.terminate_call(&session, Some(0)).await;
+        service.report_answer(&session).await;
+
+        let updates = captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|c| c.get("CC-Request-Type").and_then(|v| v.as_u64()) == Some(2))
+            .count();
+        assert_eq!(updates, 0, "no CCR-UPDATE after the session was stopped");
+    }
+
+    #[tokio::test]
+    async fn reported_usage_is_never_double_counted_across_update_and_terminate() {
+        // Usage is reported as a delta against what the OCS has already
+        // acknowledged, so an interval reported by a CCR-UPDATE must not appear
+        // again in the CCR-TERMINATION.
+        let (manager, _rx, captured) = mock_ocs_manager(2001, Some(1), 2001, None).await;
+        let service = RoChargingService::new(manager, config_charging_from("answer"));
+        let session = granted_session(&service).await;
+        service.report_answer(&session).await;
+
+        // Past one re-auth interval (floored at MIN_REAUTH_SECS).
+        tokio::time::sleep(Duration::from_secs(MIN_REAUTH_SECS as u64 + 2)).await;
+        let total_chargeable = session.chargeable_secs();
+        service.terminate_call(&session, Some(0)).await;
+
+        let ccrs = captured.lock().unwrap().clone();
+        let sum: u64 = ccrs
+            .iter()
+            .filter(|c| {
+                matches!(
+                    c.get("CC-Request-Type").and_then(|v| v.as_u64()),
+                    Some(2) | Some(3)
+                )
+            })
+            .filter_map(|c| {
+                c.get("Multiple-Services-Credit-Control")
+                    .and_then(|m| m.get("Used-Service-Unit"))
+                    .and_then(|u| u.get("CC-Time"))
+                    .and_then(|v| v.as_u64())
+            })
+            .sum();
+
+        assert!(
+            sum <= total_chargeable as u64 + 1,
+            "reported {sum}s across all records but only {total_chargeable}s was chargeable",
+        );
     }
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -10415,6 +10415,31 @@ fn ro_stamp_winning_carrier(state: &DispatcherState, internal_call_id: &str, car
     }
 }
 
+/// Report the answer on a B2BUA call's Ro session: start the chargeable clock
+/// and send the answer-time CCR-UPDATE (`Time-Stamps`, TS 32.299 §7.2.97).
+///
+/// Fire-and-forget, like every other charging spawn — the SIP path must not
+/// wait on the OCS. No-op when Ro is off or the call holds no reservation, and
+/// idempotent on a retransmitted 200 OK.
+fn spawn_ro_b2bua_answer(state: &DispatcherState, internal_call_id: &str) {
+    if state.ro_charger.is_none() {
+        return;
+    }
+    let Some(charger) = state.ro_charger.as_ref().map(Arc::clone) else {
+        return;
+    };
+    let Some(session) = state
+        .ro_sessions
+        .get(&ro_b2bua_key(internal_call_id))
+        .map(|entry| entry.clone())
+    else {
+        return;
+    };
+    tokio::spawn(async move {
+        charger.report_answer(&session).await;
+    });
+}
+
 /// Send CCR-TERMINATION for a B2BUA call's Ro session on BYE / teardown.
 ///
 /// `cause_code` is the IMS-Information `Cause-Code` for the record
@@ -15147,10 +15172,14 @@ fn handle_b2bua_response(
         if let Some(invite_arc) = &a_leg_invite {
             spawn_rf_b2bua_start(state, call_id, invite_arc);
         }
-        // Ro is NOT started here: prepaid reserve-before-connect means the
-        // CCR-INITIAL already fired in `@b2bua.on_invite` via `call.ro_authorize()`
-        // (before the B-leg was dialed). The re-auth loop it armed keeps running;
-        // there is nothing to do on answer.
+        // Ro is not *started* here — prepaid reserve-before-connect means the
+        // CCR-INITIAL already fired in `@b2bua.on_invite` via
+        // `call.ro_authorize()`, before the B-leg was dialed, and the re-auth
+        // loop it armed keeps running. But the answer is what starts the
+        // chargeable clock (TS 32.260 §5), so report it: a CCR-UPDATE carrying
+        // Time-Stamps tells the OCS when charging actually began, and under
+        // `ro.charge_from: answer` it is also what stops ring time being billed.
+        spawn_ro_b2bua_answer(state, call_id);
 
         // Wrap the 200 OK in Arc<Mutex<>> so Python handlers can modify SDP in-place
         let response_arc = Arc::new(std::sync::Mutex::new(message.clone()));


### PR DESCRIPTION
> Stacked on #195 — base it on `main` once that merges. The diff against #195 is the two commits' worth here.

## Ring time was billed

`started_at: Instant::now()` was stamped in `authorize_call`, which the script calls **before dialling any carrier**, and every reported figure was `started_at.elapsed()`.

With two carriers at `timeout_secs: 12`, 24 seconds of a 30-second grant can be gone before the callee picks up — and it gets worse the longer the carrier list. A call that never connected could report a full grant of used seconds.

New `ro.charge_from`:

| | Clock starts | Ring time billed? |
|---|---|---|
| `answer` *(default)* | the 200 OK | no |
| `invite` | the CCR-INITIAL | yes |

`answer` is what TS 32.260 §5 means by chargeable duration.

**This changes billed duration on upgrade for any existing Ro deployment.** It is a defect being fixed rather than a preference, so the spec-correct value is the default and `invite` is named in the CHANGELOG as the opt-out. Flagging it explicitly because it is a billing change.

Only the clock moved. The reservation still happens at INVITE — reserve-before-connect is the entire point of the prepaid gate.

## No request at the answer

There was no credit-control request at the 200 OK, so an OCS could not tell when charging actually started, and a Diameter-to-HTTP bridge had nothing to translate into a connect event.

TS 32.299 §7.2.97 has the place for it: `Time-Stamps` with `SIP-Request-Timestamp` (834, the INVITE that triggered the reservation) and `SIP-Response-Timestamp` (835, the answer). `ImsChargingData.response_timestamp` already existed and was never set, because at CCR-INITIAL there is no answer yet.

Idempotent: a retransmitted 200 OK neither restarts the clock nor sends a second record, and a 2xx racing a teardown is a no-op on a stopped session. Fire-and-forget, like every other charging spawn — the SIP path never waits on the OCS.

## Also: usage is now a delta

Reporting switched from "the interval just slept" to "chargeable minus already-acknowledged". Simpler, required for `charge_from` (pre-answer intervals carry zero), and it fixes a real edge: a CCR-UPDATE that failed used to lose its seconds, where now they stay unreported until a later record covers them exactly once.

## Tests

Ten new, against the in-process mock OCS:

- an unanswered call reports **0** used seconds
- `charge_from: answer` counts only the answered span after 2s ringing + 1s talking
- `charge_from: invite` still bills from the reservation
- the answer CCR-UPDATE carries **both** Time-Stamps sub-AVPs
- a retransmitted answer neither restarts the clock nor sends a second record
- an answer on a stopped session sends nothing
- summed Used-Service-Unit across UPDATE + TERMINATION never exceeds what was chargeable
- `charge_from` parsing, including an unrecognised value falling back to `answer` rather than silently billing ring time

Mutation-checked: reverting the clock to the reservation fails the two that matter.

3943 passed, clippy clean.