### PR TITLE
feat(control): report the outcome of an outbound REFER, not just that it was accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,40 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   backends rather than silently downgrading — an overlay quietly turned into a
   supersede would cut the party's live audio.
 
+- **An outbound REFER on the external control rail now reports a real verdict.**
+  An application that asked siphon to transfer a call with the `refer` verb
+  learned only that the request had been accepted for processing — the outcome
+  existed inside siphon and was thrown away into a log line. Three new events
+  carry it on the owning connection: `TransferProgress` while the transfer is
+  still moving, then exactly one `TransferCompleted` / `TransferFailed`. Shared
+  payload `{stage, refer_to?, code?, reason?, attempt?}`, with `stage` naming
+  where the verdict came from (`accepted`, `challenged`, `notify`,
+  `transferred`, `refused`, `rejected`, `unauthorized`, `no_outcome`,
+  `call_ended`) and `code`/`reason` carrying the SIP status it rests on. Three
+  things this fixes: the `2xx` to a REFER is now reported as *progress*, not
+  success — RFC 3515 §2.4.4 makes it "accepted for processing", so treating it
+  as the answer called every failed transfer a success; the `message/sipfrag`
+  body of the REFER-subscription NOTIFY, which is where the real outcome lives,
+  is now parsed rather than only logged; and a carrier that challenges the REFER
+  and is answered with credentials is distinguishable from one that refuses,
+  via the stage plus the 1-based `attempt` number, even though both carry the
+  same `407`. Exactly one terminal event is emitted per REFER — including when
+  the call is torn down mid-transfer, whose implicit subscription can never
+  report — so a transfer is never left pending. The `refer` command reply is
+  unchanged (`{refer: "sent"}`): a far-end outcome is never folded into a
+  command reply, which would mean blocking a command on the peer.
+- **Control SDKs** (Rust `siphon-control-proto` / `siphon-control-client`,
+  TypeScript `@siphon-project/control`): the three events, a typed
+  `TransferOutcomePayload` + `TransferStage`, `CallEvent::transfer_outcome()` /
+  `CallEvent::is_transfer_final()` and the TypeScript `isTransferFinal()`.
+
+### Changed
+- **`siphon-control-proto`'s `SipEvent` is now `#[non_exhaustive]`.** The
+  server's event set grows, and without it every addition breaks any downstream
+  `match` with an arm per variant. A wildcard arm is now required once, and
+  every future event is purely additive. Consumers matching `SipEvent`
+  exhaustively need to add `_ => {}`.
+
 ## [1.6.0] — 2026-08-20
 
 ### Added

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -385,6 +385,45 @@ later phase over the same envelope. The client SDK facade methods for the media,
 transfer and originate verbs land alongside it (until then, reach the verbs
 through the generic `command(verb, args)` escape hatch).
 
+An **outbound REFER** — the `refer` verb, where the app asks siphon to transfer a
+call — reports its far-end verdict as events, never in the command reply. The
+reply is `{refer: "sent"}` and means exactly that: RFC 3515 §2.4.4 makes the 2xx
+to a REFER "accepted for processing", with the real outcome arriving afterwards
+on the implicit subscription as a `message/sipfrag` NOTIFY. Folding that into the
+reply would mean blocking a command on the far end, so the rail carries it as:
+
+- `TransferProgress` — the transfer moved but is not finished. Never a success.
+- `TransferCompleted` — the referee reported a 2xx on the terminating NOTIFY.
+- `TransferFailed` — it did not happen.
+
+All three share the payload `{stage, refer_to?, code?, reason?, attempt?}`, where
+`stage` says where the verdict came from and `code`/`reason` carry the SIP status
+it rests on (the REFER's own response, or the sipfrag status):
+
+| stage | event | meaning |
+|---|---|---|
+| `accepted` | `TransferProgress` | 2xx to the REFER — taken on for processing, no outcome yet |
+| `challenged` | `TransferProgress` | 401/407, answered with the call's credentials; `attempt` is which try |
+| `notify` | `TransferProgress` | a non-terminating sipfrag NOTIFY (e.g. `100`, `180`) |
+| `transferred` | `TransferCompleted` | terminating sipfrag NOTIFY with a 2xx |
+| `refused` | `TransferFailed` | terminating sipfrag NOTIFY with a 3xx+ — the referee tried the target and it failed |
+| `rejected` | `TransferFailed` | the referee refused the REFER itself: the transfer never started |
+| `unauthorized` | `TransferFailed` | challenged with no way to answer (no credentials, unparseable challenge, retry cap) |
+| `no_outcome` | `TransferFailed` | the subscription ended with no usable status — never read as success |
+| `call_ended` | `TransferFailed` | the call was torn down with the transfer still outstanding |
+
+`attempt` is the 1-based REFER attempt the verdict is about, so a carrier that
+challenges and is answered (`TransferProgress{stage: "challenged", attempt: 1}`)
+is distinguishable from one that refuses (`TransferFailed{stage: "unauthorized"}`)
+even though both carry the same 407. Exactly one terminal event
+(`TransferCompleted` / `TransferFailed`) is emitted per `refer`, including when
+the call dies mid-transfer — a transfer is never left pending.
+
+`bridge` / `originate` verbs arrive in later phases over the same envelope. The
+client SDK facade methods for the media verbs and the transfer verbs land
+alongside them (until then, reach the verbs through the generic
+`command(verb, args)` escape hatch).
+
 The complete wire reference, both connection modes end to end, and two
 low-level example clients (one Python, one TypeScript) that drive calls with no
 SDK live in the repository:

--- a/siphon-control-sdk/siphon-control-client/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-client/src/sip.rs
@@ -17,7 +17,7 @@ use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tracing::{debug, warn};
 
 use siphon_control_proto::sip::{
-    ChannelDtmfPayload, SipEvent, SipVerb, TransferRequestedPayload,
+    ChannelDtmfPayload, SipEvent, SipVerb, TransferOutcomePayload, TransferRequestedPayload,
 };
 use siphon_control_proto::verbs::MODULE_SIP;
 use siphon_control_proto::{ChannelSnapshot, EventFrame};
@@ -265,6 +265,34 @@ impl CallEvent {
         }
         serde_json::from_value(self.payload.clone()).ok()
     }
+
+    /// The typed [`TransferOutcomePayload`] when this is a verdict on a transfer
+    /// this app asked for ([`SipEvent::TransferProgress`],
+    /// [`SipEvent::TransferCompleted`] or [`SipEvent::TransferFailed`]), else
+    /// `None`.
+    ///
+    /// This — not the `refer` call's return value — is where a transfer's
+    /// outcome lives: [`Call::refer`] resolves as soon as siphon has sent the
+    /// REFER, because RFC 3515 §2.4.4 delivers the outcome afterwards on the
+    /// implicit subscription.
+    pub fn transfer_outcome(&self) -> Option<TransferOutcomePayload> {
+        if !matches!(
+            self.kind,
+            SipEvent::TransferProgress | SipEvent::TransferCompleted | SipEvent::TransferFailed
+        ) {
+            return None;
+        }
+        serde_json::from_value(self.payload.clone()).ok()
+    }
+
+    /// Whether this event ends a transfer this app asked for — exactly one such
+    /// event arrives per `refer`, so this is the signal to stop waiting.
+    pub fn is_transfer_final(&self) -> bool {
+        matches!(
+            self.kind,
+            SipEvent::TransferCompleted | SipEvent::TransferFailed
+        )
+    }
 }
 
 struct CallInner {
@@ -427,6 +455,13 @@ impl Call {
     }
 
     /// Send an in-dialog REFER on the A-leg (blind transfer).
+    ///
+    /// Resolves as soon as siphon has sent the REFER — `Ok(())` means *sent*,
+    /// not *transferred*. RFC 3515 §2.4.4 delivers the outcome afterwards on the
+    /// implicit subscription, so read it off the event stream: zero or more
+    /// `TransferProgress`, then exactly one `TransferCompleted` /
+    /// `TransferFailed`. [`CallEvent::transfer_outcome`] decodes them and
+    /// [`CallEvent::is_transfer_final`] says when to stop waiting.
     pub async fn refer(&self, to: &str) -> Result<(), ControlError> {
         self.sip(SipVerb::Refer, json!({ "to": to })).await.map(drop)
     }
@@ -664,8 +699,10 @@ impl Call {
 
     /// Await the next event for this call (`ChannelStateChange`,
     /// `ChannelHangupRequest`, `ChannelDtmfReceived`, `TransferRequested`,
-    /// `StasisEnd`). `None` once the stream closes. Use [`CallEvent::dtmf`] /
-    /// [`CallEvent::transfer_requested`] to decode the payload.
+    /// `TransferProgress`, `TransferCompleted`, `TransferFailed`, `StasisEnd`).
+    /// `None` once the stream closes. Use [`CallEvent::dtmf`] /
+    /// [`CallEvent::transfer_requested`] / [`CallEvent::transfer_outcome`] to
+    /// decode the payload.
     pub async fn next_event(&self) -> Option<CallEvent> {
         self.inner.events.lock().await.recv().await
     }
@@ -1003,6 +1040,7 @@ impl SipServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use siphon_control_proto::sip::TransferStage;
     use siphon_control_proto::ChannelSnapshot;
     use std::collections::HashMap;
 
@@ -1241,5 +1279,65 @@ mod tests {
         assert_eq!(payload.replaces.expect("replaces").call_id, "abc");
         assert_eq!(payload.from_tag.as_deref(), Some("referrer-tag"));
         assert!(transfer.dtmf().is_none());
+        // An inbound REFER is a request to decide, not a verdict on one we sent.
+        assert!(transfer.transfer_outcome().is_none());
+        assert!(!transfer.is_transfer_final());
+    }
+
+    #[test]
+    fn outbound_transfer_verdicts_parse_from_frames() {
+        let frame = |event: &str, payload: serde_json::Value| {
+            CallEvent::from_frame(EventFrame::new(
+                event, "ch1", "ivr-app", "call-uuid", "sip@host", payload,
+            ))
+        };
+
+        // Progress: the referee challenged and siphon answered (attempt 1). The
+        // attempt number is what separates this from a refusal on the same 407.
+        let challenged = frame(
+            "TransferProgress",
+            json!({
+                "stage": "challenged",
+                "refer_to": "sip:carol@example.net",
+                "code": 407,
+                "reason": "Proxy Authentication Required",
+                "attempt": 1
+            }),
+        );
+        assert_eq!(challenged.kind, SipEvent::TransferProgress);
+        let payload = challenged.transfer_outcome().expect("outcome payload");
+        assert_eq!(payload.stage, TransferStage::Challenged);
+        assert_eq!(payload.code, Some(407));
+        assert_eq!(payload.attempt, Some(1));
+        assert!(
+            !challenged.is_transfer_final(),
+            "progress must not end the wait"
+        );
+
+        // Completion, from the terminating sipfrag NOTIFY (RFC 3515 §2.4.4).
+        let completed = frame(
+            "TransferCompleted",
+            json!({ "stage": "transferred", "code": 200, "reason": "OK" }),
+        );
+        assert_eq!(completed.kind, SipEvent::TransferCompleted);
+        assert_eq!(
+            completed.transfer_outcome().expect("outcome").stage,
+            TransferStage::Transferred
+        );
+        assert!(completed.is_transfer_final());
+
+        // Failure, carrying the sipfrag status the referee reported.
+        let failed = frame(
+            "TransferFailed",
+            json!({ "stage": "refused", "code": 486, "reason": "Busy Here" }),
+        );
+        assert_eq!(failed.kind, SipEvent::TransferFailed);
+        let payload = failed.transfer_outcome().expect("outcome");
+        assert_eq!(payload.stage, TransferStage::Refused);
+        assert_eq!(payload.code, Some(486));
+        assert!(failed.is_transfer_final());
+        // Wrong-kind accessors stay None.
+        assert!(failed.dtmf().is_none());
+        assert!(failed.transfer_requested().is_none());
     }
 }

--- a/siphon-control-sdk/siphon-control-proto/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-proto/src/sip.rs
@@ -96,8 +96,13 @@ impl std::fmt::Display for SipVerb {
 /// Deserializes from the wire event name; an unrecognised name maps to
 /// [`SipEvent::Other`] rather than failing, so a newer server that adds events
 /// never breaks an older client.
+/// `#[non_exhaustive]`: the server's event set grows (this release adds the
+/// three outbound-REFER verdicts), and every such addition would otherwise
+/// break any downstream `match` that had an arm per variant. With it, a
+/// wildcard arm is required once and every future event is purely additive.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(from = "String", into = "String")]
+#[non_exhaustive]
 pub enum SipEvent {
     /// A call was handed to this application — the first frame it sees.
     StasisStart,
@@ -113,6 +118,16 @@ pub enum SipEvent {
     /// An inbound REFER on a controlled call is asking the app to own the
     /// transfer decision ([`TransferRequestedPayload`]).
     TransferRequested,
+    /// A transfer this app asked for (the `refer` verb) moved forward but is not
+    /// finished ([`TransferOutcomePayload`]). Never a success: RFC 3515 §2.4.4
+    /// makes a `2xx` to a REFER mean "accepted for processing", with the real
+    /// outcome arriving afterwards on the implicit subscription.
+    TransferProgress,
+    /// A transfer this app asked for succeeded ([`TransferOutcomePayload`]).
+    TransferCompleted,
+    /// A transfer this app asked for failed — refused, rejected, unauthorized,
+    /// or ended without an outcome ([`TransferOutcomePayload`]).
+    TransferFailed,
     /// Any other event name (forward-compatible catch-all).
     Other(String),
 }
@@ -127,6 +142,9 @@ impl SipEvent {
             SipEvent::ChannelHangupRequest => "ChannelHangupRequest",
             SipEvent::ChannelDtmfReceived => "ChannelDtmfReceived",
             SipEvent::TransferRequested => "TransferRequested",
+            SipEvent::TransferProgress => "TransferProgress",
+            SipEvent::TransferCompleted => "TransferCompleted",
+            SipEvent::TransferFailed => "TransferFailed",
             SipEvent::Other(name) => name.as_str(),
         }
     }
@@ -141,6 +159,9 @@ impl From<&str> for SipEvent {
             "ChannelHangupRequest" => SipEvent::ChannelHangupRequest,
             "ChannelDtmfReceived" => SipEvent::ChannelDtmfReceived,
             "TransferRequested" => SipEvent::TransferRequested,
+            "TransferProgress" => SipEvent::TransferProgress,
+            "TransferCompleted" => SipEvent::TransferCompleted,
+            "TransferFailed" => SipEvent::TransferFailed,
             other => SipEvent::Other(other.to_string()),
         }
     }
@@ -217,6 +238,129 @@ pub struct TransferRequestedPayload {
     pub from_tag: Option<String>,
 }
 
+/// The `stage` of a [`TransferOutcomePayload`] — where the verdict on an
+/// outbound REFER came from.
+///
+/// Unrecognised tokens map to [`TransferStage::Other`] rather than failing, so a
+/// newer server never breaks an older client.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+#[non_exhaustive]
+pub enum TransferStage {
+    /// The referee returned a `2xx` to the REFER: accepted for processing only
+    /// (RFC 3515 §2.4.4), *not* an outcome.
+    Accepted,
+    /// The referee challenged the REFER (`401`/`407`) and siphon answered with
+    /// the call's credentials; the retry is on the wire. `attempt` says which
+    /// try this was — the signal that separates "challenged and answered" from
+    /// "refused", since both carry the same status.
+    Challenged,
+    /// A non-terminating `message/sipfrag` NOTIFY reported progress.
+    Notify,
+    /// A terminating sipfrag NOTIFY reported a `2xx`: the transfer completed.
+    Transferred,
+    /// A terminating sipfrag NOTIFY reported a `3xx`+ status: the referee tried
+    /// the target and it failed.
+    Refused,
+    /// The referee answered the REFER itself with a final non-2xx: the transfer
+    /// never started.
+    Rejected,
+    /// The REFER was challenged and the challenge could not be answered (no
+    /// credentials, an unparseable challenge, or the retry cap).
+    Unauthorized,
+    /// The subscription ended with no usable sipfrag status — terminal, and
+    /// never to be read as success.
+    NoOutcome,
+    /// The call ended with the transfer still outstanding, so its subscription
+    /// can never report.
+    CallEnded,
+    /// Any other stage token (forward-compatible catch-all).
+    Other(String),
+}
+
+impl TransferStage {
+    /// The exact wire token.
+    pub fn as_str(&self) -> &str {
+        match self {
+            TransferStage::Accepted => "accepted",
+            TransferStage::Challenged => "challenged",
+            TransferStage::Notify => "notify",
+            TransferStage::Transferred => "transferred",
+            TransferStage::Refused => "refused",
+            TransferStage::Rejected => "rejected",
+            TransferStage::Unauthorized => "unauthorized",
+            TransferStage::NoOutcome => "no_outcome",
+            TransferStage::CallEnded => "call_ended",
+            TransferStage::Other(token) => token.as_str(),
+        }
+    }
+}
+
+impl From<&str> for TransferStage {
+    fn from(token: &str) -> Self {
+        match token {
+            "accepted" => TransferStage::Accepted,
+            "challenged" => TransferStage::Challenged,
+            "notify" => TransferStage::Notify,
+            "transferred" => TransferStage::Transferred,
+            "refused" => TransferStage::Refused,
+            "rejected" => TransferStage::Rejected,
+            "unauthorized" => TransferStage::Unauthorized,
+            "no_outcome" => TransferStage::NoOutcome,
+            "call_ended" => TransferStage::CallEnded,
+            other => TransferStage::Other(other.to_string()),
+        }
+    }
+}
+
+impl From<String> for TransferStage {
+    fn from(token: String) -> Self {
+        TransferStage::from(token.as_str())
+    }
+}
+
+impl From<TransferStage> for String {
+    fn from(stage: TransferStage) -> Self {
+        stage.as_str().to_string()
+    }
+}
+
+impl std::fmt::Display for TransferStage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// The `payload` shared by [`SipEvent::TransferProgress`],
+/// [`SipEvent::TransferCompleted`] and [`SipEvent::TransferFailed`]: one verdict
+/// on a transfer this app asked for with the `refer` verb.
+///
+/// The `refer` command reply reports only that the REFER was sent. RFC 3515
+/// §2.4.4 puts the real outcome on the implicit subscription that follows, as a
+/// `message/sipfrag` NOTIFY — these events carry it. Expect zero or more
+/// `TransferProgress` and then exactly one `TransferCompleted` /
+/// `TransferFailed`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferOutcomePayload {
+    /// Where this verdict came from.
+    pub stage: TransferStage,
+    /// The `Refer-To` URI the REFER carried, when known.
+    #[serde(default)]
+    pub refer_to: Option<String>,
+    /// The SIP status this verdict rests on: the REFER's own response status for
+    /// `accepted` / `challenged` / `rejected` / `unauthorized`, the sipfrag
+    /// status for the NOTIFY-driven stages.
+    #[serde(default)]
+    pub code: Option<u16>,
+    /// That status's reason phrase, when the peer supplied one.
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Which REFER attempt this verdict is about, 1-based. `None` once the REFER
+    /// transaction is over (the NOTIFY-driven stages).
+    #[serde(default)]
+    pub attempt: Option<u32>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -256,6 +400,20 @@ mod tests {
             SipEvent::from("TransferRequested"),
             SipEvent::TransferRequested
         );
+        for name in ["TransferProgress", "TransferCompleted", "TransferFailed"] {
+            let parsed = SipEvent::from(name);
+            assert_eq!(parsed.as_str(), name);
+            assert_eq!(serde_json::to_string(&parsed).unwrap(), format!("\"{name}\""));
+        }
+        assert_eq!(
+            SipEvent::from("TransferProgress"),
+            SipEvent::TransferProgress
+        );
+        assert_eq!(
+            SipEvent::from("TransferCompleted"),
+            SipEvent::TransferCompleted
+        );
+        assert_eq!(SipEvent::from("TransferFailed"), SipEvent::TransferFailed);
         assert_eq!(
             SipEvent::from("SomethingNew"),
             SipEvent::Other("SomethingNew".to_string())
@@ -281,6 +439,65 @@ mod tests {
         assert_eq!(parsed.duration_ms, 100);
         assert_eq!(parsed.volume, -8);
         assert_eq!(parsed.from_tag, "alice-tag");
+    }
+
+    #[test]
+    fn transfer_outcome_payload_parses_every_server_shape() {
+        // Byte-identical to the server's TransferProgress / TransferCompleted /
+        // TransferFailed payloads.
+        let challenged: TransferOutcomePayload = serde_json::from_value(serde_json::json!({
+            "stage": "challenged",
+            "refer_to": "sip:carol@example.net",
+            "code": 407,
+            "reason": "Proxy Authentication Required",
+            "attempt": 1,
+        }))
+        .unwrap();
+        assert_eq!(challenged.stage, TransferStage::Challenged);
+        assert_eq!(challenged.code, Some(407));
+        assert_eq!(challenged.attempt, Some(1));
+
+        // The NOTIFY-driven stages carry no attempt and no Refer-To.
+        let completed: TransferOutcomePayload = serde_json::from_value(serde_json::json!({
+            "stage": "transferred",
+            "refer_to": null,
+            "code": 200,
+            "reason": "OK",
+            "attempt": null,
+        }))
+        .unwrap();
+        assert_eq!(completed.stage, TransferStage::Transferred);
+        assert_eq!(completed.attempt, None);
+        assert_eq!(completed.refer_to, None);
+
+        // Terminal with nothing else known at all.
+        let ended: TransferOutcomePayload =
+            serde_json::from_value(serde_json::json!({ "stage": "call_ended" })).unwrap();
+        assert_eq!(ended.stage, TransferStage::CallEnded);
+        assert_eq!(ended.code, None);
+    }
+
+    #[test]
+    fn transfer_stage_round_trips_known_and_unknown() {
+        for (token, stage) in [
+            ("accepted", TransferStage::Accepted),
+            ("challenged", TransferStage::Challenged),
+            ("notify", TransferStage::Notify),
+            ("transferred", TransferStage::Transferred),
+            ("refused", TransferStage::Refused),
+            ("rejected", TransferStage::Rejected),
+            ("unauthorized", TransferStage::Unauthorized),
+            ("no_outcome", TransferStage::NoOutcome),
+            ("call_ended", TransferStage::CallEnded),
+        ] {
+            assert_eq!(TransferStage::from(token), stage);
+            assert_eq!(stage.as_str(), token);
+            assert_eq!(stage.to_string(), token);
+            assert_eq!(serde_json::to_string(&stage).unwrap(), format!("\"{token}\""));
+        }
+        // A stage a newer server invents must not break decoding.
+        let novel: TransferStage = serde_json::from_str("\"something_new\"").unwrap();
+        assert_eq!(novel, TransferStage::Other("something_new".to_string()));
     }
 
     #[test]

--- a/siphon-control-sdk/typescript/src/index.ts
+++ b/siphon-control-sdk/typescript/src/index.ts
@@ -61,6 +61,7 @@ export {
   GET_VAR,
   SipVerb,
   sipEventKind,
+  isTransferFinal,
   encodeCommand,
   parseInboundFrame,
 } from "./protocol";
@@ -79,6 +80,8 @@ export type {
   ChannelDtmfPayload,
   TransferReplaces,
   TransferRequestedPayload,
+  TransferStage,
+  TransferOutcomePayload,
 } from "./protocol";
 
 export { ControlClient, EventStream } from "./client";

--- a/siphon-control-sdk/typescript/src/protocol.ts
+++ b/siphon-control-sdk/typescript/src/protocol.ts
@@ -202,6 +202,9 @@ export type SipEventKind =
   | "ChannelHangupRequest"
   | "ChannelDtmfReceived"
   | "TransferRequested"
+  | "TransferProgress"
+  | "TransferCompleted"
+  | "TransferFailed"
   | (string & {});
 
 /** Parse a wire event name; unknown names pass through verbatim (forward-compatible). */
@@ -247,4 +250,69 @@ export interface TransferRequestedPayload {
   replaces?: TransferReplaces | null;
   /** The From-tag of the referring party, if known. */
   from_tag?: string | null;
+}
+
+/**
+ * Where a verdict on an *outbound* REFER came from — the `stage` of a
+ * {@link TransferOutcomePayload}. Unknown tokens pass through verbatim
+ * (forward-compatible).
+ */
+export type TransferStage =
+  /** `2xx` to the REFER: accepted for processing only (RFC 3515 §2.4.4). */
+  | "accepted"
+  /** `401`/`407` answered with credentials; `attempt` says which try. */
+  | "challenged"
+  /** A non-terminating `message/sipfrag` NOTIFY reported progress. */
+  | "notify"
+  /** A terminating sipfrag NOTIFY reported a `2xx`: the transfer completed. */
+  | "transferred"
+  /** A terminating sipfrag NOTIFY reported `3xx`+: the target failed. */
+  | "refused"
+  /** The referee refused the REFER itself: the transfer never started. */
+  | "rejected"
+  /** Challenged with no way to answer (no credentials / retry cap). */
+  | "unauthorized"
+  /** The subscription ended with no usable status — never read as success. */
+  | "no_outcome"
+  /** The call ended with the transfer still outstanding. */
+  | "call_ended"
+  | (string & {});
+
+/**
+ * The `payload` shared by the `TransferProgress`, `TransferCompleted` and
+ * `TransferFailed` events — one verdict on a transfer this app asked for with
+ * the `refer` verb.
+ *
+ * The `refer` command resolves as soon as siphon has sent the REFER; RFC 3515
+ * §2.4.4 puts the real outcome on the implicit subscription that follows. Expect
+ * zero or more `TransferProgress`, then exactly one `TransferCompleted` /
+ * `TransferFailed`. Cast a {@link import("./sip").CallEvent}'s `payload` to this
+ * when `kind` is one of those three.
+ */
+export interface TransferOutcomePayload {
+  /** Where this verdict came from. */
+  stage: TransferStage;
+  /** The Refer-To URI the REFER carried, when known. */
+  refer_to?: string | null;
+  /**
+   * The SIP status this verdict rests on: the REFER's own response status for
+   * `accepted` / `challenged` / `rejected` / `unauthorized`, the sipfrag status
+   * for the NOTIFY-driven stages.
+   */
+  code?: number | null;
+  /** That status's reason phrase, when the peer supplied one. */
+  reason?: string | null;
+  /**
+   * Which REFER attempt this verdict is about, 1-based. `null` once the REFER
+   * transaction is over (the NOTIFY-driven stages).
+   */
+  attempt?: number | null;
+}
+
+/**
+ * Whether an event name ends a transfer this app asked for. Exactly one such
+ * event arrives per `refer`, so this is the signal to stop waiting.
+ */
+export function isTransferFinal(name: string): boolean {
+  return name === "TransferCompleted" || name === "TransferFailed";
 }

--- a/siphon-control-sdk/typescript/src/sip.ts
+++ b/siphon-control-sdk/typescript/src/sip.ts
@@ -37,9 +37,11 @@ import type { CommandTransport } from "./session";
 
 /** One event delivered to a call's stream (`ChannelStateChange`,
  * `ChannelHangupRequest`, `ChannelDtmfReceived`, `TransferRequested`,
- * `StasisEnd`, …). Cast `payload` to
+ * `TransferProgress`, `TransferCompleted`, `TransferFailed`, `StasisEnd`, …).
+ * Cast `payload` to
  * {@link import("./protocol").ChannelDtmfPayload} /
- * {@link import("./protocol").TransferRequestedPayload} by `kind`. */
+ * {@link import("./protocol").TransferRequestedPayload} /
+ * {@link import("./protocol").TransferOutcomePayload} by `kind`. */
 export interface CallEvent {
   /** The parsed event kind. */
   kind: SipEventKind;
@@ -293,7 +295,17 @@ export class Call {
     await this.terminate(reason);
   }
 
-  /** Send an in-dialog REFER on the A-leg (blind transfer). */
+  /**
+   * Send an in-dialog REFER on the A-leg (blind transfer).
+   *
+   * Resolves as soon as siphon has sent the REFER — that is *sent*, not
+   * *transferred*. RFC 3515 §2.4.4 delivers the outcome afterwards on the
+   * implicit subscription, so read it off {@link Call.events}: zero or more
+   * `TransferProgress`, then exactly one `TransferCompleted` /
+   * `TransferFailed`, each carrying a
+   * {@link import("./protocol").TransferOutcomePayload}. Use
+   * {@link import("./protocol").isTransferFinal} to know when to stop waiting.
+   */
   async refer(to: string): Promise<void> {
     await this.sip(SipVerb.Refer, { to });
   }

--- a/siphon-control-sdk/typescript/test/wire.test.ts
+++ b/siphon-control-sdk/typescript/test/wire.test.ts
@@ -11,11 +11,12 @@ import { AsyncQueue } from "../src/internal";
 import {
   Call,
   encodeCommand,
+  isTransferFinal,
   sipEventKind,
   SipVerb,
   MODULE_SIP,
 } from "../src/index";
-import type { CallEvent } from "../src/index";
+import type { CallEvent, TransferOutcomePayload } from "../src/index";
 import type { CommandTransport } from "../src/session";
 
 describe("command wire bytes (byte-identical to the server)", () => {
@@ -65,7 +66,32 @@ describe("SipVerb wire tokens + event names", () => {
     expect(sipEventKind("StasisStart")).toBe("StasisStart");
     expect(sipEventKind("ChannelDtmfReceived")).toBe("ChannelDtmfReceived");
     expect(sipEventKind("TransferRequested")).toBe("TransferRequested");
+    expect(sipEventKind("TransferProgress")).toBe("TransferProgress");
+    expect(sipEventKind("TransferCompleted")).toBe("TransferCompleted");
+    expect(sipEventKind("TransferFailed")).toBe("TransferFailed");
     expect(sipEventKind("SomethingNew")).toBe("SomethingNew");
+  });
+
+  it("marks exactly the terminal outbound-REFER verdicts as final", () => {
+    // RFC 3515 §2.4.4: the 2xx to a REFER is only "accepted for processing", so
+    // TransferProgress must never end an app's wait for the outcome.
+    expect(isTransferFinal("TransferCompleted")).toBe(true);
+    expect(isTransferFinal("TransferFailed")).toBe(true);
+    expect(isTransferFinal("TransferProgress")).toBe(false);
+    expect(isTransferFinal("TransferRequested")).toBe(false);
+    expect(isTransferFinal("StasisEnd")).toBe(false);
+  });
+
+  it("decodes a transfer verdict payload", () => {
+    // Byte-identical to the server's TransferFailed payload.
+    const payload: TransferOutcomePayload = JSON.parse(
+      '{"stage":"unauthorized","refer_to":"sip:carol@example.net",' +
+        '"code":407,"reason":"Proxy Authentication Required","attempt":3}',
+    );
+    expect(payload.stage).toBe("unauthorized");
+    expect(payload.code).toBe(407);
+    expect(payload.attempt).toBe(3);
+    expect(payload.refer_to).toBe("sip:carol@example.net");
   });
 });
 

--- a/src/b2bua/transfer.rs
+++ b/src/b2bua/transfer.rs
@@ -92,6 +92,45 @@ pub fn build_sipfrag_body(status_code: u16, reason: &str) -> String {
     format!("SIP/2.0 {status_code} {reason}\r\n")
 }
 
+/// Parse the `message/sipfrag` body of a REFER-subscription NOTIFY into its
+/// status code and reason phrase — the *outcome* of a transfer siphon
+/// originated (RFC 3515 §2.4.4: the referee reports progress as a sipfrag
+/// Status-Line; RFC 3420 defines the sipfrag body itself).
+///
+/// The inverse of [`build_sipfrag_body`]. Deliberately tolerant, because the
+/// body comes off the wire from a peer:
+///
+/// * A sipfrag MAY carry headers after the Status-Line (RFC 3420 §2), so only
+///   the first non-blank line is read.
+/// * A sipfrag MAY omit the start line entirely and carry only headers
+///   (RFC 3420 §2) — there is no status to report, so that yields `None`.
+/// * The reason phrase is optional in the Status-Line grammar (RFC 3261 §25.1
+///   allows an empty `Reason-Phrase`), so a bare `SIP/2.0 200` parses with an
+///   empty reason.
+///
+/// Returns `None` when the body carries no usable Status-Line; the caller
+/// treats that as "no outcome", never as success.
+pub fn parse_sipfrag_status(body: &[u8]) -> Option<(u16, String)> {
+    let text = std::str::from_utf8(body).ok()?;
+    let line = text.lines().find(|line| !line.trim().is_empty())?.trim();
+    // RFC 3261 §7.2: Status-Line = SIP-Version SP Status-Code SP Reason-Phrase.
+    let (version, rest) = line.split_once(' ')?;
+    if !version.eq_ignore_ascii_case("SIP/2.0") {
+        return None;
+    }
+    let rest = rest.trim_start();
+    let (code_text, reason) = match rest.split_once(' ') {
+        Some((code_text, reason)) => (code_text, reason.trim()),
+        None => (rest, ""),
+    };
+    let code: u16 = code_text.parse().ok()?;
+    // RFC 3261 §21: a status code is 3 digits, 100..699.
+    if !(100..700).contains(&code) {
+        return None;
+    }
+    Some((code, reason.to_string()))
+}
+
 /// Build a `Subscription-State` header value for a REFER-subscription NOTIFY
 /// (RFC 3515 §2.4.4 / RFC 6665 §4.1.3).
 ///
@@ -195,6 +234,78 @@ mod tests {
     fn build_sipfrag_503() {
         let body = build_sipfrag_body(503, "Service Unavailable");
         assert_eq!(body, "SIP/2.0 503 Service Unavailable\r\n");
+    }
+
+    #[test]
+    fn parse_sipfrag_round_trips_build() {
+        // The inverse of build_sipfrag_body, on every status class it emits.
+        for (code, reason) in [(100, "Trying"), (200, "OK"), (503, "Service Unavailable")] {
+            let body = build_sipfrag_body(code, reason);
+            assert_eq!(
+                parse_sipfrag_status(body.as_bytes()),
+                Some((code, reason.to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn parse_sipfrag_ignores_trailing_headers() {
+        // RFC 3420 §2: a sipfrag may carry headers after the Status-Line.
+        let body = b"SIP/2.0 486 Busy Here
+Contact: <sip:carol@example.com>
+";
+        assert_eq!(
+            parse_sipfrag_status(body),
+            Some((486, "Busy Here".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_sipfrag_accepts_missing_reason_phrase() {
+        // RFC 3261 §25.1 allows an empty Reason-Phrase.
+        assert_eq!(parse_sipfrag_status(b"SIP/2.0 200
+"), Some((200, String::new())));
+    }
+
+    #[test]
+    fn parse_sipfrag_multi_word_reason_is_kept_whole() {
+        assert_eq!(
+            parse_sipfrag_status(b"SIP/2.0 480 Temporarily Unavailable
+"),
+            Some((480, "Temporarily Unavailable".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_sipfrag_without_status_line_is_none() {
+        // RFC 3420 §2: a header-only fragment carries no outcome at all.
+        assert_eq!(parse_sipfrag_status(b"Contact: <sip:carol@example.com>
+"), None);
+        assert_eq!(parse_sipfrag_status(b""), None);
+        assert_eq!(parse_sipfrag_status(b"
+
+"), None);
+        assert_eq!(parse_sipfrag_status(b"SIP/2.0 not-a-code
+"), None);
+        assert_eq!(parse_sipfrag_status(b"HTTP/1.1 200 OK
+"), None);
+        // Out of the 100..699 status range (RFC 3261 §21).
+        assert_eq!(parse_sipfrag_status(b"SIP/2.0 99 Nope
+"), None);
+        assert_eq!(parse_sipfrag_status(b"SIP/2.0 700 Nope
+"), None);
+        // Not UTF-8 at all.
+        assert_eq!(parse_sipfrag_status(&[0xff, 0xfe, 0x00]), None);
+    }
+
+    #[test]
+    fn parse_sipfrag_tolerates_leading_blank_lines() {
+        assert_eq!(
+            parse_sipfrag_status(b"
+SIP/2.0 200 OK
+"),
+            Some((200, "OK".to_string()))
+        );
     }
 
     #[test]

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -50,7 +50,7 @@ pub use protocol::{
 };
 pub use registry::{
     ChannelRef, ConnHandle, ControlBus, ControlCommand, OfferOutcome, OutboundFrame, OutboundQueue,
-    Ownership, PushOutcome, SlowConsumerPolicy,
+    Ownership, PushOutcome, SlowConsumerPolicy, TransferOutcome, TransferStage,
 };
 
 /// Push an event to the control channel owning `sip_call_id`, if the call is

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -266,6 +266,217 @@ struct ChannelEntry {
     on_lost: String,
     /// Per-call variables (drain with the channel — never on `CallActor`).
     vars: Mutex<HashMap<String, String>>,
+    /// The `Refer-To` of an outbound REFER whose verdict has not landed yet.
+    ///
+    /// Set by the first non-terminal [`TransferOutcome`] on this channel and
+    /// cleared by the terminal one. Its only job is the teardown flush: RFC 3515
+    /// §2.4.4's implicit subscription dies with the dialog, so a call that goes
+    /// away mid-transfer would otherwise leave the app waiting on a verdict that
+    /// can never arrive. One `Option<String>` per channel, drained by
+    /// [`ControlBus::remove_channel`] with everything else on the entry.
+    outbound_transfer: Mutex<Option<String>>,
+}
+
+/// Where a verdict on a **siphon-originated (outbound) REFER** came from — the
+/// `stage` field of the `TransferProgress` / `TransferCompleted` /
+/// `TransferFailed` payload, and what decides which of those three names the
+/// event carries.
+///
+/// The split exists because RFC 3515 §2.4.4 separates two things an application
+/// otherwise cannot tell apart: a `2xx` to the REFER means the referee accepted
+/// it **for processing**, while the transfer's real outcome arrives later on the
+/// implicit subscription as a `message/sipfrag` NOTIFY. Reporting that `2xx` as
+/// success would call every failed transfer a success.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferStage {
+    /// The referee returned a `2xx` to the REFER: accepted for processing only
+    /// (RFC 3515 §2.4.4). Not an outcome — non-terminal.
+    Accepted,
+    /// The referee challenged the REFER (`401`/`407`) and siphon answered it
+    /// with the call's credentials; the credentialed retry is on the wire.
+    /// Non-terminal, and the signal that distinguishes "the peer challenged and
+    /// we answered" from "the peer refused".
+    Challenged,
+    /// A non-terminating sipfrag NOTIFY reported progress (e.g. `100`, `180`).
+    /// Non-terminal.
+    Notify,
+    /// A terminating sipfrag NOTIFY reported a `2xx` — the transfer completed.
+    Transferred,
+    /// A terminating sipfrag NOTIFY reported a `3xx`+ status — the referee tried
+    /// the target and it failed.
+    Refused,
+    /// The referee answered the REFER itself with a final non-2xx: the transfer
+    /// never started.
+    Rejected,
+    /// The REFER was challenged and the challenge could not be answered (no
+    /// credentials configured, an unparseable challenge, or the retry cap).
+    Unauthorized,
+    /// The subscription ended without a usable sipfrag status. Terminal by
+    /// construction: never report a transfer of unknown outcome as a success.
+    NoOutcome,
+    /// The call was torn down with the transfer still outstanding, so its
+    /// subscription can never report (RFC 3515 §2.4.4 — the implicit
+    /// subscription lives inside the dialog and dies with it).
+    CallEnded,
+}
+
+impl TransferStage {
+    /// The exact `stage` token on the wire.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TransferStage::Accepted => "accepted",
+            TransferStage::Challenged => "challenged",
+            TransferStage::Notify => "notify",
+            TransferStage::Transferred => "transferred",
+            TransferStage::Refused => "refused",
+            TransferStage::Rejected => "rejected",
+            TransferStage::Unauthorized => "unauthorized",
+            TransferStage::NoOutcome => "no_outcome",
+            TransferStage::CallEnded => "call_ended",
+        }
+    }
+
+    /// The event name this stage is published under.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            TransferStage::Accepted | TransferStage::Challenged | TransferStage::Notify => {
+                "TransferProgress"
+            }
+            TransferStage::Transferred => "TransferCompleted",
+            TransferStage::Refused
+            | TransferStage::Rejected
+            | TransferStage::Unauthorized
+            | TransferStage::NoOutcome
+            | TransferStage::CallEnded => "TransferFailed",
+        }
+    }
+
+    /// Whether this stage ends the transfer. Exactly one terminal stage is
+    /// emitted per outbound REFER — after it, no further verdict follows.
+    pub fn is_terminal(&self) -> bool {
+        !matches!(
+            self,
+            TransferStage::Accepted | TransferStage::Challenged | TransferStage::Notify
+        )
+    }
+
+    /// Classify the **final** response to a siphon-originated REFER.
+    /// `challenge_answered` is whether a credentialed retry actually went out
+    /// (`false` when there are no credentials, the challenge was unparseable, or
+    /// the retry cap was reached).
+    ///
+    /// Note what a `2xx` maps to: [`Accepted`](Self::Accepted), which is
+    /// non-terminal. RFC 3515 §2.4.4 makes a `2xx` to a REFER mean "accepted for
+    /// processing" and nothing more, so mapping it to a completion would report
+    /// every failed transfer as a success.
+    pub fn from_refer_response(status_code: u16, challenge_answered: bool) -> Self {
+        if (200..300).contains(&status_code) {
+            return TransferStage::Accepted;
+        }
+        match (status_code, challenge_answered) {
+            // RFC 3261 §22: a 401/407 is a challenge, not a refusal.
+            (401 | 407, true) => TransferStage::Challenged,
+            (401 | 407, false) => TransferStage::Unauthorized,
+            _ => TransferStage::Rejected,
+        }
+    }
+
+    /// Classify a `message/sipfrag` NOTIFY on the REFER subscription siphon owns
+    /// (RFC 3515 §2.4.4). `terminated` is whether the `Subscription-State`
+    /// header ends the subscription (RFC 6665 §4.1.3); `sipfrag` is the parsed
+    /// Status-Line status, if the body carried one.
+    ///
+    /// Returns `None` only for a *non*-terminating NOTIFY with no readable
+    /// status — nothing happened worth reporting. A terminating NOTIFY always
+    /// yields a stage, including
+    /// [`NoOutcome`](Self::NoOutcome): the subscription is over either way, so
+    /// silence there would leave the transfer pending forever.
+    pub fn from_notify(terminated: bool, sipfrag: Option<u16>) -> Option<Self> {
+        match (terminated, sipfrag) {
+            (true, Some(code)) if (200..300).contains(&code) => Some(TransferStage::Transferred),
+            (true, Some(code)) if code >= 300 => Some(TransferStage::Refused),
+            // A terminating NOTIFY still carrying a provisional (the referee gave
+            // up mid-flight), or a body with no Status-Line at all.
+            (true, _) => Some(TransferStage::NoOutcome),
+            (false, Some(_)) => Some(TransferStage::Notify),
+            (false, None) => None,
+        }
+    }
+}
+
+/// One verdict on a siphon-originated (outbound) REFER, published on the control
+/// rail as `TransferProgress` / `TransferCompleted` / `TransferFailed`.
+///
+/// Deliberately **never** folded into the `refer` command reply: the command
+/// reports only that the REFER was accepted for local processing; the far end's
+/// verdict is an event. Conflating them would make the reply wait on the peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferOutcome {
+    /// Where the verdict came from.
+    pub stage: TransferStage,
+    /// The `Refer-To` URI the REFER carried, when known.
+    pub refer_to: Option<String>,
+    /// The SIP status this verdict rests on: the REFER's own response status for
+    /// `accepted` / `challenged` / `rejected` / `unauthorized`, the sipfrag
+    /// status for the NOTIFY-driven stages.
+    pub code: Option<u16>,
+    /// That status's reason phrase, when the peer supplied one.
+    pub reason: Option<String>,
+    /// Which REFER attempt this verdict is about, 1-based — attempt 1 is the
+    /// first send, attempt N a credentialed retry (RFC 7616 §3.3). `None` for
+    /// the NOTIFY-driven stages, where the REFER transaction is long over.
+    pub attempt: Option<u32>,
+}
+
+impl TransferOutcome {
+    /// A verdict at `stage` with nothing else known yet.
+    pub fn new(stage: TransferStage) -> Self {
+        Self {
+            stage,
+            refer_to: None,
+            code: None,
+            reason: None,
+            attempt: None,
+        }
+    }
+
+    /// Attach the transfer target.
+    pub fn with_refer_to(mut self, refer_to: impl Into<String>) -> Self {
+        self.refer_to = Some(refer_to.into());
+        self
+    }
+
+    /// Attach the SIP status (and reason phrase, when the peer supplied one)
+    /// this verdict rests on.
+    pub fn with_status(mut self, code: u16, reason: &str) -> Self {
+        self.code = Some(code);
+        if !reason.is_empty() {
+            self.reason = Some(reason.to_string());
+        }
+        self
+    }
+
+    /// Attach the 1-based REFER attempt number this verdict is about.
+    pub fn with_attempt(mut self, attempt: u32) -> Self {
+        self.attempt = Some(attempt);
+        self
+    }
+
+    /// The event name this verdict publishes under.
+    pub fn event_name(&self) -> &'static str {
+        self.stage.event_name()
+    }
+
+    /// The event payload — the wire shape an SDK decodes.
+    pub fn payload(&self) -> serde_json::Value {
+        serde_json::json!({
+            "stage": self.stage.as_str(),
+            "refer_to": self.refer_to,
+            "code": self.code,
+            "reason": self.reason,
+            "attempt": self.attempt,
+        })
+    }
 }
 
 /// A read-only snapshot of a channel a connection owns (for command resolution
@@ -644,6 +855,7 @@ impl ControlBus {
                 sip_call_id: sip_call_id.to_string(),
                 on_lost: on_lost.to_string(),
                 vars: Mutex::new(vars),
+                outbound_transfer: Mutex::new(None),
             }),
         );
         self.app_calls
@@ -700,6 +912,9 @@ impl ControlBus {
             ),
             None => return false,
         };
+        // A transfer still awaiting its verdict can never get one once the
+        // channel is gone — report it before the StasisEnd that ends the stream.
+        self.flush_outbound_transfer(channel_id, &sip_call_id);
         self.publish_to_channel(
             channel_id,
             EventFrame::new(
@@ -791,6 +1006,9 @@ impl ControlBus {
             Some(entry) => (entry.app.clone(), entry.call_actor_id.clone()),
             None => return,
         };
+        // A transfer still awaiting its verdict can never get one once the call
+        // is gone — report it before the StasisEnd that ends the stream.
+        self.flush_outbound_transfer(&channel_id, sip_call_id);
         let mut payload = serde_json::json!({ "reason": reason });
         if let Some(object) = payload.as_object_mut() {
             if let Some(code) = code {
@@ -929,6 +1147,115 @@ impl ControlBus {
             debug!(%channel_id, %sip_call_id, target = %refer_to.uri, "control plane: TransferRequested forwarded");
         }
         pushed
+    }
+
+    /// Publish one verdict on a **siphon-originated (outbound) REFER** — the
+    /// `refer` verb's far-end outcome — to the owning control connection.
+    ///
+    /// The `refer` command reply says only that the REFER was accepted for local
+    /// processing; this is where the application learns what actually happened.
+    /// Three event names come out of one call, chosen by
+    /// [`TransferStage::event_name`]: `TransferProgress` while the transfer is
+    /// still moving, then exactly one of `TransferCompleted` / `TransferFailed`.
+    ///
+    /// RFC 3515 §2.4.4 is why that split has to exist: a `2xx` to the REFER is
+    /// "accepted for processing", *not* "transferred" — the real outcome arrives
+    /// afterwards on the implicit subscription as a `message/sipfrag` NOTIFY.
+    ///
+    /// A non-terminal verdict arms the channel's teardown flush; a terminal one
+    /// disarms it (see [`Self::flush_outbound_transfer`]), so a transfer is
+    /// never left pending and exactly one terminal event is emitted per REFER.
+    /// The only state involved is that one `Option<String>` on the channel
+    /// entry, which drains with the channel — no leak coverage of its own.
+    ///
+    /// Idempotent no-op — never panics — when the call is uncontrolled (the
+    /// common case) or the owning connection is gone. Returns whether an event
+    /// was pushed.
+    pub fn forward_transfer_outcome(&self, sip_call_id: &str, outcome: &TransferOutcome) -> bool {
+        let Some(channel_id) = self.channel_id_for_sip_call_id(sip_call_id) else {
+            return false;
+        };
+        let (app, call_actor_id) = match self.channels.get(&channel_id) {
+            Some(entry) => {
+                // Arm / disarm the teardown flush before publishing, so a
+                // teardown racing this event cannot double-report the transfer.
+                let mut pending = match entry.outbound_transfer.lock() {
+                    Ok(pending) => pending,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                *pending = if outcome.stage.is_terminal() {
+                    None
+                } else {
+                    outcome.refer_to.clone().or_else(|| pending.clone())
+                };
+                drop(pending);
+                (entry.app.clone(), entry.call_actor_id.clone())
+            }
+            None => return false,
+        };
+        let pushed = self.publish_to_channel(
+            &channel_id,
+            EventFrame::new(
+                outcome.event_name(),
+                &channel_id,
+                &app,
+                &call_actor_id,
+                sip_call_id,
+                outcome.payload(),
+            ),
+        );
+        if pushed {
+            debug!(
+                %channel_id,
+                %sip_call_id,
+                event = outcome.event_name(),
+                stage = outcome.stage.as_str(),
+                code = outcome.code,
+                "control plane: outbound REFER verdict forwarded"
+            );
+        }
+        pushed
+    }
+
+    /// Emit the terminal verdict for an outbound REFER still outstanding on a
+    /// channel that is about to go away, then disarm.
+    ///
+    /// The transfer's implicit subscription lives inside the dialog (RFC 3515
+    /// §2.4.4), so once the call is gone no sipfrag NOTIFY can ever report it.
+    /// Without this an application that asked for a transfer and then lost the
+    /// call would wait forever for a verdict. Runs on every channel-removal
+    /// funnel, ahead of the `StasisEnd` that ends the channel.
+    fn flush_outbound_transfer(&self, channel_id: &str, sip_call_id: &str) {
+        let (app, call_actor_id, refer_to) = match self.channels.get(channel_id) {
+            Some(entry) => {
+                let refer_to = match entry.outbound_transfer.lock() {
+                    Ok(mut pending) => pending.take(),
+                    Err(poisoned) => poisoned.into_inner().take(),
+                };
+                match refer_to {
+                    Some(refer_to) => (entry.app.clone(), entry.call_actor_id.clone(), refer_to),
+                    None => return,
+                }
+            }
+            None => return,
+        };
+        let outcome = TransferOutcome::new(TransferStage::CallEnded).with_refer_to(refer_to);
+        self.publish_to_channel(
+            channel_id,
+            EventFrame::new(
+                outcome.event_name(),
+                channel_id,
+                &app,
+                &call_actor_id,
+                sip_call_id,
+                outcome.payload(),
+            ),
+        );
+        debug!(
+            %channel_id,
+            %sip_call_id,
+            "control plane: outbound REFER left outstanding by teardown — reported failed"
+        );
     }
 
     /// Offer a handed-over call to an app: assign a persistent owner (round
@@ -1474,6 +1801,441 @@ mod tests {
         assert!(!bus.forward_transfer_requested("unknown-ch", "unknown-cid", &refer_to, None));
         assert_eq!(conn.events.depth(), 0, "no event for an uncontrolled call");
         assert_eq!(bus.channel_count(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Outbound-REFER verdicts (`TransferProgress` / `TransferCompleted` /
+    // `TransferFailed`) — the far-end outcome of the `refer` verb.
+    // -----------------------------------------------------------------------
+
+    /// Drain the transfer verdicts a connection received, as
+    /// `(event_name, stage, code, attempt)`.
+    async fn transfer_events(
+        conn: &Arc<ConnHandle>,
+    ) -> Vec<(String, String, Option<u64>, Option<u64>)> {
+        conn.events
+            .recv_many()
+            .await
+            .into_iter()
+            .filter_map(|frame| match frame {
+                OutboundFrame::Event(event)
+                    if event.event.starts_with("Transfer") && event.event != "TransferRequested" =>
+                {
+                    Some((
+                        event.event.clone(),
+                        event.payload["stage"].as_str().unwrap_or_default().to_string(),
+                        event.payload["code"].as_u64(),
+                        event.payload["attempt"].as_u64(),
+                    ))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn controlled_bus() -> (Arc<ControlBus>, Arc<ConnHandle>) {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.offer_channel(
+            "ivr-app",
+            "ch1",
+            "call-uuid",
+            "sipcid@h",
+            "hangup",
+            HashMap::new(),
+            serde_json::json!({}),
+        );
+        (bus, conn)
+    }
+
+    #[test]
+    fn transfer_stage_wire_tokens_event_names_and_terminality() {
+        // The three event names an app subscribes to, and which stages are
+        // terminal (exactly one terminal verdict per outbound REFER).
+        let progress = [
+            (TransferStage::Accepted, "accepted"),
+            (TransferStage::Challenged, "challenged"),
+            (TransferStage::Notify, "notify"),
+        ];
+        for (stage, token) in progress {
+            assert_eq!(stage.as_str(), token);
+            assert_eq!(stage.event_name(), "TransferProgress");
+            assert!(!stage.is_terminal(), "{token} must not end the transfer");
+        }
+        assert_eq!(TransferStage::Transferred.as_str(), "transferred");
+        assert_eq!(TransferStage::Transferred.event_name(), "TransferCompleted");
+        assert!(TransferStage::Transferred.is_terminal());
+        let failures = [
+            (TransferStage::Refused, "refused"),
+            (TransferStage::Rejected, "rejected"),
+            (TransferStage::Unauthorized, "unauthorized"),
+            (TransferStage::NoOutcome, "no_outcome"),
+            (TransferStage::CallEnded, "call_ended"),
+        ];
+        for (stage, token) in failures {
+            assert_eq!(stage.as_str(), token);
+            assert_eq!(stage.event_name(), "TransferFailed");
+            assert!(stage.is_terminal(), "{token} must end the transfer");
+        }
+    }
+
+    #[test]
+    fn refer_2xx_is_accepted_for_processing_never_completion() {
+        // RFC 3515 §2.4.4: a 2xx to a REFER says the referee took it on, not
+        // that the transfer happened. Reporting it as TransferCompleted would
+        // call every failed transfer a success — the whole point of the split.
+        for status in [200, 202, 299] {
+            let stage = TransferStage::from_refer_response(status, false);
+            assert_eq!(stage, TransferStage::Accepted);
+            assert_eq!(stage.event_name(), "TransferProgress");
+            assert!(!stage.is_terminal());
+        }
+    }
+
+    #[test]
+    fn refer_challenge_answered_is_progress_unanswered_is_failure() {
+        // The same 401/407 status means two opposite things; only whether a
+        // credentialed retry went out separates them.
+        for status in [401, 407] {
+            assert_eq!(
+                TransferStage::from_refer_response(status, true),
+                TransferStage::Challenged
+            );
+            assert_eq!(
+                TransferStage::from_refer_response(status, false),
+                TransferStage::Unauthorized
+            );
+        }
+        // Anything else final is a plain refusal, retry flag or not.
+        for status in [403, 404, 480, 603] {
+            assert_eq!(
+                TransferStage::from_refer_response(status, true),
+                TransferStage::Rejected
+            );
+            assert_eq!(
+                TransferStage::from_refer_response(status, false),
+                TransferStage::Rejected
+            );
+        }
+    }
+
+    #[test]
+    fn notify_classification_covers_every_terminating_body() {
+        // Terminating NOTIFY: the sipfrag status is the outcome.
+        assert_eq!(
+            TransferStage::from_notify(true, Some(200)),
+            Some(TransferStage::Transferred)
+        );
+        assert_eq!(
+            TransferStage::from_notify(true, Some(486)),
+            Some(TransferStage::Refused)
+        );
+        // A terminating NOTIFY with no usable outcome is still terminal — it
+        // must never read as success, and must never leave the app waiting.
+        assert_eq!(
+            TransferStage::from_notify(true, None),
+            Some(TransferStage::NoOutcome)
+        );
+        assert_eq!(
+            TransferStage::from_notify(true, Some(100)),
+            Some(TransferStage::NoOutcome)
+        );
+        // Non-terminating: progress when readable, nothing to report otherwise.
+        assert_eq!(
+            TransferStage::from_notify(false, Some(180)),
+            Some(TransferStage::Notify)
+        );
+        assert_eq!(TransferStage::from_notify(false, None), None);
+    }
+
+    #[test]
+    fn transfer_outcome_payload_shape() {
+        let outcome = TransferOutcome::new(TransferStage::Challenged)
+            .with_refer_to("sip:carol@example.net")
+            .with_status(407, "Proxy Authentication Required")
+            .with_attempt(2);
+        let payload = outcome.payload();
+        assert_eq!(payload["stage"], "challenged");
+        assert_eq!(payload["refer_to"], "sip:carol@example.net");
+        assert_eq!(payload["code"], 407);
+        assert_eq!(payload["reason"], "Proxy Authentication Required");
+        assert_eq!(payload["attempt"], 2);
+        // An empty reason phrase (RFC 3261 §25.1 permits one) is omitted rather
+        // than published as "".
+        let bare = TransferOutcome::new(TransferStage::Rejected).with_status(603, "");
+        assert!(bare.payload()["reason"].is_null());
+        assert!(bare.payload()["refer_to"].is_null());
+        assert!(bare.payload()["attempt"].is_null());
+    }
+
+    #[tokio::test]
+    async fn outbound_refer_accepted_then_progress_then_completed() {
+        // The full happy path: the referee 202s the REFER (progress), NOTIFYs
+        // 100 Trying (progress), then terminates the subscription with a
+        // sipfrag 200 (RFC 3515 §2.4.4) — only THAT is the completion.
+        let (bus, conn) = controlled_bus();
+        let target = "sip:carol@example.net";
+
+        assert!(bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::from_refer_response(202, false))
+                .with_refer_to(target)
+                .with_status(202, "Accepted")
+                .with_attempt(1),
+        ));
+        let notify = TransferStage::from_notify(false, Some(100)).expect("progress NOTIFY");
+        assert!(bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(notify).with_status(100, "Trying"),
+        ));
+        let done = TransferStage::from_notify(true, Some(200)).expect("terminating NOTIFY");
+        assert!(bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(done).with_status(200, "OK"),
+        ));
+
+        let events = transfer_events(&conn).await;
+        assert_eq!(
+            events
+                .iter()
+                .map(|(event, stage, ..)| (event.as_str(), stage.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("TransferProgress", "accepted"),
+                ("TransferProgress", "notify"),
+                ("TransferCompleted", "transferred"),
+            ]
+        );
+        assert_eq!(events[0].2, Some(202));
+        assert_eq!(events[0].3, Some(1));
+        assert_eq!(events[2].2, Some(200));
+
+        // The terminal verdict disarmed the teardown flush: no second, bogus
+        // TransferFailed when the call later ends.
+        bus.on_call_terminated("sipcid@h", "bye");
+        assert!(transfer_events(&conn).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn outbound_refer_accepted_then_refused() {
+        // Accepted for processing, then the referee reports the target refused
+        // it. An app that stopped at the 202 would have called this a success.
+        let (bus, conn) = controlled_bus();
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::from_refer_response(202, false))
+                .with_refer_to("sip:carol@example.net")
+                .with_status(202, "Accepted")
+                .with_attempt(1),
+        );
+        let refused = TransferStage::from_notify(true, Some(486)).expect("terminating NOTIFY");
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(refused).with_status(486, "Busy Here"),
+        );
+
+        let events = transfer_events(&conn).await;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].0, "TransferProgress");
+        assert_eq!(events[1].0, "TransferFailed");
+        assert_eq!(events[1].1, "refused");
+        assert_eq!(events[1].2, Some(486), "the sipfrag status must ride along");
+    }
+
+    #[tokio::test]
+    async fn outbound_refer_challenged_retried_then_completed() {
+        // The carrier challenges, siphon answers with credentials, the retry is
+        // accepted and the transfer completes. The challenge must read as
+        // progress carrying the attempt number, not as a refusal.
+        let (bus, conn) = controlled_bus();
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::from_refer_response(407, true))
+                .with_refer_to("sip:carol@example.net")
+                .with_status(407, "Proxy Authentication Required")
+                .with_attempt(1),
+        );
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::from_refer_response(202, false))
+                .with_refer_to("sip:carol@example.net")
+                .with_status(202, "Accepted")
+                .with_attempt(2),
+        );
+        let done = TransferStage::from_notify(true, Some(200)).expect("terminating NOTIFY");
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(done).with_status(200, "OK"),
+        );
+
+        let events = transfer_events(&conn).await;
+        assert_eq!(
+            events
+                .iter()
+                .map(|(event, stage, code, attempt)| (
+                    event.as_str(),
+                    stage.as_str(),
+                    *code,
+                    *attempt
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("TransferProgress", "challenged", Some(407), Some(1)),
+                ("TransferProgress", "accepted", Some(202), Some(2)),
+                ("TransferCompleted", "transferred", Some(200), None),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn outbound_refer_unretryable_challenge_is_terminal_failure() {
+        // Challenged with no way to answer (no credentials / unparseable
+        // challenge / retry cap): terminal, and distinguishable from the
+        // retried case by the event name + stage despite the identical status.
+        let (bus, conn) = controlled_bus();
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::from_refer_response(407, false))
+                .with_refer_to("sip:carol@example.net")
+                .with_status(407, "Proxy Authentication Required")
+                .with_attempt(3),
+        );
+
+        let events = transfer_events(&conn).await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "TransferFailed");
+        assert_eq!(events[0].1, "unauthorized");
+        assert_eq!(events[0].2, Some(407));
+        assert_eq!(events[0].3, Some(3), "the attempt count must ride along");
+
+        // Terminal means terminal: the teardown flush was disarmed.
+        bus.on_call_terminated("sipcid@h", "bye");
+        assert!(transfer_events(&conn).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn outbound_refer_rejected_outright_is_terminal_failure() {
+        // The referee refuses the REFER itself: the transfer never started.
+        let (bus, conn) = controlled_bus();
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::from_refer_response(603, false))
+                .with_refer_to("sip:carol@example.net")
+                .with_status(603, "Decline")
+                .with_attempt(1),
+        );
+        let events = transfer_events(&conn).await;
+        assert_eq!(events.len(), 1);
+        assert_eq!((events[0].0.as_str(), events[0].1.as_str()), ("TransferFailed", "rejected"));
+        assert_eq!(events[0].2, Some(603));
+    }
+
+    #[tokio::test]
+    async fn outbound_refer_outstanding_at_teardown_reports_failed_before_stasis_end() {
+        // A transfer that can never complete: the referee accepted the REFER,
+        // then the call went away before any terminating NOTIFY. The implicit
+        // subscription lives in the dialog (RFC 3515 §2.4.4), so no verdict can
+        // ever arrive — the app must get a terminal one anyway, and it must
+        // arrive before the StasisEnd that ends the stream.
+        let (bus, conn) = controlled_bus();
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::Accepted)
+                .with_refer_to("sip:carol@example.net")
+                .with_status(202, "Accepted")
+                .with_attempt(1),
+        );
+        bus.on_call_terminated("sipcid@h", "bye");
+
+        let names: Vec<String> = conn
+            .events
+            .recv_many()
+            .await
+            .into_iter()
+            .filter_map(|frame| match frame {
+                OutboundFrame::Event(event) => Some(event.event),
+                _ => None,
+            })
+            .collect();
+        let failed = names
+            .iter()
+            .position(|name| name == "TransferFailed")
+            .expect("a transfer left pending by teardown must be reported failed");
+        let ended = names
+            .iter()
+            .position(|name| name == "StasisEnd")
+            .expect("StasisEnd still fires");
+        assert!(failed < ended, "the verdict must precede StasisEnd: {names:?}");
+        // Everything drained — the flush marker lives on the channel entry.
+        assert_eq!(bus.channel_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn outbound_refer_outstanding_at_release_reports_failed() {
+        // Same guarantee on the other channel-removal funnel: the controller
+        // handed the call back to siphon (`route`) mid-transfer.
+        let (bus, conn) = controlled_bus();
+        bus.forward_transfer_outcome(
+            "sipcid@h",
+            &TransferOutcome::new(TransferStage::Accepted).with_refer_to("sip:carol@example.net"),
+        );
+        assert!(bus.release_channel("ch1", "routed"));
+
+        let events = transfer_events(&conn).await;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].0, "TransferFailed");
+        assert_eq!(events[1].1, "call_ended");
+        assert_eq!(bus.channel_count(), 0);
+    }
+
+    #[test]
+    fn forward_transfer_outcome_on_uncontrolled_call_is_clean_noop() {
+        // A transfer verdict for a call no control app owns: silent no-op, no
+        // panic, no state (the in-process transfer path is unaffected).
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        assert!(!bus.forward_transfer_outcome(
+            "unknown-cid",
+            &TransferOutcome::new(TransferStage::Transferred).with_status(200, "OK"),
+        ));
+        assert_eq!(conn.events.depth(), 0, "no event for an uncontrolled call");
+        assert_eq!(bus.channel_count(), 0);
+    }
+
+    #[test]
+    fn outbound_transfer_marker_drains_to_baseline() {
+        // Steady-state leak gate for the one piece of per-call state this adds:
+        // N transfers armed and torn down leave the channel map at baseline.
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        assert_eq!(bus.channel_count(), 0);
+        for cycle in 0..5 {
+            let conn = bus.register_connection("ivr-app");
+            for index in 0..8 {
+                let channel = format!("ch-{cycle}-{index}");
+                let sip_call_id = format!("sip-{cycle}-{index}");
+                bus.register_channel(
+                    &channel,
+                    &conn,
+                    &format!("call-{cycle}-{index}"),
+                    &sip_call_id,
+                    "hangup",
+                    HashMap::new(),
+                );
+                // Arm (non-terminal), then end the call without a verdict.
+                bus.forward_transfer_outcome(
+                    &sip_call_id,
+                    &TransferOutcome::new(TransferStage::Accepted).with_refer_to("sip:c@example.net"),
+                );
+                bus.on_call_terminated(&sip_call_id, "bye");
+            }
+            assert_eq!(bus.channel_count(), 0, "channels leaked on cycle {cycle}");
+            if let Some(fanout) = bus.apps.get(&conn.app) {
+                fanout.remove(conn.id);
+            }
+            conn.events.close();
+            bus.apps.remove_if(&conn.app, |_, fanout| fanout.is_empty());
+        }
+        assert!(bus.app_calls.is_empty(), "app_calls index leaked");
     }
 
     #[test]

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -56,7 +56,7 @@ impl ControlAdapter for SipControlAdapter {
                 verb("progress", "Send a UAS 1xx / early media (args: code, reason, body, content_type)"),
                 verb("reject", "Send a final non-2xx and tear the call down (args: code, reason)"),
                 verb("hangup", "BYE an answered call, or reject an unanswered one (args: reason)"),
-                verb("refer", "Send an in-dialog REFER on the A-leg (args: to, replaces)"),
+                verb("refer", "Send an in-dialog REFER on the A-leg; the reply reports only that it was sent, the far end's verdict arrives as TransferProgress then TransferCompleted / TransferFailed (args: to, replaces)"),
                 verb("accept_refer", "Accept a pending inbound REFER (from a TransferRequested event) and run the transfer (args: target, next_hop, mode)"),
                 verb("reject_refer", "Reject a pending inbound REFER with a final non-2xx (args: code, reason)"),
                 verb("route", "Return control to siphon with a routing decision: un-park the call and dial the B-leg via LCR sequential failover (args: targets, strategy, headers)"),
@@ -78,6 +78,14 @@ impl ControlAdapter for SipControlAdapter {
                 "ChannelHangupRequest".to_string(),
                 "ChannelDtmfReceived".to_string(),
                 "TransferRequested".to_string(),
+                // The verdict on an *outbound* REFER (the `refer` verb). Three
+                // names, because RFC 3515 §2.4.4 splits "accepted for
+                // processing" (the 2xx to the REFER) from the real outcome (the
+                // message/sipfrag NOTIFY that follows): TransferProgress while
+                // it moves, then exactly one TransferCompleted / TransferFailed.
+                "TransferProgress".to_string(),
+                "TransferCompleted".to_string(),
+                "TransferFailed".to_string(),
             ],
         }
     }
@@ -847,6 +855,15 @@ fn hangup(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
     }
 }
 
+/// `refer` — send an in-dialog REFER on the A-leg (a siphon-originated cold
+/// transfer).
+///
+/// The reply says `{"refer": "sent"}` and nothing more, deliberately: RFC 3515
+/// §2.4.4 puts the transfer's outcome on the implicit subscription that follows
+/// (a `message/sipfrag` NOTIFY), so folding it into the reply would mean waiting
+/// on the far end inside a command. The verdict arrives as events instead —
+/// `TransferProgress` while it moves, then exactly one `TransferCompleted` /
+/// `TransferFailed` (see [`crate::control::TransferStage`]).
 fn refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
     let Some(to) = args.get("to").and_then(|v| v.as_str()) else {
         return ControlResult::error(ControlErrorCode::BadRequest, "refer requires args.to");
@@ -1502,9 +1519,32 @@ mod tests {
             "ChannelHangupRequest",
             "ChannelDtmfReceived",
             "TransferRequested",
+            "TransferProgress",
+            "TransferCompleted",
+            "TransferFailed",
         ] {
             assert!(events.contains(&expected), "missing event {expected}");
         }
+    }
+
+    #[test]
+    fn refer_reply_reports_only_local_acceptance() {
+        // The command/event split, asserted rather than assumed: the `refer`
+        // verb's summary must promise the outcome as an event, because the reply
+        // can only report that siphon sent the REFER. RFC 3515 §2.4.4 puts the
+        // real verdict on the implicit subscription, which arrives later.
+        let schema = SipControlAdapter::new().describe();
+        let refer = schema
+            .verbs
+            .iter()
+            .find(|verb| verb.verb == "refer")
+            .expect("refer verb");
+        assert!(
+            refer.summary.contains("TransferCompleted")
+                && refer.summary.contains("TransferFailed"),
+            "the refer verb must point at its outcome events, got: {}",
+            refer.summary
+        );
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17920,11 +17920,30 @@ fn handle_originated_refer_response(
         return;
     };
 
+    // The attempt this response is about: attempt 1 is the first send, attempt
+    // N a credentialed retry (RFC 7616 §3.3).
+    let attempt = pending.auth_retries + 1;
+    let reason = response_reason_phrase(message);
+
     if (200..300).contains(&status_code) {
         debug!(
             call_id = %pending.call_id,
             status = status_code,
             "B2BUA: siphon-originated REFER accepted"
+        );
+        // RFC 3515 §2.4.4: a 2xx to a REFER means the referee accepted it *for
+        // processing* — it is NOT the transfer's outcome, which arrives later on
+        // the implicit subscription as a message/sipfrag NOTIFY. So this is
+        // progress, never completion.
+        control_forward_transfer_outcome(
+            state,
+            &pending.call_id,
+            crate::control::TransferOutcome::new(
+                crate::control::TransferStage::from_refer_response(status_code, false),
+            )
+            .with_refer_to(pending.refer_to.uri.clone())
+            .with_status(status_code, reason)
+            .with_attempt(attempt),
         );
         return;
     }
@@ -17934,6 +17953,22 @@ fn handle_originated_refer_response(
         && pending.auth_retries < MAX_B2BUA_AUTH_RETRIES
         && retry_originated_refer_with_credentials(&pending, message, status_code, state)
     {
+        // Progress, not failure: the peer challenged and siphon answered. The
+        // attempt number is what lets an application tell this apart from a
+        // refusal — the same 401/407 status carries both meanings.
+        control_forward_transfer_outcome(
+            state,
+            &pending.call_id,
+            crate::control::TransferOutcome::new(
+                crate::control::TransferStage::from_refer_response(
+                    status_code,
+                    /*challenge_answered=*/ true,
+                ),
+            )
+            .with_refer_to(pending.refer_to.uri.clone())
+            .with_status(status_code, reason)
+            .with_attempt(attempt),
+        );
         return;
     }
 
@@ -17956,9 +17991,63 @@ fn handle_originated_refer_response(
             "B2BUA: siphon-originated REFER rejected by the peer"
         );
     }
+    let stage = crate::control::TransferStage::from_refer_response(
+        status_code,
+        /*challenge_answered=*/ false,
+    );
+    // Terminal: the transfer never started. Emitted together with the
+    // subscription clear below so the two can never diverge — a cleared
+    // subscription with no verdict is a transfer that stays pending forever.
+    control_forward_transfer_outcome(
+        state,
+        &pending.call_id,
+        crate::control::TransferOutcome::new(stage)
+            .with_refer_to(pending.refer_to.uri.clone())
+            .with_status(status_code, reason)
+            .with_attempt(attempt),
+    );
     state
         .call_actors
         .clear_refer_subscriptions_on_leg(&pending.call_id, pending.on_a_leg);
+}
+
+/// The reason phrase of a response, or `""` when the peer sent none (RFC 3261
+/// §25.1 allows an empty `Reason-Phrase`).
+fn response_reason_phrase(message: &SipMessage) -> &str {
+    match &message.start_line {
+        StartLine::Response(status_line) => status_line.reason_phrase.as_str(),
+        StartLine::Request(_) => "",
+    }
+}
+
+/// Forward one verdict on a siphon-originated (outbound) REFER to the control
+/// connection owning this call, as `TransferProgress` / `TransferCompleted` /
+/// `TransferFailed` (RFC 3515 §2.4.4 — see [`crate::control::TransferStage`]).
+///
+/// **Additive** — this runs next to, never in place of, the in-process transfer
+/// machinery, and fires whether or not any Python handler is registered. A no-op
+/// when the control plane isn't configured or the call isn't controlled.
+///
+/// `internal_call_id` is the `CallActor` id; the control bus keys channels on
+/// the **A-leg** SIP Call-ID, which is not the dialog a REFER on the B-leg (or
+/// its NOTIFYs) travels on, so the A-leg Call-ID is resolved from the store here
+/// rather than taken from the message.
+fn control_forward_transfer_outcome(
+    state: &DispatcherState,
+    internal_call_id: &str,
+    outcome: crate::control::TransferOutcome,
+) {
+    let Some(bus) = crate::control::ControlBus::global() else {
+        return;
+    };
+    let Some(sip_call_id) = state
+        .call_actors
+        .get_call(internal_call_id)
+        .map(|call| call.a_leg.dialog.call_id.clone())
+    else {
+        return;
+    };
+    bus.forward_transfer_outcome(&sip_call_id, &outcome);
 }
 
 /// Re-send a challenged REFER carrying digest credentials. Returns `false` when
@@ -22316,12 +22405,31 @@ fn handle_b2bua_notify(inbound: InboundMessage, message: SipMessage, state: &Dis
             .get("Subscription-State")
             .map(|value| value.to_ascii_lowercase().contains("terminated"))
             .unwrap_or(false);
+        // RFC 3515 §2.4.4: the sipfrag Status-Line in this NOTIFY *is* the
+        // transfer's outcome — the 2xx to the REFER only said "accepted for
+        // processing". Parsing it is what turns the control rail's transfer
+        // report from "asked" into "happened".
+        let sipfrag = crate::b2bua::transfer::parse_sipfrag_status(&message.body);
         debug!(
             call_id = %call_id,
             terminated,
             body = %String::from_utf8_lossy(&message.body),
             "B2BUA NOTIFY: siphon-owned REFER subscription progress"
         );
+        // A terminating NOTIFY always yields a stage — including the
+        // no-readable-status one — so a transfer is never left pending; the
+        // verdict goes out alongside the subscription clear below, never instead
+        // of it.
+        if let Some(stage) = crate::control::TransferStage::from_notify(
+            terminated,
+            sipfrag.as_ref().map(|(code, _)| *code),
+        ) {
+            let mut outcome = crate::control::TransferOutcome::new(stage);
+            if let Some((code, reason)) = &sipfrag {
+                outcome = outcome.with_status(*code, reason);
+            }
+            control_forward_transfer_outcome(state, &call_id, outcome);
+        }
         if terminated {
             state
                 .call_actors


### PR DESCRIPTION
An application that asked siphon to transfer a call learned only that the request was *accepted
for processing*. It never learned whether the transfer happened. A refused transfer was silent:
the caller sits on a call nobody was told failed to move.

## The verdict already existed — it went into log lines

All three outcomes were computed in `handle_originated_refer_response` and dropped:

- `2xx` → `debug!("REFER accepted")`
- `401`/`407` under the retry cap, retry built → returned silently
- everything else → a `warn!` pair, then `clear_refer_subscriptions_on_leg`

And the **real** outcome — RFC 3515 §2.4.4 makes the `message/sipfrag` on the subscriber NOTIFY
the result report — was `String::from_utf8_lossy`'d into a debug line and **parsed nowhere**.
Parsing it is the only genuinely new logic here.

## Design

**`parse_sipfrag_status`** (`src/b2bua/transfer.rs`) — the inverse of the existing
`build_sipfrag_body`. Tolerant per RFC 3420 §2 (headers may follow the Status-Line; a
header-only fragment has no status → `None`) and RFC 3261 §25.1 (an empty Reason-Phrase is
legal).

**`TransferStage`** (`src/control/registry.rs`) — two pure classifiers the dispatcher calls, so
the tests exercise production logic rather than restating it:

- `from_refer_response(status, challenge_answered)`. **A `2xx` is `Accepted`, and `Accepted` is
  non-terminal.** §2.4.4 makes it "accepted for processing" — mapping it to completion is
  precisely the bug that would make every failed transfer read as a success. `401`/`407` splits
  on `challenge_answered` into `Challenged` (progress) and `Unauthorized` (terminal).
- `from_notify(terminated, sipfrag)`. A terminating NOTIFY **always** yields a stage, including
  `NoOutcome` when the body carries no readable status. Silence there is what leaves a transfer
  pending forever.

Nine stages fold into three event names — `TransferProgress`, `TransferCompleted`,
`TransferFailed` — over a shared `{stage, refer_to?, code?, reason?, attempt?}` payload.
`attempt` is 1-based per REFER sent, and it is what separates "the carrier challenged and we
answered it" from "the carrier refused" when both arrive as `407`.

**Terminal guarantee.** `forward_transfer_outcome` arms a per-channel marker on a non-terminal
verdict and disarms it on a terminal one; `flush_outbound_transfer` emits
`TransferFailed{call_ended}` before `StasisEnd` on **both** channel-removal funnels. The guard
sits in the bus rather than at the five `control_notify_terminated` sites — smaller dispatcher
diff, covers all of them, and the marker drains with the channel entry so there is no new leak
surface.

**A-leg resolution.** The dispatcher helper resolves the A-leg Call-ID from the store rather
than trusting the message: the bus keys channels on the A-leg Call-ID, and a B-leg REFER's
NOTIFYs arrive on a different dialog.

**The `refer` reply is unchanged** — still `{"refer":"sent"}`. A far-end outcome must never be
folded into a command reply; that is an existing rule of the rail and this keeps it.

## Mutation check — all three caught

| mutation | result |
|---|---|
| `forward_transfer_outcome` returns `false` without publishing | **7 failed** / 28 passed |
| `from_refer_response` maps `2xx` → `Transferred` (the §2.4.4 bug) | **4 failed** / 31 passed |
| `from_notify(true, None)` → `None` (drop the terminal guarantee) | **1 failed** / 34 passed |

## SDK

The event is added in all four places — proto enum with its `to_string`/`From` round-trip plus
typed `TransferStage`/`TransferOutcomePayload`, the client's `transfer_outcome()` /
`is_transfer_final()`, the TypeScript union and interfaces with `isTransferFinal()`, and the TS
re-export.

`SipEvent` was **not** `#[non_exhaustive]`. Adding three variants already breaks exhaustive
matchers downstream, so it is marked `non_exhaustive` in the same change and future events stay
additive — recorded under `### Changed`.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean; **4046 tests pass**.
SDK: clippy clean, 38 Rust tests, 21 TypeScript tests, `tsc --noEmit` clean.

## Not in this PR

**The external control rail has no SIPp harness at all.** No `sipp/configs/` file enables a
`control:` block, there is no mock control-plane WebSocket app in the test plumbing, and
`run-tests.sh` has no control mode. Standing one up is a mock server, a config, a compose
profile, two scenarios, a runner flag and a CI job — new shared CI plumbing, and a second agent
is working the same adapter right now. It belongs in its own change, and it would also close the
one seam these unit tests cannot reach: that the dispatcher actually *calls* the classifiers.
