### PR TITLE
ci(release): publish the extensions binary as a container image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,11 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # The opt-in-extensions image (siphon-bin): the same siphon, plus the SMPP,
+  # HTTP and SIGTRAN modules. Published on the same tag cadence as the core
+  # image, so an operator who needs a scriptable `http` / `smpp` namespace can
+  # pin a release instead of side-loading a build.
+  EXTENSIONS_IMAGE_NAME: ${{ github.repository }}-bin
 
 permissions:
   contents: write
@@ -33,7 +38,7 @@ jobs:
             echo "::error::Cargo.toml version ($cargo_version) does not match tag ($tag_version) — bump Cargo.toml in the release commit (use scripts/cut-release.sh)."
             exit 1
           fi
-          # A release must document its version in CHANGELOG.md (CLAUDE.md rule).
+          # A release must document its version in CHANGELOG.md (project convention).
           ver_re="$(printf '%s' "$tag_version" | sed 's/\./\\./g')"
           if ! grep -qE "^## \[?${ver_re}\]?" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [$tag_version]' section — add the release notes (scripts/cut-release.sh gates on this)."
@@ -287,6 +292,158 @@ jobs:
 
       - name: Inspect manifest
         run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  # ── Extensions image (siphon-bin) → GHCR ─────────────────────────────
+  # Same native-per-arch shape as the core image above: no QEMU, push by digest,
+  # merged into one manifest list below.
+  #
+  # Built with `--features full`, i.e. every extension module. The namespaces
+  # are inert until a `siphon.yaml` configures them, so one image beats a tag
+  # matrix per feature — an operator enables what they need in config, not by
+  # choosing a different image.
+  docker-extensions:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Normalise platform name
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
+
+      # siphon-bin git-deps siphon-sip from `main`, which is right for CI but
+      # wrong for a release: `siphon-bin:X.Y.Z` has to contain siphon-sip X.Y.Z,
+      # not whatever main happened to be. Repoint the dep at the tag being
+      # released and re-resolve, so the image matches the tag it is published
+      # under.
+      - name: Pin siphon-sip to the release tag
+        working-directory: siphon-bin
+        run: |
+          python3 - "$GITHUB_REF_NAME" <<'PY'
+          import re, sys, pathlib
+          tag = sys.argv[1]
+          path = pathlib.Path("Cargo.toml")
+          text = path.read_text()
+          # Anchored to line start: the same string appears in a comment above
+          # the real dep, and a silent second substitution there would go
+          # unnoticed until the build failed.
+          pinned, count = re.subn(
+              r'^(siphon-sip = \{ git = "[^"]+", )branch = "main"',
+              lambda m: f'{m.group(1)}tag = "{tag}"',
+              text,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              sys.exit(f"expected exactly one siphon-sip branch dep, replaced {count}")
+          path.write_text(pinned)
+          print(f"pinned siphon-sip to {tag}")
+          PY
+          grep -n 'siphon-sip = ' Cargo.toml
+
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Re-resolve the lockfile against the tag
+        working-directory: siphon-bin
+        run: cargo update -p siphon-sip --offline || cargo update -p siphon-sip
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.EXTENSIONS_IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build + push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          # The build context is the package directory: siphon-bin git-deps
+          # everything it needs, so it never sees the root tree.
+          context: siphon-bin
+          file: siphon-bin/Dockerfile
+          build-args: |
+            FEATURES=full
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=extensions-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=extensions-${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.EXTENSIONS_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${digest#sha256:}"
+        env:
+          digest: ${{ steps.build.outputs.digest }}
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: extensions-digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Merge the extensions image's per-arch digests + tag it ────────────
+  docker-extensions-merge:
+    needs: docker-extensions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: extensions-digests-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.EXTENSIONS_IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Create + push the multi-arch manifest list
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.EXTENSIONS_IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.EXTENSIONS_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   # ── SBOM (SPDX + CycloneDX), attached to the GitHub Release ───────────
   sbom:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **The extensions binary is published as a container image**,
+  `ghcr.io/siphon-project/siphon-sip-bin`, on the same tag cadence and with the
+  same multi-arch (amd64 + arm64) shape as the core image. `siphon-bin` is a
+  separate excluded workspace and was never published, so the only way to run a
+  build with the `smpp` / `http` / `sigtran` namespaces was to build it
+  yourself — `from siphon import http` could not work in any released artifact.
+  Built with `--features full`: the namespaces are inert until `siphon.yaml`
+  configures them, so one image beats a tag per feature. Its `siphon-sip` git
+  dep is repointed at the tag being released before the build, so
+  `siphon-sip-bin:X.Y.Z` genuinely contains siphon-sip X.Y.Z rather than
+  whatever `main` happened to be.
 - **CI covers re-INVITE renegotiation on the `siphon-rtp` backend** (`--reoffer`).
   The existing `--reinvite` mode runs the same hold/resume flow against
   rtpengine, where a repeat `offer` on a live call-id *is* the re-offer — so it

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -81,7 +81,7 @@ exact version.
 - **Security:** ship as a PATCH, expedited; backport to the supported line.
 - **Performance is not a version decision — it is a release gate.** Every
   release must re-run the 16-row README perf baseline with **0 Failed / 0
-  Retransmits** on every row (see `CLAUDE.md`). A perf *improvement* that raises
+  Retransmits** on every row (see the project's contributing conventions). A perf *improvement* that raises
   the floor → PATCH + update the README table.
 - **Lockstep cost:** a docs-only or SDK-only change still bumps everything
   (PATCH). Accepted — one number across the whole project is worth it.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,6 +15,23 @@ built-in `proxy`, `registrar`, `cache`, and friends.
   [`siphon-bin`](https://github.com/siphon-project/siphon-sip/tree/main/siphon-bin)
   package with the module's cargo feature turned on (e.g. `--features smpp`). It
   is a drop-in `siphon` binary — same CLI, same `siphon.yaml`, plus the module.
+- **Or pull the published image.** `ghcr.io/siphon-project/siphon-sip-bin` is
+  released on the same tag cadence as the core image, built with **every**
+  module compiled in:
+
+  ```bash
+  docker pull ghcr.io/siphon-project/siphon-sip-bin:1.6.0
+  ```
+
+  One image rather than a tag per feature: the namespaces are inert until a
+  `siphon.yaml` configures them, so you enable what you need in config, not by
+  picking a different image. Its `siphon-sip` is pinned to the tag it is
+  published under, so `siphon-sip-bin:X.Y.Z` contains siphon-sip X.Y.Z.
+
+  | Image | Contains |
+  |---|---|
+  | `ghcr.io/siphon-project/siphon-sip` | siphon only |
+  | `ghcr.io/siphon-project/siphon-sip-bin` | siphon + `smpp`, `http`, `sigtran` |
 - **Configured in `siphon.yaml`.** An `extensions:` map points each enabled
   module at its own config file:
 
@@ -43,6 +60,9 @@ cargo build -p siphon-bin --release --features smpp
 
 # …or a container image (mount your config + script at runtime)
 docker build -f siphon-bin/Dockerfile -t siphon-smpp siphon-bin/
+
+# …or skip the build: the published image already has every module
+docker pull ghcr.io/siphon-project/siphon-sip-bin:latest
 ```
 
 ### 2. Point siphon at the SMPP config

--- a/scripts/scale_test.sh
+++ b/scripts/scale_test.sh
@@ -45,7 +45,7 @@ cleanup() {
 trap cleanup EXIT
 
 # --- Pick Python interpreter ---
-# CLAUDE.md baseline assumes free-threaded Python 3.14t. Without it we'd be
+# The published baseline assumes free-threaded Python 3.14t. Without it we'd be
 # benchmarking a GIL-serialized build, which silently ceiling-limits throughput
 # regardless of how many cores the box has. Resolution order:
 #   1. PYO3_PYTHON env var if explicitly set

--- a/tests/integration/packaging_tests.rs
+++ b/tests/integration/packaging_tests.rs
@@ -103,6 +103,79 @@ fn every_support_file_ships_in_the_release_tarball() {
     }
 }
 
+/// The extensions image (`siphon-bin`) is published on the same tag cadence as
+/// the core image. Both halves have to be there — a build job with no merge job
+/// pushes untagged digests nobody can pull, which looks like success.
+#[test]
+fn the_release_publishes_the_extensions_image() {
+    let workflow = read(".github/workflows/release.yaml");
+
+    for job in ["docker-extensions:", "docker-extensions-merge:"] {
+        assert!(
+            workflow.contains(job),
+            "release.yaml no longer defines the {job} job — the extensions image \
+             would stop being published on release"
+        );
+    }
+    assert!(
+        workflow.contains("EXTENSIONS_IMAGE_NAME"),
+        "the extensions image name is no longer declared"
+    );
+    assert!(
+        workflow.contains("siphon-bin/Dockerfile"),
+        "the extensions image no longer builds from siphon-bin/Dockerfile"
+    );
+}
+
+/// The image is built with every module compiled in, so one artifact covers
+/// every extension. A narrower feature set would silently ship an image whose
+/// `http` / `smpp` / `sigtran` namespace does not exist.
+#[test]
+fn the_extensions_image_is_built_with_every_module() {
+    let workflow = read(".github/workflows/release.yaml");
+    assert!(
+        workflow.contains("FEATURES=full"),
+        "the extensions image is no longer built with --features full"
+    );
+
+    // `full` has to actually aggregate the modules, or the build-arg is a lie.
+    let manifest = read("siphon-bin/Cargo.toml");
+    let full = manifest
+        .lines()
+        .find(|line| line.trim_start().starts_with("full = "))
+        .expect("siphon-bin declares a `full` feature");
+    for module in ["smpp", "http", "sigtran"] {
+        assert!(
+            full.contains(module),
+            "the `full` feature no longer includes {module}: {full}"
+        );
+    }
+}
+
+/// `siphon-bin` git-deps siphon-sip from `main`, which is right for CI and
+/// wrong for a release: `siphon-bin:X.Y.Z` has to contain siphon-sip X.Y.Z.
+/// The release job repoints it at the tag, and this guards that step surviving.
+#[test]
+fn the_extensions_image_pins_siphon_sip_to_the_release_tag() {
+    let workflow = read(".github/workflows/release.yaml");
+    assert!(
+        workflow.contains("Pin siphon-sip to the release tag"),
+        "the extensions image no longer pins siphon-sip to the tag — it would \
+         publish an image built against whatever main happened to be"
+    );
+
+    // The step rewrites this exact declaration; if the manifest stops spelling
+    // it this way the rewrite silently matches nothing.
+    let manifest = read("siphon-bin/Cargo.toml");
+    assert!(
+        manifest
+            .lines()
+            .any(|line| line.starts_with("siphon-sip = { git = ") && line.contains("branch = \"main\"")),
+        "siphon-bin no longer declares siphon-sip as a `branch = \"main\"` git dep \
+         at line start — the release-time pin in release.yaml matches on that shape"
+    );
+}
+
 /// The sandboxed unit makes exactly one log directory writable. Rotation has
 /// to name that directory, or it rotates nothing siphon ever writes.
 #[test]


### PR DESCRIPTION
`siphon-bin` — the drop-in `siphon` binary that composes the `smpp`, `http` and `sigtran` extension crates — is a separate excluded workspace, and the release workflow never built it. It has a Dockerfile and a CI job that proves it compiles, but nothing publishes it.

So the only way to run a binary carrying those namespaces was to build one yourself: `from siphon import http` cannot work in any released artifact.

## What lands

A `docker-extensions` / `docker-extensions-merge` job pair publishing `ghcr.io/siphon-project/siphon-sip-bin`, mirroring the core image exactly:

- native per-arch runners, no QEMU (the pyo3 + aws-lc-sys compile is far too heavy to emulate)
- push by digest, then stitch into one multi-arch manifest list
- the same semver tag set, same `latest=auto` prerelease handling

| Image | Contains |
|---|---|
| `siphon-sip` | siphon only |
| `siphon-sip-bin` | siphon + `smpp`, `http`, `sigtran` |

## Design calls

**One image at `--features full`, not a tag per feature.** The extension namespaces are inert until a `siphon.yaml` configures them, so an operator enables what they need in config rather than by picking a different image. `libsctp` is already unconditional in the Dockerfile, so `sigtran` costs nothing to include.

**The build context is `siphon-bin/`**, not the repo root — `siphon-bin` git-deps everything it needs and never sees the root tree.

**`siphon-sip` is pinned to the release tag before building.** `siphon-bin` git-deps it from `branch = "main"`, which is right for CI and wrong for a release: an image tagged `X.Y.Z` containing whatever `main` happened to be is worse than no image. The job rewrites the dep to the tag and re-resolves the lockfile, so `siphon-sip-bin:X.Y.Z` genuinely contains siphon-sip X.Y.Z.

The rewrite is anchored to line start — the same declaration appears in a comment above the real dep, and I caught it substituting twice before anchoring. It asserts exactly one replacement and fails the job otherwise.

## Tests

Three packaging guards, following the existing drift-guard pattern:

- both halves of the job pair still exist — a build job with **no merge job** pushes untagged digests nobody can pull, which looks like success
- `FEATURES=full` is still passed, **and** `full` still aggregates all three modules in `siphon-bin/Cargo.toml` (otherwise the build-arg is a lie)
- `siphon-bin/Cargo.toml` still spells the dep the way the release-time pin matches on, so the rewrite cannot silently match nothing

The YAML parses and both jobs register. The pin script was run against the real `siphon-bin/Cargo.toml`.

**Not verified here:** the image build itself only runs on a tag push, so this is exercised for the first time at the next release cut. Worth watching that job on the 1.6.0 run.

3938 passed, clippy clean.