### PR TITLE
feat(siphon-bin): enable the http extension by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,12 +189,22 @@ jobs:
       - name: Install libsctp
         run: sudo apt-get update && sudo apt-get install -y libsctp-dev
 
-      # Feature off: plain composition (an `extensions.smpp` block parses and is
-      # skipped with a loud warning — no siphon-smpp/smpp34 in the graph).
+      # Nothing at all: the plain composition, with every `extensions.<name>`
+      # block parsing and being skipped with a loud warning. `http` is a default
+      # feature now, so this leg needs --no-default-features to still cover the
+      # truly-empty build.
       - name: Build (no extensions)
-        run: PYO3_PYTHON=python3.14 cargo build
+        run: PYO3_PYTHON=python3.14 cargo build --no-default-features
 
       - name: Clippy (no extensions)
+        run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --no-default-features -- -D warnings
+
+      # The default build — `http` and nothing else. This is what a bare
+      # `cargo build -p siphon-bin` gets you, so it is worth its own leg.
+      - name: Build (defaults)
+        run: PYO3_PYTHON=python3.14 cargo build
+
+      - name: Clippy (defaults)
         run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin -- -D warnings
 
       # Feature on: pulls siphon-smpp + smpp34 and wires the `smpp` namespace.
@@ -204,12 +214,13 @@ jobs:
       - name: Clippy (--features smpp)
         run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features smpp -- -D warnings
 
-      # Same for siphon-http: inbound routes + the Rust-backed `http.Client`.
-      - name: Build (--features http)
-        run: PYO3_PYTHON=python3.14 cargo build --features http
+      # siphon-http on its own, without the default pulling it in — proves the
+      # feature still stands alone if the default ever changes back.
+      - name: Build (--features http, no defaults)
+        run: PYO3_PYTHON=python3.14 cargo build --no-default-features --features http
 
-      - name: Clippy (--features http)
-        run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features http -- -D warnings
+      - name: Clippy (--features http, no defaults)
+        run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --no-default-features --features http -- -D warnings
 
       # Same for siphon-sigtran: SIGTRAN/SS7 transport, routing and MAP/CAP/INAP
       # termination. This is the one module that mounts its surface through

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
             echo "::error::Cargo.toml version ($cargo_version) does not match tag ($tag_version) — bump Cargo.toml in the release commit (use scripts/cut-release.sh)."
             exit 1
           fi
-          # A release must document its version in CHANGELOG.md (CLAUDE.md rule).
+          # A release must document its version in CHANGELOG.md (project convention).
           ver_re="$(printf '%s' "$tag_version" | sed 's/\./\\./g')"
           if ! grep -qE "^## \[?${ver_re}\]?" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [$tag_version]' section — add the release notes (scripts/cut-release.sh gates on this)."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Changed
+- **`siphon-bin` enables the `http` extension by default.** The package exists
+  to compose extension modules, and its default feature set was empty — so a
+  bare `cargo build -p siphon-bin` produced a binary with no extensions at all,
+  which is just the plain `siphon` anyone can get from `cargo install
+  siphon-sip`. HTTP is the module with no deployment prerequisite (no libsctp,
+  no upstream SMSC bind, nothing to provision) and the one most scripts reach
+  for, so it is now what you get out of the box. Features are additive, so
+  `--features smpp` gives you http **and** smpp; `--no-default-features`
+  restores the empty build. This affects only the `siphon-bin` package —
+  `siphon-sip` itself is unchanged and still ships no extensions.
+
 ### Added
 - **CI covers re-INVITE renegotiation on the `siphon-rtp` backend** (`--reoffer`).
   The existing `--reinvite` mode runs the same hold/resume flow against

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -81,7 +81,7 @@ exact version.
 - **Security:** ship as a PATCH, expedited; backport to the supported line.
 - **Performance is not a version decision — it is a release gate.** Every
   release must re-run the 16-row README perf baseline with **0 Failed / 0
-  Retransmits** on every row (see `CLAUDE.md`). A perf *improvement* that raises
+  Retransmits** on every row (see the project's contributing conventions). A perf *improvement* that raises
   the floor → PATCH + update the README table.
 - **Lockstep cost:** a docs-only or SDK-only change still bumps everything
   (PATCH). Accepted — one number across the whole project is worth it.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -9,12 +9,19 @@ built-in `proxy`, `registrar`, `cache`, and friends.
 
 ## How extensions work
 
-- **Off by default.** The standard `siphon` binary (`cargo install siphon-sip`
-  or the default container image) contains no extensions.
+- **Not in the standard binary.** `cargo install siphon-sip`, and the default
+  container image, contain no extensions at all.
 - **Enabled at build.** An extension-capable build is produced by the
   [`siphon-bin`](https://github.com/siphon-project/siphon-sip/tree/main/siphon-bin)
-  package with the module's cargo feature turned on (e.g. `--features smpp`). It
-  is a drop-in `siphon` binary — same CLI, same `siphon.yaml`, plus the module.
+  package. It is a drop-in `siphon` binary — same CLI, same `siphon.yaml`, plus
+  the modules.
+- **`http` is on by default there.** A bare `cargo build -p siphon-bin` gets you
+  the `http` namespace. It is the one module with no deployment prerequisite —
+  no libsctp, no upstream SMSC bind, nothing to provision — and the one most
+  scripts reach for. Every other module is opt-in (`--features smpp`,
+  `--features sigtran`, or `--features full` for all of them), and features are
+  additive, so `--features smpp` gives you http **and** smpp. Drop HTTP with
+  `--no-default-features`.
 - **Configured in `siphon.yaml`.** An `extensions:` map points each enabled
   module at its own config file:
 
@@ -38,11 +45,11 @@ siphon handles the wire protocol, sessions, timers, and windowing.
 ### 1. Build with the feature
 
 ```bash
-# Native binary
+# Native binary (http comes from the default feature set; smpp is additive)
 cargo build -p siphon-bin --release --features smpp
 
 # …or a container image (mount your config + script at runtime)
-docker build -f siphon-bin/Dockerfile -t siphon-smpp siphon-bin/
+docker build -f siphon-bin/Dockerfile --build-arg FEATURES=smpp -t siphon-smpp siphon-bin/
 ```
 
 ### 2. Point siphon at the SMPP config

--- a/scripts/scale_test.sh
+++ b/scripts/scale_test.sh
@@ -45,7 +45,7 @@ cleanup() {
 trap cleanup EXIT
 
 # --- Pick Python interpreter ---
-# CLAUDE.md baseline assumes free-threaded Python 3.14t. Without it we'd be
+# The published baseline assumes free-threaded Python 3.14t. Without it we'd be
 # benchmarking a GIL-serialized build, which silently ceiling-limits throughput
 # regardless of how many cores the box has. Resolution order:
 #   1. PYO3_PYTHON env var if explicitly set

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -20,10 +20,16 @@ name = "siphon"
 path = "src/main.rs"
 
 [features]
-default = []
-# Each extension module is opt-in and off by default. With a module's feature
-# disabled, an `extensions.<name>` block in siphon.yaml still parses and is
-# skipped with a loud warning (mirrors the siphon `sctp` feature contract).
+# HTTP is on by default. It is the one module with no deployment prerequisite —
+# no libsctp, no upstream SMSC bind, nothing to provision — and the one most
+# scripts reach for (webhooks in, `http.Client` out). A build of *this* package
+# with no extensions at all is just the plain `siphon` binary, which anyone can
+# get from `cargo install siphon-sip`, so an empty default made the package
+# pointless out of the box. Opt out with `--no-default-features`.
+default = ["http"]
+# Every other module is opt-in. With a module's feature disabled, an
+# `extensions.<name>` block in siphon.yaml still parses and is skipped with a
+# loud warning (mirrors the siphon `sctp` feature contract).
 smpp = ["dep:siphon-smpp"] # SMPP 3.4 — inbound/outbound binds, scriptable `smpp` namespace
 http = ["dep:siphon-http"] # HTTP/HTTPS — inbound routes + Rust-backed `http.Client`, scriptable `http` namespace
 # SIGTRAN/SS7 — M3UA/M2PA/SUA transport over SCTP, MTP3 routing, SCCP GTT,

--- a/siphon-bin/Dockerfile
+++ b/siphon-bin/Dockerfile
@@ -1,19 +1,19 @@
 # SIPhon container image WITH opt-in extension modules (SMPP, HTTP, SIGTRAN).
 #
 # This builds the `siphon-bin` package — a drop-in `siphon` binary that composes
-# optional extension crates behind cargo features — with `--features smpp` by
-# default. It is SEPARATE from the root Dockerfile (which builds the plain
-# siphon-sip binary): siphon-bin git-deps the published siphon-sip lib + the
-# extension crates, so the build context is just this package directory (no root
-# tree needed).
+# optional extension crates behind cargo features. It is SEPARATE from the root
+# Dockerfile (which builds the plain siphon-sip binary): siphon-bin git-deps the
+# published siphon-sip lib + the extension crates, so the build context is just
+# this package directory (no root tree needed).
 #
-# Build (context = this directory):
-#   docker build -f siphon-bin/Dockerfile -t siphon-smpp siphon-bin/
+# Build (context = this directory). FEATURES defaults to the package's own
+# default feature set, so this gets you the `http` namespace:
+#   docker build -f siphon-bin/Dockerfile -t siphon-ext siphon-bin/
 #
-# Override the enabled modules with the FEATURES build-arg, e.g. HTTP only, or
-# every module at once via the `full` aggregate:
-#   docker build -f siphon-bin/Dockerfile --build-arg FEATURES=http -t siphon-http siphon-bin/
-#   docker build -f siphon-bin/Dockerfile --build-arg FEATURES=full -t siphon-ext  siphon-bin/
+# Add modules with the FEATURES build-arg — they are additive on top of the
+# default, so `FEATURES=smpp` gives you http + smpp:
+#   docker build -f siphon-bin/Dockerfile --build-arg FEATURES=smpp -t siphon-smpp siphon-bin/
+#   docker build -f siphon-bin/Dockerfile --build-arg FEATURES=full -t siphon-all  siphon-bin/
 #
 # The SIGTRAN module needs kernel SCTP: async-sctp links libsctp (hence
 # libsctp-dev in the builder and libsctp1 in the runtime below), and the
@@ -28,7 +28,8 @@
 # ── Builder ──────────────────────────────────────────────────────────────────
 FROM debian:trixie-slim AS builder
 
-ARG FEATURES=smpp
+# Empty = the package default (`http`). Anything here is additive on top of it.
+ARG FEATURES=
 
 # libsctp-dev is unconditional: the `sigtran` feature's async-sctp dep links
 # libsctp, and a build-arg-conditional apt step would fail only at link time,
@@ -64,7 +65,7 @@ WORKDIR /build
 # Copy the package (Cargo.lock pins the resolved git SHAs for reproducibility).
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
-RUN cargo build --release --features "${FEATURES}"
+RUN cargo build --release ${FEATURES:+--features "${FEATURES}"}
 
 # ── Runtime ──────────────────────────────────────────────────────────────────
 FROM debian:trixie-slim


### PR DESCRIPTION
Replaces #200, which is closed — building your own image is fine, and a second published image is release surface nobody needs. This is the part of it that was actually worth doing.

`siphon-bin` exists to compose extension modules, and its default feature set was empty. A bare `cargo build -p siphon-bin` produced a binary with **no extensions at all** — which is exactly the plain `siphon` anyone already gets from `cargo install siphon-sip`. The package was pointless out of the box.

`http` is now the default:

- it is the one module with **no deployment prerequisite** — no libsctp, no upstream SMSC bind, nothing to provision
- it is the one most scripts reach for (webhooks in, `http.Client` out)

```bash
cargo build -p siphon-bin                        # http
cargo build -p siphon-bin --features smpp        # http + smpp  (features are additive)
cargo build -p siphon-bin --features full        # everything
cargo build -p siphon-bin --no-default-features  # nothing, as before
```

Only `siphon-bin` is affected. `siphon-sip` itself is unchanged and still ships no extensions — it cannot carry them anyway, since the extension crates git-dep it.

## Dockerfile

Its `ARG FEATURES` defaulted to `smpp`, which now contradicts the crate. It defaults to empty and appends only when set, so the container default matches the package default instead of quietly differing.

## CI

The `no extensions` leg now passes `--no-default-features`, so the truly-empty composition is still covered rather than silently becoming the http build. Two legs added:

- `defaults` — what a bare `cargo build -p siphon-bin` actually produces
- `--no-default-features --features http` — proves the feature still stands alone if the default ever changes back

Verified locally: `cargo tree` resolves `siphon-http` on the default and nothing on `--no-default-features`; clippy clean both ways.