### PR TITLE
feat(auth): expose generate_nonce and validate_nonce to scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`auth.generate_nonce()` and `auth.validate_nonce(nonce)` are reachable from
+  scripts.** Both existed, but in a plain `impl` rather than a `#[pymethods]`
+  block, so neither the engine nor the SDK exposed them. A script that verifies
+  credentials itself — rather than through a configured `auth.backend` — has to
+  build its own `WWW-Authenticate` header, and had no way to mint a nonce this
+  engine would recognise coming back, or to reject a replayed one. Validating
+  the nonce is what bounds replay of a captured `Authorization`; without it a
+  script-side digest check is replayable forever.
 - **CI covers re-INVITE renegotiation on the `siphon-rtp` backend** (`--reoffer`).
   The existing `--reinvite` mode runs the same hold/resume flow against
   rtpengine, where a repeat `offer` on a live call-id *is* the re-offer — so it

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -52,6 +52,43 @@ path.
 
 ## `auth` namespace
 
+### Issuing your own challenge
+
+`require_www_digest` / `require_proxy_digest` build the challenge for you. A
+script that verifies credentials itself — rather than through a configured
+`auth.backend` — builds its own `WWW-Authenticate` header instead, and needs the
+engine's nonce for it:
+
+```python
+@proxy.on_request("REGISTER")
+def register(request):
+    header = request.get_header("Authorization")
+    if header is None:
+        nonce = auth.generate_nonce()
+        request.set_reply_header(
+            "WWW-Authenticate",
+            f'Digest realm="{realm}", nonce="{nonce}", algorithm=MD5, qop="auth"',
+        )
+        request.reply(401, "Unauthorized")
+        return
+
+    if not auth.validate_nonce(nonce_of(header)):
+        return challenge(request)        # stale — re-challenge, do not trust it
+    ...
+```
+
+`auth.generate_nonce()` mints `{unix_seconds:016x}.{tag}` — the timestamp is
+embedded rather than stored, so any instance in a fleet can reject a stale nonce
+without shared state. `auth.validate_nonce(nonce)` returns True only for a nonce
+this engine minted, no older than `auth.nonce_ttl_secs`, not future-dated beyond
+60 s of clock skew, and carrying a matching HMAC tag when `auth.nonce_secret` is
+configured.
+
+Validating the nonce is what bounds replay. Without it a captured
+`Authorization` is replayable forever, which is why the built-in `verify_digest`
+/ `require_*_digest` paths always check it — this pair is for scripts that do
+not go through them.
+
 ::: siphon_sdk.mock_module.MockAuth
 
 ## `ipsec` namespace

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -15,6 +15,7 @@ import asyncio
 import ipaddress
 import re
 import sys
+import time
 import uuid
 from types import ModuleType
 from typing import Any, Callable, Optional, Union
@@ -1585,6 +1586,65 @@ class MockAuth:
     def __init__(self) -> None:
         self._allow: bool = False
         self._credentials: dict[str, dict[str, str]] = {}
+        # Seconds a minted nonce stays valid, mirroring the engine's
+        # `auth.nonce_ttl_secs` default. Tests override it to exercise expiry
+        # without sleeping.
+        self._nonce_ttl_secs: int = 300
+
+    def generate_nonce(self) -> str:
+        """Mint a digest challenge nonce.
+
+        Shape is ``{unix_seconds:016x}.{tag}``, matching the engine, which
+        embeds the timestamp rather than storing it so any instance in a fleet
+        can reject a stale nonce without shared state.
+
+        A script that builds its own ``WWW-Authenticate`` /
+        ``Proxy-Authenticate`` header — because it verifies credentials itself
+        rather than through a configured backend — mints the nonce here::
+
+            nonce = auth.generate_nonce()
+            request.set_reply_header(
+                "WWW-Authenticate",
+                f'Digest realm="{realm}", nonce="{nonce}", algorithm=MD5, qop="auth"',
+            )
+            request.reply(401, "Unauthorized")
+
+        The mock uses a random tag (the engine does too when no
+        ``auth.nonce_secret`` is configured); it does not compute the HMAC
+        variant, so a mock-minted nonce is not interchangeable with a real one.
+        """
+        return f"{int(time.time()):016x}.{uuid.uuid4().hex}"
+
+    def validate_nonce(self, nonce: str) -> bool:
+        """Whether ``nonce`` is well-formed and still fresh.
+
+        Mirrors the engine's freshness rules: a well-formed
+        ``{timestamp}.{tag}``, no older than the TTL, and not implausibly
+        future-dated (60 s of clock skew allowed).  This is what bounds replay
+        of a captured ``Authorization`` for a script doing its own digest
+        check::
+
+            if not auth.validate_nonce(nonce_from_the_header):
+                auth.require_www_digest(request, realm)   # stale — re-challenge
+                return
+
+        The mock checks freshness only — it has no shared secret, so it cannot
+        verify the engine's HMAC tag.
+        """
+        timestamp_hex, separator, _tag = nonce.partition(".")
+        if not separator:
+            return False
+        try:
+            timestamp = int(timestamp_hex, 16)
+        except ValueError:
+            return False
+
+        now = int(time.time())
+        if now - timestamp > self._nonce_ttl_secs:
+            return False
+        if timestamp - now > 60:  # clock skew
+            return False
+        return True
 
     def add_user(self, realm: str, username: str, password: str) -> None:
         """Add credentials for testing (test helper).

--- a/sdk/tests/test_auth_nonce.py
+++ b/sdk/tests/test_auth_nonce.py
@@ -1,0 +1,92 @@
+"""`auth.generate_nonce()` / `auth.validate_nonce()`.
+
+A script that verifies credentials itself — rather than through a configured
+`auth.backend` — has to build its own `WWW-Authenticate` header. It needs the
+engine's nonce for that: mint one the engine will recognise coming back, and
+reject a replayed one. Neither primitive was reachable from Python before, on
+the engine or in the mock.
+
+The mock checks freshness only. It has no shared secret, so it cannot verify
+the engine's HMAC tag, and a mock-minted nonce is not interchangeable with a
+real one — the shape and the expiry rules are what these tests pin.
+"""
+
+import time
+
+from siphon_sdk.mock_module import MockAuth
+from siphon_sdk.request import Request
+
+
+def test_generate_nonce_has_the_engine_shape():
+    nonce = MockAuth().generate_nonce()
+
+    timestamp_hex, separator, tag = nonce.partition(".")
+    assert separator == ".", nonce
+    assert len(timestamp_hex) == 16, "timestamp is zero-padded 16 hex chars"
+    int(timestamp_hex, 16)  # parses
+    assert tag, "a nonce carries a tag"
+
+
+def test_a_freshly_minted_nonce_validates():
+    auth = MockAuth()
+    assert auth.validate_nonce(auth.generate_nonce()) is True
+
+
+def test_every_nonce_is_distinct():
+    auth = MockAuth()
+    assert len({auth.generate_nonce() for _ in range(50)}) == 50
+
+
+def test_a_stale_nonce_is_rejected():
+    """The property the primitive exists for: replay is bounded by the TTL."""
+    auth = MockAuth()
+    stale = f"{int(time.time()) - auth._nonce_ttl_secs - 60:016x}.deadbeef"
+
+    assert auth.validate_nonce(stale) is False
+
+
+def test_a_nonce_just_inside_the_ttl_still_validates():
+    auth = MockAuth()
+    recent = f"{int(time.time()) - auth._nonce_ttl_secs + 30:016x}.deadbeef"
+
+    assert auth.validate_nonce(recent) is True
+
+
+def test_an_implausibly_future_dated_nonce_is_rejected():
+    """Beyond the 60s clock-skew allowance — a forged timestamp."""
+    auth = MockAuth()
+    future = f"{int(time.time()) + 3600:016x}.deadbeef"
+
+    assert auth.validate_nonce(future) is False
+
+
+def test_a_small_clock_skew_is_tolerated():
+    auth = MockAuth()
+    skewed = f"{int(time.time()) + 30:016x}.deadbeef"
+
+    assert auth.validate_nonce(skewed) is True
+
+
+def test_malformed_nonces_are_rejected_without_raising():
+    auth = MockAuth()
+
+    for bad in ["", "no-separator", "nothex.tag", ".", "..", "zzzz.tag"]:
+        assert auth.validate_nonce(bad) is False, bad
+
+
+def test_a_script_can_issue_and_check_its_own_challenge():
+    """The shape this exists for: challenge, then bound the replay window."""
+    auth = MockAuth()
+    request = Request(method="REGISTER", to_uri="sip:alice@example.com")
+
+    # Challenge with a nonce the engine will recognise coming back.
+    nonce = auth.generate_nonce()
+    request.set_reply_header(
+        "WWW-Authenticate",
+        f'Digest realm="example.com", nonce="{nonce}", algorithm=MD5, qop="auth"',
+    )
+    request.reply(401, "Unauthorized")
+
+    assert request.last_action.status_code == 401
+    # The credential comes back carrying that nonce; it is still fresh.
+    assert auth.validate_nonce(nonce) is True

--- a/src/script/api/auth.rs
+++ b/src/script/api/auth.rs
@@ -294,7 +294,11 @@ impl PyAuth {
     /// an HMAC-SHA256 over the timestamp (when a secret is configured) or a
     /// random value otherwise. The embedded timestamp lets any instance reject
     /// a stale (replayed) nonce without shared state.
-    fn generate_nonce(&self) -> String {
+    ///
+    /// Also reachable from Python — see the `#[pymethods]` wrapper below, which
+    /// is what a script issuing its own challenge uses so the nonce it hands
+    /// out is one this engine will accept back.
+    pub(crate) fn generate_nonce(&self) -> String {
         let timestamp_hex = format!("{:016x}", now_unix_secs());
         let tag = match &self.nonce_secret {
             Some(secret) => hmac_sha256_hex(secret, timestamp_hex.as_bytes()),
@@ -308,7 +312,7 @@ impl PyAuth {
     /// implausibly far in the future), and — when a secret is configured — carry
     /// a matching HMAC tag. This is what turns digest auth from "replayable
     /// forever" into "replayable for at most `nonce_ttl_secs`".
-    fn validate_nonce(&self, nonce: &str) -> bool {
+    pub(crate) fn validate_nonce(&self, nonce: &str) -> bool {
         let Some((timestamp_hex, tag)) = nonce.split_once('.') else {
             return false;
         };
@@ -339,6 +343,54 @@ impl PyAuth {
     /// `target` is a `Request` (`@proxy.on_request`) or a `Call`
     /// (`@b2bua.on_invite`) — see [`AuthTarget`].
     ///
+    /// Mint a digest challenge nonce.
+    ///
+    /// Shape is `{unix_seconds:016x}.{tag}`, where `tag` is an HMAC-SHA256 over
+    /// the timestamp when `auth.nonce_secret` is configured, and a random value
+    /// otherwise. The timestamp is embedded rather than stored, so any instance
+    /// in a fleet can reject a stale nonce without shared state.
+    ///
+    /// This is the nonce `require_www_digest` / `require_proxy_digest` issue.
+    /// A script that builds its own `WWW-Authenticate` / `Proxy-Authenticate`
+    /// header — because it verifies credentials itself rather than through a
+    /// configured backend — must mint the nonce here, or it hands out a value
+    /// this engine has no way to recognise on the way back:
+    ///
+    /// ```python
+    /// nonce = auth.generate_nonce()
+    /// request.set_reply_header(
+    ///     "WWW-Authenticate",
+    ///     f'Digest realm="{realm}", nonce="{nonce}", algorithm=MD5, qop="auth"',
+    /// )
+    /// request.reply(401, "Unauthorized")
+    /// ```
+    #[pyo3(name = "generate_nonce")]
+    fn py_generate_nonce(&self) -> String {
+        self.generate_nonce()
+    }
+
+    /// Whether `nonce` is one this engine minted and still accepts.
+    ///
+    /// True only for a well-formed `{timestamp}.{tag}` that is no older than
+    /// `auth.nonce_ttl_secs`, not implausibly future-dated (60 s of clock skew
+    /// allowed), and — when a secret is configured — carries a matching HMAC
+    /// tag. This is what turns a script-side digest check from "replayable
+    /// forever" into "replayable for at most the TTL", so a script verifying
+    /// credentials itself should call it *before* trusting the response:
+    ///
+    /// ```python
+    /// if not auth.validate_nonce(nonce_from_the_header):
+    ///     auth.require_www_digest(request, realm)   # stale — re-challenge
+    ///     return
+    /// ```
+    ///
+    /// The built-in `verify_digest` / `require_*_digest` paths already do this
+    /// internally; this is for a script that does not go through them.
+    #[pyo3(name = "validate_nonce")]
+    fn py_validate_nonce(&self, nonce: &str) -> bool {
+        self.validate_nonce(nonce)
+    }
+
     /// If the message carries valid credentials, sets `request.auth_user` /
     /// `call.auth_user` and returns True. Otherwise arms a 401 response with a
     /// nonce and returns False.
@@ -1717,6 +1769,59 @@ mod tests {
             "10.0.0.1".to_string(),
             5060,
         )
+    }
+
+    #[test]
+    fn nonce_primitives_are_reachable_from_python() {
+        // They existed as Rust-internal helpers in a plain `impl PyAuth`, so a
+        // script could not reach them at all — which left a script that issues
+        // its own challenge with no way to mint a nonce this engine would
+        // recognise on the way back, or to reject a replayed one.
+        Python::initialize();
+        Python::attach(|python| {
+            let auth = Py::new(python, PyAuth::empty()).expect("auth into Python");
+            let bound = auth.bind(python);
+
+            let nonce: String = bound
+                .call_method0("generate_nonce")
+                .and_then(|value| value.extract())
+                .expect("auth.generate_nonce() must be callable from Python");
+            assert!(nonce.contains('.'), "nonce shape is {{ts}}.{{tag}}: {nonce}");
+
+            // A freshly minted nonce validates through the Python surface.
+            let fresh: bool = bound
+                .call_method1("validate_nonce", (nonce.as_str(),))
+                .and_then(|value| value.extract())
+                .expect("auth.validate_nonce() must be callable from Python");
+            assert!(fresh, "a nonce we just minted must validate");
+
+            // And a forged one does not.
+            let forged: bool = bound
+                .call_method1("validate_nonce", ("not-a-nonce",))
+                .and_then(|value| value.extract())
+                .expect("validate_nonce runs");
+            assert!(!forged);
+        });
+    }
+
+    #[test]
+    fn a_replayed_nonce_is_rejected_through_the_python_surface() {
+        // The property that makes the primitive worth exposing: a script doing
+        // its own digest check can bound replay to the TTL.
+        Python::initialize();
+        Python::attach(|python| {
+            let auth = Py::new(python, PyAuth::empty()).expect("auth into Python");
+            let stale = format!(
+                "{:016x}.x",
+                now_unix_secs().saturating_sub(DEFAULT_NONCE_TTL_SECS + 60)
+            );
+            let valid: bool = auth
+                .bind(python)
+                .call_method1("validate_nonce", (stale.as_str(),))
+                .and_then(|value| value.extract())
+                .expect("validate_nonce runs");
+            assert!(!valid, "a stale nonce must not validate");
+        });
     }
 
     #[test]


### PR DESCRIPTION
Takes A3's slot now that engine-side verification against a supplied credential is no longer needed.

## It was not a mock gap

Both primitives already existed — but in a plain `impl PyAuth`, not a `#[pymethods]` block. So **neither side** exposed them: not the engine, not the SDK, not the docs. Worth flagging, since the request described it as a mock gap and the fix is bigger than mirroring something into `MockAuth`.

## Why it matters

A script that verifies credentials itself — rather than through a configured `auth.backend` — has to build its own `WWW-Authenticate` header. Without these it either invents a nonce this engine has no way to recognise coming back, or ships no anti-replay at all.

Validating the nonce is the whole thing that turns a script-side digest check from *replayable forever* into *replayable for at most `nonce_ttl_secs`*. It is why `verify_digest` and the `require_*_digest` paths always check it internally.

```python
nonce = auth.generate_nonce()
request.set_reply_header(
    "WWW-Authenticate",
    f'Digest realm="{realm}", nonce="{nonce}", algorithm=MD5, qop="auth"',
)
request.reply(401, "Unauthorized")

# …and on the way back
if not auth.validate_nonce(nonce_of(header)):
    return challenge(request)      # stale — do not trust the response
```

Shape is unchanged: `{unix_seconds:016x}.{tag}`, timestamp embedded rather than stored so any instance in a fleet can reject a stale nonce without shared state, HMAC-tagged when `auth.nonce_secret` is set.

## SDK

`MockAuth` gains both, with the same shape and the same freshness / clock-skew rules. It checks **freshness only** — it holds no secret, so it cannot verify the HMAC tag, and a mock-minted nonce is not interchangeable with a real one. The mock and the tests both say so rather than implying parity that is not there.

## Tests

Driven through the interpreter, because the gap being closed is precisely that the Python surface did not exist:

- `generate_nonce()` / `validate_nonce()` callable from Python; a freshly minted nonce validates, a forged one does not
- a stale nonce is rejected through the Python surface
- SDK: engine-shaped output, distinctness across 50 mints, stale rejected, just-inside-TTL accepted, future-dated beyond the 60 s skew rejected, small skew tolerated, six malformed inputs rejected without raising
- SDK: the full issue-a-challenge-then-bound-the-replay-window flow

Mutation-checked: dropping the `#[pyo3]` wrapper fails the reachability test.

Rust 3937 passed, SDK 551 passed, clippy clean.