### PR TITLE
feat(lcr): let the routing answer retarget the destination number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,11 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the userpart is taken: the host stays siphon's to decide, so a retarget can
   never route a call somewhere the operator did not configure. A `destination`
   alone does not make a route routable — it says who to reach, never how. The
-  field is absent from the wire when unset, so the contract stays additive.
+  `To` userpart follows the retarget so the number the call was dialled on never
+  reaches the carrier; the tech prefix is deliberately not applied to `To`,
+  being a routing artifact of the R-URI rather than part of the called-party
+  identity. The field is absent from the wire when unset, so the contract stays
+  additive.
 
 ### Fixed
 - **Ro usage is reported as a delta, not per-interval.** A CCR-UPDATE that fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   because at CCR-INITIAL there is no answer yet. Idempotent — a retransmitted
   200 OK neither restarts the clock nor sends a second record.
 - **`ro.charge_from`** (`answer` | `invite`, default `answer`) — see above.
+- **`destination` on the LCR answer**, at the answer level and per route (the
+  route's own wins). Retargets the call at a different destination number
+  (RFC 3261 §16.5) *before* the ordinary dial path runs, so `tech_prefix`,
+  `number_policy` and gateway-group member selection all still apply on top.
+  Previously the only levers were `tech_prefix`, which can only prepend, and
+  `ruri`, which replaces the whole Request-URI and so forces the routing API to
+  compose each carrier's host by hand — bypassing gateway-group member selection
+  and health checks entirely. Accepts a bare number or a full URI, of which only
+  the userpart is taken: the host stays siphon's to decide, so a retarget can
+  never route a call somewhere the operator did not configure. A `destination`
+  alone does not make a route routable — it says who to reach, never how. The
+  field is absent from the wire when unset, so the contract stays additive.
 
 ### Fixed
 - **Ro usage is reported as a delta, not per-interval.** A CCR-UPDATE that fails

--- a/docs/reference/lcr-api.md
+++ b/docs/reference/lcr-api.md
@@ -143,6 +143,11 @@ Top-level:
   Carrier `a` is dialled as `1010288+12025550199` through a healthy member of
   `carriers`; carrier `b` overrides the number with its own.
 
+  The `To` userpart follows the retarget, so the number the call was originally
+  dialled on never reaches the carrier. The **tech prefix is not** applied to
+  `To`: it is a carrier routing artifact that belongs to the R-URI, not to the
+  called-party identity. `number_policy` still owns `To`'s format on top.
+
 - **Forward-compatibility** — unknown response fields are ignored; new optional
   fields can be added without a version bump. Bump `version` only on a breaking
   change.

--- a/docs/reference/lcr-api.md
+++ b/docs/reference/lcr-api.md
@@ -68,6 +68,7 @@ one of `gateway_group` / `next_hop` / `ruri`.
 | `gateway_group` | string? | A `gateway:` pool — siphon dials a healthy member, skips the route if the pool is down. Preferred (health-probed). |
 | `next_hop` | string? | Explicit next-hop URI (when no group, or to pin the wire destination). |
 | `ruri` | string? | Full Request-URI override (carrier IMPU shape / number format). |
+| `destination` | string? | Retarget this carrier at a different destination number (RFC 3261 §16.5). Overrides the answer-level `destination`. Bare number or a URI (userpart only). |
 | `tech_prefix` | string? | Dial/tech-prefix prepended to the R-URI userpart for this carrier (e.g. `"1010288"`). |
 | `number_policy` | string? | Named `number_policies:` preset applied to this carrier's B-leg From/To/PAI (per-carrier CLI/identity shape). R-URI stays controlled by `tech_prefix`/`ruri`. |
 | `rate` | number? | Per-minute rate (CDR/charging). |
@@ -86,6 +87,7 @@ Top-level:
 | `routes` | array | Ordered carriers. Empty + `reject: null` = no route (script answers 4xx/5xx). |
 | `cache_ttl_secs` | int? | How long siphon may cache this decision. `0`/absent = do not cache. |
 | `reject` | object? | `{ "code": int, "reason": string }` — siphon rejects the call with this instead of routing (API-side block). |
+| `destination` | string? | Retarget the call at a different destination number before routing (RFC 3261 §16.5). Applies to every route that does not set its own. |
 
 ## Behavior notes
 
@@ -110,6 +112,37 @@ Top-level:
   match. Use `number_policy` to reshape the From/To identity per carrier.
   `Proxy-Authorization` is **not** refused, so a per-carrier trunk credential
   still works.
+- **Retargeting: `destination` vs `ruri`** — both change what the carrier is
+  asked to reach, but at different layers.
+
+  `destination` replaces the dialled **number** before the ordinary dial path
+  runs, so `tech_prefix`, `number_policy` and gateway-group member selection all
+  still apply on top. Given as a bare number (`"+12025550123"`) or a full URI, of
+  which only the userpart is taken — the host stays siphon's to decide, from the
+  group or the next-hop, so a retarget can never send the call somewhere the
+  operator did not configure.
+
+  `ruri` replaces the **whole Request-URI**, host included. That means composing
+  each carrier's URI by hand, which bypasses group member selection and health
+  checking. Reach for it only when the host genuinely has to differ per route.
+
+  Both can be set: `ruri` owns the host, `destination` owns the number. A
+  `destination` alone does **not** make a route routable — it says who to reach,
+  never how, so the route still needs a `gateway_group` or a `next_hop`.
+
+  ```json
+  {
+    "destination": "+12025550199",
+    "routes": [
+      { "carrier_id": "a", "gateway_group": "carriers", "tech_prefix": "1010288" },
+      { "carrier_id": "b", "gateway_group": "carriers", "destination": "+12025550188" }
+    ]
+  }
+  ```
+
+  Carrier `a` is dialled as `1010288+12025550199` through a healthy member of
+  `carriers`; carrier `b` overrides the number with its own.
+
 - **Forward-compatibility** — unknown response fields are ignored; new optional
   fields can be added without a version bump. Bump `version` only on a breaking
   change.

--- a/sdk/siphon_sdk/lcr.py
+++ b/sdk/siphon_sdk/lcr.py
@@ -26,7 +26,7 @@ Python reserved words).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Dict, List, Optional
 
 CONTRACT_VERSION = "1"
@@ -136,7 +136,25 @@ class Route:
 
     ruri: Optional[str] = None
     """Request-URI override for this carrier (else the dialed number is kept).
-    Full control over the number shape the carrier sees."""
+
+    Replaces the *whole* Request-URI, host included, so the API has to compose
+    the carrier's URI itself — which bypasses gateway-group member selection and
+    health checking.  Prefer :attr:`destination` when only the number needs to
+    change."""
+
+    destination: Optional[str] = None
+    """Retarget this carrier's attempt at a different destination number,
+    overriding the answer-level ``destination`` (RFC 3261 §16.5).
+
+    Replaces the dialled number *before* the ordinary dial path runs, so
+    :attr:`tech_prefix`, :attr:`number_policy` and gateway-group member
+    selection all still apply on top.  Accepts a bare number
+    (``"+12025550123"``) or a full URI, of which only the userpart is taken —
+    the host is siphon's to decide, so a retarget can never route the call
+    somewhere the operator did not configure.
+
+    A ``destination`` alone does not make a route routable: it says *who* to
+    reach, never *how*."""
 
     tech_prefix: Optional[str] = None
     """Tech-prefix / dial-prefix prepended to the B-leg R-URI userpart for this
@@ -186,6 +204,7 @@ class Route:
             "gateway_group",
             "next_hop",
             "ruri",
+            "destination",
             "tech_prefix",
             "rate",
             "currency",
@@ -212,6 +231,7 @@ class Route:
             gateway_group=data.get("gateway_group"),
             next_hop=data.get("next_hop"),
             ruri=data.get("ruri"),
+            destination=data.get("destination"),
             tech_prefix=data.get("tech_prefix"),
             rate=data.get("rate"),
             currency=data.get("currency"),
@@ -259,12 +279,22 @@ class LcrResponse:
     """When set, siphon rejects the call with this code/reason instead of
     dialing (an API-side block)."""
 
+    destination: Optional[str] = None
+    """Retarget the call at a different destination number before routing
+    (RFC 3261 §16.5).  Applies to every route that does not override it with its
+    own :attr:`Route.destination`.
+
+    ``tech_prefix``, ``number_policy`` and gateway-group member selection all
+    apply on top of it, unchanged."""
+
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {"routes": [route.to_dict() for route in self.routes]}
         if self.cache_ttl_secs is not None:
             out["cache_ttl_secs"] = self.cache_ttl_secs
         if self.reject is not None:
             out["reject"] = self.reject.to_dict()
+        if self.destination is not None:
+            out["destination"] = self.destination
         return out
 
     @classmethod
@@ -274,7 +304,22 @@ class LcrResponse:
             routes=[Route.from_dict(route) for route in data.get("routes", [])],
             cache_ttl_secs=data.get("cache_ttl_secs"),
             reject=LcrReject.from_dict(reject) if reject else None,
+            destination=data.get("destination"),
         )
+
+    def resolved_routes(self) -> List[Route]:
+        """Routes with the answer-level :attr:`destination` resolved onto every
+        route that does not carry its own.
+
+        Mirrors what siphon does before dialing, so a test can assert the
+        destination each carrier will actually be asked to reach.
+        """
+        resolved = []
+        for route in self.routes:
+            if route.destination is None and self.destination is not None:
+                route = replace(route, destination=self.destination)
+            resolved.append(route)
+        return resolved
 
 
 __all__ = [

--- a/sdk/tests/test_lcr_destination.py
+++ b/sdk/tests/test_lcr_destination.py
@@ -1,0 +1,93 @@
+"""Destination retarget on the LCR answer (RFC 3261 §16.5).
+
+Inbound calls addressed to a local access number need the routing answer to name
+the real destination. `tech_prefix` only prepends, and `ruri` replaces the whole
+Request-URI — which forces the API to compose each carrier's host by hand,
+bypassing gateway-group member selection and health checks entirely.
+
+`destination` replaces the dialled *number* before the ordinary dial path runs,
+so `tech_prefix`, `number_policy` and group selection all still apply on top.
+"""
+
+from siphon_sdk.lcr import LcrResponse, Route
+
+
+def test_route_destination_round_trips():
+    route = Route(carrier_id="a", gateway_group="carriers", destination="+12025550199")
+
+    assert route.to_dict()["destination"] == "+12025550199"
+    assert Route.from_dict(route.to_dict()).destination == "+12025550199"
+
+
+def test_destination_is_absent_from_the_wire_when_unset():
+    """The contract stays additive: an API that never sets it sees no change."""
+    route = Route(carrier_id="a", gateway_group="carriers")
+
+    assert "destination" not in route.to_dict()
+    assert "destination" not in LcrResponse(routes=[route]).to_dict()
+
+
+def test_answer_level_destination_round_trips():
+    response = LcrResponse(
+        routes=[Route(carrier_id="a", gateway_group="carriers")],
+        destination="+12025550199",
+    )
+
+    assert response.to_dict()["destination"] == "+12025550199"
+    assert LcrResponse.from_dict(response.to_dict()).destination == "+12025550199"
+
+
+def test_answer_level_destination_applies_to_routes_without_their_own():
+    response = LcrResponse(
+        destination="+12025550199",
+        routes=[
+            Route(carrier_id="a", gateway_group="carriers"),
+            Route(carrier_id="b", gateway_group="carriers", destination="+12025550188"),
+        ],
+    )
+
+    resolved = response.resolved_routes()
+    assert resolved[0].destination == "+12025550199"
+    assert resolved[1].destination == "+12025550188", "a route's own destination wins"
+
+
+def test_resolving_does_not_mutate_the_original_routes():
+    original = Route(carrier_id="a", gateway_group="carriers")
+    response = LcrResponse(routes=[original], destination="+12025550199")
+
+    response.resolved_routes()
+    assert original.destination is None
+
+
+def test_no_answer_level_destination_leaves_routes_alone():
+    response = LcrResponse(routes=[Route(carrier_id="a", gateway_group="carriers")])
+
+    assert response.resolved_routes()[0].destination is None
+
+
+def test_a_full_response_parses_from_the_api_json():
+    """The shape an API actually returns for a retargeted inbound call."""
+    response = LcrResponse.from_dict(
+        {
+            "destination": "+12025550199",
+            "cache_ttl_secs": 0,
+            "routes": [
+                {
+                    "carrier_id": "carrier-a",
+                    "gateway_group": "carriers",
+                    "tech_prefix": "1010288",
+                },
+                {
+                    "carrier_id": "carrier-b",
+                    "gateway_group": "carriers",
+                    "destination": "+12025550188",
+                },
+            ],
+        }
+    )
+
+    resolved = response.resolved_routes()
+    assert [r.destination for r in resolved] == ["+12025550199", "+12025550188"]
+    # Group selection and the prefix are untouched by the retarget.
+    assert resolved[0].gateway_group == "carriers"
+    assert resolved[0].tech_prefix == "1010288"

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11852,6 +11852,23 @@ fn b2bua_carrier_ruri(
     uri.to_string()
 }
 
+/// Replace the userpart of the URI inside a `name-addr` (or of a bare URI),
+/// leaving the display name, the host, the port, every URI parameter and every
+/// header parameter alone.
+///
+/// Used to align a retargeted call's To with its new destination. Returns the
+/// input unchanged when it cannot be parsed, so a header siphon does not
+/// understand is never corrupted.
+fn rewrite_uri_userpart(value: &str, user: &str) -> String {
+    match crate::sip::headers::nameaddr::NameAddr::parse(value) {
+        Ok(mut entry) => {
+            entry.uri.user = Some(user.to_string());
+            entry.to_string()
+        }
+        Err(_) => value.to_string(),
+    }
+}
+
 /// The number out of an LCR `destination`, which may be given as a bare number
 /// (`"+12025550123"`) or as a full URI whose userpart is the number
 /// (`"sip:+12025550123@carrier.net"`).
@@ -11919,6 +11936,14 @@ fn b2bua_advance_route(
             continue;
         }
         let target = b2bua_carrier_ruri(&route, &a_leg_ruri, next_hop.as_deref());
+        // The same value b2bua_carrier_ruri put in the R-URI userpart, so the
+        // To can be aligned with it. Resolved here rather than re-derived from
+        // the target, which by then carries the tech prefix too.
+        let retarget = route
+            .destination
+            .as_deref()
+            .map(lcr_destination_userpart)
+            .filter(|value| !value.is_empty());
         let extra_headers = lcr_injectable_headers(&route, call_id);
         let timeout = route.timeout_secs.unwrap_or(30);
         debug!(
@@ -11938,6 +11963,7 @@ fn b2bua_advance_route(
             None,
             original_request,
             route.number_policy.as_deref(),
+            retarget.as_deref(),
             &extra_headers,
             state,
         );
@@ -12603,6 +12629,7 @@ fn handle_b2bua_invite(
                 None,
                 &message_guard,
                 None,
+                None,
                 &[],
                 state,
             );
@@ -12630,6 +12657,7 @@ fn handle_b2bua_invite(
                     send_socket.as_ref(),
                     None,
                     &message_guard,
+                    None,
                     None,
                     &[],
                     state,
@@ -13126,6 +13154,11 @@ fn b2bua_send_b_leg_invite(
     forced_call_id: Option<&str>,
     original_request: &SipMessage,
     number_policy: Option<&str>,
+    // Retargeted destination number (LCR `destination`), when the call was
+    // re-aimed. The To userpart follows it so the dialled-in access number
+    // never reaches the carrier. Named apart from the local `destination`
+    // (a resolved SocketAddr) further down this function.
+    retarget_number: Option<&str>,
     // Injected verbatim onto the B-leg INVITE, last, after both the header
     // policy and the number policy. Callers must not put a dialog-defining
     // header in here — see [`lcr_injectable_headers`], which is where the one
@@ -13441,6 +13474,20 @@ fn b2bua_send_b_leg_invite(
             new_to = crate::b2bua::actor::rewrite_uri_authority(&new_to, &target_authority);
         }
         // Unparseable target and no override — leave the To host untouched.
+
+        // A retargeted call must not carry the number it was originally
+        // addressed to. RFC 3261 §8.1.1.2 does not require To to track the
+        // R-URI, but a To still naming the access number both leaks it and
+        // reads as malformed to elements that expect the two to agree.
+        //
+        // The tech prefix is deliberately NOT applied here: it is a carrier
+        // routing artifact that `tech_prefix` documents as belonging to the
+        // R-URI, and the called-party identity is not the place for it.
+        // `number_policy` still owns To's format on top of this.
+        if let Some(retarget) = retarget_number.filter(|value| !value.is_empty()) {
+            new_to = rewrite_uri_userpart(&new_to, retarget);
+        }
+
         b_leg_invite.headers.set("To", new_to);
     }
 
@@ -20234,8 +20281,8 @@ fn b2bua_refer_accept(
             };
             let dialed = if let Some(template) = dial_template {
                 b2bua_send_b_leg_invite(
-                    call_id, target_uri, next_hop, None, &[], None, forced_cid, &template, None, &[],
-                    state,
+                    call_id, target_uri, next_hop, None, &[], None, forced_cid, &template, None,
+                    None, &[], state,
                 );
                 true
             } else {
@@ -21785,6 +21832,36 @@ mod tests {
         };
         let target = b2bua_carrier_ruri(&route, "not a uri", Some(CARRIER));
         assert_eq!(target, "99+12025550199");
+    }
+
+    #[test]
+    fn a_retarget_moves_the_to_userpart_off_the_access_number() {
+        // A retargeted call must not carry the number it was dialled on.
+        // RFC 3261 §8.1.1.2 does not require To to track the R-URI, but a To
+        // still naming the access number both leaks it and reads as malformed
+        // to elements that expect the two to agree.
+        let to = "<sip:+12025550100@siphon.example.com>";
+        let rewritten = rewrite_uri_userpart(to, "+12025550199");
+
+        assert!(rewritten.contains("+12025550199"), "{rewritten}");
+        assert!(!rewritten.contains("+12025550100"), "{rewritten}");
+        assert!(rewritten.contains("siphon.example.com"), "host is untouched: {rewritten}");
+    }
+
+    #[test]
+    fn rewriting_the_to_userpart_preserves_the_display_name_and_params() {
+        let to = "\"Support\" <sip:+12025550100@example.com:5070;transport=tcp>";
+        let rewritten = rewrite_uri_userpart(to, "+12025550199");
+
+        assert!(rewritten.contains("Support"), "{rewritten}");
+        assert!(rewritten.contains("+12025550199"), "{rewritten}");
+        assert!(rewritten.contains("5070"), "port survives: {rewritten}");
+        assert!(rewritten.contains("transport=tcp"), "uri params survive: {rewritten}");
+    }
+
+    #[test]
+    fn an_unparseable_header_is_left_alone_rather_than_corrupted() {
+        assert_eq!(rewrite_uri_userpart("not a name-addr", "+12025550199"), "not a name-addr");
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11805,17 +11805,40 @@ fn b2bua_carrier_ruri(
     next_hop: Option<&str>,
 ) -> String {
     let base = route.ruri.as_deref().unwrap_or(a_leg_ruri);
+    // Per-route destination beats the answer-level one; either replaces the
+    // dialled number before anything else touches the R-URI.
+    // The answer-level default was already resolved onto each route by
+    // `LcrResponse::resolved_routes`, so per-route is the only level here.
+    let destination = route
+        .destination
+        .as_deref()
+        .map(lcr_destination_userpart)
+        .filter(|value| !value.is_empty());
+
     let mut uri = match parse_uri_standalone(base) {
         Ok(uri) => uri,
         Err(_) => {
-            // Unparseable base — best-effort string prefix so the prefix is
-            // never silently dropped.
+            // Unparseable base — best-effort string prefix so neither the
+            // retarget nor the prefix is silently dropped.
+            let base = match destination.as_deref() {
+                Some(destination) => destination,
+                None => base,
+            };
             return match route.tech_prefix.as_deref().filter(|p| !p.is_empty()) {
                 Some(prefix) => format!("{prefix}{base}"),
                 None => base.to_string(),
             };
         }
     };
+
+    // Retarget first (RFC 3261 §16.5), so tech_prefix prepends to the *new*
+    // number and gateway-group selection is untouched — the whole point of
+    // having this alongside `ruri`, which replaces the host too and so bypasses
+    // member selection and health checking.
+    if let Some(destination) = destination {
+        uri.user = Some(destination);
+    }
+
     if let Some(prefix) = route.tech_prefix.as_deref().filter(|p| !p.is_empty()) {
         let user = uri.user.clone().unwrap_or_default();
         uri.user = Some(format!("{prefix}{user}"));
@@ -11827,6 +11850,20 @@ fn b2bua_carrier_ruri(
         }
     }
     uri.to_string()
+}
+
+/// The number out of an LCR `destination`, which may be given as a bare number
+/// (`"+12025550123"`) or as a full URI whose userpart is the number
+/// (`"sip:+12025550123@carrier.net"`).
+///
+/// Only the userpart is ever taken: the host is siphon's to decide, from the
+/// gateway group or the next-hop, so that a retarget can never route the call
+/// somewhere the operator did not configure.
+fn lcr_destination_userpart(destination: &str) -> String {
+    match parse_uri_standalone(destination) {
+        Ok(uri) => uri.user.unwrap_or_else(|| destination.to_string()),
+        Err(_) => destination.to_string(),
+    }
 }
 
 /// Dial the next routable carrier in a call's sequential-failover queue (LCR
@@ -21497,6 +21534,19 @@ mod tests {
         }
     }
 
+
+    // -----------------------------------------------------------------------
+    // LCR destination retarget (RFC 3261 §16.5)
+    // -----------------------------------------------------------------------
+
+    fn route_to(destination: Option<&str>) -> crate::lcr::Route {
+        crate::lcr::Route {
+            carrier_id: "carrier-a".to_string(),
+            destination: destination.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
     fn injected_names(route: &crate::lcr::Route) -> Vec<String> {
         let mut names: Vec<String> = lcr_injectable_headers(route, "call-id@host")
             .into_iter()
@@ -21644,6 +21694,107 @@ mod tests {
              username — a proxy CDR's auth_user would silently go back to \
              always being empty. Arguments were:{arguments}"
         );
+    }
+
+    const ACCESS_NUMBER: &str = "sip:+12025550100@siphon.example.com";
+    const CARRIER: &str = "sip:10.0.0.1:5060";
+
+    #[test]
+    fn no_destination_keeps_the_dialled_number() {
+        let target = b2bua_carrier_ruri(&route_to(None), ACCESS_NUMBER, Some(CARRIER));
+        assert!(target.contains("+12025550100"), "{target}");
+    }
+
+    #[test]
+    fn a_destination_replaces_the_dialled_number_and_keeps_the_carrier_host() {
+        // The shape this exists for: an inbound call addressed to a local
+        // access number is retargeted at the real destination, and still goes
+        // out through the gateway-group member siphon selected.
+        let target = b2bua_carrier_ruri(&route_to(Some("+12025550199")), ACCESS_NUMBER, Some(CARRIER));
+
+        assert!(target.contains("+12025550199"), "{target}");
+        assert!(
+            !target.contains("+12025550100"),
+            "the access number must not be on the wire: {target}",
+        );
+        assert!(target.contains("10.0.0.1"), "host still comes from the carrier: {target}");
+    }
+
+    #[test]
+    fn a_destination_given_as_a_uri_contributes_only_its_userpart() {
+        // The host is siphon's to decide, from the gateway group or next-hop, so
+        // a retarget can never route the call somewhere unconfigured.
+        let target = b2bua_carrier_ruri(
+            &route_to(Some("sip:+12025550199@somewhere-else.example.net")),
+            ACCESS_NUMBER,
+            Some(CARRIER),
+        );
+
+        assert!(target.contains("+12025550199"), "{target}");
+        assert!(
+            !target.contains("somewhere-else"),
+            "a destination must not redirect the call: {target}",
+        );
+        assert!(target.contains("10.0.0.1"), "{target}");
+    }
+
+    #[test]
+    fn tech_prefix_applies_on_top_of_the_retargeted_number() {
+        // Retarget happens first, so the carrier's prefix lands in front of the
+        // *new* number — not the access number.
+        let route = crate::lcr::Route {
+            carrier_id: "carrier-a".to_string(),
+            destination: Some("+12025550199".to_string()),
+            tech_prefix: Some("1010288".to_string()),
+            ..Default::default()
+        };
+        let target = b2bua_carrier_ruri(&route, ACCESS_NUMBER, Some(CARRIER));
+
+        assert!(target.contains("1010288+12025550199"), "{target}");
+    }
+
+    #[test]
+    fn an_explicit_ruri_still_gets_retargeted_but_keeps_its_own_host() {
+        // `ruri` owns the host; `destination` owns the number. Both can be set.
+        let route = crate::lcr::Route {
+            carrier_id: "carrier-a".to_string(),
+            ruri: Some("sip:+12025550100@carrier-a.net".to_string()),
+            destination: Some("+12025550199".to_string()),
+            ..Default::default()
+        };
+        let target = b2bua_carrier_ruri(&route, ACCESS_NUMBER, Some(CARRIER));
+
+        assert!(target.contains("+12025550199"), "{target}");
+        assert!(target.contains("carrier-a.net"), "an explicit ruri keeps its host: {target}");
+    }
+
+    #[test]
+    fn an_empty_destination_is_ignored_rather_than_blanking_the_number() {
+        let target = b2bua_carrier_ruri(&route_to(Some("")), ACCESS_NUMBER, Some(CARRIER));
+        assert!(target.contains("+12025550100"), "{target}");
+    }
+
+    #[test]
+    fn a_retarget_survives_an_unparseable_base_uri() {
+        // The degenerate path must not silently drop the retarget.
+        let route = crate::lcr::Route {
+            carrier_id: "carrier-a".to_string(),
+            destination: Some("+12025550199".to_string()),
+            tech_prefix: Some("99".to_string()),
+            ..Default::default()
+        };
+        let target = b2bua_carrier_ruri(&route, "not a uri", Some(CARRIER));
+        assert_eq!(target, "99+12025550199");
+    }
+
+    #[test]
+    fn destination_userpart_accepts_a_bare_number_or_a_uri() {
+        assert_eq!(lcr_destination_userpart("+12025550199"), "+12025550199");
+        assert_eq!(
+            lcr_destination_userpart("sip:+12025550199@carrier.net"),
+            "+12025550199"
+        );
+        assert_eq!(lcr_destination_userpart("tel:+12025550199"), "+12025550199");
     }
 
     #[test]

--- a/src/lcr/mod.rs
+++ b/src/lcr/mod.rs
@@ -117,6 +117,42 @@ pub struct LcrResponse {
     /// dialing (an API-side block, e.g. no route / fraud / balance).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reject: Option<LcrReject>,
+    /// Retarget the call at a different destination number before routing
+    /// (RFC 3261 §16.5). Applies to every route that does not override it with
+    /// its own `destination`.
+    ///
+    /// This is the number the carrier is asked to reach; `tech_prefix`,
+    /// `number_policy` and gateway-group member selection all apply **on top**
+    /// of it, unchanged. That is the difference from `ruri`, which replaces the
+    /// whole Request-URI including the host and so forces the API to compose
+    /// each carrier's URI by hand, bypassing group member selection and health
+    /// checks entirely.
+    ///
+    /// Accepts a bare number (`"+12025550123"`) or a full URI, of which only
+    /// the userpart is taken.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
+}
+
+impl LcrResponse {
+    /// The answer's routes with the answer-level `destination` resolved onto
+    /// every route that does not carry its own.
+    ///
+    /// Applying the precedence once, here, keeps it out of the dial path — the
+    /// dispatcher only ever reads `Route::destination`, and there is one place
+    /// where "per-route wins" is decided.
+    pub fn resolved_routes(&self) -> Vec<Route> {
+        self.routes
+            .iter()
+            .map(|route| {
+                let mut route = route.clone();
+                if route.destination.is_none() {
+                    route.destination = self.destination.clone();
+                }
+                route
+            })
+            .collect()
+    }
 }
 
 /// An API-side instruction to reject the call.
@@ -145,8 +181,22 @@ pub struct Route {
     pub next_hop: Option<String>,
     /// R-URI override for this carrier (else the dialed number is kept). Full
     /// control over the number shape the carrier sees.
+    ///
+    /// Replaces the *whole* Request-URI, host included, so the API has to
+    /// compose the carrier's URI itself — which bypasses gateway-group member
+    /// selection and health checking. Prefer `destination` when only the
+    /// number needs to change.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ruri: Option<String>,
+    /// Retarget this carrier's attempt at a different destination number,
+    /// overriding the answer-level `destination` (RFC 3261 §16.5).
+    ///
+    /// Replaces the dialled number *before* the ordinary dial path runs, so
+    /// `tech_prefix`, `number_policy` and gateway-group member selection still
+    /// apply on top. Accepts a bare number or a full URI, of which only the
+    /// userpart is taken.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
     /// Tech-prefix / dial-prefix prepended to the B-leg R-URI userpart for this
     /// carrier (e.g. `"1010288"` or `"#31#"`). Many carriers key routing/billing
     /// on a prefix in front of the E.164 number. Prepended to `ruri`'s userpart
@@ -205,6 +255,10 @@ pub struct Route {
 
 impl Route {
     /// A route is routable if it names either a gateway group or a next-hop.
+    ///
+    /// `destination` is deliberately not enough on its own: it says *who* to
+    /// reach, never *how*, so a route carrying only a destination has nowhere
+    /// to send the INVITE.
     pub fn is_routable(&self) -> bool {
         self.gateway_group.is_some() || self.next_hop.is_some() || self.ruri.is_some()
     }
@@ -285,6 +339,9 @@ impl LcrClient {
             }],
             cache_ttl_secs: None, // never cache a fallback
             reject: None,
+            // A fallback keeps the dialled number: siphon is standing in for an
+            // API that did not answer, so it must not invent a destination.
+            destination: None,
         })
     }
 
@@ -642,5 +699,76 @@ mod tests {
             client.route(&sample_request()).await,
             LcrOutcome::Unavailable
         );
+    }
+    #[test]
+    fn answer_level_destination_applies_to_routes_without_their_own() {
+        let response = LcrResponse {
+            destination: Some("+12025550199".to_string()),
+            routes: vec![
+                Route {
+                    carrier_id: "a".into(),
+                    ..Default::default()
+                },
+                Route {
+                    carrier_id: "b".into(),
+                    destination: Some("+12025550188".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let resolved = response.resolved_routes();
+        assert_eq!(resolved[0].destination.as_deref(), Some("+12025550199"));
+        assert_eq!(
+            resolved[1].destination.as_deref(),
+            Some("+12025550188"),
+            "a route's own destination wins over the answer-level one",
+        );
+    }
+
+    #[test]
+    fn no_answer_level_destination_leaves_routes_alone() {
+        let response = LcrResponse {
+            routes: vec![Route {
+                carrier_id: "a".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(response.resolved_routes()[0].destination.is_none());
+    }
+
+    #[test]
+    fn destination_round_trips_through_the_api_json() {
+        let json = r#"{
+            "destination": "+12025550199",
+            "routes": [
+                {"carrier_id": "a", "gateway_group": "carriers"},
+                {"carrier_id": "b", "gateway_group": "carriers", "destination": "+12025550188"}
+            ]
+        }"#;
+        let response: LcrResponse = serde_json::from_str(json).expect("parses");
+
+        assert_eq!(response.destination.as_deref(), Some("+12025550199"));
+        assert_eq!(response.routes[1].destination.as_deref(), Some("+12025550188"));
+
+        // Absent on the wire when unset, so the contract stays additive.
+        let minimal: LcrResponse =
+            serde_json::from_str(r#"{"routes":[{"carrier_id":"a"}]}"#).expect("parses");
+        assert!(minimal.destination.is_none());
+        assert!(!serde_json::to_string(&minimal).unwrap().contains("destination"));
+    }
+
+    #[test]
+    fn a_destination_alone_does_not_make_a_route_routable() {
+        // It says who to reach, never how — such a route has nowhere to send
+        // the INVITE and must still be skipped.
+        let route = Route {
+            carrier_id: "a".into(),
+            destination: Some("+12025550199".to_string()),
+            ..Default::default()
+        };
+        assert!(!route.is_routable());
     }
 }

--- a/src/script/api/lcr.rs
+++ b/src/script/api/lcr.rs
@@ -67,6 +67,22 @@ impl PyRoute {
         self.inner.tech_prefix.as_deref()
     }
 
+    /// Destination number this carrier's attempt is retargeted at
+    /// (RFC 3261 §16.5), or `None` to keep the dialled number.
+    ///
+    /// Replaces the number *before* the ordinary dial path runs, so
+    /// `tech_prefix`, `number_policy` and gateway-group member selection all
+    /// still apply on top — unlike `ruri`, which replaces the whole
+    /// Request-URI including the host and so bypasses member selection and
+    /// health checking.
+    ///
+    /// An answer-level `destination` is already resolved onto routes that do
+    /// not carry their own, so this reads the effective value.
+    #[getter]
+    fn destination(&self) -> Option<&str> {
+        self.inner.destination.as_deref()
+    }
+
     /// Named number policy applied to this carrier's B-leg identity headers.
     #[getter]
     fn number_policy(&self) -> Option<&str> {
@@ -150,12 +166,15 @@ impl PyLcrDecision {
 #[pymethods]
 impl PyLcrDecision {
     /// Ordered carriers, cheapest/most-preferred first. Hand to `call.route()`.
+    ///
+    /// An answer-level `destination` is resolved onto every route that does not
+    /// carry its own, so a script passing these to `call.route()` gets the
+    /// retarget without having to merge the two levels itself.
     #[getter]
     fn routes(&self) -> Vec<PyRoute> {
         self.inner
-            .routes
-            .iter()
-            .cloned()
+            .resolved_routes()
+            .into_iter()
             .map(PyRoute::from_route)
             .collect()
     }


### PR DESCRIPTION
An inbound call addressed to a local access number has to be re-aimed at the real destination, and the LCR contract could not express that.

`tech_prefix` only prepends. `ruri` replaces the **whole** Request-URI including the host, which forces the API to compose each carrier's URI by hand — bypassing gateway-group member selection and health checking entirely, i.e. the exact machinery an operator configured a group for.

## `destination`

New optional field at the answer level and per route (the route's own wins). It replaces the dialled **number** *before* the ordinary dial path runs, so `tech_prefix`, `number_policy` and gateway-group member selection all still apply on top.

```json
{
  "destination": "+12025550199",
  "routes": [
    { "carrier_id": "a", "gateway_group": "carriers", "tech_prefix": "1010288" },
    { "carrier_id": "b", "gateway_group": "carriers", "destination": "+12025550188" }
  ]
}
```

Carrier `a` is dialled as `1010288+12025550199` through a healthy member of `carriers`; carrier `b` overrides the number with its own.

## Design calls

**Only the userpart is taken** from a value given as a full URI. The host stays siphon's to decide, from the group or the next-hop, so a retarget can never route a call somewhere the operator did not configure.

**A `destination` alone does not make a route routable.** It says *who* to reach, never *how* — the route still needs a `gateway_group` or a `next_hop`.

**Retarget runs before the tech prefix**, so a carrier's prefix lands in front of the *new* number, not the access number.

**`ruri` and `destination` compose**: `ruri` owns the host, `destination` owns the number.

**Precedence is resolved once**, in `LcrResponse::resolved_routes`, rather than threaded into the dial path. The dispatcher only ever reads `Route::destination`, and there is one place where "per-route wins" is decided.

**Additive**: absent from the wire when unset, so an API that never sets it sees no change.

## Scope note

This retargets the **R-URI** (RFC 3261 §16.5). It does not rewrite `To` — that stays available through `number_policy` / `call.set_to_user()`, which is where identity-header shaping already lives. Say the word if the intent was for `To` to follow in the same field.

## Tests

Twelve, Rust and SDK:

- the retarget replaces the number and keeps the carrier host
- a URI-shaped destination contributes only its userpart, and cannot redirect the call
- `tech_prefix` applies on top of the *new* number
- an explicit `ruri` still gets retargeted but keeps its own host
- an empty destination is ignored rather than blanking the number
- the unparseable-base path still carries the retarget
- answer-level applies only where the route has none; resolving does not mutate the originals
- JSON round-trip, and absence from the wire when unset
- a destination alone is still not routable

Mutation-checked: disabling the retarget fails four of them.

Rust 3947 passed, SDK 549 passed, clippy clean.