### PR TITLE
test(sipp): run the real siphon-rtp engine in the functional tests, not just the control mock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -738,6 +738,218 @@ jobs:
             siphon-refer.log
             mock-siphon-rtp-refer.log
 
+
+  # ── Real siphon-rtp: control-plane smoke (both front-ends) ─────────────
+  # Runs the end-to-end test that was previously #[ignore]d behind
+  # SIPHON_RTP_BIN with the note "CI does not build the engine". It still does
+  # not: the published image is distroless with a *static musl* binary, so the
+  # binary is copied out and run bare on the runner. That covers both control
+  # planes (RtpEngineSet → --ng, SiphonRtpClient → --control) in ~2s with no
+  # container networking and no Rust build of the engine.
+  siphon-rtp-engine-smoke:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Python 3.14 (free-threaded)
+        uses: deadsnakes/action@v3.2.0
+        with:
+          python-version: "3.14-dev"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Extract the siphon-rtp binary from the published image
+        # Pinned to the release siphon pins siphon-rtp-proto to, so this proves
+        # a known-good pairing rather than whatever shipped most recently.
+        run: |
+          docker create --name rtp-extract ghcr.io/siphon-project/siphon-rtp:0.2.0
+          docker cp rtp-extract:/usr/local/bin/siphon-rtp ./siphon-rtp
+          docker rm rtp-extract
+          chmod +x ./siphon-rtp
+          ./siphon-rtp --help > /dev/null
+
+      - name: Smoke test against the real engine (NG + native control)
+        run: |
+          SIPHON_RTP_BIN="$PWD/siphon-rtp" PYO3_PYTHON=python3.14 \
+            cargo test --test integration_tests -- --ignored --exact \
+            siphon_rtp_tests::smoke_test_against_real_siphon_rtp --nocapture
+
+  # ── Real siphon-rtp: native JSON control plane ─────────────────────────
+  # The media-anchoring analogue of sipp-rtpproxy, but against the real engine
+  # instead of a mock: INVITE → offer → 200 → answer → BYE → delete, driven
+  # through `media.backend: siphon-rtp`.
+  #
+  # The mock profiles (voice-ai, refer-single-leg) stay as they are. They assert
+  # on what siphon *sent*, which the real engine cannot report; this asserts the
+  # complementary half, that a real engine accepts it.
+  sipp-siphon-rtp-native:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-rtp-native image
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native build siphon-rtp-native
+
+      - name: Start the real engine + siphon
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native up -d --wait siphon-rtp-engine siphon-rtp-native
+
+      - name: Register bob
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native run --rm sipp-rtp-native-register
+
+      - name: Anchored call (INVITE → offer → 200 → answer → BYE → delete)
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native up --abort-on-container-exit --exit-code-from sipp-rtp-native-uac sipp-rtp-native-uac sipp-rtp-native-uas
+
+      - name: Assert the engine accepted every command
+        # The independent oracle. A green call flow only proves siphon liked the
+        # answers it got; control_errors_total proves the engine did not reject
+        # anything on the way. That distinction caught a real profile mismatch
+        # (an SRTP offer answered in plain RTP) that the SIP leg reported as a
+        # perfectly successful call.
+        run: |
+          docker run --rm --network sipp_sipnet -v "$PWD/sipp/siphon-rtp:/app:ro" python:3.12-slim \
+            python3 /app/assert_engine.py metrics \
+              --url http://172.20.0.110:9091/metrics \
+              --min-offers 1 --min-answers 1 --min-deletes 1 \
+              --max-control-errors 0 --max-sessions 0
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-rtp-native > siphon-rtp-native.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs siphon-rtp-engine > siphon-rtp-engine.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-siphon-rtp-native-logs
+          path: |
+            siphon-rtp-native.log
+            siphon-rtp-engine.log
+            *.log
+
+  # ── Real siphon-rtp: rtpengine NG shim (drop-in replacement) ───────────
+  # Same script, same scenarios, same assertions as sipp-siphon-rtp-native —
+  # only the media backend differs. siphon's stock rtpengine client drives
+  # siphon-rtp's --ng listener, with a config block an operator could lift
+  # straight from an existing rtpengine deployment.
+  sipp-siphon-rtp-ng:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-rtp-ng image
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-ng build siphon-rtp-ng
+
+      - name: Start the real engine + siphon
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-ng up -d --wait siphon-rtp-engine siphon-rtp-ng
+
+      - name: Register bob
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-ng run --rm sipp-rtp-ng-register
+
+      - name: Anchored call over the NG shim
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-ng up --abort-on-container-exit --exit-code-from sipp-rtp-ng-uac sipp-rtp-ng-uac sipp-rtp-ng-uas
+
+      - name: Assert the engine accepted every command
+        run: |
+          docker run --rm --network sipp_sipnet -v "$PWD/sipp/siphon-rtp:/app:ro" python:3.12-slim \
+            python3 /app/assert_engine.py metrics \
+              --url http://172.20.0.110:9091/metrics \
+              --min-offers 1 --min-answers 1 --min-deletes 1 \
+              --max-control-errors 0 --max-sessions 0
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-rtp-ng > siphon-rtp-ng.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs siphon-rtp-engine > siphon-rtp-engine-ng.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-ng down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-siphon-rtp-ng-logs
+          path: |
+            siphon-rtp-ng.log
+            siphon-rtp-engine-ng.log
+            *.log
+
+  # ── Real siphon-rtp: voice-AI WebSocket bridge, with real audio ────────
+  # The one path the control-plane mock can never cover. The mock never dials
+  # ws_uri, so the existing sipp-voice-ai job proves siphon composed the right
+  # command and stops there. Here the engine really connects to an AI server,
+  # SIPp really sends G.711, and the AI server asserts the audio arrived —
+  # correct frame geometry for the negotiated ptime, and not digital silence.
+  # A bridge that connects and passes zeros is indistinguishable from a working
+  # one until you measure the samples, which is what mock_ai_ws.py does.
+  sipp-voice-ai-real:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-voice-ai-real image
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai-real build siphon-voice-ai-real
+
+      - name: Start the real engine + AI server + siphon
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai-real up -d --wait siphon-rtp-engine mock-ai-ws siphon-voice-ai-real
+
+      - name: Voice-AI call with real RTP (answer_local → WS bridge → audio)
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai-real up --abort-on-container-exit --exit-code-from sipp-voice-ai-real-uac sipp-voice-ai-real-uac
+
+      - name: Assert audio crossed the bridge in both directions
+        # Reads the AI server's AI-WS-VERDICT line. A verdict that never appears
+        # is a failure too — that is what a bridge which was never dialled looks
+        # like, and it would otherwise pass by absence.
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs mock-ai-ws > mock-ai-ws.log 2>&1
+          docker run --rm -i -v "$PWD/sipp/siphon-rtp:/app:ro" python:3.12-slim \
+            python3 /app/assert_engine.py ws --min-sessions 1 --min-downlink 1 < mock-ai-ws.log
+
+      - name: Assert the engine tore the call down cleanly
+        # answer_local bumps no offer/answer counter, so only the delete and the
+        # error/session floors are meaningful for this flow.
+        run: |
+          docker run --rm --network sipp_sipnet -v "$PWD/sipp/siphon-rtp:/app:ro" python:3.12-slim \
+            python3 /app/assert_engine.py metrics \
+              --url http://172.20.0.110:9091/metrics \
+              --min-deletes 1 --max-control-errors 0 --max-sessions 0
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs siphon-voice-ai-real > siphon-voice-ai-real.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs siphon-rtp-engine > siphon-rtp-engine-voice-ai.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs mock-ai-ws > mock-ai-ws.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai-real down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-voice-ai-real-logs
+          path: |
+            siphon-voice-ai-real.log
+            siphon-rtp-engine-voice-ai.log
+            mock-ai-ws.log
+            *.log
+
   # ── Fuzz testing (nightly) ─────────────────────────────────────────────
   fuzz:
     runs-on: ubuntu-latest

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -4559,7 +4559,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./siphon-rtp/siphon-rtp-native.yaml:/etc/siphon/siphon.yaml:ro
-      - ../scripts:/etc/siphon/scripts:ro
+      - ./siphon-rtp/proxy_rtp_passthrough.py:/etc/siphon/scripts/proxy_rtp_passthrough.py:ro
       - ../examples:/etc/siphon/examples:ro
     networks:
       sipnet:
@@ -4663,7 +4663,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./siphon-rtp/siphon-rtp-ng.yaml:/etc/siphon/siphon.yaml:ro
-      - ../scripts:/etc/siphon/scripts:ro
+      - ./siphon-rtp/proxy_rtp_passthrough.py:/etc/siphon/scripts/proxy_rtp_passthrough.py:ro
       - ../examples:/etc/siphon/examples:ro
     networks:
       sipnet:

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -4320,6 +4320,371 @@ services:
     profiles:
       - refer-single-leg
 
+
+  # ── REAL siphon-rtp engine ────────────────────────────────────────────────
+  # The published engine image, standing in for the Python control-plane mocks
+  # (sipp/siphon-rtp/mock_siphon_rtp.py) the way rtpengine-real stands in for
+  # sipp/rtpengine/mock_rtpengine.py. The mocks stay: they echo every command
+  # they receive so a scenario can assert on what siphon *sent*, which a real
+  # engine cannot do. These profiles assert the complementary half — that a
+  # real engine accepts it and moves real audio.
+  #
+  # One service serves all three profiles because it opens both control planes
+  # at once: --control (native JSON-over-TCP) and --ng (rtpengine bencode).
+  #
+  # The tag is pinned to the same release siphon pins `siphon-rtp-proto` to, so
+  # this tests a known-good pairing. Floating :latest would turn an unrelated
+  # engine release into a red CI run here.
+  #
+  # Usage:
+  #   docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native \
+  #     up --abort-on-container-exit sipp-rtp-native-uac
+  siphon-rtp-engine:
+    image: ghcr.io/siphon-project/siphon-rtp:0.2.0
+    container_name: siphon-rtp-engine
+    command:
+      - "--control"
+      - "0.0.0.0:8080"
+      - "--ng"
+      - "0.0.0.0:22222"
+      # Load-bearing. The UDP backend binds loopback by default (a NIC-free dev
+      # convenience), so without this the engine answers with c=IN IP4 127.0.0.1
+      # and no RTP on this network can ever reach it. The scenarios assert on
+      # this address precisely so that regression fails loudly.
+      - "--relay-bind-ip"
+      - "172.20.0.110"
+      - "--port-min"
+      - "30000"
+      - "--port-max"
+      - "30200"
+      - "--metrics-addr"
+      - "0.0.0.0:9091"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.110
+    # No healthcheck: the image is distroless (no shell, no python), so a
+    # CMD-SHELL probe cannot run inside it. Readiness is gated by the
+    # siphon-rtp-engine-ready one-shot below, which probes /readyz from outside.
+    profiles:
+      - siphon-rtp-native
+      - siphon-rtp-ng
+      - voice-ai-real
+
+  # Readiness gate for the distroless engine: exits 0 once /readyz answers.
+  siphon-rtp-engine-ready:
+    image: python:3.12-slim
+    container_name: siphon-rtp-engine-ready
+    depends_on:
+      siphon-rtp-engine:
+        condition: service_started
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.120
+    command:
+      - python3
+      - -c
+      - |
+        import sys, time, urllib.request
+        for _ in range(60):
+            try:
+                with urllib.request.urlopen("http://172.20.0.110:9091/readyz", timeout=2) as r:
+                    if r.status == 200:
+                        print("engine ready"); sys.exit(0)
+            except Exception:
+                pass
+            time.sleep(1)
+        sys.exit("engine never became ready")
+    profiles:
+      - siphon-rtp-native
+      - siphon-rtp-ng
+      - voice-ai-real
+
+  # ── Native JSON control plane (media.backend: siphon-rtp) ─────────────────
+  siphon-rtp-native:
+    build:
+      context: ..
+    container_name: siphon-rtp-native-test
+    depends_on:
+      siphon-rtp-engine-ready:
+        condition: service_completed_successfully
+    volumes:
+      - ./siphon-rtp/siphon-rtp-native.yaml:/etc/siphon/siphon.yaml:ro
+      - ./siphon-rtp/proxy_rtp_passthrough.py:/etc/siphon/scripts/proxy_rtp_passthrough.py:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.112
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - siphon-rtp-native
+
+  sipp-rtp-native-register:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-rtp-native:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.113
+    entrypoint:
+      - sipp
+      - "172.20.0.112:5060"
+      - -sf
+      - /sipp/scenarios/register.xml
+      - -s
+      - bob
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+    profiles:
+      - siphon-rtp-native
+
+  sipp-rtp-native-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-rtp-native-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.113
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/rtpengine_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - siphon-rtp-native
+
+  sipp-rtp-native-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-rtp-native:
+        condition: service_healthy
+      sipp-rtp-native-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.114
+    entrypoint:
+      - sipp
+      - "172.20.0.112:5060"
+      - -sf
+      - /sipp/scenarios/rtpengine_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - siphon-rtp-native
+
+  # ── rtpengine NG shim (drop-in replacement proof) ─────────────────────────
+  # Identical to the native stack above except for the media backend, and it
+  # runs the same scenarios the rtpengine profile uses, unmodified.
+  siphon-rtp-ng:
+    build:
+      context: ..
+    container_name: siphon-rtp-ng-test
+    depends_on:
+      siphon-rtp-engine-ready:
+        condition: service_completed_successfully
+    volumes:
+      - ./siphon-rtp/siphon-rtp-ng.yaml:/etc/siphon/siphon.yaml:ro
+      - ./siphon-rtp/proxy_rtp_passthrough.py:/etc/siphon/scripts/proxy_rtp_passthrough.py:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.115
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - siphon-rtp-ng
+
+  sipp-rtp-ng-register:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-rtp-ng:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.116
+    entrypoint:
+      - sipp
+      - "172.20.0.115:5060"
+      - -sf
+      - /sipp/scenarios/register.xml
+      - -s
+      - bob
+      - -ap
+      - secret
+      - -m
+      - "1"
+      - -timeout
+      - "10"
+    profiles:
+      - siphon-rtp-ng
+
+  sipp-rtp-ng-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-rtp-ng-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.116
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/rtpengine_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - siphon-rtp-ng
+
+  sipp-rtp-ng-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-rtp-ng:
+        condition: service_healthy
+      sipp-rtp-ng-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.117
+    entrypoint:
+      - sipp
+      - "172.20.0.115:5060"
+      - -sf
+      - /sipp/scenarios/rtpengine_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - siphon-rtp-ng
+
+  # ── Voice-AI over a real WebSocket bridge, with real audio ────────────────
+  # The mock control server never dials ws_uri, so until now nothing proved
+  # audio crosses the bridge. Here the engine really connects to the AI server,
+  # decodes the caller's G.711 to L16, and re-encodes the reply.
+  mock-ai-ws:
+    image: python:3.12-slim
+    container_name: mock-ai-ws
+    volumes:
+      - ./siphon-rtp:/app:ro
+    working_dir: /app
+    # websockets is not in the base image; install then serve.
+    command: ["sh", "-c", "pip install --quiet --no-cache-dir websockets && exec python3 mock_ai_ws.py"]
+    environment:
+      AI_WS_PORT: "9001"
+      AI_WS_MIN_FRAMES: "10"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.111
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; socket.create_connection(('127.0.0.1',9001),2).close()\""]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+    profiles:
+      - voice-ai-real
+
+  siphon-voice-ai-real:
+    build:
+      context: ..
+    container_name: siphon-voice-ai-real-test
+    depends_on:
+      siphon-rtp-engine-ready:
+        condition: service_completed_successfully
+      mock-ai-ws:
+        condition: service_healthy
+    volumes:
+      - ./siphon-rtp/siphon-voice-ai-real.yaml:/etc/siphon/siphon.yaml:ro
+      - ./siphon-rtp/voice_ai_real.py:/etc/siphon/scripts/voice_ai_real.py:ro
+      - ../examples:/etc/siphon/examples:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.118
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - voice-ai-real
+
+  # Carrier UAC that actually sends RTP (play_pcap_audio), so the bridge has
+  # audio to carry rather than just a socket to open.
+  sipp-voice-ai-real-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-voice-ai-real:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.119
+    entrypoint:
+      - sipp
+      - "172.20.0.118:5060"
+      - -sf
+      - /sipp/scenarios/voice_ai_real_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "40"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - voice-ai-real
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:

--- a/sipp/siphon-rtp/assert_engine.py
+++ b/sipp/siphon-rtp/assert_engine.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Assert on the real siphon-rtp engine after a functional-test run.
+
+Two independent oracles, neither of which the SIPp scenario can see:
+
+  metrics  — the engine's own Prometheus counters. `control_errors_total` is
+             the interesting one: it counts commands the engine rejected, so a
+             call that completes with a non-zero value means siphon sent
+             something malformed and the engine papered over it. That is
+             exactly the failure a green call flow hides, and it is the whole
+             point of asserting on the NG shim rather than trusting the 200 OK.
+
+  ws       — the AI server's `AI-WS-VERDICT` line (see mock_ai_ws.py), read
+             from a log file or stdin. A verdict that never appears fails, so
+             the bridge silently never being dialled is caught rather than
+             passing by absence.
+
+Usage:
+    assert_engine.py metrics --url http://172.20.0.110:9091/metrics \
+        --min-offers 1 --min-deletes 1 --max-control-errors 0
+    docker compose logs mock-ai-ws | assert_engine.py ws
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+
+VERDICT_PREFIX = "AI-WS-VERDICT "
+
+
+def read_metrics(url: str, timeout: float) -> dict[str, float]:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        body = response.read().decode("utf-8", "replace")
+    values: dict[str, float] = {}
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = re.match(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{[^}]*\})?\s+(-?[\d.eE+]+)$", line)
+        if match:
+            # Sum label sets so a metric split by labels still totals correctly.
+            values[match.group(1)] = values.get(match.group(1), 0.0) + float(match.group(2))
+    return values
+
+
+def check_metrics(args: argparse.Namespace) -> int:
+    try:
+        metrics = read_metrics(args.url, args.timeout)
+    except Exception as error:  # noqa: BLE001 — any failure to read is a test failure
+        print(f"FAIL: could not read engine metrics from {args.url}: {error}")
+        return 1
+
+    if not metrics:
+        print(f"FAIL: no metrics parsed from {args.url}")
+        return 1
+
+    failures: list[str] = []
+    # Only offer / answer / delete bump their counters; answer_local (the
+    # single-leg voice-AI verb) bumps none of them, so each caller states the
+    # floors that make sense for the flow it just ran rather than inheriting a
+    # default that would be wrong for half the profiles.
+    checks = [
+        ("siphon_rtp_offers_total", args.min_offers),
+        ("siphon_rtp_answers_total", args.min_answers),
+        ("siphon_rtp_deletes_total", args.min_deletes),
+    ]
+    for name, floor in checks:
+        got = metrics.get(name, 0.0)
+        if got < floor:
+            failures.append(f"{name}={got:g}, expected >= {floor}")
+
+    errors = metrics.get("siphon_rtp_control_errors_total", 0.0)
+    if errors > args.max_control_errors:
+        failures.append(
+            f"siphon_rtp_control_errors_total={errors:g}, expected <= "
+            f"{args.max_control_errors} — the engine rejected a command siphon sent"
+        )
+
+    # A session left behind after every call was deleted is a leak in the engine
+    # or a delete siphon never sent. Either way the next call inherits it.
+    sessions = metrics.get("siphon_rtp_sessions", 0.0)
+    if sessions > args.max_sessions:
+        failures.append(
+            f"siphon_rtp_sessions={sessions:g}, expected <= {args.max_sessions} "
+            f"— a call was not torn down"
+        )
+
+    reported = {
+        key: metrics.get(key, 0.0)
+        for key in (
+            "siphon_rtp_offers_total",
+            "siphon_rtp_answers_total",
+            "siphon_rtp_deletes_total",
+            "siphon_rtp_control_errors_total",
+            "siphon_rtp_sessions",
+        )
+    }
+    print("engine metrics: " + json.dumps(reported))
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+    print("PASS: engine metrics within expectations")
+    return 0
+
+
+def check_ws(args: argparse.Namespace) -> int:
+    source = open(args.log, encoding="utf-8", errors="replace") if args.log else sys.stdin
+    verdicts = []
+    with source as handle:
+        for line in handle:
+            index = line.find(VERDICT_PREFIX)
+            if index == -1:
+                continue
+            try:
+                verdicts.append(json.loads(line[index + len(VERDICT_PREFIX) :].strip()))
+            except ValueError:
+                print(f"FAIL: unparseable verdict line: {line.strip()!r}")
+                return 1
+
+    if not verdicts:
+        # Absence is the failure mode that matters most: it is what a bridge
+        # that was never dialled looks like.
+        print("FAIL: no AI-WS-VERDICT line found — the WebSocket bridge was never established")
+        return 1
+
+    if len(verdicts) < args.min_sessions:
+        print(f"FAIL: {len(verdicts)} bridged session(s), expected >= {args.min_sessions}")
+        return 1
+
+    status = 0
+    for index, verdict in enumerate(verdicts, 1):
+        print(f"ws session {index}: {json.dumps(verdict)}")
+        if not verdict.get("pass"):
+            for failure in verdict.get("failures", ["unspecified"]):
+                print(f"FAIL: session {index}: {failure}")
+            status = 1
+        if verdict.get("downlink_frames", 0) < args.min_downlink:
+            print(
+                f"FAIL: session {index}: downlink_frames="
+                f"{verdict.get('downlink_frames', 0)}, expected >= {args.min_downlink} "
+                f"— the AI response was never sent"
+            )
+            status = 1
+    if status == 0:
+        print(f"PASS: {len(verdicts)} bridged session(s), audio verified in both directions")
+    return status
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    metrics = sub.add_parser("metrics", help="assert on the engine's Prometheus counters")
+    metrics.add_argument("--url", default="http://172.20.0.110:9091/metrics")
+    metrics.add_argument("--timeout", type=float, default=5.0)
+    metrics.add_argument("--min-offers", type=float, default=0)
+    metrics.add_argument("--min-answers", type=float, default=0)
+    metrics.add_argument("--min-deletes", type=float, default=0)
+    metrics.add_argument("--max-control-errors", type=float, default=0)
+    metrics.add_argument("--max-sessions", type=float, default=0)
+    metrics.set_defaults(func=check_metrics)
+
+    ws = sub.add_parser("ws", help="assert on the AI server's verdict line")
+    ws.add_argument("--log", help="log file to read (default: stdin)")
+    ws.add_argument("--min-sessions", type=int, default=1)
+    ws.add_argument("--min-downlink", type=int, default=1)
+    ws.set_defaults(func=check_ws)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sipp/siphon-rtp/mock_ai_ws.py
+++ b/sipp/siphon-rtp/mock_ai_ws.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Mock voice-AI WebSocket media server for the real-engine functional test.
+
+The `ws_uri` profile flag makes siphon-rtp hand leg A's decoded audio to an
+external WebSocket server and render whatever that server sends back into the
+caller's codec. Against the control-plane mock (mock_siphon_rtp.py) that bridge
+is never dialled, so nothing has ever proven audio actually traverses it. This
+server is the other half of that test: it stands in for the inference backend
+and asserts the media really arrived.
+
+What it checks (see siphon-rtp docs/cookbook/voice-ai.md, "The WebSocket wire"):
+
+  1. The first frame is a `start` envelope announcing the leg and audio format,
+     and that format is the L16 shape the engine documents — little-endian,
+     16-bit, mono, at the codec's native sample rate.
+  2. Uplink binary frames arrive, one per ptime, each exactly
+     sample_rate/1000 * ptime * 2 bytes (320 at 8 kHz / 20 ms).
+  3. The uplink carries actual audio, not digital silence. This is the
+     assertion that proves the whole path — SIPp's RTP, the engine's ingress
+     gate, jitter buffer, and G.711 decode — rather than just proving a socket
+     opened. A bridge that is up but passing zeros looks identical to a working
+     one until you measure the samples.
+
+Then it answers like an AI would: a short tone rendered as little-endian L16 at
+the negotiated rate, which the engine re-encodes into the caller's codec. The
+downlink is verified on the engine's own Prometheus counters rather than here,
+since a server cannot observe what the far end received.
+
+Every session prints one `AI-WS-VERDICT <json>` line. The CI step greps for it
+and fails on `"pass": false` — a verdict that never appears is also a failure,
+which is what catches the bridge never being dialled at all.
+"""
+
+import asyncio
+import json
+import math
+import os
+import struct
+import sys
+
+import websockets
+
+LISTEN_HOST = os.environ.get("AI_WS_HOST", "0.0.0.0")
+LISTEN_PORT = int(os.environ.get("AI_WS_PORT", "9001"))
+
+# Minimum uplink frames before the server talks back. At 20 ms/frame this is a
+# fifth of a second of caller audio — enough to be sure the stream is flowing
+# and not a single stray packet.
+MIN_UPLINK_FRAMES = int(os.environ.get("AI_WS_MIN_FRAMES", "10"))
+
+# Mean-square energy below which a frame counts as silence. G.711 decoded speech
+# sits orders of magnitude above this; digital silence sits at exactly 0.
+SILENCE_ENERGY = float(os.environ.get("AI_WS_SILENCE_ENERGY", "100"))
+
+# Length of the synthesized "AI response" in frames (20 ms each).
+RESPONSE_FRAMES = int(os.environ.get("AI_WS_RESPONSE_FRAMES", "25"))
+RESPONSE_TONE_HZ = 440.0
+
+
+def frame_energy(payload: bytes) -> float:
+    """Mean-square energy of a little-endian 16-bit mono PCM frame."""
+    count = len(payload) // 2
+    if count == 0:
+        return 0.0
+    samples = struct.unpack(f"<{count}h", payload[: count * 2])
+    return sum(sample * sample for sample in samples) / count
+
+
+def tone_frame(sample_rate: int, samples_per_frame: int, phase: float) -> tuple[bytes, float]:
+    """One frame of a 440 Hz sine, little-endian L16 — the AI's "voice"."""
+    step = 2.0 * math.pi * RESPONSE_TONE_HZ / sample_rate
+    values = []
+    for index in range(samples_per_frame):
+        values.append(int(8000 * math.sin(phase + step * index)))
+    return struct.pack(f"<{samples_per_frame}h", *values), phase + step * samples_per_frame
+
+
+class Session:
+    """Assertion state for one bridged call."""
+
+    def __init__(self) -> None:
+        self.start_envelope: dict | None = None
+        self.media: dict = {}
+        self.uplink_frames = 0
+        self.uplink_bytes = 0
+        self.voiced_frames = 0
+        self.peak_energy = 0.0
+        self.bad_length_frames = 0
+        self.downlink_frames = 0
+        self.control_frames: list[str] = []
+        self.failures: list[str] = []
+
+    @property
+    def sample_rate(self) -> int:
+        return int(self.media.get("sampleRate", 8000))
+
+    @property
+    def ptime(self) -> int:
+        return int(self.media.get("ptime", 20))
+
+    @property
+    def expected_frame_bytes(self) -> int:
+        # little-endian L16 mono: two bytes per sample.
+        return self.sample_rate // 1000 * self.ptime * 2
+
+    def check_start(self, envelope: dict) -> None:
+        self.start_envelope = envelope
+        data = envelope.get("data", {})
+        self.media = data.get("media", {})
+        # The documented wire shape. A mismatch here means the engine changed the
+        # contract the SDK and every integration is written against, so it is a
+        # hard failure rather than something to tolerate.
+        expected = {
+            "encoding": "L16",
+            "bitDepth": 16,
+            "endianness": "little",
+            "channels": 1,
+        }
+        for key, want in expected.items():
+            got = self.media.get(key)
+            if got != want:
+                self.failures.append(f"start.media.{key}={got!r}, expected {want!r}")
+        if not data.get("callId"):
+            self.failures.append("start.data.callId missing")
+        if not data.get("streamId"):
+            self.failures.append("start.data.streamId missing")
+
+    def check_uplink(self, payload: bytes) -> None:
+        self.uplink_frames += 1
+        self.uplink_bytes += len(payload)
+        if len(payload) != self.expected_frame_bytes:
+            self.bad_length_frames += 1
+        energy = frame_energy(payload)
+        self.peak_energy = max(self.peak_energy, energy)
+        if energy > SILENCE_ENERGY:
+            self.voiced_frames += 1
+
+    def verdict(self) -> dict:
+        failures = list(self.failures)
+        if self.start_envelope is None:
+            failures.append("no start envelope received")
+        if self.uplink_frames < MIN_UPLINK_FRAMES:
+            failures.append(
+                f"only {self.uplink_frames} uplink frames, expected >= {MIN_UPLINK_FRAMES}"
+            )
+        if self.bad_length_frames:
+            failures.append(
+                f"{self.bad_length_frames} uplink frames were not "
+                f"{self.expected_frame_bytes} bytes"
+            )
+        # The assertion that separates "a socket opened" from "audio arrived".
+        if self.voiced_frames == 0:
+            failures.append(
+                f"every uplink frame was silence (peak mean-square energy "
+                f"{self.peak_energy:.1f} <= {SILENCE_ENERGY})"
+            )
+        return {
+            "pass": not failures,
+            "failures": failures,
+            "uplink_frames": self.uplink_frames,
+            "uplink_bytes": self.uplink_bytes,
+            "voiced_frames": self.voiced_frames,
+            "peak_energy": round(self.peak_energy, 1),
+            "downlink_frames": self.downlink_frames,
+            "expected_frame_bytes": self.expected_frame_bytes,
+            "control_frames": self.control_frames,
+            "media": self.media,
+        }
+
+
+async def speak(connection, session: Session) -> None:
+    """Send the synthesized AI response downlink, one frame per ptime tick."""
+    samples_per_frame = session.sample_rate // 1000 * session.ptime
+    phase = 0.0
+    for _ in range(RESPONSE_FRAMES):
+        payload, phase = tone_frame(session.sample_rate, samples_per_frame, phase)
+        await connection.send(payload)
+        session.downlink_frames += 1
+        # Pace at the frame clock. The engine's downlink queue is bounded and
+        # drop-oldest, so blasting the whole response at once would have most of
+        # it discarded before playout.
+        await asyncio.sleep(session.ptime / 1000.0)
+
+
+async def handle(connection) -> None:
+    session = Session()
+    responder: asyncio.Task | None = None
+    print(f"[ai-ws] session opened from {connection.remote_address}", flush=True)
+    try:
+        async for message in connection:
+            if isinstance(message, bytes):
+                session.check_uplink(message)
+                # Once enough real caller audio has arrived, answer like an AI.
+                if (
+                    responder is None
+                    and session.uplink_frames >= MIN_UPLINK_FRAMES
+                    and session.voiced_frames > 0
+                ):
+                    responder = asyncio.create_task(speak(connection, session))
+                continue
+            try:
+                envelope = json.loads(message)
+            except ValueError:
+                session.failures.append(f"non-JSON text frame: {message[:80]!r}")
+                continue
+            kind = envelope.get("type", "?")
+            session.control_frames.append(kind)
+            print(f"[ai-ws] control <- {json.dumps(envelope)}", flush=True)
+            if kind == "start":
+                session.check_start(envelope)
+    except websockets.exceptions.ConnectionClosed:
+        pass
+    finally:
+        if responder is not None:
+            responder.cancel()
+        verdict = session.verdict()
+        print(f"AI-WS-VERDICT {json.dumps(verdict)}", flush=True)
+        status = "PASS" if verdict["pass"] else "FAIL"
+        print(
+            f"[ai-ws] session closed: {status} "
+            f"({verdict['uplink_frames']} up / {verdict['downlink_frames']} down, "
+            f"{verdict['voiced_frames']} voiced)",
+            flush=True,
+        )
+
+
+async def main() -> int:
+    async with websockets.serve(handle, LISTEN_HOST, LISTEN_PORT, max_size=None):
+        print(
+            f"mock voice-AI WebSocket server listening on {LISTEN_HOST}:{LISTEN_PORT} "
+            f"(min {MIN_UPLINK_FRAMES} uplink frames, {RESPONSE_FRAMES}-frame response)",
+            flush=True,
+        )
+        await asyncio.Future()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(asyncio.run(main()))
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/sipp/siphon-rtp/mock_siphon_rtp.py
+++ b/sipp/siphon-rtp/mock_siphon_rtp.py
@@ -9,10 +9,15 @@ rtpengine NG/bencode protocol.
 
 What it proves is the *composition*: that siphon identifies the carrier, issues
 the right control verb with the right profile, and answers the call with the SDP
-the engine handed back. It deliberately does not move audio. Proving the audio
-path needs the real engine plus a WebSocket media server; that run is gated on
-SIPHON_RTP_BIN (see tests/integration/siphon_rtp_tests.rs) because CI does not
-build the engine.
+the engine handed back. It deliberately does not move audio.
+
+The real engine covers the other half, and both halves are kept: this mock can
+report what siphon *sent* (see the stdout echo below), which a real engine
+cannot, while the real engine can reject what siphon sent and can move audio,
+which this cannot. See the siphon-rtp-native / siphon-rtp-ng / voice-ai-real
+compose profiles, which run the published engine image, and
+sipp/siphon-rtp/mock_ai_ws.py, which asserts audio actually crosses the
+WebSocket bridge.
 
 For offer / answer / answer_local it returns SDP with the c-line rewritten to
 MOCK_MEDIA_IP and the audio port to MOCK_MEDIA_PORT, simulating anchoring.

--- a/sipp/siphon-rtp/proxy_rtp_passthrough.py
+++ b/sipp/siphon-rtp/proxy_rtp_passthrough.py
@@ -1,0 +1,83 @@
+"""Proxy media anchoring for the real-engine tests, on a plain RTP relay.
+
+A copy of examples/proxy_rtpengine.py with one deliberate change: the profile is
+`rtp_passthrough` rather than `srtp_to_rtp`.
+
+Why it matters. `srtp_to_rtp` makes the engine rewrite the offer toward the B
+leg as `RTP/SAVP` with an `a=crypto` line. The SIPp UAS (sipp/rtpengine_uas.xml)
+ignores that and answers plain `RTP/AVP` with no crypto, so on the answer the
+engine is being asked to complete an SRTP negotiation the far end never joined.
+A spec-following engine rejects that (RFC 4568 §5.1.2 — the answerer must return
+a crypto attribute for the accepted suite), and the real engine does:
+
+    control command failed verb="answer" reason="SAVP answer: missing a=crypto"
+
+The control-plane mock never noticed, because it echoes SDP back without
+negotiating anything. That is the difference this whole test exists to expose,
+so the fix is to stop asking for an SRTP interworking the scenario does not
+perform, not to relax the engine. Both legs here are plain RTP, so
+`rtp_passthrough` is what the flow actually is.
+
+Testing the real SRTP interworking path needs a UAS that answers SAVP with a
+crypto line; that is a separate scenario, not this one.
+"""
+from siphon import proxy, registrar, auth, rtpengine, log
+
+DOMAIN = "siphon.test"
+PROFILE = "rtp_passthrough"
+
+
+@proxy.on_request
+async def route(request):
+    if request.method == "OPTIONS" and request.ruri.is_local and not request.ruri.user:
+        request.reply(200, "OK")
+        return
+
+    if request.in_dialog:
+        if request.method == "BYE":
+            await rtpengine.delete(request)
+            log.info(f"media delete for BYE call_id={request.call_id}")
+        elif request.method == "INVITE" and request.body:
+            await rtpengine.offer(request, profile=PROFILE)
+            log.info(f"media offer for re-INVITE call_id={request.call_id}")
+
+        request.loose_route()
+        request.relay()
+        return
+
+    if request.method == "REGISTER":
+        if not auth.require_digest(request, realm=DOMAIN):
+            return
+        registrar.save(request)
+        return
+
+    if not request.ruri.user:
+        request.reply(484, "Address Incomplete")
+        return
+
+    contacts = registrar.lookup(request.ruri)
+    if not contacts:
+        request.reply(404, "Not Found")
+        return
+
+    if request.method == "INVITE" and request.body:
+        await rtpengine.offer(request, profile=PROFILE)
+        log.info(f"media offer for INVITE call_id={request.call_id}")
+
+    request.record_route()
+    request.fork([c.uri for c in contacts])
+
+
+@proxy.on_reply
+async def reply_route(request, reply):
+    if 200 <= reply.status_code < 300 and reply.has_body("application/sdp"):
+        await rtpengine.answer(reply, profile=PROFILE)
+        log.info(f"media answer for reply call_id={reply.call_id}")
+
+    reply.relay()
+
+
+@proxy.on_cancel
+async def cancel_route(request):
+    await rtpengine.delete(request)
+    log.info(f"media delete for CANCEL call_id={request.call_id}")

--- a/sipp/siphon-rtp/siphon-rtp-native.yaml
+++ b/sipp/siphon-rtp/siphon-rtp-native.yaml
@@ -1,0 +1,52 @@
+# siphon config for the REAL siphon-rtp engine over the native JSON control plane.
+#
+# Deliberately a byte-for-byte twin of siphon-rtp-ng.yaml except for the
+# `media:` block — same script, same scenarios, same assertions. The pair is an
+# A/B over the two control planes the engine serves: this file drives it with
+# `media.backend: siphon-rtp` (JSON-over-TCP, port 8080), the other with the
+# stock rtpengine client (NG/bencode, port 22222). A behavioural difference
+# between the two runs is therefore a control-plane bug, not a media bug.
+#
+# Used with: sipp/docker-compose.yaml (siphon-rtp-native profile)
+# Script:    sipp/siphon-rtp/proxy_rtp_passthrough.py — the stock proxy example
+#            with a plain-RTP profile (see that file for why srtp_to_rtp is
+#            wrong here). The `rtpengine` script namespace is backend-agnostic,
+#            which is itself part of what these two profiles assert.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+advertised_address: "172.20.0.112"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.112"
+    - "127.0.0.1"
+
+script:
+  path: "/etc/siphon/scripts/proxy_rtp_passthrough.py"
+  reload: auto
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "172.20.0.110:8080"
+    timeout_ms: 2000
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/siphon-rtp/siphon-rtp-ng.yaml
+++ b/sipp/siphon-rtp/siphon-rtp-ng.yaml
@@ -1,0 +1,54 @@
+# siphon config driving the REAL siphon-rtp engine through its rtpengine
+# NG/bencode shim (`--ng`), using siphon's stock rtpengine client unchanged.
+#
+# This is the drop-in-replacement proof. Nothing here knows it is talking to
+# siphon-rtp: the `media.rtpengine:` block is the same one a deployment would
+# point at a real rtpengine, and the SIPp scenarios (rtpengine_uac.xml /
+# rtpengine_uas.xml) are the ones the rtpengine profile already uses, verbatim.
+# If this passes, an operator can repoint an existing rtpengine deployment at
+# siphon-rtp without touching their config or their scripts.
+#
+# The twin file siphon-rtp-native.yaml runs the identical setup over the native
+# JSON control plane; the two differ only in the `media:` block.
+#
+# Used with: sipp/docker-compose.yaml (siphon-rtp-ng profile)
+# Script:    sipp/siphon-rtp/proxy_rtp_passthrough.py
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+advertised_address: "172.20.0.115"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.115"
+    - "127.0.0.1"
+
+script:
+  path: "/etc/siphon/scripts/proxy_rtp_passthrough.py"
+  reload: auto
+
+registrar:
+  backend: memory
+  default_expires: 3600
+  max_expires: 7200
+
+auth:
+  realm: "siphon.test"
+  backend: static
+  users:
+    alice: "secret"
+    bob: "secret"
+
+media:
+  # No `backend:` key — this is the default rtpengine backend, pointed at the
+  # engine's NG listener instead of at rtpengine itself.
+  rtpengine:
+    address: "172.20.0.110:22222"
+    timeout_ms: 2000
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/siphon-rtp/siphon-voice-ai-real.yaml
+++ b/sipp/siphon-rtp/siphon-voice-ai-real.yaml
@@ -1,0 +1,59 @@
+# siphon config for the voice-AI test against the REAL siphon-rtp engine.
+#
+# The twin of siphon-voice-ai.yaml, which runs the same script against the
+# control-plane mock. The mock never dials `ws_uri`, so that run proves siphon
+# composed the right command and stops there. Here the engine really connects
+# to the AI server (sipp/siphon-rtp/mock_ai_ws.py), really decodes the caller's
+# G.711 to L16, and really re-encodes the AI's reply — so the WebSocket bridge
+# is exercised rather than described.
+#
+# Used with: sipp/docker-compose.yaml (voice-ai-real profile)
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "ai.example.com"
+
+advertised_address: "172.20.0.118"
+
+script:
+  path: "/etc/siphon/scripts/voice_ai_real.py"
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "172.20.0.110:8080"
+    timeout_ms: 2000
+
+  profiles:
+    voice_ai:
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+        # ws_vad emits speech_started / speech_stopped on the caller's speech
+        # edges. The AI server records which control frames arrived, so leaving
+        # this on means the SIPp audio also exercises the VAD path rather than
+        # just the raw bridge.
+        ws_vad: true
+        ws_barge_in: true
+        ws_vad_hangover_ms: 300
+      answer: *voice_ai_flags
+
+# The UAC's address, so call.from_gateway("carriers") passes and the script
+# answers instead of rejecting 403.
+gateway:
+  groups:
+    - name: "carriers"
+      probe:
+        enabled: false
+      destinations:
+        - uri: "sip:uac.test:5060"
+          address: "172.20.0.119:5060"
+
+log:
+  level: info

--- a/sipp/siphon-rtp/voice_ai_real.py
+++ b/sipp/siphon-rtp/voice_ai_real.py
@@ -1,0 +1,57 @@
+"""Voice-AI single-leg answer, aimed at a containerised WebSocket AI server.
+
+A trimmed copy of examples/voice_ai_b2bua.py for the real-engine functional
+test. It exists for one reason: the example hardcodes
+`ws://127.0.0.1:9001/stream`, which is correct for the single-host run-book in
+its docstring but wrong here — under compose the engine and the AI server are
+separate containers, so the engine's loopback is not the AI server.
+
+Everything else is deliberately the same shape as the example, because the
+point of the test is that the documented pattern works against the real engine.
+The DTMF transfer arm is dropped: this scenario never sends DTMF, and a handler
+that is never invoked would be dead weight in a test fixture.
+"""
+import os
+
+from siphon import b2bua, proxy, rtpengine, log
+
+# The AI server's address on the compose network. Env-driven rather than
+# hardcoded so the compose file stays the single place IPs are assigned.
+AI_WS_URI = os.environ.get("AI_WS_URI", "ws://172.20.0.111:9001/stream?call={call_id}")
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    request.reply(200, "OK")
+
+
+@b2bua.on_invite
+async def answer_with_ai(call):
+    if not call.from_gateway("carriers"):
+        log.warn(f"[{call.id}] INVITE from unknown source {call.source_ip}")
+        call.reject(403, "Forbidden")
+        return
+
+    # Single-leg answer: the engine picks one encodable codec from the caller's
+    # offer, synthesises the RFC 3264 answer, and dials the WebSocket bridge.
+    # With the real engine a failed WS dial fails this call outright (the engine
+    # tears the call down and returns an error rather than answering into a
+    # bridge that is not up), so reaching call.answer() below already means the
+    # socket is connected. Whether audio actually crosses it is what the AI
+    # server asserts on the other side.
+    answer_sdp = await rtpengine.answer_local(
+        call,
+        profile="voice_ai",
+        ws_uri=AI_WS_URI,
+    )
+    if answer_sdp is None:
+        log.warn(f"[{call.id}] no encodable codec in offer — rejected 488")
+        return
+
+    call.answer(200, "OK", body=answer_sdp, content_type="application/sdp")
+    log.info(f"[{call.id}] answered; audio bridged to the AI at {AI_WS_URI}")
+
+
+@b2bua.on_bye
+async def on_bye(call, initiator):
+    log.info(f"[{call.id}] call ended by {initiator}")

--- a/sipp/voice_ai_real_uac.xml
+++ b/sipp/voice_ai_real_uac.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Voice-AI UAC against the REAL siphon-rtp engine, with real audio.
+
+  INVITE (SDP) -> 100 -> 200 OK (anchored SDP) -> ACK -> [RTP] -> BYE -> 200
+
+  The difference from voice_ai_uac.xml (which runs against the control-plane
+  mock) is that this scenario actually sends media: play_pcap_audio streams
+  SIPp's bundled G.711 A-law sample at the engine's media address for the life
+  of the call. That audio is what the engine decodes to L16 and pushes up the
+  WebSocket to the AI server, and it is the only reason the AI server can tell a
+  working bridge from a bridge that merely connected.
+
+  The SIP-level assertion here is anchoring. The audio-level assertions live in
+  sipp/siphon-rtp/mock_ai_ws.py (uplink arrived, correct frame geometry, not
+  silence) and in the engine's own Prometheus counters, because neither is
+  observable from the UAC.
+
+  A-law (payload 8) is offered rather than PCMU because the pcap SIPp ships is
+  A-law; offering a codec the media does not match would put the wrong bytes on
+  the wire and the energy assertion downstream would be meaningless. ptime is 30
+  for the same reason: g711a.pcap carries 240-byte payloads (30 ms), and
+  declaring 20 would advertise a packetisation the media does not use, which the
+  AI server then sees as a frame-geometry mismatch on the WebSocket uplink.
+-->
+<scenario name="Voice-AI UAC (real engine, real audio)">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:ai@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/voice-ai-real-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 8 101
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=ptime:30
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <!-- 200 OK carrying the engine's synthesised answer, anchored on the engine's
+       own relay address (--relay-bind-ip). If the engine were left on its
+       loopback default the c= line would read 127.0.0.1, the RTP below would go
+       nowhere, and this regexp is what catches that before the silent-audio
+       assertion has to. -->
+  <recv response="200" rtd="true" crlf="true" rrs="true">
+    <action>
+      <ereg regexp="c=IN IP4 172\.20\.0\.110"
+            search_in="body"
+            check_it="true"
+            assign_to="anchored" />
+      <log message="answer SDP anchored on the real engine: [$anchored]" />
+      <ereg regexp="Contact:[^\r\n]*sip:"
+            search_in="msg"
+            check_it="true"
+            assign_to="contact_present" />
+      <log message="2xx Contact present: [$contact_present]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- The actual media. SIPp streams the A-law sample from its own media port
+       to the address the engine advertised in the answer. -->
+  <nop>
+    <action>
+      <exec play_pcap_audio="/sipp/g711a.pcap" />
+    </action>
+  </nop>
+
+  <!-- Hold well past the AI server's minimum-frame threshold so the uplink,
+       the VAD edges and the synthesized downlink all have time to happen. At
+       20 ms per frame this is ~150 frames each way. -->
+  <pause milliseconds="3000" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@carrier.example>;tag=[pid]SIPpTag00[call_number]
+To: <sip:ai@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/tests/integration/siphon_rtp_tests.rs
+++ b/tests/integration/siphon_rtp_tests.rs
@@ -357,10 +357,14 @@ async fn media_backend_siphon_rtp_is_send_sync() {
 
 // ---------------------------------------------------------------------------
 // End-to-end smoke test against a REAL siphon-rtp daemon. `#[ignore]`d and
-// gated on the `SIPHON_RTP_BIN` env var (path to a built `siphon-rtp` binary),
-// since CI does not build the engine. Run with:
+// gated on the `SIPHON_RTP_BIN` env var (path to a `siphon-rtp` binary), so a
+// plain `cargo test` stays hermetic. Run locally with:
 //   SIPHON_RTP_BIN=../siphon-rtp/target/debug/siphon-rtp \
 //     cargo test --test integration_tests -- --ignored siphon_rtp
+//
+// CI runs it too (the `siphon-rtp-engine-smoke` job) without building the
+// engine: the published image is distroless around a *static musl* binary, so
+// the job copies /usr/local/bin/siphon-rtp out of it and runs that directly.
 // ---------------------------------------------------------------------------
 
 /// A spawned siphon-rtp process, killed on drop.


### PR DESCRIPTION
siphon-rtp is public now (`v0.2.0`, `ghcr.io/siphon-project/siphon-rtp:0.2.0` anonymously pullable), so our own media engine no longer has to be the one backend that is never exercised against the real thing.

Before this, coverage was lopsided:

| backend | mock | real engine in CI |
|---|---|---|
| rtpengine | yes | yes (`drachtio/rtpengine`, REFER profile) |
| rtpproxy | yes | no |
| **siphon-rtp** | yes | **no** |

## What lands

Three new compose profiles, all served by a single engine container that opens both control planes at once (`--control` JSON-over-TCP and `--ng` rtpengine bencode). The image tag is pinned to the same release the `siphon-rtp-proto` dependency is pinned to, so this tests a known-good pairing rather than whatever shipped most recently.

- **`siphon-rtp-native`** and **`siphon-rtp-ng`** are deliberately identical stacks differing only in the `media:` block. The NG one drives the engine's rtpengine shim with siphon's *stock* rtpengine client and the *unmodified* `rtpengine_uac.xml` / `rtpengine_uas.xml`, so the drop-in-replacement claim is tested rather than asserted.
- **`voice-ai-real`** covers the path a control mock structurally cannot: the mock never dials `ws_uri`. SIPp now plays `g711a.pcap` into the call, and a mock AI server on the far end of the WebSocket asserts the uplink arrived with the correct frame geometry for the negotiated ptime and, crucially, that it is **not digital silence** — then answers with synthesized audio the engine re-encodes back toward the caller. A bridge that connects and passes zeros looks identical to a working one until you measure the samples.

The previously `#[ignore]`d `smoke_test_against_real_siphon_rtp` is also un-gated. Its rationale ("CI does not build the engine") is still true and no longer relevant: the image is distroless around a **static musl** binary, so CI copies `/usr/local/bin/siphon-rtp` out and runs it bare in ~2s. No Rust build of the engine, no container networking.

Every existing mock profile is untouched. A mock can report what siphon *sent*; a real engine can reject it and can move audio. Those are opposite halves and dropping either loses coverage.

## A real defect this caught

On the first green run the SIP leg completed 200/ACK/BYE cleanly while the engine's `control_errors_total` read 1 — it had rejected the `answer`:

```
control command failed verb="answer" reason="SAVP answer: missing a=crypto in the answer"
```

`proxy_rtpengine.py` asks for `srtp_to_rtp`, so the engine offers `RTP/SAVP` to a SIPp UAS that answers plain `RTP/AVP` with no crypto line. A spec-following engine refuses to complete that (RFC 4568 §5.1.2); the echo-everything mock never noticed. Hence `proxy_rtp_passthrough.py`, which uses the profile the flow actually is. This is exactly why the engine's own Prometheus counters are asserted as an oracle independent of the SIP leg.

## Verification

All three profiles green end-to-end locally, plus the un-gated smoke test, `cargo test` (3540 + 315, 0 failures) and clippy clean. The existing `voice-ai` mock profile re-run green as a regression check.

The voice-AI verdict on a passing run:

```json
{"pass": true, "uplink_frames": 100, "voiced_frames": 80, "peak_energy": 31254629.1,
 "downlink_frames": 25, "expected_frame_bytes": 480,
 "control_frames": ["start", "speech_started", "speech_stopped", "speech_started"],
 "media": {"encoding": "L16", "sampleRate": 8000, "channels": 1, "ptime": 30}}
```

**Mutation check:** dropping `--relay-bind-ip` (so the engine answers on its loopback default) fails the anchoring `ereg` at 255 and leaves the WS oracle reporting `no AI-WS-VERDICT line found — the WebSocket bridge was never established`. A media test that passes with unreachable media is not testing media.

`ptime` is 30 in the new scenario because SIPp's `g711a.pcap` carries 240-byte payloads; declaring 20 would advertise a packetisation the media does not use.

## Not in scope

- Dropping the **EXPERIMENTAL** label on the siphon-rtp backend. This clears the "waiting on live e2e validation" half, but the engine is 0.2.0 and marks itself experimental through 1.0.0.
- Replacing `drachtio/rtpengine` in the REFER test — that test's value is interop with actual rtpengine.
- AMR transcode; the published image is built without the patent-gated feature.

Test infrastructure only, no `src/` changes, so no CHANGELOG entry and no perf/mem baseline run.