### PR TITLE
feat(lcr): per-route presented CLI, and CLIR that actually anonymises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   engine would recognise coming back, or to reject a replayed one. Validating
   the nonce is what bounds replay of a captured `Authorization`; without it a
   script-side digest check is replayable forever.
+- **RFC 3323 caller-ID restriction (CLIR)** — `call.restrict_caller_id()`, and
+  `caller_id_presentation: "restricted"` on an LCR route. There was no RFC 3323
+  anonymisation anywhere in the tree, so a deployment asserting `Privacy: id`
+  left the subscriber's real number in the `From`, leaking it to every carrier
+  that renders `From` rather than `P-Asserted-Identity` — which defeats CLIR
+  while looking like it works. The two now move together: `From` becomes
+  `"Anonymous" <sip:anonymous@anonymous.invalid>` with its dialog tag intact,
+  `Privacy: id` is appended to any existing value, `P-Preferred-Identity` is
+  dropped (it is the UA's *request*, and forwarding it past a privacy boundary
+  re-leaks the number), and `P-Asserted-Identity` keeps the real identity for
+  the trusted next hop per RFC 3325 §7.
+- **Per-route presented CLI** — `caller_id` on an LCR route, and
+  `call.set_caller_id(number)`. The presented CLI is a per-call, per-carrier
+  decision the contract could not express: `number_policy` reshapes a number's
+  *format* but cannot substitute a different one, `call.set_from_user` is
+  tag-safe but identical for every carrier attempt, and a `From` in a route's
+  `headers` would take the dialog tag with it. Applied through the same
+  tag-preserving path the identity reshaping already uses, to `From` and to
+  `P-Asserted-Identity` / `P-Preferred-Identity` where present. Two carriers in
+  one answer can now present different CLIs on the same call.
 - **CI covers re-INVITE renegotiation on the `siphon-rtp` backend** (`--reoffer`).
   The existing `--reinvite` mode runs the same hold/resume flow against
   rtpengine, where a repeat `offer` on a live call-id *is* the re-offer — so it

--- a/docs/reference/lcr-api.md
+++ b/docs/reference/lcr-api.md
@@ -71,6 +71,8 @@ one of `gateway_group` / `next_hop` / `ruri`.
 | `destination` | string? | Retarget this carrier at a different destination number (RFC 3261 §16.5). Overrides the answer-level `destination`. Bare number or a URI (userpart only). |
 | `tech_prefix` | string? | Dial/tech-prefix prepended to the R-URI userpart for this carrier (e.g. `"1010288"`). |
 | `number_policy` | string? | Named `number_policies:` preset applied to this carrier's B-leg From/To/PAI (per-carrier CLI/identity shape). R-URI stays controlled by `tech_prefix`/`ruri`. |
+| `caller_id` | string? | Calling number this carrier is presented (the CLI). Tag-preserving; also applied to PAI/PPI. |
+| `caller_id_presentation` | string? | `allowed` (default) or `restricted` — CLIR per RFC 3323 / TS 24.607. |
 | `rate` | number? | Per-minute rate (CDR/charging). |
 | `currency` | string? | ISO 4217. |
 | `billing_increment` | int? | Seconds (60 = per-minute, 1 = per-second). |
@@ -147,6 +149,38 @@ Top-level:
   dialled on never reaches the carrier. The **tech prefix is not** applied to
   `To`: it is a carrier routing artifact that belongs to the R-URI, not to the
   called-party identity. `number_policy` still owns `To`'s format on top.
+- **Presented CLI and CLIR** — `caller_id` substitutes the calling number this
+  carrier sees, on `From` and on `P-Asserted-Identity` / `P-Preferred-Identity`
+  where present. It goes through the tag-preserving identity path, which is why
+  it is a field rather than something for `headers`: a `From` written without
+  its dialog tag breaks every subsequent in-dialog request, and only surfaces
+  later, on the ACK. `number_policy` reshapes the *format* of whatever number is
+  present; `caller_id` substitutes a different one, which a policy cannot do.
+
+  `caller_id_presentation: "restricted"` withholds the identity (RFC 3323 §4.1,
+  3GPP TS 24.607):
+
+  - `From` becomes `"Anonymous" <sip:anonymous@anonymous.invalid>`, tag intact
+  - `Privacy: id` is asserted (RFC 3325 §7), appended to any existing value
+  - `P-Asserted-Identity` keeps the real identity for the trusted next hop —
+    that is how the network stays able to identify the caller for regulatory and
+    emergency purposes
+  - `P-Preferred-Identity` is removed: it is the UA's *request* for what to
+    assert, and forwarding it past a privacy boundary re-leaks the number
+
+  The two always move together. Asserting `Privacy: id` while leaving the real
+  number in `From` leaks it to every carrier that renders `From` rather than
+  PAI, which defeats CLIR while looking like it works.
+
+  Ordering is fixed: `caller_id` is substituted **before** `number_policy`
+  reshapes formats, and anonymisation runs **after** — so under `restricted` the
+  substituted number still reaches PAI, and no policy tries to reformat
+  `anonymous` as a number. An unrecognised `caller_id_presentation` is logged
+  and treated as `restricted`, because a withheld call going out with the real
+  number is the failure that matters.
+
+  The script-level twins are `call.set_caller_id(number)` and
+  `call.restrict_caller_id()`, for deployments not using the LCR API.
 
 - **Forward-compatibility** — unknown response fields are ignored; new optional
   fields can be added without a version bump. Bump `version` only on a breaking

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -1054,6 +1054,82 @@ class Call:
         if self._ruri is not None:
             self._ruri.user = value
 
+    def restrict_caller_id(self) -> None:
+        """Withhold the calling party's identity on the B-leg (CLIR).
+
+        RFC 3323 §4.1 / 3GPP TS 24.607::
+
+            @b2bua.on_invite
+            def route(call):
+                if caller_withheld(call):
+                    call.restrict_caller_id()
+                call.dial(str(call.ruri))
+
+        - ``From`` becomes ``"Anonymous" <sip:anonymous@anonymous.invalid>``,
+          keeping its dialog tag.
+        - ``Privacy: id`` is asserted (RFC 3325 §7), appended to any existing
+          ``Privacy`` value rather than replacing it.
+        - ``P-Asserted-Identity`` is left intact, carrying the real identity to
+          the trusted next hop — that is how the network stays able to identify
+          the caller for regulatory and emergency purposes.
+        - ``P-Preferred-Identity`` is removed: it is the UA's *request* for what
+          to assert, and forwarding it past a privacy boundary re-leaks the
+          number.
+
+        Setting ``Privacy: id`` by hand while leaving the real number in
+        ``From`` leaks it to every carrier that renders ``From`` rather than
+        PAI — which defeats CLIR while looking like it works.  This moves both
+        together.
+
+        Call it *after* any identity reshaping: anonymisation is the last step,
+        or a number policy will try to reformat ``anonymous`` as a number.  The
+        LCR twin is a route's ``caller_id_presentation="restricted"``.
+        """
+        from_raw = self._headers.get("From")
+        tag = None
+        if from_raw and ";tag=" in from_raw:
+            tag = from_raw.split(";tag=", 1)[1].split(";")[0]
+        anonymous = '"Anonymous" <sip:anonymous@anonymous.invalid>'
+        if tag:
+            anonymous = f"{anonymous};tag={tag}"
+        self._headers["From"] = anonymous
+        self._headers.pop("P-Preferred-Identity", None)
+
+        existing = self._headers.get("Privacy", "")
+        tokens = [t.strip() for t in existing.split(";") if t.strip()]
+        if "id" not in [t.lower() for t in tokens]:
+            tokens.append("id")
+        self._headers["Privacy"] = ";".join(tokens)
+
+    def set_caller_id(self, number: str) -> bool:
+        """Present ``number`` as the calling party.
+
+        Applied to ``From`` and to ``P-Asserted-Identity`` /
+        ``P-Preferred-Identity`` where present, preserving the dialog tag —
+        which is why this exists rather than a ``set_header("From", ...)``: the
+        B-leg ``From`` host is rewritten after the script runs, and a ``From``
+        set without a tag drops the mandatory dialog tag (RFC 3261 §8.1.1.3), a
+        failure that only surfaces later on the ACK.
+
+        Unlike a number policy, which reshapes the *format* of whatever number
+        is already there, this substitutes a different one.  The LCR twin is a
+        route's ``caller_id``.
+
+        Returns ``True`` if anything was rewritten.
+        """
+        if not number:
+            return False
+        rewritten = False
+        for header in ("From", "P-Asserted-Identity", "P-Preferred-Identity"):
+            value = self._headers.get(header)
+            if not value or "@" not in value:
+                continue
+            before, _, after = value.partition("@")
+            scheme, _, _user = before.rpartition(":")
+            self._headers[header] = f"{scheme}:{number}@{after}"
+            rewritten = True
+        return rewritten
+
     def set_from_user(self, value: str) -> None:
         """Set the user part of the From header URI.
 

--- a/sdk/siphon_sdk/lcr.py
+++ b/sdk/siphon_sdk/lcr.py
@@ -176,6 +176,34 @@ class Route:
     timeout_secs: Optional[int] = None
     """Per-attempt ring timeout in seconds (else the call-level default)."""
 
+    caller_id: Optional[str] = None
+    """Calling number this carrier should see (the presented CLI), or ``None``
+    to keep the caller's own.
+
+    Applied through the same tag-preserving path that reshapes identity headers,
+    so the B-leg's ``From`` tag survives — which is why this is a field rather
+    than something to put in :attr:`headers`, where a ``From`` is refused
+    precisely because it would take the dialog tag with it.
+    :attr:`number_policy` reshapes the *format* of whatever number is present;
+    this substitutes a different one, which a number policy cannot do.
+
+    Also applied to ``P-Asserted-Identity`` / ``P-Preferred-Identity`` when the
+    message carries them."""
+
+    caller_id_presentation: Optional[str] = None
+    """``"allowed"`` (default) or ``"restricted"`` — whether the calling
+    identity may be presented to this carrier (CLIR).
+
+    ``restricted`` applies RFC 3323 §4.1 / TS 24.607: the ``From`` becomes
+    ``"Anonymous" <sip:anonymous@anonymous.invalid>`` with its tag intact,
+    ``Privacy: id`` is asserted, ``P-Preferred-Identity`` is dropped, and
+    ``P-Asserted-Identity`` keeps the real identity for the trusted next hop
+    (RFC 3325 §7).
+
+    Asserting ``Privacy: id`` without anonymising the ``From`` leaks the number
+    to every carrier that renders ``From`` rather than PAI, which defeats CLIR
+    while looking like it works — so the two always move together."""
+
     number_policy: Optional[str] = None
     """Named ``number_policies:`` preset applied to this carrier's B-leg identity
     headers (From/To/PAI) so the From/To shape can differ per carrier. The R-URI
@@ -211,6 +239,8 @@ class Route:
             "billing_increment",
             "min_duration",
             "timeout_secs",
+            "caller_id",
+            "caller_id_presentation",
             "number_policy",
         ):
             value = getattr(self, name)
@@ -238,6 +268,8 @@ class Route:
             billing_increment=data.get("billing_increment"),
             min_duration=data.get("min_duration"),
             timeout_secs=data.get("timeout_secs"),
+            caller_id=data.get("caller_id"),
+            caller_id_presentation=data.get("caller_id_presentation"),
             number_policy=data.get("number_policy"),
             headers=dict(data.get("headers", {})),
             cdr_fields=dict(data.get("cdr_fields", {})),

--- a/sdk/tests/test_caller_id_clir.py
+++ b/sdk/tests/test_caller_id_clir.py
@@ -1,0 +1,155 @@
+"""Per-route caller ID, and CLIR that actually anonymises.
+
+The presented CLI is a per-call, per-carrier decision. `number_policy` reshapes
+a number's *format* but cannot substitute a different one; `call.set_from_user`
+is tag-safe but identical for every carrier attempt; and a `From` in a route's
+`headers` is refused because it would take the dialog tag with it.
+
+Separately: asserting `Privacy: id` while leaving the real number in the `From`
+leaks it to every carrier that renders `From` rather than `P-Asserted-Identity`,
+which defeats CLIR while looking like it works. The two always move together.
+"""
+
+from siphon_sdk.call import Call
+from siphon_sdk.lcr import LcrResponse, Route
+
+ANONYMOUS = "sip:anonymous@anonymous.invalid"
+
+
+def _call() -> Call:
+    return Call(
+        call_id="clir-1",
+        from_uri="sip:+12025550100@siphon.example.com",
+        headers={
+            "From": '"Alice" <sip:+12025550100@siphon.example.com>;tag=a-tag',
+            "P-Asserted-Identity": "<sip:+12025550100@siphon.example.com>",
+        },
+    )
+
+
+# ── LCR contract ─────────────────────────────────────────────────────────
+
+
+def test_route_caller_id_round_trips():
+    route = Route(carrier_id="a", gateway_group="g", caller_id="+12025550111")
+
+    assert route.to_dict()["caller_id"] == "+12025550111"
+    assert Route.from_dict(route.to_dict()).caller_id == "+12025550111"
+
+
+def test_route_presentation_round_trips():
+    route = Route(carrier_id="a", gateway_group="g", caller_id_presentation="restricted")
+
+    assert route.to_dict()["caller_id_presentation"] == "restricted"
+    assert Route.from_dict(route.to_dict()).caller_id_presentation == "restricted"
+
+
+def test_caller_id_fields_are_absent_from_the_wire_when_unset():
+    """Additive: an API that never sets them sees no change."""
+    wire = Route(carrier_id="a", gateway_group="g").to_dict()
+
+    assert "caller_id" not in wire
+    assert "caller_id_presentation" not in wire
+
+
+def test_two_carriers_in_one_answer_can_present_different_clis():
+    response = LcrResponse.from_dict(
+        {
+            "routes": [
+                {"carrier_id": "a", "gateway_group": "g", "caller_id": "+12025550111"},
+                {"carrier_id": "b", "gateway_group": "g", "caller_id": "+442071838750"},
+            ]
+        }
+    )
+
+    assert [r.caller_id for r in response.routes] == ["+12025550111", "+442071838750"]
+
+
+# ── Script primitives ────────────────────────────────────────────────────
+
+
+def test_set_caller_id_rewrites_from_and_keeps_the_dialog_tag():
+    call = _call()
+    assert call.set_caller_id("+12025550111") is True
+
+    assert "+12025550111" in call.get_header("From")
+    assert "+12025550100" not in call.get_header("From")
+    assert "tag=a-tag" in call.get_header("From"), "the dialog tag must survive"
+
+
+def test_set_caller_id_also_rewrites_asserted_identity():
+    call = _call()
+    call.set_caller_id("+12025550111")
+
+    assert "+12025550111" in call.get_header("P-Asserted-Identity")
+
+
+def test_set_caller_id_ignores_an_empty_number():
+    call = _call()
+    assert call.set_caller_id("") is False
+    assert "+12025550100" in call.get_header("From")
+
+
+def test_restrict_anonymises_from_and_asserts_privacy_id():
+    call = _call()
+    call.restrict_caller_id()
+
+    from_header = call.get_header("From")
+    assert ANONYMOUS in from_header
+    assert "Anonymous" in from_header
+    assert "+12025550100" not in from_header, "the real number must not survive in From"
+    assert "tag=a-tag" in from_header, "the dialog tag must survive"
+    assert call.get_header("Privacy") == "id"
+
+
+def test_restrict_keeps_the_real_identity_in_pai():
+    """RFC 3325 §7 — the trusted next hop still learns who is calling."""
+    call = _call()
+    call.restrict_caller_id()
+
+    assert "+12025550100" in call.get_header("P-Asserted-Identity")
+
+
+def test_restrict_removes_p_preferred_identity():
+    call = Call(
+        call_id="clir-2",
+        headers={
+            "From": "<sip:+12025550100@siphon.example.com>;tag=a-tag",
+            "P-Preferred-Identity": "<sip:+12025550100@siphon.example.com>",
+        },
+    )
+    call.restrict_caller_id()
+
+    assert call.get_header("P-Preferred-Identity") is None
+
+
+def test_restrict_appends_to_an_existing_privacy_value():
+    call = Call(
+        call_id="clir-3",
+        headers={"From": "<sip:a@b>;tag=t", "Privacy": "header"},
+    )
+    call.restrict_caller_id()
+
+    privacy = call.get_header("Privacy")
+    assert "header" in privacy
+    assert "id" in privacy
+
+
+def test_restrict_is_idempotent():
+    call = Call(call_id="clir-4", headers={"From": "<sip:a@b>;tag=t", "Privacy": "id"})
+    call.restrict_caller_id()
+    call.restrict_caller_id()
+
+    assert call.get_header("Privacy") == "id"
+
+
+def test_a_withheld_call_goes_out_anonymous_with_a_real_pai():
+    """The whole point, end to end."""
+    call = _call()
+    call.set_caller_id("+12025550111")
+    call.restrict_caller_id()
+
+    assert ANONYMOUS in call.get_header("From")
+    assert "tag=a-tag" in call.get_header("From")
+    assert "+12025550111" in call.get_header("P-Asserted-Identity")
+    assert call.get_header("Privacy") == "id"

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11946,6 +11946,25 @@ fn b2bua_advance_route(
             .filter(|value| !value.is_empty());
         let extra_headers = lcr_injectable_headers(&route, call_id);
         let timeout = route.timeout_secs.unwrap_or(30);
+        // An unparseable presentation must not silently become "allowed": a
+        // withheld call going out with the caller's real number is the failure
+        // that matters here, so refuse the value loudly and present nothing
+        // rather than guess.
+        let caller_id_presentation = match route.caller_id_presentation.as_deref() {
+            None => None,
+            Some(value) => match crate::sip::privacy::CallerIdPresentation::parse(value) {
+                Some(parsed) => Some(parsed),
+                None => {
+                    warn!(
+                        call_id = %call_id,
+                        carrier = %route.carrier_id,
+                        caller_id_presentation = %value,
+                        "LCR: unknown caller_id_presentation, treating the call as restricted",
+                    );
+                    Some(crate::sip::privacy::CallerIdPresentation::Restricted)
+                }
+            },
+        };
         debug!(
             call_id = %call_id,
             carrier = %route.carrier_id,
@@ -11964,6 +11983,8 @@ fn b2bua_advance_route(
             original_request,
             route.number_policy.as_deref(),
             retarget.as_deref(),
+            route.caller_id.as_deref(),
+            caller_id_presentation,
             &extra_headers,
             state,
         );
@@ -12630,6 +12651,8 @@ fn handle_b2bua_invite(
                 &message_guard,
                 None,
                 None,
+                None,
+                None,
                 &[],
                 state,
             );
@@ -12657,6 +12680,8 @@ fn handle_b2bua_invite(
                     send_socket.as_ref(),
                     None,
                     &message_guard,
+                    None,
+                    None,
                     None,
                     None,
                     &[],
@@ -13163,6 +13188,12 @@ fn b2bua_send_b_leg_invite(
     // policy and the number policy. Callers must not put a dialog-defining
     // header in here — see [`lcr_injectable_headers`], which is where the one
     // caller with externally-supplied headers filters them.
+    // Presented CLI for this carrier (LCR `caller_id`), substituted before the
+    // number policy reshapes its format.
+    caller_id: Option<&str>,
+    // Whether the calling identity may be presented to this carrier (LCR
+    // `caller_id_presentation`). Applied last, after the number policy.
+    caller_id_presentation: Option<crate::sip::privacy::CallerIdPresentation>,
     extra_headers: &[(String, String)],
     state: &DispatcherState,
 ) {
@@ -13513,6 +13544,15 @@ fn b2bua_send_b_leg_invite(
         crate::b2bua::header_policy::apply_to_request(&mut b_leg_invite, &policy, &ctx);
     }
 
+    // Per-carrier (LCR) presented CLI: substitute the calling number before the
+    // number policy reshapes its format, through the tag-preserving path so the
+    // B-leg's From tag survives. `set_header("From", ...)` cannot do this — the
+    // host is rewritten after the script runs, and a From written without a tag
+    // drops the mandatory dialog tag (RFC 3261 §8.1.1.3).
+    if let Some(caller_id) = caller_id.filter(|value| !value.is_empty()) {
+        crate::sip::privacy::set_calling_number(&mut b_leg_invite, caller_id);
+    }
+
     // Per-carrier (LCR) number policy: reshape this B-leg's identity headers
     // (From / To / P-Asserted-Identity / P-Preferred-Identity) to the carrier's
     // format. The R-URI is owned by tech_prefix / ruri, so it is left untouched.
@@ -13528,6 +13568,14 @@ fn b2bua_send_b_leg_invite(
                 "LCR: unknown number_policy on route, skipping identity reshape"
             ),
         }
+    }
+
+    // Per-carrier (LCR) CLIR: withhold the calling identity from this carrier
+    // (RFC 3323 §4.1 / TS 24.607). Deliberately *after* the number policy —
+    // anonymisation is the last identity step, or the policy would try to
+    // reshape "anonymous" as a number.
+    if caller_id_presentation == Some(crate::sip::privacy::CallerIdPresentation::Restricted) {
+        crate::sip::privacy::restrict_calling_identity(&mut b_leg_invite);
     }
 
     // Inject per-carrier (LCR) headers after the header policy, so a carrier's
@@ -20281,8 +20329,20 @@ fn b2bua_refer_accept(
             };
             let dialed = if let Some(template) = dial_template {
                 b2bua_send_b_leg_invite(
-                    call_id, target_uri, next_hop, None, &[], None, forced_cid, &template, None,
-                    None, &[], state,
+                    call_id,
+                    target_uri,
+                    next_hop,
+                    None,
+                    &[],
+                    None,
+                    forced_cid,
+                    &template,
+                    None,
+                    None,
+                    None,
+                    None,
+                    &[],
+                    state,
                 );
                 true
             } else {

--- a/src/lcr/mod.rs
+++ b/src/lcr/mod.rs
@@ -218,6 +218,34 @@ pub struct Route {
     /// Per-attempt ring timeout in seconds (else the call-level default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_secs: Option<u32>,
+    /// Calling number this carrier should see (the presented CLI), or `None` to
+    /// keep the caller's own.
+    ///
+    /// Applied through the same tag-preserving path that reshapes identity
+    /// headers, so the B-leg's `From` tag survives — which is why this is a
+    /// field rather than something to put in `headers`, where a `From` is
+    /// refused precisely because it would take the dialog tag with it.
+    /// `number_policy` reshapes the *format* of whatever number is present; this
+    /// substitutes a different one, which `number_policy` cannot do.
+    ///
+    /// Also applied to `P-Asserted-Identity` / `P-Preferred-Identity` when the
+    /// message carries them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_id: Option<String>,
+    /// Whether the calling identity may be presented to this carrier:
+    /// `"allowed"` (default) or `"restricted"` (CLIR).
+    ///
+    /// `restricted` applies RFC 3323 §4.1 / TS 24.607: the `From` becomes
+    /// `"Anonymous" <sip:anonymous@anonymous.invalid>` with its tag intact,
+    /// `Privacy: id` is asserted, `P-Preferred-Identity` is dropped, and
+    /// `P-Asserted-Identity` keeps the real identity for the trusted next hop
+    /// (RFC 3325 §7).
+    ///
+    /// Asserting `Privacy: id` without anonymising the `From` leaks the number
+    /// to every carrier that renders `From` rather than PAI, which defeats CLIR
+    /// while looking like it works — so the two always move together.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_id_presentation: Option<String>,
     /// Named `number_policies:` preset applied to *this carrier's* B-leg identity
     /// headers (From / To / P-Asserted-Identity / P-Preferred-Identity) — so the
     /// From/To shape can differ per carrier and a failover to a second carrier
@@ -761,6 +789,28 @@ mod tests {
     }
 
     #[test]
+    fn caller_id_and_presentation_round_trip_through_the_api_json() {
+        let json = r#"{
+            "routes": [
+                {"carrier_id": "a", "gateway_group": "carriers",
+                 "caller_id": "+12025550111"},
+                {"carrier_id": "b", "gateway_group": "carriers",
+                 "caller_id": "+12025550122",
+                 "caller_id_presentation": "restricted"}
+            ]
+        }"#;
+        let response: LcrResponse = serde_json::from_str(json).expect("parses");
+
+        assert_eq!(response.routes[0].caller_id.as_deref(), Some("+12025550111"));
+        assert!(response.routes[0].caller_id_presentation.is_none());
+        assert_eq!(response.routes[1].caller_id.as_deref(), Some("+12025550122"));
+        assert_eq!(
+            response.routes[1].caller_id_presentation.as_deref(),
+            Some("restricted")
+        );
+    }
+
+    #[test]
     fn a_destination_alone_does_not_make_a_route_routable() {
         // It says who to reach, never how — such a route has nowhere to send
         // the INVITE and must still be skipped.
@@ -770,5 +820,40 @@ mod tests {
             ..Default::default()
         };
         assert!(!route.is_routable());
+    }
+
+    #[test]
+    fn two_carriers_in_one_answer_can_present_different_clis() {
+        // The per-call, per-carrier decision the contract could not express:
+        // `number_policy` reshapes a number's format but cannot substitute a
+        // different one, and `headers` refuses `From` because it would take the
+        // dialog tag with it.
+        let response: LcrResponse = serde_json::from_str(
+            r#"{"routes":[
+                {"carrier_id":"a","gateway_group":"g","caller_id":"+12025550111"},
+                {"carrier_id":"b","gateway_group":"g","caller_id":"+442071838750"}
+            ]}"#,
+        )
+        .expect("parses");
+
+        let presented: Vec<_> = response
+            .routes
+            .iter()
+            .map(|route| route.caller_id.as_deref())
+            .collect();
+        assert_eq!(presented, vec![Some("+12025550111"), Some("+442071838750")]);
+    }
+
+    #[test]
+    fn caller_id_fields_are_absent_from_the_wire_when_unset() {
+        // Additive: an API that never sets them sees no change.
+        let route = Route {
+            carrier_id: "a".into(),
+            gateway_group: Some("g".into()),
+            ..Default::default()
+        };
+        let wire = serde_json::to_string(&route).expect("serializes");
+        assert!(!wire.contains("caller_id"), "{wire}");
+        assert!(!wire.contains("caller_id_presentation"), "{wire}");
     }
 }

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -1833,6 +1833,63 @@ impl PyCall {
         Ok(super::numbers::apply_to_message(&mut message, &resolved))
     }
 
+    /// Withhold the calling party's identity on the B-leg (CLIR), per
+    /// RFC 3323 §4.1 and 3GPP TS 24.607.
+    ///
+    /// ```python
+    /// @b2bua.on_invite
+    /// def route(call):
+    ///     if caller_withheld(call):
+    ///         call.restrict_caller_id()
+    ///     call.dial(str(call.ruri))
+    /// ```
+    ///
+    /// - `From` becomes `"Anonymous" <sip:anonymous@anonymous.invalid>`,
+    ///   keeping its dialog tag.
+    /// - `Privacy: id` is asserted (RFC 3325 §7), appended to any existing
+    ///   `Privacy` value rather than replacing it.
+    /// - `P-Asserted-Identity` is left intact, carrying the real identity to
+    ///   the trusted next hop — that is how the network stays able to identify
+    ///   the caller for regulatory and emergency purposes.
+    /// - `P-Preferred-Identity` is removed: it is the UA's *request* for what
+    ///   to assert, and forwarding it past a privacy boundary re-leaks the
+    ///   number.
+    ///
+    /// Setting `Privacy: id` by hand while leaving the real number in `From`
+    /// leaks it to every carrier that renders `From` rather than
+    /// `P-Asserted-Identity` — which defeats CLIR while looking like it works.
+    /// This moves both together.
+    ///
+    /// Call it *after* any identity reshaping: anonymisation is the last step,
+    /// or a number policy will try to reformat `anonymous` as a number. The
+    /// LCR twin is a route's `caller_id_presentation: "restricted"`.
+    fn restrict_caller_id(&self) -> PyResult<()> {
+        let mut message = self.message.lock().map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+        })?;
+        crate::sip::privacy::restrict_calling_identity(&mut message);
+        Ok(())
+    }
+
+    /// Present `number` as the calling party, on `From` and on
+    /// `P-Asserted-Identity` / `P-Preferred-Identity` where present.
+    ///
+    /// The dialog tag is preserved, which is why this exists rather than a
+    /// `set_header("From", ...)`: the B-leg From host is rewritten after the
+    /// script runs, and a `From` set without a tag drops the mandatory dialog
+    /// tag (RFC 3261 §8.1.1.3) — a failure that only surfaces later, on the
+    /// ACK.
+    ///
+    /// Unlike a number policy, which reshapes the *format* of whatever number
+    /// is already there, this substitutes a different one. The LCR twin is a
+    /// route's `caller_id`.
+    fn set_caller_id(&self, number: &str) -> PyResult<bool> {
+        let mut message = self.message.lock().map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+        })?;
+        Ok(crate::sip::privacy::set_calling_number(&mut message, number))
+    }
+
     /// Set the user part of the From header URI.
     ///
     /// Usage in Python:

--- a/src/script/api/lcr.rs
+++ b/src/script/api/lcr.rs
@@ -83,6 +83,20 @@ impl PyRoute {
         self.inner.destination.as_deref()
     }
 
+    /// Calling number this carrier is presented (the CLI), or `None` to keep
+    /// the caller's own.
+    #[getter]
+    fn caller_id(&self) -> Option<&str> {
+        self.inner.caller_id.as_deref()
+    }
+
+    /// `"allowed"` | `"restricted"` — whether the calling identity may be
+    /// presented to this carrier (CLIR, RFC 3323 / TS 24.607).
+    #[getter]
+    fn caller_id_presentation(&self) -> Option<&str> {
+        self.inner.caller_id_presentation.as_deref()
+    }
+
     /// Named number policy applied to this carrier's B-leg identity headers.
     #[getter]
     fn number_policy(&self) -> Option<&str> {

--- a/src/sip/mod.rs
+++ b/src/sip/mod.rs
@@ -7,6 +7,7 @@ pub mod uri;
 pub mod headers;
 pub mod codec;
 pub mod validate;
+pub mod privacy;
 
 pub use message::*;
 pub use parser::parse_sip_message;

--- a/src/sip/privacy.rs
+++ b/src/sip/privacy.rs
@@ -1,0 +1,368 @@
+//! Calling-party identity: presentation and restriction.
+//!
+//! Two operations a network element performs on the identity a call presents,
+//! both of which have to preserve the dialog:
+//!
+//! - **Substitute** the presented number ([`set_calling_number`]) — the CLI a
+//!   given carrier should see, which is a per-call, per-carrier decision.
+//! - **Restrict** it ([`restrict_calling_identity`]) — CLIR, per RFC 3323 §4.1
+//!   and 3GPP TS 24.607: the `From` is anonymised, `Privacy: id` is added, and
+//!   `P-Asserted-Identity` keeps the real identity for the trusted next hop
+//!   (RFC 3325 §7).
+//!
+//! Both go through [`NameAddr`], which round-trips the `tag` parameter, so
+//! neither can break the dialog the way a raw `headers.set("From", …)` would —
+//! a `From` written without its tag drops the mandatory dialog tag
+//! (RFC 3261 §8.1.1.3) and the breakage only surfaces later, on the ACK.
+//!
+//! Sending `Privacy: id` while leaving the real number in the `From` is the
+//! failure this module exists to prevent: it leaks the number to every carrier
+//! that renders `From` rather than `P-Asserted-Identity`, which defeats CLIR
+//! entirely while looking like it works.
+
+use crate::sip::headers::nameaddr::NameAddr;
+use crate::sip::message::SipMessage;
+
+/// RFC 3323 §4.1: the anonymous URI a restricted identity presents.
+pub const ANONYMOUS_URI: &str = "sip:anonymous@anonymous.invalid";
+
+/// RFC 3323 §4.1: the display name that accompanies it.
+pub const ANONYMOUS_DISPLAY_NAME: &str = "Anonymous";
+
+/// Whether the calling party's identity may be presented to the far end
+/// (3GPP TS 24.607 — Originating Identification Restriction).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallerIdPresentation {
+    /// Present the calling identity normally.
+    Allowed,
+    /// Withhold it: anonymise `From`, assert `Privacy: id`, keep the real
+    /// identity in `P-Asserted-Identity` for the trusted next hop.
+    Restricted,
+}
+
+impl CallerIdPresentation {
+    /// Parse the wire/config spelling. Unrecognised values are `None` so the
+    /// caller can complain rather than silently guessing at a privacy setting.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "allowed" | "allow" | "present" | "presented" => Some(Self::Allowed),
+            "restricted" | "restrict" | "private" | "anonymous" => Some(Self::Restricted),
+            _ => None,
+        }
+    }
+}
+
+/// Rewrite the userpart of every `name-addr` on `header`, preserving the
+/// display name, the tag and every other parameter.
+///
+/// Returns the number of values rewritten.
+fn rewrite_userpart(message: &mut SipMessage, header: &str, user: &str) -> usize {
+    let Some(values) = message.headers.get_all(header).cloned() else {
+        return 0;
+    };
+
+    let mut rewritten = 0;
+    let mut new_values = Vec::with_capacity(values.len());
+    for value in values {
+        match NameAddr::parse_multi(&value) {
+            Ok(entries) if !entries.is_empty() => {
+                let mut kept = Vec::with_capacity(entries.len());
+                for mut entry in entries {
+                    entry.uri.user = Some(user.to_string());
+                    rewritten += 1;
+                    kept.push(entry.to_string());
+                }
+                new_values.push(kept.join(", "));
+            }
+            // Unparseable — keep verbatim rather than corrupt it.
+            _ => new_values.push(value),
+        }
+    }
+
+    if rewritten > 0 {
+        message.headers.remove(header);
+        for value in new_values {
+            message.headers.add(header, value);
+        }
+    }
+    rewritten
+}
+
+/// Present `number` as the calling party on `From`, and on
+/// `P-Asserted-Identity` / `P-Preferred-Identity` when the message carries
+/// them.
+///
+/// The dialog tag on `From` is preserved, which is why this exists rather than
+/// a `set_header("From", …)`: the B-leg's From tag is siphon's, and a header
+/// written without it breaks every subsequent in-dialog request.
+///
+/// Returns `true` if anything was rewritten.
+pub fn set_calling_number(message: &mut SipMessage, number: &str) -> bool {
+    if number.is_empty() {
+        return false;
+    }
+    let mut rewritten = rewrite_userpart(message, "From", number);
+    rewritten += rewrite_userpart(message, "P-Asserted-Identity", number);
+    rewritten += rewrite_userpart(message, "P-Preferred-Identity", number);
+    rewritten > 0
+}
+
+/// Withhold the calling party's identity (CLIR), per RFC 3323 §4.1 and
+/// TS 24.607.
+///
+/// - `From` becomes `"Anonymous" <sip:anonymous@anonymous.invalid>`, keeping
+///   its tag so the dialog survives.
+/// - `Privacy: id` is asserted (RFC 3325 §7), appended to any existing
+///   `Privacy` value rather than replacing it.
+/// - `P-Asserted-Identity` is left intact: it carries the real identity to the
+///   trusted next hop, which is the entire mechanism by which the network can
+///   still identify the caller for regulatory and emergency purposes.
+/// - `P-Preferred-Identity` is removed. It is the UA's *request* for what to
+///   assert (RFC 3325 §9.1) and has no meaning once the network has decided;
+///   forwarding it past a privacy boundary re-leaks the number.
+///
+/// Do not call this and then reformat identity headers — anonymisation is the
+/// last step, or a number policy will try to reshape `anonymous` as a number.
+pub fn restrict_calling_identity(message: &mut SipMessage) {
+    anonymize_from(message);
+
+    message.headers.remove("P-Preferred-Identity");
+
+    // RFC 3323 §4.2: Privacy is a list. Preserve anything already asserted.
+    let existing = message.headers.get("Privacy").cloned().unwrap_or_default();
+    let already_set = existing
+        .split(';')
+        .any(|token| token.trim().eq_ignore_ascii_case("id"));
+    if !already_set {
+        let value = if existing.trim().is_empty() {
+            "id".to_string()
+        } else {
+            format!("{};id", existing.trim())
+        };
+        message.headers.set("Privacy", value);
+    }
+}
+
+/// Replace `From` with the RFC 3323 anonymous name-addr, preserving the tag.
+fn anonymize_from(message: &mut SipMessage) {
+    let Some(value) = message.headers.get("From").cloned() else {
+        return;
+    };
+    let tag = NameAddr::parse(&value).ok().and_then(|entry| entry.tag);
+
+    let anonymous = match tag {
+        Some(tag) => format!("\"{ANONYMOUS_DISPLAY_NAME}\" <{ANONYMOUS_URI}>;tag={tag}"),
+        // No tag to preserve (a malformed From, or a non-dialog request).
+        None => format!("\"{ANONYMOUS_DISPLAY_NAME}\" <{ANONYMOUS_URI}>"),
+    };
+    message.headers.set("From", anonymous);
+}
+
+/// Apply a presentation decision: substitute `number` when given, then restrict
+/// if the presentation says so.
+///
+/// Ordering is load-bearing. The substitution runs first so that under
+/// `Restricted` the real number reaches `P-Asserted-Identity` before `From` is
+/// anonymised — otherwise the trusted next hop would be asserted an anonymous
+/// identity, and the caller would be unidentifiable even inside the trust
+/// domain.
+pub fn apply_calling_identity(
+    message: &mut SipMessage,
+    number: Option<&str>,
+    presentation: Option<CallerIdPresentation>,
+) {
+    if let Some(number) = number {
+        set_calling_number(message, number);
+    }
+    if presentation == Some(CallerIdPresentation::Restricted) {
+        restrict_calling_identity(message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sip::parser::parse_sip_message;
+
+    fn invite_with(extra: &str) -> SipMessage {
+        let raw = format!(
+            concat!(
+                "INVITE sip:+12025550199@carrier.example.net SIP/2.0\r\n",
+                "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-privacy\r\n",
+                "From: \"Alice\" <sip:+12025550100@siphon.example.com>;tag=a-tag\r\n",
+                "To: <sip:+12025550199@carrier.example.net>\r\n",
+                "Call-ID: privacy-1@host\r\n",
+                "CSeq: 1 INVITE\r\n",
+                "{}",
+                "Content-Length: 0\r\n",
+                "\r\n",
+            ),
+            extra
+        );
+        parse_sip_message(&raw).expect("fixture parses").1
+    }
+
+    fn header(message: &SipMessage, name: &str) -> Option<String> {
+        message.headers.get(name).cloned()
+    }
+
+    #[test]
+    fn presentation_parses_its_spellings() {
+        assert_eq!(
+            CallerIdPresentation::parse("allowed"),
+            Some(CallerIdPresentation::Allowed)
+        );
+        assert_eq!(
+            CallerIdPresentation::parse("RESTRICTED"),
+            Some(CallerIdPresentation::Restricted)
+        );
+        assert_eq!(
+            CallerIdPresentation::parse(" private "),
+            Some(CallerIdPresentation::Restricted)
+        );
+        // Unrecognised is None, never a silent guess at a privacy setting.
+        assert!(CallerIdPresentation::parse("maybe").is_none());
+        assert!(CallerIdPresentation::parse("").is_none());
+    }
+
+    #[test]
+    fn set_calling_number_rewrites_from_and_keeps_the_dialog_tag() {
+        // The reason this exists rather than a set_header("From", …): a From
+        // written without its tag drops the mandatory dialog tag and the
+        // breakage only surfaces later, on the ACK.
+        let mut message = invite_with("");
+        assert!(set_calling_number(&mut message, "+12025550111"));
+
+        let from = header(&message, "From").expect("From present");
+        assert!(from.contains("+12025550111"), "{from}");
+        assert!(!from.contains("+12025550100"), "{from}");
+        assert!(from.contains("tag=a-tag"), "the dialog tag must survive: {from}");
+        assert!(from.contains("Alice"), "the display name survives: {from}");
+    }
+
+    #[test]
+    fn set_calling_number_also_rewrites_asserted_identity_when_present() {
+        let mut message =
+            invite_with("P-Asserted-Identity: <sip:+12025550100@siphon.example.com>\r\n");
+        set_calling_number(&mut message, "+12025550111");
+
+        let pai = header(&message, "P-Asserted-Identity").expect("PAI present");
+        assert!(pai.contains("+12025550111"), "{pai}");
+    }
+
+    #[test]
+    fn set_calling_number_ignores_an_empty_number() {
+        let mut message = invite_with("");
+        assert!(!set_calling_number(&mut message, ""));
+        assert!(header(&message, "From").expect("From").contains("+12025550100"));
+    }
+
+    #[test]
+    fn restrict_anonymises_from_and_asserts_privacy_id() {
+        let mut message = invite_with("");
+        restrict_calling_identity(&mut message);
+
+        let from = header(&message, "From").expect("From present");
+        assert!(from.contains(ANONYMOUS_URI), "{from}");
+        assert!(from.contains(ANONYMOUS_DISPLAY_NAME), "{from}");
+        assert!(
+            !from.contains("+12025550100"),
+            "the real number must not survive in From: {from}",
+        );
+        assert!(from.contains("tag=a-tag"), "the dialog tag must survive: {from}");
+        assert_eq!(header(&message, "Privacy").as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn restrict_keeps_the_real_identity_in_p_asserted_identity() {
+        // RFC 3325 §7: PAI carries the identity to the trusted next hop. That
+        // is the mechanism by which the caller stays identifiable inside the
+        // trust domain, for regulatory and emergency purposes.
+        let mut message =
+            invite_with("P-Asserted-Identity: <sip:+12025550100@siphon.example.com>\r\n");
+        restrict_calling_identity(&mut message);
+
+        let pai = header(&message, "P-Asserted-Identity").expect("PAI present");
+        assert!(pai.contains("+12025550100"), "{pai}");
+        assert!(header(&message, "From").expect("From").contains(ANONYMOUS_URI));
+    }
+
+    #[test]
+    fn restrict_removes_p_preferred_identity() {
+        // It is the UA's *request* for what to assert (RFC 3325 §9.1), with no
+        // meaning once the network has decided — and forwarding it past a
+        // privacy boundary re-leaks the number.
+        let mut message =
+            invite_with("P-Preferred-Identity: <sip:+12025550100@siphon.example.com>\r\n");
+        restrict_calling_identity(&mut message);
+
+        assert!(header(&message, "P-Preferred-Identity").is_none());
+    }
+
+    #[test]
+    fn restrict_appends_to_an_existing_privacy_value() {
+        let mut message = invite_with("Privacy: header\r\n");
+        restrict_calling_identity(&mut message);
+
+        let privacy = header(&message, "Privacy").expect("Privacy present");
+        assert!(privacy.contains("header"), "existing tokens survive: {privacy}");
+        assert!(privacy.contains("id"), "{privacy}");
+    }
+
+    #[test]
+    fn restrict_is_idempotent_on_privacy_id() {
+        let mut message = invite_with("Privacy: id\r\n");
+        restrict_calling_identity(&mut message);
+        restrict_calling_identity(&mut message);
+
+        assert_eq!(header(&message, "Privacy").as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn a_withheld_call_presents_an_anonymous_from_and_a_real_pai() {
+        // The whole point, end to end: substitution runs before anonymisation,
+        // so the trusted next hop is still asserted a real identity.
+        let mut message =
+            invite_with("P-Asserted-Identity: <sip:+12025550100@siphon.example.com>\r\n");
+        apply_calling_identity(
+            &mut message,
+            Some("+12025550111"),
+            Some(CallerIdPresentation::Restricted),
+        );
+
+        let from = header(&message, "From").expect("From");
+        let pai = header(&message, "P-Asserted-Identity").expect("PAI");
+
+        assert!(from.contains(ANONYMOUS_URI), "{from}");
+        assert!(from.contains("tag=a-tag"), "{from}");
+        assert!(
+            pai.contains("+12025550111"),
+            "the substituted number must reach the trusted hop: {pai}",
+        );
+        assert_eq!(header(&message, "Privacy").as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn presentation_allowed_leaves_the_identity_visible() {
+        let mut message = invite_with("");
+        apply_calling_identity(
+            &mut message,
+            Some("+12025550111"),
+            Some(CallerIdPresentation::Allowed),
+        );
+
+        let from = header(&message, "From").expect("From");
+        assert!(from.contains("+12025550111"), "{from}");
+        assert!(header(&message, "Privacy").is_none(), "no privacy asserted");
+    }
+
+    #[test]
+    fn no_number_and_no_presentation_changes_nothing() {
+        let mut message = invite_with("");
+        let before = header(&message, "From");
+        apply_calling_identity(&mut message, None, None);
+
+        assert_eq!(header(&message, "From"), before);
+        assert!(header(&message, "Privacy").is_none());
+    }
+}


### PR DESCRIPTION
Two related gaps in how siphon presents the calling identity.

## The presented CLI could not be chosen per carrier

It is a per-call, per-carrier decision, and nothing could express it:

- `number_policy` reshapes a number's **format** per carrier, but cannot substitute a different number
- `call.set_from_user()` is tag-safe but identical for every carrier attempt
- a `From` in a route's `headers` is refused, precisely because it would take the dialog tag with it

New `caller_id` on an LCR route (and `call.set_caller_id(number)`), applied through the same tag-preserving `NameAddr` path the identity reshaping already uses — `From`, plus `P-Asserted-Identity` / `P-Preferred-Identity` where present. Two carriers in one answer can now present different CLIs on the same call.

## `Privacy: id` was decorative

There was **no RFC 3323 anonymisation anywhere in the tree** — the only `anonymous.invalid` was an Rf test fixture. So a deployment asserting `Privacy: id` left the subscriber's real number sitting in the `From`, where every carrier that renders `From` rather than `P-Asserted-Identity` reads it. That defeats CLIR entirely, while looking like it works.

`caller_id_presentation: "restricted"` (and `call.restrict_caller_id()`) now move both together, per RFC 3323 §4.1 / TS 24.607:

- `From` → `"Anonymous" <sip:anonymous@anonymous.invalid>`, **dialog tag intact**
- `Privacy: id` appended to any existing value, not replacing the list (RFC 3323 §4.2)
- `P-Preferred-Identity` removed — it is the UA's *request* for what to assert, and forwarding it past a privacy boundary re-leaks the number
- `P-Asserted-Identity` **kept**, carrying the real identity to the trusted next hop (RFC 3325 §7) — that is how the network stays able to identify the caller for regulatory and emergency purposes

## Design calls

**Built as a general primitive** (`src/sip/privacy.rs`), not an LCR field. RFC 3323 is not LCR-specific, so a script not using the routing API reaches it through `call.restrict_caller_id()` / `call.set_caller_id()`.

**Ordering is fixed and load-bearing.** `caller_id` substitutes *before* `number_policy` reshapes formats; anonymisation runs *after*. So under `restricted` the substituted number still reaches PAI, and no policy tries to reformat `anonymous` as a number.

**An unrecognised `caller_id_presentation` is logged and treated as `restricted`.** A withheld call going out with the real number is the failure that matters, so it refuses to guess in the permissive direction.

**Additive**: both fields are absent from the wire when unset.

## Tests

16 Rust + 13 SDK:

- substitution keeps the dialog tag and the display name, and reaches PAI/PPI
- an empty number is ignored rather than blanking the identity
- restrict anonymises `From`, keeps its tag, and asserts `Privacy: id`
- restrict keeps the real identity in PAI, and removes PPI
- `Privacy` appending and idempotence
- end to end: a withheld call presents an anonymous `From` **and** a real PAI
- `allowed` leaves the identity visible and asserts no privacy
- presentation parsing, including an unrecognised value being refused
- LCR JSON round-trip, two carriers with different CLIs, absence when unset

Mutation-checked: asserting `Privacy: id` without anonymising — the exact leak — fails three of them.

Rust 3950 passed, SDK 555 passed, clippy clean.