### PR TITLE
feat(media): move the native media contract to 0.3.0 and expose the surface it adds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,70 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 - Two new stable control-plane error codes, `conflict` and `invalid_state`,
   mirrored into `siphon-control-proto` and the TypeScript SDK so a client parses
   them as the refusals they are rather than a transport error.
+- **Answering-machine detection — `beep_detection` on a media profile and the
+  `@rtpengine.on_beep` handler.** The engine could hear the short record tone an
+  answering machine plays before it starts recording, but nothing carried it to a
+  script, so a transfer had no way to tell a person from a voicemail box and the
+  caller got bridged into the greeting. Arm it per leg (the profile used toward
+  the callee is what watches the party that might be a machine) and the tone
+  arrives as `fn(call_id, from_tag, to_tag, frequency_hz, duration_ms,
+  offset_ms)`, filterable by `call_id` / `from_tag` like the sibling media hooks.
+  It fires once per leg per call, so a handler never de-duplicates.
+  `beep_cadence_guard_ms` tunes the guard that tells a record tone from a
+  cadenced ringback or busy tone; it is also the detection latency, so the event
+  trails the tone itself by that long, and `offset_ms` is the offset of the
+  **tone**, not of the event.
+- **Synthesised call-progress tones and engine-fetched HTTP prompts** —
+  `rtpengine.play_media(target, tone=...)` and `url=...`. `tone` takes either a
+  preset name (`ringback_eu`, `busy_na`, `dial_uk`, …) or an explicit cadence
+  spec (`425/1000,0/4000*inf`), rendered at the leg's codec rate, so early media
+  no longer needs a provisioned audio file. `url` is fetched by the **engine**
+  from its own network position, bounded engine-side and off the media path: a
+  URL that never answers ends the playback, never the leg.
+- **Overlay playback with per-play gain** — `rtpengine.play_overlay(...)` mixes
+  audio *under* a party's live egress instead of replacing it and returns the
+  playback's `play_id`; `rtpengine.set_play_gain(target, play_id, decibels)`
+  retunes one that is already running, and `rtpengine.stop_media(target,
+  play_id=...)` stops a single slot rather than everything on the leg. Up to four
+  overlays run concurrently per direction. This is what a music bed ducked under
+  a prompt needs: `play_media` is a *start*, so reusing it to change a level
+  would mean "start another playback".
+- **Independent L16 wire rates for the WebSocket bridge and tee** —
+  `ws_sample_rate` and `ws_tee_sample_rate` on a media profile,
+  `rtpengine.attach_ws_tee(..., sample_rate=...)` per attach. The bridge rate
+  applies in both directions, so an 8 kHz G.711 call can speak 16 kHz to an
+  inference server and a server rendering 24 kHz audio plays at the right speed
+  and pitch instead of the wrong one. The tee rate is send-only and never changes
+  what the call hears. Both must be a multiple of 1000 within 8000–48000; the
+  media engine *fails* the offer rather than clamping, so siphon rejects a bad
+  value at config load and at the call instead of letting the box come up healthy
+  and answer every call into silence.
+- **Selectable uplink voice-activity detector** — `ws_vad_engine: energy |
+  neural` on a media profile. `energy` (the default, and the previous behaviour)
+  answers "is something loud here", so breathing, mains hum and uncancelled echo
+  all read as speech; `neural` answers "is what is here speech" and does not
+  turn-start on non-speech noise. An unknown value is a hard config error rather
+  than a quiet fall back to the detector the operator was avoiding.
+- **Leading minimum-speech run before barge-in** — `ws_vad_min_speech_ms`, the
+  counterpart to the existing trailing `ws_vad_hangover_ms`. Without it the
+  speech-start edge fires on the first speech frame, which is what lets a cough,
+  a door or one burst of echo interrupt a prompt. 60–120 ms is the useful range;
+  it adds directly to turn-start latency.
+- **All six new profile fields are accepted per call** on `rtpengine.offer()`,
+  `answer()` and `answer_local()`, the same way `ws_uri=` already was — so beep
+  detection can be armed on one leg of one call without a second profile.
+
+### Changed
+- The native media control contract moved from 0.2.0 to 0.3.0. The JSON wire is
+  unchanged (every new field is optional and omitted when unset, and a default
+  profile still serialises to `{}`), so an unset knob emits exactly the command
+  it did before. A media profile that sets any of the six new fields on the
+  `rtpengine` or `rtpproxy` backend is rejected at config load, as the existing
+  WebSocket and DSP fields already were: a field the engine never receives is a
+  dead call, not a degraded one. Likewise `tone=` / `url=` / `overlay` /
+  `gain_decibels` / a targeted `stop_media` / `set_play_gain` raise on those
+  backends rather than silently downgrading — an overlay quietly turned into a
+  supersede would cut the party's live audio.
 
 ## [1.6.0] — 2026-08-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,9 +3093,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592452d239ffe9f9502311773f1d36db56871dbbb27229e6ebf3a0b1b421fb53"
+checksum = "c4dbd8c70053af200a0d5d77e55e439fc3650e1ea06e3236627d7e58a951daf7"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.2.0"
+siphon-rtp-proto = "0.3.0"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -184,7 +184,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.2.0"
+siphon-rtp-proto = "0.3.0"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/docs/media-engines.md
+++ b/docs/media-engines.md
@@ -131,6 +131,105 @@ the negotiated `channels` and `sample_rate` so a consumer decodes the binary
 frames rather than guessing; `stream_id` correlates the control event with the
 `start` envelope on the socket.
 
+Both the bridge and the tee can run at a wire rate independent of the legs'
+codec rates. `ws_sample_rate` applies to the `ws_uri` bridge in **both**
+directions, so an 8 kHz G.711 call can speak 16 kHz to an inference server, and
+a server rendering 24 kHz audio into that call plays at the right speed and
+pitch instead of the wrong one. `ws_tee_sample_rate` (or
+`attach_ws_tee(..., sample_rate=...)`) is send-only and changes only what the
+tee consumer receives. Both must be a multiple of 1000 within 8000–48000; the
+engine fails the offer rather than clamping, so siphon rejects a bad value at
+boot.
+
+---
+
+## Answering-machine detection
+
+The media half of AMD: the engine watches a leg's decoded audio for the short
+single tone an answering machine plays before it starts recording, and reports
+it. Without it a transfer cannot tell a person from a voicemail box, and the
+caller gets bridged into the greeting.
+
+Arm it **per leg**. The profile used toward the callee is what watches the party
+that might be a machine:
+
+```yaml
+media:
+  backend: siphon-rtp
+  profiles:
+    screened_callee:
+      offer:
+        replace: ["origin"]
+      answer:
+        replace: ["origin"]
+        beep_detection: true
+        beep_cadence_guard_ms: 4500   # default
+```
+
+```python
+@rtpengine.on_beep
+def machine(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    log.info(f"{call_id}: answering machine ({frequency_hz:.0f} Hz at {offset_ms} ms)")
+    b2bua.terminate(call_id, "Answering machine detected")
+```
+
+Three things to know:
+
+- **It fires once per leg per call.** The engine drops the detector after the
+  first tone, so a handler never de-duplicates, and there is no mid-call re-arm —
+  a fresh `offer`/`answer` with the flag set re-arms it.
+- **`beep_cadence_guard_ms` is also the detection latency.** It is the window the
+  detector waits to rule out a repeat, which is what tells a record tone from a
+  cadenced ringback, busy or congestion tone. The event therefore arrives that
+  long *after* the beep. Lowering it trades cadence robustness for latency.
+- **`offset_ms` is the offset of the tone, not of the event.** It counts decoded
+  audio seen on the leg before the tone started, so it is the right number to
+  reason about "how far into the call" — the event trails it by the guard.
+
+Detection needs decoded audio, so like `noise_suppression` it promotes a
+same-codec plaintext call onto the userspace media pipeline, and it is inert on
+a codec whose native rate is neither 8 nor 16 kHz.
+
+---
+
+## Prompts, tones and overlays
+
+`rtpengine.play_media(...)` replaces a party's outgoing audio with a prompt. Its
+source can be a file, raw bytes, an engine prompt-DB id, a **synthesised tone**,
+or a URL the **engine** fetches:
+
+```python
+await rtpengine.play_media(call, tone="ringback_eu")            # preset
+await rtpengine.play_media(call, tone="425/1000,0/4000*inf")     # cadence spec
+await rtpengine.play_media(call, url="https://prompts.internal/welcome.wav")
+```
+
+A tone needs no provisioned audio file and renders at the leg's codec rate, so it
+is never resampled. A preset name is told from a cadence spec by the `/`. An
+HTTP source is fetched by the engine from its own network position, bounded
+engine-side and off the media path — a URL that never answers ends the
+*playback*, never the leg — so restrict the reachable hosts if you do not fully
+trust whoever supplies the URL.
+
+**Overlays** mix audio *under* a party's live egress instead of replacing it, and
+return a handle so you can change or stop that one playback:
+
+```python
+bed = await rtpengine.play_overlay(call, file="/prompts/hold.wav", repeat=0)
+await rtpengine.play_media(call, file="/prompts/agent.wav")
+await rtpengine.set_play_gain(call, bed, -18)     # duck the bed under the prompt
+await rtpengine.stop_media(call, play_id=bed)     # stop just the bed
+```
+
+Up to four overlays run per direction, each with its own `play_id` and its own
+completion. Starting a fifth is rejected rather than displacing one — a script
+that lost a playback it believes is running has no way to notice.
+
+Tones, HTTP sources, overlays, per-play gain and a targeted `stop_media` are
+native `siphon-rtp` features. On the rtpengine and rtpproxy backends they raise
+rather than silently downgrading: an overlay quietly turned into a supersede
+would cut the party's live audio.
+
 ---
 
 ## Managing rtpengine

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -2266,6 +2266,95 @@ def _resolve_media_target(
     return getattr(target, "call_id", None), getattr(target, "from_tag", None)
 
 
+def _media_overrides(
+    beep_detection: Optional[bool],
+    beep_cadence_guard_ms: Optional[int],
+    ws_sample_rate: Optional[int],
+    ws_tee_sample_rate: Optional[int],
+    ws_vad_engine: Optional[str],
+    ws_vad_min_speech_ms: Optional[int],
+) -> dict[str, Any]:
+    """Validate and collect the per-call media overrides for offer/answer.
+
+    Mirrors the runtime's ``MediaOverrides::parse``: the two wire rates and the
+    VAD-engine name are rejected here rather than at the engine, because the
+    engine *fails the whole offer* on a bad value instead of clamping or
+    falling back -- a script that passed one would get a call that answers and
+    never carries media.
+    """
+    if ws_sample_rate is not None:
+        _validate_ws_sample_rate("ws_sample_rate", ws_sample_rate)
+    if ws_tee_sample_rate is not None:
+        _validate_ws_sample_rate("ws_tee_sample_rate", ws_tee_sample_rate)
+    if ws_vad_engine is not None and ws_vad_engine.strip().lower() not in ("energy", "neural"):
+        raise ValueError(
+            f"ws_vad_engine must be one of energy / neural, got {ws_vad_engine!r}"
+        )
+    return {
+        "beep_detection": beep_detection,
+        "beep_cadence_guard_ms": beep_cadence_guard_ms,
+        "ws_sample_rate": ws_sample_rate,
+        "ws_tee_sample_rate": ws_tee_sample_rate,
+        "ws_vad_engine": ws_vad_engine,
+        "ws_vad_min_speech_ms": ws_vad_min_speech_ms,
+    }
+
+
+def _validate_ws_sample_rate(field: str, rate: int) -> None:
+    """Validate an L16 wire sample rate the way the media engine does.
+
+    The engine **fails** the offer/answer/attach on a bad rate rather than
+    clamping it, so a value that slips through produces a call that answers and
+    never carries media. Checked here so a script learns at the call site.
+    """
+    if rate < 8000 or rate > 48000 or rate % 1000 != 0:
+        raise ValueError(
+            f"{field} must be a multiple of 1000 within 8000-48000 Hz, got {rate}"
+        )
+
+
+def _resolve_play_source(
+    file: Optional[str],
+    blob: Optional[bytes],
+    db_id: Optional[int],
+    tone: Optional[str],
+    url: Optional[str],
+) -> str:
+    """Validate the exactly-one play-source rule and name the chosen source.
+
+    Mirrors the runtime's ``resolve_play_media_source``, including the two
+    checks it performs before the command leaves siphon: a ``tone`` is passed
+    through verbatim (the engine tells a preset name from a cadence spec by the
+    ``/``, and siphon deliberately keeps no copy of the preset table, which
+    would go stale the first time the engine adds one), and a ``url`` must be
+    ``http://`` or ``https://`` because those are the only schemes the engine
+    fetches.
+    """
+    count = sum(1 for x in (file, blob, db_id, tone, url) if x is not None)
+    if count != 1:
+        raise ValueError(
+            "play_media requires exactly one of file=, blob=, db_id=, tone=, or url="
+        )
+    if tone is not None:
+        if not tone.strip():
+            raise ValueError(
+                'play_media tone= must be a preset name (e.g. "ringback_eu") or a '
+                'cadence spec (e.g. "425/1000,0/4000*inf"), not an empty string'
+            )
+        return "tone"
+    if url is not None:
+        if not url.strip().lower().startswith(("http://", "https://")):
+            raise ValueError(
+                f"play_media url= must be an http:// or https:// URL, got {url!r}"
+            )
+        return "http"
+    if file is not None:
+        return "file"
+    if blob is not None:
+        return "blob"
+    return "db-id"
+
+
 class MockRtpEngine:
     """Mock RTPEngine namespace — records media operations for assertions.
 
@@ -2315,6 +2404,15 @@ class MockRtpEngine:
         self._ws_tee_started_handlers: list[dict[str, Any]] = []
         self._ws_tee_ended_handlers: list[dict[str, Any]] = []
         self._text_handlers: list[dict[str, Any]] = []
+        self._beep_handlers: list[dict[str, Any]] = []
+        self._play_overlay_id: Optional[int] = 1
+        self.media_overrides: list[tuple[str, dict[str, Any]]] = []
+        """``(operation, overrides)`` per offer/answer/answer_local.
+
+        The per-call media knobs (``beep_detection``, ``ws_sample_rate``,
+        ``ws_vad_engine``, ...) a script passed for that call, already
+        validated. ``None`` values mean "leave the profile's value alone".
+        """
 
     @property
     def active_sessions(self) -> int:
@@ -2380,7 +2478,13 @@ class MockRtpEngine:
 
     async def offer(self, request: Any,
                     profile: Optional[str] = None,
-                    ws_uri: Optional[str] = None) -> bool:
+                    ws_uri: Optional[str] = None,
+                    beep_detection: Optional[bool] = None,
+                    beep_cadence_guard_ms: Optional[int] = None,
+                    ws_sample_rate: Optional[int] = None,
+                    ws_tee_sample_rate: Optional[int] = None,
+                    ws_vad_engine: Optional[str] = None,
+                    ws_vad_min_speech_ms: Optional[int] = None) -> bool:
         """Send ``offer`` command to RTPEngine.
 
         Extracts SDP from message body, sends to engine, replaces body
@@ -2412,12 +2516,22 @@ class MockRtpEngine:
         """
         self.operations.append(("offer", profile or "rtp_passthrough"))
         self.ws_uris.append(("offer", self._resolve_ws_uri(ws_uri, request)))
+        self.media_overrides.append(("offer", _media_overrides(
+            beep_detection, beep_cadence_guard_ms, ws_sample_rate,
+            ws_tee_sample_rate, ws_vad_engine, ws_vad_min_speech_ms,
+        )))
         return True
 
     async def answer(self, reply: Any,
                      profile: Optional[str] = None,
                      call: Any = None,
-                     ws_uri: Optional[str] = None) -> bool:
+                     ws_uri: Optional[str] = None,
+                     beep_detection: Optional[bool] = None,
+                     beep_cadence_guard_ms: Optional[int] = None,
+                     ws_sample_rate: Optional[int] = None,
+                     ws_tee_sample_rate: Optional[int] = None,
+                     ws_vad_engine: Optional[str] = None,
+                     ws_vad_min_speech_ms: Optional[int] = None) -> bool:
         """Send ``answer`` command to RTPEngine.
 
         Profile precedence (matches the real implementation):
@@ -2455,6 +2569,10 @@ class MockRtpEngine:
                 profile = "rtp_passthrough"
         self.operations.append(("answer", profile))
         self.ws_uris.append(("answer", self._resolve_ws_uri(ws_uri, call or reply)))
+        self.media_overrides.append(("answer", _media_overrides(
+            beep_detection, beep_cadence_guard_ms, ws_sample_rate,
+            ws_tee_sample_rate, ws_vad_engine, ws_vad_min_speech_ms,
+        )))
         return True
 
     async def answer_local(
@@ -2463,6 +2581,12 @@ class MockRtpEngine:
         profile: Optional[str] = None,
         auto_reject: bool = True,
         ws_uri: Optional[str] = None,
+        beep_detection: Optional[bool] = None,
+        beep_cadence_guard_ms: Optional[int] = None,
+        ws_sample_rate: Optional[int] = None,
+        ws_tee_sample_rate: Optional[int] = None,
+        ws_vad_engine: Optional[str] = None,
+        ws_vad_min_speech_ms: Optional[int] = None,
     ) -> Optional[str]:
         """Single-leg UAS answer — synthesise an RFC 3264 answer for the
         caller's **own** offer, with the media engine as the far side (IVR /
@@ -2546,6 +2670,10 @@ class MockRtpEngine:
 
         self.operations.append(("answer_local", profile))
         self.ws_uris.append(("answer_local", resolved_ws_uri))
+        self.media_overrides.append(("answer_local", _media_overrides(
+            beep_detection, beep_cadence_guard_ms, ws_sample_rate,
+            ws_tee_sample_rate, ws_vad_engine, ws_vad_min_speech_ms,
+        )))
         self.media_calls.append({
             "op": "answer_local",
             "profile": profile,
@@ -2581,15 +2709,19 @@ class MockRtpEngine:
         file: Optional[str] = None,
         blob: Optional[bytes] = None,
         db_id: Optional[int] = None,
+        tone: Optional[str] = None,
+        url: Optional[str] = None,
         repeat: Optional[int] = None,
         start_ms: Optional[int] = None,
         duration_ms: Optional[int] = None,
+        gain_decibels: Optional[int] = None,
         to_tag: Optional[str] = None,
         wait: bool = True,
     ) -> Optional[int]:
-        """Inject an audio prompt into the call.
+        """Inject an audio prompt, replacing the party's live egress.
 
-        Exactly one of ``file``/``blob``/``db_id`` must be supplied. Per
+        Exactly one of ``file``/``blob``/``db_id``/``tone``/``url`` must be
+        supplied. Per
         rtpengine semantics, ``from-tag`` (derived from ``target``) selects
         the monologue whose outgoing audio is replaced by the prompt — the
         **peer** of that monologue hears it. Pass ``to_tag`` to scope to a
@@ -2604,9 +2736,26 @@ class MockRtpEngine:
             file: Absolute path to an audio file on the rtpengine host.
             blob: Raw audio bytes to play (e.g. TTS output).
             db_id: Reference to a prompt stored in rtpengine's prompt DB.
+            tone: A synthesised call-progress tone, with no audio file to
+                provision. Either a preset name (``"ringback_eu"``,
+                ``"busy_na"``, ``"dial_uk"``, ...) or an explicit cadence spec
+                in the engine's tone grammar (``"425/1000,0/4000*inf"`` is
+                425 Hz one second on, four seconds off, forever). The two are
+                told apart by the ``/``. Rendered at the leg's codec rate, so
+                never resampled. Native **siphon-rtp** backend only.
+            url: An ``http://`` / ``https://`` WAV the **engine** fetches from
+                its own network position. The fetch is bounded engine-side
+                (connect, first-byte, deadline, size cap, redirect cap) and runs
+                off the media path, so a URL that never answers ends the
+                *playback*, never the leg. The accept carries no duration, since
+                the length is unknown until the body arrives. Native
+                **siphon-rtp** backend only.
             repeat: Number of times to repeat the prompt.
             start_ms: Offset into the file at which to start (ms).
             duration_ms: Cap on playback length (ms).
+            gain_decibels: Playout gain in whole decibels relative to the
+                source's own level, clamped engine-side to -60..=+12. Native
+                **siphon-rtp** backend only.
             to_tag: Optional peer tag for MPTY scoping.
             wait: When ``True`` (default, native siphon-rtp backend), the real
                 runtime blocks until the prompt finishes playing so a script can
@@ -2629,12 +2778,7 @@ class MockRtpEngine:
                 await rtpengine.play_media(call, file="/prompts/welcome.wav")  # wait=True
                 await rtpengine.echo(call)                                     # after prompt
         """
-        count = sum(1 for x in (file, blob, db_id) if x is not None)
-        if count != 1:
-            raise ValueError(
-                "play_media requires exactly one of file=, blob=, or db_id="
-            )
-        source = "file" if file is not None else "blob" if blob is not None else "db-id"
+        source = _resolve_play_source(file, blob, db_id, tone, url)
         call_id, resolved_from_tag = _resolve_media_target(target)
         self.operations.append(("play_media", source))
         self.media_calls.append({
@@ -2644,26 +2788,160 @@ class MockRtpEngine:
             "file": file,
             "blob": blob,
             "db_id": db_id,
+            "tone": tone,
+            "url": url,
             "repeat": repeat,
             "start_ms": start_ms,
             "duration_ms": duration_ms,
+            "gain_decibels": gain_decibels,
+            "overlay": False,
             "to_tag": to_tag,
             "wait": wait,
         })
         return self._play_media_duration_ms
 
-    async def stop_media(self, target: Any) -> bool:
-        """Stop any prompt currently playing on the selected monologue.
+    async def play_overlay(
+        self,
+        target: Any,
+        file: Optional[str] = None,
+        blob: Optional[bytes] = None,
+        db_id: Optional[int] = None,
+        tone: Optional[str] = None,
+        url: Optional[str] = None,
+        repeat: Optional[int] = None,
+        start_ms: Optional[int] = None,
+        duration_ms: Optional[int] = None,
+        gain_decibels: Optional[int] = None,
+        to_tag: Optional[str] = None,
+    ) -> Optional[int]:
+        """Start an **overlay** playback and return its ``play_id`` handle.
+
+        The additive twin of :meth:`play_media`: audio is mixed *under* the
+        party's live egress instead of replacing it. Where ``play_media``
+        answers "how long did it play", this answers "which playback is it",
+        because that is what an overlay is for -- a music bed you will duck
+        with :meth:`set_play_gain` and stop individually with
+        ``stop_media(target, play_id=...)``.
+
+        Up to **four** overlays run concurrently per direction, each with its
+        own ``play_id`` and its own completion. Starting a fifth is rejected
+        rather than displacing one, since a script that lost a playback it
+        believes is running has no way to notice. An overlay never supersedes
+        anything, including another overlay.
+
+        Returns on the engine's accept: an overlay is background audio, so
+        there is no ``wait``. Native **siphon-rtp** backend only.
 
         Args:
             target: Request, Reply, or Call object.
+            file: Absolute path to an audio file on the engine host.
+            blob: Raw audio bytes to play.
+            db_id: Reference to a prompt in the engine's prompt DB.
+            tone: A preset name or cadence spec, as for :meth:`play_media`.
+            url: An ``http://`` / ``https://`` WAV the engine fetches.
+            repeat: Number of times to repeat.
+            start_ms: Offset into the source at which to start (ms).
+            duration_ms: Hard playout cap -- the only bound, short of a stop,
+                on an endless (``*inf``) tone.
+            gain_decibels: Playout gain relative to the source's own level.
+            to_tag: Optional peer tag for MPTY scoping.
+
+        Returns:
+            The ``play_id`` of the started overlay (mock returns the value set
+            via :meth:`set_play_overlay_id`, default ``1``).
+
+        Example::
+
+            bed = await rtpengine.play_overlay(call, file="/prompts/hold.wav")
+            await rtpengine.play_media(call, file="/prompts/agent.wav")
+            await rtpengine.set_play_gain(call, bed, -18)
+            await rtpengine.stop_media(call, play_id=bed)
+        """
+        source = _resolve_play_source(file, blob, db_id, tone, url)
+        call_id, resolved_from_tag = _resolve_media_target(target)
+        self.operations.append(("play_overlay", source))
+        self.media_calls.append({
+            "op": "play_overlay",
+            "call_id": call_id,
+            "from_tag": resolved_from_tag,
+            "file": file,
+            "blob": blob,
+            "db_id": db_id,
+            "tone": tone,
+            "url": url,
+            "repeat": repeat,
+            "start_ms": start_ms,
+            "duration_ms": duration_ms,
+            "gain_decibels": gain_decibels,
+            "overlay": True,
+            "to_tag": to_tag,
+        })
+        return self._play_overlay_id
+
+    async def stop_media(self, target: Any, play_id: Optional[int] = None) -> bool:
+        """Stop prompt playback on the selected monologue.
+
+        Args:
+            target: Request, Reply, or Call object.
+            play_id: Stop one specific playback (an individual overlay slot,
+                from :meth:`play_overlay`). Omitting it stops everything
+                playing on the leg. Native **siphon-rtp** backend only: the
+                other backends have no handle on an individual playback and
+                raise rather than widening this into "stop everything", which
+                would kill playbacks the script meant to keep running.
 
         Returns:
             ``True`` on success.
         """
         call_id, from_tag = _resolve_media_target(target)
-        self.operations.append(("stop_media", None))
-        self.media_calls.append({"op": "stop_media", "call_id": call_id, "from_tag": from_tag})
+        self.operations.append(("stop_media", play_id))
+        self.media_calls.append({
+            "op": "stop_media",
+            "call_id": call_id,
+            "from_tag": from_tag,
+            "play_id": play_id,
+        })
+        return True
+
+    async def set_play_gain(
+        self,
+        target: Any,
+        play_id: int,
+        gain_decibels: int,
+        to_tag: Optional[str] = None,
+    ) -> bool:
+        """Retune the playout gain of a playback that is already running.
+
+        How a script ducks a music bed under a prompt and lifts it again. A
+        separate verb rather than a field on :meth:`play_media` because
+        ``play_media`` is a *start*: reusing it would mean "start another
+        playback", not "change this one". ``play_id`` is already the contract's
+        handle on a running playback, so gain is addressed the same way.
+
+        The engine answers an error when no playback on the call holds that
+        ``play_id``, so a stale handle raises rather than silently doing
+        nothing. Native **siphon-rtp** backend only.
+
+        Args:
+            target: Request, Reply, or Call object.
+            play_id: The running playback to retune, from :meth:`play_overlay`.
+            gain_decibels: New gain in whole decibels, clamped engine-side to
+                -60..=+12.
+            to_tag: Optional peer tag for MPTY scoping.
+
+        Returns:
+            ``True`` on success.
+        """
+        call_id, from_tag = _resolve_media_target(target)
+        self.operations.append(("set_play_gain", play_id))
+        self.media_calls.append({
+            "op": "set_play_gain",
+            "call_id": call_id,
+            "from_tag": from_tag,
+            "play_id": play_id,
+            "gain_decibels": gain_decibels,
+            "to_tag": to_tag,
+        })
         return True
 
     async def play_dtmf(
@@ -2834,6 +3112,7 @@ class MockRtpEngine:
         ws_uri: str,
         direction: str = "both",
         channels: Optional[int] = None,
+        sample_rate: Optional[int] = None,
     ) -> bool:
         """Attach a **WebSocket tee** to a live call — stream a copy of its
         decoded audio to a WebSocket media server while the call keeps relaying.
@@ -2866,6 +3145,11 @@ class MockRtpEngine:
                 stereo, ``1`` mixes them to mono. Only meaningful with
                 ``direction="both"``; a single-leg tee is always mono. ``None``
                 (default) leaves the engine's choice: 2 for both legs, 1 for one.
+            sample_rate: L16 wire sample rate in Hz, independent of the legs'
+                codec rates -- the engine resamples the teed copy into it. Must
+                be a multiple of 1000 within 8000-48000; the engine *fails* the
+                attach on anything else rather than clamping, so it is checked
+                here first. ``None`` (default) leaves the engine's choice.
 
         Returns:
             ``True`` on success.
@@ -2889,6 +3173,8 @@ class MockRtpEngine:
             raise ValueError(
                 f"attach_ws_tee channels must be 1 or 2, got {channels}"
             )
+        if sample_rate is not None:
+            _validate_ws_sample_rate("attach_ws_tee sample_rate", sample_rate)
         call_id, from_tag = _resolve_media_target(target)
         self.operations.append(("attach_ws_tee", ws_uri))
         self.media_calls.append({
@@ -2898,6 +3184,7 @@ class MockRtpEngine:
             "ws_uri": ws_uri,
             "direction": direction,
             "channels": channels,
+            "sample_rate": sample_rate,
         })
         return True
 
@@ -3065,6 +3352,74 @@ class MockRtpEngine:
             fired += 1
         return fired
 
+    def on_beep(self, func_or_none: Any = None, *,
+                call_id: Optional[str] = None,
+                from_tag: Optional[str] = None) -> Any:
+        """Register a handler for **record-tone ("voicemail beep")** events.
+
+        Fires when the engine hears the short single tone an answering machine
+        plays before it starts recording, on a leg whose media profile set
+        ``beep_detection``. This is the *media* half of answering-machine
+        detection: a script can abort an attended transfer here instead of
+        bridging the caller into a voicemail box.
+
+        Arm it **per leg** -- the profile used toward the callee is what watches
+        the party that might be a machine. It fires **once per leg per call**
+        (the engine drops the detector after the first tone, so a handler never
+        has to de-duplicate, and there is no mid-call re-arm).
+
+        ``offset_ms`` is how much decoded audio was seen on the leg before the
+        tone **started** -- the offset of the tone itself, *not* of this event.
+        The event trails it by roughly the profile's ``beep_cadence_guard_ms``
+        (4500 ms by default), which is the detector's cadence guard *and* its
+        detection latency.
+
+        Delivered by the native **siphon-rtp** backend only.
+
+        Usage::
+
+            @rtpengine.on_beep
+            def machine(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+                log.info(f"{call_id}: answering machine ({frequency_hz:.0f} Hz)")
+                b2bua.terminate(call_id, "Answering machine detected")
+
+            @rtpengine.on_beep(call_id="abc", from_tag="ftag1")
+            def machine_specific(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+                ...
+        """
+        def decorator(fn: Any) -> Any:
+            self._beep_handlers.append({
+                "fn": fn,
+                "call_id": call_id,
+                "from_tag": from_tag,
+            })
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
+    def fire_beep(self, call_id: str, from_tag: str,
+                  to_tag: Optional[str] = None,
+                  frequency_hz: float = 1000.0,
+                  duration_ms: int = 420,
+                  offset_ms: int = 7300) -> int:
+        """Test helper: fire a record-tone event.  Returns the number of
+        handlers that matched (and were invoked).
+
+        The defaults describe a typical voicemail beep: a ~1 kHz tone a few
+        hundred milliseconds long, several seconds into the leg's audio.
+        """
+        fired = 0
+        for entry in self._beep_handlers:
+            if entry["call_id"] is not None and entry["call_id"] != call_id:
+                continue
+            if entry["from_tag"] is not None and entry["from_tag"] != from_tag:
+                continue
+            entry["fn"](call_id, from_tag, to_tag, frequency_hz, duration_ms,
+                        offset_ms)
+            fired += 1
+        return fired
+
     def on_ws_tee_started(self, func_or_none: Any = None, *,
                           call_id: Optional[str] = None,
                           from_tag: Optional[str] = None) -> Any:
@@ -3182,6 +3537,16 @@ class MockRtpEngine:
         """Configure the duration returned by :meth:`play_media` (test helper)."""
         self._play_media_duration_ms = duration_ms
 
+    def set_play_overlay_id(self, play_id: Optional[int]) -> None:
+        """Configure the ``play_id`` returned by :meth:`play_overlay` (test
+        helper).
+
+        Set it to ``None`` to model an engine that accepted the overlay without
+        assigning a handle, which is what a script's "can I duck this later"
+        branch has to cope with.
+        """
+        self._play_overlay_id = play_id
+
     def set_answer_local_sdp(self, sdp: str) -> None:
         """Configure the answer SDP returned by :meth:`answer_local` (test helper)."""
         self._answer_local_sdp = sdp
@@ -3196,11 +3561,13 @@ class MockRtpEngine:
         """Clear recorded operations and registered event handlers (test helper)."""
         self.operations.clear()
         self.media_calls.clear()
+        self.media_overrides.clear()
         self._dtmf_handlers.clear()
         self._media_timeout_handlers.clear()
         self._ws_tee_started_handlers.clear()
         self._ws_tee_ended_handlers.clear()
         self._text_handlers.clear()
+        self._beep_handlers.clear()
         self._answer_local_no_codec = False
 
 

--- a/sdk/tests/test_rtpengine_beep_and_tone.py
+++ b/sdk/tests/test_rtpengine_beep_and_tone.py
@@ -1,0 +1,368 @@
+"""Tests for the 0.3.0 media surface: tone/HTTP play sources, overlay playback
+with per-play gain, the ``ws_sample_rate`` / ``ws_vad_engine`` / beep-detection
+per-call overrides, and the ``@rtpengine.on_beep`` hook.
+
+The theme throughout is that the media engine *fails* an offer (or a play)
+carrying a value it cannot honour rather than clamping it or falling back — so
+every one of these is validated before it leaves siphon, and the tests assert
+the refusal, not just the happy path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from siphon_sdk.testing import SipTestHarness
+
+
+@pytest.fixture
+def harness():
+    h = SipTestHarness()
+    h.reset()
+    return h
+
+
+class TestTonePlaySource:
+    def test_preset_name_is_passed_through_verbatim(self, harness):
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    await rtpengine.play_media(request, tone="ringback_eu")
+    request.reply(180, "Ringing")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+
+        assert ("play_media", "tone") in harness.rtpengine.operations
+        call = harness.rtpengine.media_calls[-1]
+        assert call["tone"] == "ringback_eu"
+        assert call["overlay"] is False
+
+    def test_cadence_spec_is_passed_through_verbatim(self, harness):
+        # A cadence spec is told from a preset by the "/" — siphon keeps no copy
+        # of the preset table, so both forms travel unchanged.
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    await rtpengine.play_media(request, tone="425/1000,0/4000*inf")
+    request.reply(180, "Ringing")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+        assert harness.rtpengine.media_calls[-1]["tone"] == "425/1000,0/4000*inf"
+
+    def test_empty_tone_is_rejected(self, harness):
+        # Neither a preset name nor a cadence spec — the one thing that is wrong
+        # under either reading, so it is caught before it reaches the engine.
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(ValueError, match="tone="):
+                loop.run_until_complete(
+                    harness.rtpengine.play_media(("c", "f"), tone="   ")
+                )
+        finally:
+            loop.close()
+
+
+class TestHttpPlaySource:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://prompts.invalid/a.wav",
+            "https://prompts.invalid/a.wav",
+            "HTTPS://prompts.invalid/a.wav",
+        ],
+    )
+    def test_http_and_https_accepted(self, harness, url):
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(harness.rtpengine.play_media(("c", "f"), url=url))
+        finally:
+            loop.close()
+
+        assert ("play_media", "http") in harness.rtpengine.operations
+        assert harness.rtpengine.media_calls[-1]["url"] == url
+
+    @pytest.mark.parametrize(
+        "url", ["file:///etc/passwd", "ftp://host/a.wav", "prompts/a.wav"]
+    )
+    def test_non_http_scheme_rejected(self, harness, url):
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(ValueError, match="http://"):
+                loop.run_until_complete(
+                    harness.rtpengine.play_media(("c", "f"), url=url)
+                )
+        finally:
+            loop.close()
+
+    def test_exactly_one_source_still_enforced(self, harness):
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(ValueError, match="exactly one"):
+                loop.run_until_complete(
+                    harness.rtpengine.play_media(
+                        ("c", "f"),
+                        tone="ringback_eu",
+                        url="https://prompts.invalid/a.wav",
+                    )
+                )
+        finally:
+            loop.close()
+
+
+class TestOverlayAndGain:
+    def test_overlay_returns_play_id_and_marks_overlay(self, harness):
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    play_id = await rtpengine.play_overlay(
+        request, file="/prompts/hold.wav", gain_decibels=-6
+    )
+    await rtpengine.set_play_gain(request, play_id, -18)
+    await rtpengine.stop_media(request, play_id=play_id)
+    request.reply(200, "OK")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+
+        ops = [op for op, _ in harness.rtpengine.operations]
+        assert "play_overlay" in ops
+        assert "set_play_gain" in ops
+
+        overlay = next(
+            c for c in harness.rtpengine.media_calls if c["op"] == "play_overlay"
+        )
+        assert overlay["overlay"] is True
+        assert overlay["gain_decibels"] == -6
+
+        gain = next(
+            c for c in harness.rtpengine.media_calls if c["op"] == "set_play_gain"
+        )
+        assert gain["play_id"] == 1
+        assert gain["gain_decibels"] == -18
+
+        # The targeted stop must carry the handle, not stop everything.
+        stop = next(c for c in harness.rtpengine.media_calls if c["op"] == "stop_media")
+        assert stop["play_id"] == 1
+
+    def test_untargeted_stop_carries_no_play_id(self, harness):
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    await rtpengine.stop_media(request)
+    request.reply(200, "OK")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+        assert harness.rtpengine.media_calls[-1]["play_id"] is None
+
+    def test_overlay_id_can_be_absent(self, harness):
+        # An engine that accepted the overlay but assigned no handle: a script's
+        # "can I duck this later" branch has to cope, so the mock can model it.
+        harness.rtpengine.set_play_overlay_id(None)
+        loop = asyncio.new_event_loop()
+        try:
+            play_id = loop.run_until_complete(
+                harness.rtpengine.play_overlay(("c", "f"), tone="ringback_eu")
+            )
+        finally:
+            loop.close()
+        assert play_id is None
+
+
+class TestMediaOverrides:
+    def test_offer_records_per_call_overrides(self, harness):
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    await rtpengine.offer(
+        request,
+        profile="voice_ai",
+        beep_detection=True,
+        beep_cadence_guard_ms=3000,
+        ws_sample_rate=16000,
+        ws_vad_engine="neural",
+        ws_vad_min_speech_ms=80,
+    )
+    request.reply(200, "OK")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+
+        operation, overrides = harness.rtpengine.media_overrides[-1]
+        assert operation == "offer"
+        assert overrides["beep_detection"] is True
+        assert overrides["beep_cadence_guard_ms"] == 3000
+        assert overrides["ws_sample_rate"] == 16000
+        assert overrides["ws_vad_engine"] == "neural"
+        assert overrides["ws_vad_min_speech_ms"] == 80
+
+    def test_unset_overrides_leave_the_profile_alone(self, harness):
+        harness.load_source(
+            """
+from siphon import proxy, rtpengine
+
+@proxy.on_request
+async def route(request):
+    await rtpengine.offer(request, profile="voice_ai")
+    request.reply(200, "OK")
+"""
+        )
+        harness.send_request("INVITE", "sip:alice@example.com")
+
+        _, overrides = harness.rtpengine.media_overrides[-1]
+        assert all(value is None for value in overrides.values())
+
+    @pytest.mark.parametrize("rate", [44100, 4000, 96000, 0])
+    def test_bad_ws_sample_rate_rejected(self, harness, rate):
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(ValueError, match="ws_sample_rate"):
+                loop.run_until_complete(
+                    harness.rtpengine.offer(None, ws_sample_rate=rate)
+                )
+        finally:
+            loop.close()
+
+    @pytest.mark.parametrize("rate", [8000, 16000, 24000, 48000])
+    def test_boundary_ws_sample_rates_accepted(self, harness, rate):
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(harness.rtpengine.offer(None, ws_sample_rate=rate))
+        finally:
+            loop.close()
+        assert harness.rtpengine.media_overrides[-1][1]["ws_sample_rate"] == rate
+
+    def test_unknown_vad_engine_rejected(self, harness):
+        # A closed selector: falling back to the detector the script was
+        # explicitly avoiding is a silent downgrade, so it must raise.
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(ValueError, match="ws_vad_engine"):
+                loop.run_until_complete(
+                    harness.rtpengine.offer(None, ws_vad_engine="telepathy")
+                )
+        finally:
+            loop.close()
+
+    def test_bad_tee_sample_rate_rejected_on_attach(self, harness):
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(ValueError, match="sample_rate"):
+                loop.run_until_complete(
+                    harness.rtpengine.attach_ws_tee(
+                        ("c", "f"), "wss://asr.invalid/t", sample_rate=44100
+                    )
+                )
+        finally:
+            loop.close()
+
+    def test_attach_ws_tee_records_sample_rate(self, harness):
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                harness.rtpengine.attach_ws_tee(
+                    ("c", "f"), "wss://asr.invalid/t", sample_rate=16000
+                )
+            )
+        finally:
+            loop.close()
+        assert harness.rtpengine.media_calls[-1]["sample_rate"] == 16000
+
+
+class TestOnBeep:
+    def test_bare_handler_is_a_catch_all(self, harness):
+        harness.load_source(
+            """
+from siphon import rtpengine, log
+
+seen = []
+
+@rtpengine.on_beep
+def machine(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    log.info(f"beep {call_id} {frequency_hz} {offset_ms}")
+"""
+        )
+        fired = harness.rtpengine.fire_beep("any-call", "any-tag")
+        assert fired == 1
+
+    def test_filters_scope_to_call_and_leg(self, harness):
+        harness.load_source(
+            """
+from siphon import rtpengine, log
+
+@rtpengine.on_beep
+def any_beep(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    log.info("any")
+
+@rtpengine.on_beep(call_id="abc", from_tag="callee-tag")
+def specific(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    log.info("specific")
+"""
+        )
+        # Catch-all only.
+        assert harness.rtpengine.fire_beep("xyz", "other") == 1
+        # Both.
+        assert harness.rtpengine.fire_beep("abc", "callee-tag") == 2
+        # Right call, wrong leg — the filter is per-leg because detection is
+        # armed per leg.
+        assert harness.rtpengine.fire_beep("abc", "caller-tag") == 1
+        # Right leg, wrong call.
+        assert harness.rtpengine.fire_beep("zzz", "callee-tag") == 1
+
+    def test_handler_receives_the_full_payload(self, harness):
+        harness.load_source(
+            """
+from siphon import rtpengine, log
+
+@rtpengine.on_beep
+def machine(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    log.info(f"{call_id}|{from_tag}|{to_tag}|{frequency_hz}|{duration_ms}|{offset_ms}")
+"""
+        )
+        harness.rtpengine.fire_beep(
+            "call-1",
+            "callee-tag",
+            to_tag="caller-tag",
+            frequency_hz=1000.5,
+            duration_ms=420,
+            offset_ms=7300,
+        )
+        # offset_ms is the offset of the *tone*, so it must arrive unrounded and
+        # unmodified — a consumer reasons about "how far into the leg" with it.
+        assert (
+            "call-1|callee-tag|caller-tag|1000.5|420|7300"
+            in [message for _, message in harness.log.messages]
+        )
+
+    def test_clear_drops_registered_handlers(self, harness):
+        harness.load_source(
+            """
+from siphon import rtpengine, log
+
+@rtpengine.on_beep
+def machine(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    log.info("beep")
+"""
+        )
+        assert harness.rtpengine.fire_beep("c", "f") == 1
+        harness.rtpengine.clear()
+        assert harness.rtpengine.fire_beep("c", "f") == 0

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -698,8 +698,70 @@ auth:
 #   ws_vad_threshold    Mean-square energy threshold for the uplink VAD. Unset
 #                       uses the engine's 8/16 kHz L16 default (~1_000_000);
 #                       higher is less sensitive.
-#   ws_vad_hangover_ms  How long speech is held after energy drops before the
-#                       turn endpoint fires. Unset uses the engine's ~200 ms.
+#   ws_vad_hangover_ms  TRAILING hangover: how long speech is held after energy
+#                       drops before the turn endpoint fires. Unset uses the
+#                       engine's ~200 ms. Only meaningful with the energy
+#                       detector — neural holds speech with its own probability
+#                       hysteresis instead.
+#   ws_vad_min_speech_ms
+#                       LEADING minimum-speech run: how long the uplink must read
+#                       as speech CONTINUOUSLY before the speech-start edge (and
+#                       barge-in) fires. The counterpart to the trailing
+#                       ws_vad_hangover_ms. Unset means no leading requirement,
+#                       i.e. the edge fires on the first speech frame — which is
+#                       what lets a cough, a door or one burst of echo interrupt
+#                       a prompt. Rounded up to whole ptime frames, and it adds
+#                       directly to turn-start latency, so 60-120 ms is the
+#                       useful range. Works with either detector.
+#   ws_vad_engine       Which detector the uplink VAD runs:
+#                         energy (default) — mean-square energy against a
+#                           threshold. Cheap and exact, but it answers "is
+#                           something loud here", so breathing, mains hum, fan
+#                           noise and uncancelled echo all read as speech.
+#                         neural — a speech classifier; answers "is what is here
+#                           speech", so it does not turn-start on non-speech
+#                           noise. ~32 ms detection floor plus up to one media
+#                           frame. Pick it for turn taking and barge-in.
+#                       An unknown value is a hard config error, never a quiet
+#                       fall back to the detector you were avoiding.
+#   ws_sample_rate      L16 wire sample rate in Hz for the ws_uri bridge,
+#                       INDEPENDENT of the leg's codec rate and applied in BOTH
+#                       directions: the uplink is resampled into it and the
+#                       server's downlink is resampled back to the leg's codec
+#                       rate before re-encoding. So an 8 kHz G.711 call can speak
+#                       16 kHz L16 to the server, and a server rendering 24 kHz
+#                       audio is played at the right speed and pitch instead of
+#                       the wrong one. It is also the domain the uplink noise
+#                       suppressor and echo canceller run in, and those engage
+#                       only at 8 or 16 kHz — another rate leaves them off
+#                       without changing the wire rate. Must be a multiple of
+#                       1000 within 8000-48000; the engine FAILS the offer on
+#                       anything else rather than clamping, so siphon rejects a
+#                       bad value at boot. Unset leaves the leg codec's own PCM
+#                       rate with no conversion either way. Inert without ws_uri.
+#   beep_detection      Watch this leg's decoded ingress audio for the short
+#                       single tone an answering machine plays before it starts
+#                       recording (the "voicemail beep"), and deliver it to
+#                       @rtpengine.on_beep — the media half of answering-machine
+#                       detection, so a script can abort a transfer instead of
+#                       bridging the caller into a voicemail box. Set PER LEG:
+#                       arming it on the profile used toward the callee is what
+#                       watches the party that might be a machine. Like
+#                       noise_suppression it needs decoded audio, so it promotes
+#                       a same-codec plaintext call onto the userspace pipeline,
+#                       and it is inert unless the codec's native rate is 8 or
+#                       16 kHz. Fires ONCE per leg per call — there is no
+#                       mid-call re-arm (a fresh offer/answer re-arms it).
+#   beep_cadence_guard_ms
+#                       How long the beep detector waits after a candidate tone
+#                       ends to confirm no repeat follows — the discriminator
+#                       that keeps a cadenced ringback / busy / congestion tone
+#                       from reading as a record tone. It is ALSO the detection
+#                       latency: the event arrives this long after the beep.
+#                       Unset uses the engine default (4500 ms, longer than the
+#                       4 s silent interval of the slowest widely deployed
+#                       ringback cadence). Lower it to trade cadence robustness
+#                       for latency. Inert without beep_detection.
 #   ws_tee              Stream a COPY of this call's decoded audio to a WebSocket
 #                       media server. Not the same thing as ws_uri, and the
 #                       difference matters: ws_uri is a TAKEOVER (the WS server
@@ -721,6 +783,15 @@ auth:
 #                       ws_tee_direction: both — a single-leg tee is always mono.
 #                       Unset uses the engine default (2 for both legs, 1 for
 #                       one). Inert without ws_tee.
+#   ws_tee_sample_rate  L16 wire sample rate in Hz for ws_tee, independent of the
+#                       legs' codec rates — the engine resamples the teed copy
+#                       into it. Unlike ws_sample_rate this is SEND-ONLY, so it
+#                       changes only what the tee consumer receives and never
+#                       what the call itself hears. Same rule: a multiple of 1000
+#                       within 8000-48000, rejected at boot rather than clamped.
+#                       Unset uses the engine default. Inert without ws_tee.
+#                       A script can also set it per attach with
+#                       rtpengine.attach_ws_tee(..., sample_rate=...).
 #   text_events         Observe RFC 4103 real-time text (T.140) on this call.
 #                       When the call negotiates a plaintext m=text stream the
 #                       engine promotes ONLY that low-rate stream to its
@@ -757,10 +828,31 @@ auth:
 #         ws_vad: true
 #         ws_barge_in: true
 #         ws_vad_threshold: 2000000
-#         ws_vad_hangover_ms: 300
+#         ws_vad_hangover_ms: 300       # trailing: hold speech after energy drops
+#         ws_vad_engine: neural         # energy (default) | neural
+#         ws_vad_min_speech_ms: 80      # leading: continuous speech before barge-in
+#         ws_sample_rate: 16000         # multiple of 1000, 8000-48000
 #         noise_suppression: true
 #         echo_cancellation: true
 #       answer: *voice_ai_flags
+#
+# Answering-machine detection — arm the record-tone detector on the leg toward
+# the callee, so a transfer can be abandoned instead of dropped into voicemail.
+# The event arrives on @rtpengine.on_beep about beep_cadence_guard_ms after the
+# tone itself (the guard is what tells a record tone from a ringback cadence, and
+# it doubles as the detection latency):
+# media:
+#   backend: siphon-rtp
+#   siphon_rtp:
+#     address: "127.0.0.1:9000"
+#   profiles:
+#     screened_callee:
+#       offer:
+#         replace: ["origin"]
+#       answer:                         # the leg that might be a machine
+#         replace: ["origin"]
+#         beep_detection: true
+#         beep_cadence_guard_ms: 4500   # default; lower trades robustness for latency
 #
 # WebSocket tee — an ordinary relayed call, plus a copy of its audio streamed to
 # a transcription/analytics backend (the call keeps relaying; SIPREC unaffected):
@@ -775,6 +867,7 @@ auth:
 #         ws_tee: "wss://asr.example.com/stream/{call_id}"
 #         ws_tee_direction: both        # both | caller | callee
 #         ws_tee_channels: 2            # 2 = caller/callee stereo, 1 = mixed mono
+#         ws_tee_sample_rate: 16000     # multiple of 1000, 8000-48000
 #       answer: *tee_flags
 #
 # IPv4/IPv6 interworking — v6 access leg, v4 core:

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::path::Path;
 use std::sync::LazyLock;
 use crate::error::{Result, SiphonError};
-use crate::rtpengine::profile::WsTeeDirection;
+use crate::rtpengine::profile::{validate_ws_sample_rate, WsTeeDirection, WsVadEngine};
 
 // ---------------------------------------------------------------------------
 // Environment variable expansion — `${VAR}` and `${VAR:-default}`
@@ -2040,6 +2040,21 @@ impl MediaBackendKind {
             if flags.ws_vad_hangover_ms.is_some() {
                 unsupported.push("ws_vad_hangover_ms");
             }
+            if flags.ws_sample_rate.is_some() {
+                unsupported.push("ws_sample_rate");
+            }
+            if flags.ws_vad_engine.is_some() {
+                unsupported.push("ws_vad_engine");
+            }
+            if flags.ws_vad_min_speech_ms.is_some() {
+                unsupported.push("ws_vad_min_speech_ms");
+            }
+            if flags.beep_detection {
+                unsupported.push("beep_detection");
+            }
+            if flags.beep_cadence_guard_ms.is_some() {
+                unsupported.push("beep_cadence_guard_ms");
+            }
             if flags.noise_suppression {
                 unsupported.push("noise_suppression");
             }
@@ -2054,6 +2069,9 @@ impl MediaBackendKind {
             }
             if flags.ws_tee_channels.is_some() {
                 unsupported.push("ws_tee_channels");
+            }
+            if flags.ws_tee_sample_rate.is_some() {
+                unsupported.push("ws_tee_sample_rate");
             }
             if flags.text_events {
                 unsupported.push("text_events");
@@ -2406,6 +2424,75 @@ where
     })
 }
 
+/// Accept `energy` / `neural` case-insensitively for `ws_vad_engine`.
+///
+/// A detector the engine would reject is a config error rather than a value
+/// relayed onto the wire, matching `ws_tee_direction` above.  It is deliberately
+/// *not* forgiving: falling back to a detector the operator was explicitly
+/// avoiding is the silent downgrade the media engine already refuses.
+fn deserialize_ws_vad_engine<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<WsVadEngine>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    let value: Option<String> = Option::deserialize(deserializer)?;
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    WsVadEngine::parse(&value).map(Some).ok_or_else(|| {
+        de::Error::custom(format!(
+            "media profile ws_vad_engine must be one of {}, got {value:?}",
+            WsVadEngine::VALUES.join(" / ")
+        ))
+    })
+}
+
+/// Validate `ws_sample_rate` at config load.
+///
+/// The media engine *fails* an offer/answer carrying an out-of-range rate rather
+/// than clamping it, so a profile with a bad value produces calls that answer
+/// and never get media.  Rejecting at load means the operator learns at boot.
+fn deserialize_ws_sample_rate<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_checked_sample_rate(deserializer, "ws_sample_rate")
+}
+
+/// Validate `ws_tee_sample_rate` at config load — same rule, same reason.
+fn deserialize_ws_tee_sample_rate<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_checked_sample_rate(deserializer, "ws_tee_sample_rate")
+}
+
+/// Shared body for the two L16 wire-rate fields, so the rule lives in one place.
+fn deserialize_checked_sample_rate<'de, D>(
+    deserializer: D,
+    field: &str,
+) -> std::result::Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    let value: Option<u32> = Option::deserialize(deserializer)?;
+    let Some(rate) = value else {
+        return Ok(None);
+    };
+    validate_ws_sample_rate(rate)
+        .map_err(|reason| de::Error::custom(format!("media profile {field} {reason}")))?;
+    Ok(Some(rate))
+}
+
 /// A user-defined RTPEngine media profile with separate offer/answer NG flags.
 #[derive(Debug, Deserialize, Clone)]
 pub struct MediaProfileConfig {
@@ -2480,9 +2567,57 @@ pub struct NgFlagsConfig {
     pub ws_vad_threshold: Option<i64>,
     /// Trailing hangover for the WebSocket uplink VAD in milliseconds — how long
     /// speech is held after energy drops before the turn endpoint fires.  Unset
-    /// uses the engine default.
+    /// uses the engine default.  Only meaningful with the `energy` detector;
+    /// `neural` holds speech with its own probability hysteresis.
     #[serde(default)]
     pub ws_vad_hangover_ms: Option<u32>,
+    /// L16 wire sample rate in Hz for the `ws_uri` takeover bridge, independent
+    /// of the leg's codec rate and applied in both directions (uplink resampled
+    /// into it, downlink resampled back before re-encoding).  So an 8 kHz G.711
+    /// call can speak 16 kHz to the server, and a server rendering 24 kHz audio
+    /// plays at the right speed and pitch.
+    ///
+    /// Also the domain the noise suppressor and echo canceller run in, and those
+    /// engage only at 8 or 16 kHz.  Must be a multiple of 1000 within
+    /// 8000–48000 — the engine *fails* the offer rather than clamping, so a bad
+    /// value is rejected here at boot.  Inert without `ws_uri`.  `siphon-rtp`
+    /// backend only.
+    #[serde(default, deserialize_with = "deserialize_ws_sample_rate")]
+    pub ws_sample_rate: Option<u32>,
+    /// Which detector the WebSocket uplink VAD runs: `energy` (default, cheap,
+    /// but any loud sound reads as speech) or `neural` (answers "is this
+    /// speech", so it does not turn-start on noise).  Inert without `ws_vad` /
+    /// `ws_barge_in`.  `siphon-rtp` backend only.
+    #[serde(default, deserialize_with = "deserialize_ws_vad_engine")]
+    pub ws_vad_engine: Option<WsVadEngine>,
+    /// **Leading** minimum-speech run in milliseconds: how long the uplink must
+    /// read as speech *continuously* before the speech-start edge (and barge-in)
+    /// fires.  Distinct from the trailing `ws_vad_hangover_ms`.
+    ///
+    /// Unset means no leading requirement — the edge fires on the first speech
+    /// frame, which is what lets a cough or one burst of echo interrupt a
+    /// prompt.  Rounded up to whole ptime frames and added directly to
+    /// turn-start latency, so 60–120 ms is the useful range.  `siphon-rtp` only.
+    #[serde(default)]
+    pub ws_vad_min_speech_ms: Option<u32>,
+    /// Watch this leg's decoded ingress audio for the short tone an answering
+    /// machine plays before recording (the "voicemail beep") and deliver it to
+    /// `@rtpengine.on_beep` — the media half of answering-machine detection.
+    ///
+    /// Set per leg, so arming it on the profile used toward the callee is what
+    /// watches the party that might be a machine.  Needs decoded audio, so it
+    /// promotes a same-codec plaintext call onto the userspace pipeline, and it
+    /// is inert unless the codec's native rate is 8 or 16 kHz.  Fires once per
+    /// leg per call — no mid-call re-arm.  `siphon-rtp` backend only.
+    #[serde(default)]
+    pub beep_detection: bool,
+    /// How long in milliseconds the beep detector waits after a candidate tone
+    /// to confirm no repeat follows — what keeps a cadenced ringback / busy tone
+    /// from reading as a record tone.  **Also the detection latency**: the event
+    /// arrives this long after the beep.  Unset uses the engine default
+    /// (4500 ms).  Inert without `beep_detection`.  `siphon-rtp` backend only.
+    #[serde(default)]
+    pub beep_cadence_guard_ms: Option<u32>,
     /// Attach a **WebSocket tee** to this call: the engine dials this URI and
     /// streams a copy of the call's decoded audio to it as L16.  `siphon-rtp`
     /// backend only.
@@ -2508,6 +2643,16 @@ pub struct NgFlagsConfig {
     /// both legs, 1 for one).  Inert without `ws_tee`.
     #[serde(default)]
     pub ws_tee_channels: Option<u8>,
+    /// L16 wire sample rate in Hz for `ws_tee`, independent of the legs' codec
+    /// rates — the engine resamples the teed copy into it.  Send-only, unlike
+    /// `ws_sample_rate`: it changes only what the tee consumer receives, never
+    /// what the call itself hears.
+    ///
+    /// Must be a multiple of 1000 within 8000–48000 — the engine *fails* the
+    /// offer rather than clamping, so a bad value is rejected here at boot.
+    /// Inert without `ws_tee`.  `siphon-rtp` backend only.
+    #[serde(default, deserialize_with = "deserialize_ws_tee_sample_rate")]
+    pub ws_tee_sample_rate: Option<u32>,
     /// Carry the real post-NAT source IP the proxy saw the request arrive from
     /// (rtpengine's `received from`), gating the leg's media ingress to it.
     ///
@@ -5651,6 +5796,127 @@ media:
                 .ws_tee_direction,
             Some(WsTeeDirection::Caller)
         );
+    }
+
+    /// The six fields added with the 0.3.0 media contract must parse on the
+    /// native backend and land on the profile.
+    #[test]
+    fn parses_media_profile_beep_and_vad_engine_fields() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_uri: \"wss://ai.example.com/s\"\n        \
+             ws_vad: true\n        ws_sample_rate: 16000\n        \
+             ws_vad_engine: \"neural\"\n        ws_vad_min_speech_ms: 80\n        \
+             beep_detection: true\n        beep_cadence_guard_ms: 3000\n        \
+             ws_tee: \"wss://asr.example.com/t\"\n        \
+             ws_tee_sample_rate: 48000\n      answer: {}\n",
+        );
+        let config = Config::from_str(&yaml).unwrap();
+        let media = config.media.expect("media block");
+        let offer = &media.profiles.get("voice_ai_custom").unwrap().offer;
+
+        assert_eq!(offer.ws_sample_rate, Some(16_000));
+        assert_eq!(offer.ws_vad_engine, Some(WsVadEngine::Neural));
+        assert_eq!(offer.ws_vad_min_speech_ms, Some(80));
+        assert!(offer.beep_detection);
+        assert_eq!(offer.beep_cadence_guard_ms, Some(3_000));
+        assert_eq!(offer.ws_tee_sample_rate, Some(48_000));
+    }
+
+    /// `ws_vad_engine` is a closed selector: an unknown detector must be a hard
+    /// config error, never a quiet fall back to the detector the operator was
+    /// explicitly avoiding.
+    #[test]
+    fn rejects_media_profile_bad_ws_vad_engine() {
+        let yaml = ws_profile_yaml(
+            SIPHON_RTP_BACKEND,
+            "      offer:\n        ws_vad_engine: \"telepathy\"\n      answer: {}\n",
+        );
+        let error = Config::from_str(&yaml).expect_err("unknown detector must be rejected");
+        assert!(
+            error.to_string().contains("ws_vad_engine"),
+            "error should name the field: {error}"
+        );
+    }
+
+    /// The engine *fails* an offer carrying an out-of-range wire rate rather
+    /// than clamping it, so a bad value must be caught at boot — otherwise the
+    /// box comes up healthy and every call answers with no media.
+    #[test]
+    fn rejects_media_profile_bad_ws_sample_rates() {
+        for (field, value) in [
+            ("ws_sample_rate", "44100"),  // not a whole kHz
+            ("ws_sample_rate", "4000"),   // below the floor
+            ("ws_sample_rate", "96000"),  // above the ceiling
+            ("ws_tee_sample_rate", "12345"),
+            ("ws_tee_sample_rate", "0"),
+        ] {
+            let yaml = ws_profile_yaml(
+                SIPHON_RTP_BACKEND,
+                &format!("      offer:\n        {field}: {value}\n      answer: {{}}\n"),
+            );
+            let error = Config::from_str(&yaml)
+                .expect_err("{field}={value} must be rejected");
+            assert!(
+                error.to_string().contains(field),
+                "error should name {field}: {error}"
+            );
+        }
+    }
+
+    /// The boundary values must be accepted — a validator that is merely strict
+    /// is as wrong as one that is merely lax.
+    #[test]
+    fn accepts_media_profile_boundary_ws_sample_rates() {
+        for value in ["8000", "48000", "16000"] {
+            let yaml = ws_profile_yaml(
+                SIPHON_RTP_BACKEND,
+                &format!("      offer:\n        ws_sample_rate: {value}\n      answer: {{}}\n"),
+            );
+            Config::from_str(&yaml).unwrap_or_else(|error| panic!("{value} Hz rejected: {error}"));
+        }
+    }
+
+    /// All six are native `siphon-rtp` extensions.  On any other backend the
+    /// engine never sees them, so the call answers into a media path that was
+    /// never wired — a hard config error, not a warning.
+    #[test]
+    fn rejects_new_media_fields_on_non_native_backends() {
+        for field_line in [
+            "ws_sample_rate: 16000",
+            "ws_vad_engine: \"neural\"",
+            "ws_vad_min_speech_ms: 80",
+            "beep_detection: true",
+            "beep_cadence_guard_ms: 3000",
+            "ws_tee_sample_rate: 16000",
+        ] {
+            let field = field_line.split(':').next().expect("field name");
+            for backend in [RTPENGINE_BACKEND, RTPPROXY_BACKEND] {
+                let yaml = ws_profile_yaml(
+                    backend,
+                    &format!("      offer:\n        {field_line}\n      answer: {{}}\n"),
+                );
+                let error = Config::from_str(&yaml)
+                    .err()
+                    .unwrap_or_else(|| {
+                        panic!("{field} must be rejected on backend block {backend:?}")
+                    })
+                    .to_string();
+                assert!(
+                    error.contains(field),
+                    "error should name {field} on {backend:?}: {error}"
+                );
+            }
+
+            // ...and must be accepted on the native backend, so the gate is
+            // proven to be backend-specific rather than a blanket refusal.
+            let yaml = ws_profile_yaml(
+                SIPHON_RTP_BACKEND,
+                &format!("      offer:\n        {field_line}\n      answer: {{}}\n"),
+            );
+            Config::from_str(&yaml)
+                .unwrap_or_else(|error| panic!("{field} rejected on siphon-rtp: {error}"));
+        }
     }
 
     #[test]

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -220,13 +220,22 @@ fn parse_play_source(
     let file = args.get("file").and_then(|value| value.as_str());
     let db_id = args.get("db_id").and_then(|value| value.as_u64());
     let blob = args.get("blob").and_then(|value| value.as_str());
-    let count = [file.is_some(), db_id.is_some(), blob.is_some()]
-        .iter()
-        .filter(|present| **present)
-        .count();
+    let tone = args.get("tone").and_then(|value| value.as_str());
+    let url = args.get("url").and_then(|value| value.as_str());
+    let count = [
+        file.is_some(),
+        db_id.is_some(),
+        blob.is_some(),
+        tone.is_some(),
+        url.is_some(),
+    ]
+    .iter()
+    .filter(|present| **present)
+    .count();
     if count != 1 {
         return Err(
-            "play requires exactly one of args.file (path), args.db_id (int), or args.blob (base64)"
+            "play requires exactly one of args.file (path), args.db_id (int), args.blob \
+             (base64), args.tone (preset or cadence spec), or args.url (http/https)"
                 .to_string(),
         );
     }
@@ -235,6 +244,19 @@ fn parse_play_source(
     }
     if let Some(id) = db_id {
         return Ok(PlayMediaSource::DbId(id));
+    }
+    if let Some(spec) = tone {
+        if spec.trim().is_empty() {
+            return Err("play args.tone must be a preset name or a cadence spec".to_string());
+        }
+        return Ok(PlayMediaSource::Tone(spec.to_string()));
+    }
+    if let Some(location) = url {
+        let lowered = location.trim().to_ascii_lowercase();
+        if !(lowered.starts_with("http://") || lowered.starts_with("https://")) {
+            return Err("play args.url must be an http:// or https:// URL".to_string());
+        }
+        return Ok(PlayMediaSource::Http(location.to_string()));
     }
     if let Some(encoded) = blob {
         use base64::Engine as _;
@@ -290,6 +312,12 @@ async fn play(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
             start_ms,
             duration_ms,
             to_tag.as_deref(),
+            // The control plane's `play` is a supersede, matching its documented
+            // "start an announcement" shape; overlays are a scripting-API verb.
+            false,
+            args.get("gain_decibels")
+                .and_then(|value| value.as_i64())
+                .and_then(|value| i32::try_from(value).ok()),
             false,
         )
         .await
@@ -307,7 +335,7 @@ async fn stop(channel: &ChannelRef) -> ControlResult {
         Ok(target) => target,
         Err(result) => return result,
     };
-    match backend.stop_media(&call_id, &from_tag).await {
+    match backend.stop_media(&call_id, &from_tag, None).await {
         Ok(()) => ControlResult::Ok(
             serde_json::json!({ "channel": channel.channel_id, "state": "stopped" }),
         ),
@@ -414,13 +442,35 @@ async fn stream_start(channel: &ChannelRef, args: &serde_json::Value) -> Control
         Ok(channels) => channels,
         Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
     };
+    // Rejected here rather than at the engine, which fails the attach on a bad
+    // rate rather than clamping — the controller gets the rule, not a generic
+    // engine refusal.
+    let sample_rate = match args.get("sample_rate") {
+        None => None,
+        Some(value) if value.is_null() => None,
+        Some(value) => {
+            let Some(rate) = value.as_u64().and_then(|rate| u32::try_from(rate).ok()) else {
+                return ControlResult::error(
+                    ControlErrorCode::BadRequest,
+                    "stream_start args.sample_rate must be an integer".to_string(),
+                );
+            };
+            if let Err(reason) = crate::rtpengine::profile::validate_ws_sample_rate(rate) {
+                return ControlResult::error(
+                    ControlErrorCode::BadRequest,
+                    format!("stream_start args.sample_rate {reason}"),
+                );
+            }
+            Some(rate)
+        }
+    };
 
     let (backend, call_id, from_tag) = match media_target(channel) {
         Ok(target) => target,
         Err(result) => return result,
     };
     match backend
-        .attach_ws_tee(&call_id, &from_tag, &ws_uri, direction, channels)
+        .attach_ws_tee(&call_id, &from_tag, &ws_uri, direction, channels, sample_rate)
         .await
     {
         Ok(()) => ControlResult::Ok(

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1432,6 +1432,61 @@ pub async fn run(
                         })
                         .await;
                     }
+                    crate::rtpengine::events::RtpEngineEvent::BeepDetected(beep) => {
+                        tracing::debug!(
+                            call_id = %beep.call_id,
+                            from_tag = %beep.from_tag,
+                            frequency_hz = beep.frequency_hz,
+                            duration_ms = beep.duration_ms,
+                            offset_ms = beep.offset_ms,
+                            "media engine detected a record tone"
+                        );
+                        let engine_state = state_for_events.engine.state();
+                        let handlers =
+                            engine_state.beep_handlers(&beep.call_id, &beep.from_tag);
+                        if handlers.is_empty() {
+                            continue;
+                        }
+                        let state_ref = Arc::clone(&state_for_events);
+                        let beep_clone = beep.clone();
+                        let _ = crate::script::py_executor::try_run(move || {
+                            let engine_state = state_ref.engine.state();
+                            let handlers = engine_state
+                                .beep_handlers(&beep_clone.call_id, &beep_clone.from_tag);
+                            pyo3::Python::attach(|python| {
+                                for handler in handlers {
+                                    let callable = handler.callable.bind(python);
+                                    let result = callable.call1((
+                                        beep_clone.call_id.as_str(),
+                                        beep_clone.from_tag.as_str(),
+                                        beep_clone.to_tag.as_deref(),
+                                        beep_clone.frequency_hz,
+                                        beep_clone.duration_ms,
+                                        beep_clone.offset_ms,
+                                    ));
+                                    match result {
+                                        Ok(ret) => {
+                                            if handler.is_async {
+                                                if let Err(error) = run_coroutine(python, &ret) {
+                                                    tracing::error!(
+                                                        %error,
+                                                        "async rtpengine.on_beep handler error"
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        Err(error) => {
+                                            tracing::error!(
+                                                %error,
+                                                "rtpengine.on_beep handler failed"
+                                            );
+                                        }
+                                    }
+                                }
+                            });
+                        })
+                        .await;
+                    }
                     crate::rtpengine::events::RtpEngineEvent::Unknown { event, call_id, .. } => {
                         tracing::debug!(
                             %event,

--- a/src/rtpengine/backend.rs
+++ b/src/rtpengine/backend.rs
@@ -27,7 +27,7 @@ use super::client::{PlayMediaSource, RtpEngineSet};
 use super::error::RtpEngineError;
 use super::profile::{NgFlags, WsTeeDirection};
 use super::rtpproxy::RtpProxyClientSet;
-use super::siphon_rtp::SiphonRtpClientSet;
+use super::siphon_rtp::{PlayMediaOutcome, SiphonRtpClientSet};
 
 /// The configured media-control backend.
 pub enum MediaBackend {
@@ -152,23 +152,49 @@ impl MediaBackend {
         start_pos_ms: Option<u64>,
         duration_ms: Option<u64>,
         to_tag: Option<&str>,
+        overlay: bool,
+        gain_decibels: Option<i32>,
         wait: bool,
-    ) -> Result<Option<u64>, RtpEngineError> {
+    ) -> Result<PlayMediaOutcome, RtpEngineError> {
         match self {
             Self::RtpEngine(set) => {
                 if wait {
                     debug!(call_id, "play_media(wait=True) ignored on rtpengine backend (no completion event); returning on accept");
                 }
-                set.play_media(
-                    call_id,
-                    from_tag,
-                    source,
-                    repeat_times,
-                    start_pos_ms,
+                // Overlay mixing and per-play gain are native siphon-rtp
+                // features with no NG equivalent. Refused rather than dropped:
+                // an overlay silently downgraded to a supersede would cut the
+                // party's live audio, and a dropped gain would play a music bed
+                // at full level under a prompt.
+                if overlay {
+                    return Err(RtpEngineError::Unsupported {
+                        operation: "play_media(overlay=True)",
+                        backend: "rtpengine",
+                    });
+                }
+                if gain_decibels.is_some() {
+                    return Err(RtpEngineError::Unsupported {
+                        operation: "play_media(gain_decibels=...)",
+                        backend: "rtpengine",
+                    });
+                }
+                let duration_ms = set
+                    .play_media(
+                        call_id,
+                        from_tag,
+                        source,
+                        repeat_times,
+                        start_pos_ms,
+                        duration_ms,
+                        to_tag,
+                    )
+                    .await?;
+                // No play_id: the NG protocol has no handle on a playback, which
+                // is why set_play_gain and a targeted stop are siphon-rtp only.
+                Ok(PlayMediaOutcome {
+                    play_id: None,
                     duration_ms,
-                    to_tag,
-                )
-                .await
+                })
             }
             Self::SiphonRtp(client) => {
                 client
@@ -180,6 +206,8 @@ impl MediaBackend {
                         start_pos_ms,
                         duration_ms,
                         to_tag,
+                        overlay,
+                        gain_decibels,
                         wait,
                     )
                     .await
@@ -188,7 +216,7 @@ impl MediaBackend {
                 if wait {
                     debug!(call_id, "play_media(wait=True) ignored on rtpproxy backend (no completion event); returning on accept");
                 }
-                client
+                let duration_ms = client
                     .play_media(
                         call_id,
                         from_tag,
@@ -198,17 +226,78 @@ impl MediaBackend {
                         duration_ms,
                         to_tag,
                     )
-                    .await
+                    .await?;
+                Ok(PlayMediaOutcome {
+                    play_id: None,
+                    duration_ms,
+                })
             }
         }
     }
 
-    /// Stop a prompt playing on the monologue selected by `from_tag`.
-    pub async fn stop_media(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
+    /// Stop prompt playback on the monologue selected by `from_tag`.
+    ///
+    /// `play_id` targets one playback (an individual overlay slot); `None` stops
+    /// everything on the leg.  Only the native backend can address a single
+    /// playback — the others have no handle, so a `play_id` there is refused
+    /// rather than widened into "stop everything", which would silently kill
+    /// playbacks the script meant to keep running.
+    pub async fn stop_media(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        play_id: Option<u64>,
+    ) -> Result<(), RtpEngineError> {
         match self {
-            Self::RtpEngine(set) => set.stop_media(call_id, from_tag).await,
-            Self::SiphonRtp(client) => client.stop_media(call_id, from_tag).await,
-            Self::RtpProxy(client) => client.stop_media(call_id, from_tag).await,
+            Self::RtpEngine(set) => {
+                if play_id.is_some() {
+                    return Err(RtpEngineError::Unsupported {
+                        operation: "stop_media(play_id=...)",
+                        backend: "rtpengine",
+                    });
+                }
+                set.stop_media(call_id, from_tag).await
+            }
+            Self::SiphonRtp(client) => client.stop_media(call_id, from_tag, play_id).await,
+            Self::RtpProxy(client) => {
+                if play_id.is_some() {
+                    return Err(RtpEngineError::Unsupported {
+                        operation: "stop_media(play_id=...)",
+                        backend: "rtpproxy",
+                    });
+                }
+                client.stop_media(call_id, from_tag).await
+            }
+        }
+    }
+
+    /// Retune a running playback's gain — how a controller ducks a music bed
+    /// under a prompt and lifts it again afterwards.
+    ///
+    /// Native `siphon-rtp` only: the NG and rtpproxy protocols have no handle on
+    /// an individual playback, so there is nothing to address.
+    pub async fn set_play_gain(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        play_id: u64,
+        gain_decibels: i32,
+        to_tag: Option<&str>,
+    ) -> Result<(), RtpEngineError> {
+        match self {
+            Self::SiphonRtp(client) => {
+                client
+                    .set_play_gain(call_id, from_tag, play_id, gain_decibels, to_tag)
+                    .await
+            }
+            Self::RtpEngine(_) => Err(RtpEngineError::Unsupported {
+                operation: "set_play_gain",
+                backend: "rtpengine",
+            }),
+            Self::RtpProxy(_) => Err(RtpEngineError::Unsupported {
+                operation: "set_play_gain",
+                backend: "rtpproxy",
+            }),
         }
     }
 
@@ -439,11 +528,12 @@ impl MediaBackend {
         ws_uri: &str,
         direction: WsTeeDirection,
         channels: Option<u8>,
+        sample_rate: Option<u32>,
     ) -> Result<(), RtpEngineError> {
         match self {
             Self::SiphonRtp(client) => {
                 client
-                    .attach_ws_tee(call_id, from_tag, ws_uri, direction, channels)
+                    .attach_ws_tee(call_id, from_tag, ws_uri, direction, channels, sample_rate)
                     .await
             }
             Self::RtpEngine(_) => Err(RtpEngineError::Unsupported {

--- a/src/rtpengine/client.rs
+++ b/src/rtpengine/client.rs
@@ -23,11 +23,52 @@ use super::profile::NgFlags;
 /// - `File` — absolute path on the rtpengine host
 /// - `Blob` — raw audio bytes embedded in the ng command (binary-safe via bencode)
 /// - `DbId` — reference to a prompt stored in rtpengine's internal database
+/// - `Tone` — a synthesised call-progress tone (`siphon-rtp` only)
+/// - `Http` — a WAV the *engine* fetches over HTTP(S) (`siphon-rtp` only)
 #[derive(Debug, Clone)]
 pub enum PlayMediaSource {
     File(String),
     Blob(Vec<u8>),
     DbId(u64),
+    /// A synthesised call-progress tone — no audio file to ship or provision.
+    ///
+    /// Either a **preset name** (`ringback_eu`, `busy_na`, `dial_uk`, …) or an
+    /// explicit **cadence spec** in the engine's tone grammar, e.g.
+    /// `425/1000,0/4000*inf` for 425 Hz one second on, four seconds off,
+    /// forever.  The two are told apart by the `/`: a preset name never contains
+    /// one and a cadence spec is never valid without one.  Rendered directly at
+    /// the leg's codec rate, so it is never resampled.
+    ///
+    /// A native `siphon-rtp` extension — the NG/bencode and rtpproxy backends
+    /// have no equivalent.
+    Tone(String),
+    /// A WAV fetched over HTTP(S) **by the engine**, from the engine's own
+    /// network position.
+    ///
+    /// siphon never performs this fetch: it passes the URL and the engine
+    /// bounds it (connect timeout, first-byte timeout, overall deadline,
+    /// response-size cap, redirect cap — all daemon-side settings) off the media
+    /// path, so a URL that never answers can never stall the leg.  The accept is
+    /// immediate with no duration (the length is unknown until the body
+    /// arrives); a fetch that fails for any reason ends the playback with a
+    /// play-finished `error` reason carrying the same `play_id`.
+    ///
+    /// A native `siphon-rtp` extension — the NG/bencode and rtpproxy backends
+    /// have no equivalent.
+    Http(String),
+}
+
+impl PlayMediaSource {
+    /// The source's name as it appears in the scripting API, for error text.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::File(_) => "file",
+            Self::Blob(_) => "blob",
+            Self::DbId(_) => "db_id",
+            Self::Tone(_) => "tone",
+            Self::Http(_) => "url",
+        }
+    }
 }
 
 /// Async client for the RTPEngine NG control protocol.
@@ -186,6 +227,22 @@ impl RtpEngineClient {
             }
             PlayMediaSource::DbId(id) => {
                 pairs.push(("db-id", BencodeValue::Integer(*id as i64)));
+            }
+            // Native siphon-rtp sources with no NG equivalent.  Refused rather
+            // than dropped: silently omitting the source would send a `play
+            // media` with no source at all, which the engine either rejects
+            // opaquely or answers with a play that never produces audio.
+            PlayMediaSource::Tone(_) => {
+                return Err(RtpEngineError::Unsupported {
+                    operation: "play_media(tone=...)",
+                    backend: "rtpengine",
+                });
+            }
+            PlayMediaSource::Http(_) => {
+                return Err(RtpEngineError::Unsupported {
+                    operation: "play_media(url=...)",
+                    backend: "rtpengine",
+                });
             }
         }
         if let Some(repeat) = repeat_times {

--- a/src/rtpengine/events.rs
+++ b/src/rtpengine/events.rs
@@ -58,6 +58,10 @@ pub enum RtpEngineEvent {
     /// Emitted exactly once per started tee, so a script learns the stream died
     /// rather than silently losing audio.  `siphon-rtp` native backend only.
     WsTeeEnded(WsTeeEnded),
+    /// A record tone (the "voicemail beep") was detected on a leg armed with
+    /// `beep_detection` — the media half of answering-machine detection.
+    /// Emitted once per leg per call.  `siphon-rtp` native backend only.
+    BeepDetected(BeepDetectedEvent),
     /// An event we didn't recognise — passed through for logging.
     Unknown {
         event: String,
@@ -206,6 +210,34 @@ pub struct WsTeeStarted {
     pub channels: u8,
     /// Wire sample rate in Hz (L16, little-endian).
     pub sample_rate: u32,
+}
+
+/// A record tone was detected on a leg, carried by
+/// [`RtpEngineEvent::BeepDetected`].  A siphon-side mirror of the native
+/// backend's `siphon_rtp_proto::Event::BeepDetected` payload, keeping this
+/// generic event enum free of the proto type.
+///
+/// The engine drops the detector after the first tone, so this arrives **once
+/// per leg per call** and a consumer never has to de-duplicate.
+#[derive(Debug, Clone)]
+pub struct BeepDetectedEvent {
+    /// SIP Call-ID the media session is keyed on.
+    pub call_id: String,
+    /// The leg the tone was heard *on* — arming `beep_detection` on the profile
+    /// used toward the callee is what watches the party that might be a machine.
+    pub from_tag: String,
+    /// Optional peer tag, matching the `Dtmf` event's triple.
+    pub to_tag: Option<String>,
+    /// Measured tone frequency in Hz (sub-bin accurate, typically within a few Hz).
+    pub frequency_hz: f32,
+    /// Measured tone length in milliseconds, accurate to about one analysis
+    /// window (±32 ms).
+    pub duration_ms: u32,
+    /// Milliseconds of decoded audio seen on this leg before the tone
+    /// **started** — the offset of the tone itself, *not* of the event.  The
+    /// event is emitted after the detector's cadence guard has elapsed, so it
+    /// always trails this by roughly `beep_cadence_guard_ms`.
+    pub offset_ms: u64,
 }
 
 /// A WebSocket tee stopped, carried by [`RtpEngineEvent::WsTeeEnded`].

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -315,6 +315,84 @@ impl WsTeeDirection {
     pub const VALUES: [&'static str; 3] = ["both", "caller", "callee"];
 }
 
+/// Which voice-activity detector the WebSocket uplink VAD runs.
+///
+/// A siphon-side mirror of the native backend's `siphon_rtp_proto::WsVadEngine`,
+/// keeping the config and profile layers free of the proto type (the same
+/// posture [`WsTeeDirection`] takes).
+///
+/// Deliberately **not** `#[non_exhaustive]`, mirroring the proto: this selects
+/// behaviour the script asked for *by name*.  A consumer that met an unknown
+/// detector through a wildcard would have to fall back to the detector the
+/// script was explicitly avoiding — a silent downgrade.  Exhaustiveness forces
+/// that question to be answered in code.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WsVadEngine {
+    /// Mean-square energy against a threshold with a trailing hangover.  Cheap
+    /// and exact, but it answers "is something loud here", so breathing, mains
+    /// hum, fan noise and uncancelled echo all read as speech.  The engine's
+    /// default, and the right choice when a false turn start is harmless.
+    #[default]
+    Energy,
+    /// A neural speech classifier.  Answers "is what is here speech", so it does
+    /// not turn-start on non-speech noise, at the cost of a 32 ms detection
+    /// floor plus up to one media frame.  Pick it for turn taking and barge-in.
+    Neural,
+}
+
+impl WsVadEngine {
+    /// The YAML / Python spelling, matching the proto's `snake_case` wire form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Energy => "energy",
+            Self::Neural => "neural",
+        }
+    }
+
+    /// Parse the YAML / Python spelling, case-insensitively.
+    ///
+    /// Returns `None` for anything else so the caller can raise a named error
+    /// rather than silently relaying a detector the engine would reject.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "energy" => Some(Self::Energy),
+            "neural" => Some(Self::Neural),
+            _ => None,
+        }
+    }
+
+    /// The accepted values, for error messages.
+    pub const VALUES: [&'static str; 2] = ["energy", "neural"];
+}
+
+/// Lowest L16 wire sample rate the engine accepts (`ws_sample_rate` /
+/// `ws_tee_sample_rate`).
+pub const WS_SAMPLE_RATE_MIN: u32 = 8_000;
+/// Highest L16 wire sample rate the engine accepts.
+pub const WS_SAMPLE_RATE_MAX: u32 = 48_000;
+/// The engine requires a whole number of kHz.
+pub const WS_SAMPLE_RATE_STEP: u32 = 1_000;
+
+/// Validate an L16 wire sample rate the way the engine does.
+///
+/// The engine **fails the offer/answer** on a bad rate rather than clamping it,
+/// so a profile carrying one is a call that never gets media.  Checking here
+/// lets config load reject it at boot and the script API reject it at the call,
+/// instead of the operator learning from a dead leg.
+///
+/// Returns a ready-to-print reason on rejection.
+pub fn validate_ws_sample_rate(rate: u32) -> Result<(), String> {
+    if !(WS_SAMPLE_RATE_MIN..=WS_SAMPLE_RATE_MAX).contains(&rate)
+        || rate % WS_SAMPLE_RATE_STEP != 0
+    {
+        return Err(format!(
+            "must be a multiple of {WS_SAMPLE_RATE_STEP} within \
+             {WS_SAMPLE_RATE_MIN}–{WS_SAMPLE_RATE_MAX} Hz, got {rate}"
+        ));
+    }
+    Ok(())
+}
+
 /// NG protocol flags sent with offer/answer commands.
 #[derive(Debug, Clone, Default)]
 pub struct NgFlags {
@@ -398,8 +476,71 @@ pub struct NgFlags {
     /// Trailing hangover for the WS uplink VAD in milliseconds — how long speech
     /// is held after energy drops before `speech_stopped` (the turn endpoint)
     /// fires.  `None` uses the engine's ~200 ms default.  Only meaningful with
-    /// [`NgFlags::ws_vad`] / [`NgFlags::ws_barge_in`].
+    /// [`NgFlags::ws_vad`] / [`NgFlags::ws_barge_in`], and only with the
+    /// [`WsVadEngine::Energy`] detector — [`WsVadEngine::Neural`] holds speech
+    /// with its own probability hysteresis instead.
     pub ws_vad_hangover_ms: Option<u32>,
+    /// L16 wire sample rate in Hz for the [`NgFlags::ws_uri`] takeover bridge,
+    /// **independent of the leg's codec rate** and applied in *both* directions:
+    /// the engine resamples the leg's decoded uplink into it and resamples the
+    /// server's downlink back into the leg's codec rate before re-encoding.  So
+    /// an 8 kHz G.711 call can speak 16 kHz L16 to the server, and a server
+    /// rendering 24 kHz audio is played at the right speed and pitch.
+    ///
+    /// It is also the domain the uplink noise suppressor and echo canceller run
+    /// in, and those engage only at 8 or 16 kHz — another rate leaves them off
+    /// without changing the wire rate.
+    ///
+    /// Must satisfy [`validate_ws_sample_rate`]; the engine *fails* the
+    /// offer/answer on a bad value rather than clamping.  `None` leaves the leg
+    /// codec's own PCM rate with no conversion in either direction.  Inert
+    /// without [`NgFlags::ws_uri`].
+    pub ws_sample_rate: Option<u32>,
+    /// Which detector the WS uplink VAD runs.  `None` leaves the engine's
+    /// default ([`WsVadEngine::Energy`]).  Only meaningful with
+    /// [`NgFlags::ws_vad`] / [`NgFlags::ws_barge_in`].
+    pub ws_vad_engine: Option<WsVadEngine>,
+    /// **Leading** minimum-speech run in milliseconds: how long the uplink must
+    /// read as speech *continuously* before the `speech_started` edge (and
+    /// barge-in) fires.  Distinct from the *trailing*
+    /// [`NgFlags::ws_vad_hangover_ms`].
+    ///
+    /// `None` means no leading requirement — the edge fires on the first speech
+    /// frame, which is what lets a cough, a door or one burst of echo interrupt
+    /// a prompt.  Rounded up to whole ptime frames by the engine, and it adds
+    /// directly to turn-start latency, so 60–120 ms is the useful range.  Works
+    /// with either detector.  Only meaningful with [`NgFlags::ws_vad`] /
+    /// [`NgFlags::ws_barge_in`].
+    pub ws_vad_min_speech_ms: Option<u32>,
+    /// Watch this leg's decoded ingress audio for the short single tone an
+    /// answering machine plays before it starts recording (the "voicemail
+    /// beep"), reporting it as `@rtpengine.on_beep` — the media half of
+    /// answering-machine detection, so a script can abort a transfer instead of
+    /// bridging the caller into a voicemail box.
+    ///
+    /// Set **per leg**: the flag arms the detector on the leg whose
+    /// `offer`/`answer` carries it, so arming it on the outbound (callee) leg is
+    /// what watches the party that might be a machine.  Like
+    /// [`NgFlags::noise_suppression`] it needs decoded audio, so it promotes a
+    /// same-codec plaintext call onto the userspace media pipeline, and it is
+    /// inert on a codec whose native rate is neither 8 nor 16 kHz.
+    ///
+    /// Fires **once per leg per call** — there is no mid-call re-arm; a fresh
+    /// `offer`/`answer` with the flag set re-arms it.
+    ///
+    /// A native `siphon-rtp` extension: the NG/bencode and rtpproxy backends
+    /// have no equivalent and cannot honour it.
+    pub beep_detection: bool,
+    /// How long in milliseconds the beep detector waits after a candidate tone
+    /// ends to confirm no repeat follows — the discriminator that keeps a
+    /// cadenced ringback / busy / congestion tone from reading as a record tone.
+    ///
+    /// It is **also the detection latency**: the event arrives this long after
+    /// the beep.  `None` uses the engine default (4500 ms, longer than the 4 s
+    /// silent interval of the slowest widely deployed ringback cadence).  Lower
+    /// it to trade cadence robustness for latency.  Inert without
+    /// [`NgFlags::beep_detection`].
+    pub beep_cadence_guard_ms: Option<u32>,
     /// Attach a **WebSocket tee** to this call at offer/answer time — the
     /// declarative twin of `rtpengine.attach_ws_tee(...)`, so a profile can turn
     /// the tee on without a second round-trip.
@@ -425,6 +566,15 @@ pub struct NgFlags {
     /// a single-leg tee is always mono.  `None` leaves the engine's default (2
     /// for both legs, 1 for one).  Inert without [`NgFlags::ws_tee`].
     pub ws_tee_channels: Option<u8>,
+    /// L16 wire sample rate in Hz for [`NgFlags::ws_tee`], independent of the
+    /// legs' codec rates — the engine resamples the teed copy into it.  Unlike
+    /// [`NgFlags::ws_sample_rate`] this is send-only, so it affects only what the
+    /// tee consumer receives and never what the call itself hears.
+    ///
+    /// Must satisfy [`validate_ws_sample_rate`]; the engine *fails* the
+    /// offer/answer on a bad value rather than clamping.  `None` leaves the
+    /// engine's default.  Inert without [`NgFlags::ws_tee`].
+    pub ws_tee_sample_rate: Option<u32>,
     /// Profile **policy**: carry the real post-NAT source IP the proxy saw this
     /// request arrive from (rtpengine's `received from`) on offer/answer.
     ///
@@ -477,9 +627,15 @@ impl NgFlags {
             ws_barge_in: config.ws_barge_in,
             ws_vad_threshold: config.ws_vad_threshold,
             ws_vad_hangover_ms: config.ws_vad_hangover_ms,
+            ws_sample_rate: config.ws_sample_rate,
+            ws_vad_engine: config.ws_vad_engine,
+            ws_vad_min_speech_ms: config.ws_vad_min_speech_ms,
+            beep_detection: config.beep_detection,
+            beep_cadence_guard_ms: config.beep_cadence_guard_ms,
             ws_tee: config.ws_tee.clone(),
             ws_tee_direction: config.ws_tee_direction,
             ws_tee_channels: config.ws_tee_channels,
+            ws_tee_sample_rate: config.ws_tee_sample_rate,
             carry_received_from: config.received_from,
             received_from: None,
             rtcp_mux: config.rtcp_mux.clone(),
@@ -547,12 +703,15 @@ impl NgFlags {
             let items: Vec<&str> = self.rtcp_mux.iter().map(|s| s.as_str()).collect();
             pairs.push(("rtcp-mux", BencodeValue::string_list(&items)));
         }
-        // The WS bridge, WS tee and DSP knobs (ws_uri, ws_vad, ws_barge_in,
-        // ws_vad_threshold, ws_vad_hangover_ms, ws_tee, ws_tee_direction,
-        // ws_tee_channels, noise_suppression, echo_cancellation) are native
-        // siphon-rtp extensions with no NG equivalent, so they are deliberately
-        // not emitted here.  A profile that sets them on this backend is rejected
-        // at config load rather than silently degraded — see
+        // The WS bridge, WS tee, VAD, beep-detection and DSP knobs (ws_uri,
+        // ws_vad, ws_barge_in, ws_vad_threshold, ws_vad_hangover_ms,
+        // ws_vad_engine, ws_vad_min_speech_ms, ws_sample_rate, ws_tee,
+        // ws_tee_direction, ws_tee_channels, ws_tee_sample_rate,
+        // beep_detection, beep_cadence_guard_ms, noise_suppression,
+        // echo_cancellation) are native siphon-rtp extensions with no NG
+        // equivalent, so they are deliberately not emitted here.  A profile that
+        // sets them on this backend is rejected at config load rather than
+        // silently degraded — see
         // `MediaBackendKind::unsupported_profile_fields`.
 
         pairs
@@ -566,6 +725,38 @@ impl NgFlags {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ws_vad_engine_round_trips_its_wire_spelling() {
+        for engine in [WsVadEngine::Energy, WsVadEngine::Neural] {
+            assert_eq!(WsVadEngine::parse(engine.as_str()), Some(engine));
+        }
+        // Case-insensitive and whitespace-tolerant, matching WsTeeDirection.
+        assert_eq!(WsVadEngine::parse("  NEURAL "), Some(WsVadEngine::Neural));
+        // Anything else is None so the caller can raise a named error rather
+        // than silently downgrading to the detector the operator avoided.
+        assert_eq!(WsVadEngine::parse("telepathy"), None);
+        assert_eq!(WsVadEngine::parse(""), None);
+        assert_eq!(WsVadEngine::default(), WsVadEngine::Energy);
+    }
+
+    #[test]
+    fn ws_sample_rate_validation_matches_the_engines_rule() {
+        // Whole kHz within 8000-48000 inclusive.
+        for rate in [8_000, 16_000, 24_000, 47_000, 48_000] {
+            assert!(validate_ws_sample_rate(rate).is_ok(), "{rate} must be accepted");
+        }
+        // Out of range, or not a whole kHz. The engine fails the offer on these
+        // rather than clamping, so they must never reach it.
+        for rate in [0, 1_000, 7_999, 44_100, 48_001, 96_000] {
+            let error = validate_ws_sample_rate(rate)
+                .expect_err(&format!("{rate} must be rejected"));
+            assert!(
+                error.contains(&rate.to_string()),
+                "reason should quote the offending rate: {error}"
+            );
+        }
+    }
 
     #[test]
     fn default_registry_has_builtins() {

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -31,6 +31,7 @@ use siphon_rtp_proto::{
     frame, CmdResult, Command, Event, LegSummary as ProtoLegSummary, PlayEndReason,
     PlayMediaSource as ProtoPlayMediaSource, ProfileFlags, Request, Response,
     WsTeeDirection as ProtoWsTeeDirection, WsTeeEndReason as ProtoWsTeeEndReason,
+    WsVadEngine as ProtoWsVadEngine,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -41,10 +42,10 @@ use tracing::{debug, info, trace, warn};
 use super::client::PlayMediaSource;
 use super::error::RtpEngineError;
 use super::events::{
-    CallLegSummary, CallSummary, DtmfEvent, RtpEngineEvent, TextEvent, TextStreamStats,
-    WsTeeEndReason, WsTeeStarted, WsTeeEnded,
+    BeepDetectedEvent, CallLegSummary, CallSummary, DtmfEvent, RtpEngineEvent, TextEvent,
+    TextStreamStats, WsTeeEndReason, WsTeeStarted, WsTeeEnded,
 };
-use super::profile::{NgFlags, WsTeeDirection};
+use super::profile::{NgFlags, WsTeeDirection, WsVadEngine};
 
 /// Reserved request id for the auth handshake (real requests start at 1).
 const AUTH_REQUEST_ID: u64 = 0;
@@ -85,9 +86,15 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         ws_barge_in: flags.ws_barge_in,
         ws_vad_threshold: flags.ws_vad_threshold,
         ws_vad_hangover_ms: flags.ws_vad_hangover_ms,
+        ws_sample_rate: flags.ws_sample_rate,
+        ws_vad_engine: flags.ws_vad_engine.map(proto_ws_vad_engine),
+        ws_vad_min_speech_ms: flags.ws_vad_min_speech_ms,
+        beep_detection: flags.beep_detection,
+        beep_cadence_guard_ms: flags.beep_cadence_guard_ms,
         ws_tee: flags.ws_tee.clone(),
         ws_tee_direction: flags.ws_tee_direction.map(proto_ws_tee_direction),
         ws_tee_channels: flags.ws_tee_channels,
+        ws_tee_sample_rate: flags.ws_tee_sample_rate,
         // The per-call address, not the `carry_received_from` policy bit — the
         // script API injects the former only when the latter is set, so an
         // opted-out profile leaves this `None` and serialises away.
@@ -106,6 +113,19 @@ pub(crate) fn proto_ws_tee_direction(direction: WsTeeDirection) -> ProtoWsTeeDir
     }
 }
 
+/// Map siphon's [`WsVadEngine`] onto the proto twin.
+///
+/// Deliberately exhaustive, mirroring the proto's own refusal to mark
+/// `WsVadEngine` `#[non_exhaustive]`: a detector swept into a wildcard here
+/// would silently downgrade the call to the detector the script was explicitly
+/// avoiding.  A new detector must break this function.
+pub(crate) fn proto_ws_vad_engine(engine: WsVadEngine) -> ProtoWsVadEngine {
+    match engine {
+        WsVadEngine::Energy => ProtoWsVadEngine::Energy,
+        WsVadEngine::Neural => ProtoWsVadEngine::Neural,
+    }
+}
+
 /// Map the proto [`ProtoWsTeeDirection`] back onto siphon's own enum, so the
 /// generic event type stays free of the proto.
 fn ws_tee_direction_from_proto(direction: ProtoWsTeeDirection) -> WsTeeDirection {
@@ -117,17 +137,44 @@ fn ws_tee_direction_from_proto(direction: ProtoWsTeeDirection) -> WsTeeDirection
 }
 
 /// Map siphon's [`PlayMediaSource`] to the proto variant.
+///
+/// Deliberately exhaustive on **siphon's own** enum (which is local, so no
+/// wildcard is forced): a source siphon grows must be carried here or fail to
+/// compile, never be silently dropped into a `play media` with no source.
 fn proto_play_source(source: &PlayMediaSource) -> ProtoPlayMediaSource {
     match source {
         PlayMediaSource::File(path) => ProtoPlayMediaSource::File { path: path.clone() },
         PlayMediaSource::Blob(data) => ProtoPlayMediaSource::Blob { data: data.clone() },
         PlayMediaSource::DbId(id) => ProtoPlayMediaSource::DbId { id: *id },
+        PlayMediaSource::Tone(tone) => ProtoPlayMediaSource::Tone { tone: tone.clone() },
+        // The engine fetches this itself, bounded by its own connect /
+        // first-byte / deadline / size / redirect caps and off the media path.
+        // siphon deliberately does not fetch: a controller-side fetch would put
+        // an unbounded third-party HTTP round-trip on the call-setup path.
+        PlayMediaSource::Http(url) => ProtoPlayMediaSource::Http { url: url.clone() },
     }
 }
 
 /// Completion signal for a blocking `play_media(wait=True)`: how the prompt ended
 /// plus the actual played duration (from `Event::PlayFinished`).
 type PlayWaiter = oneshot::Sender<(PlayEndReason, Option<u64>)>;
+
+/// What a `play media` accept (and, when waited on, its completion) yielded.
+///
+/// The `play_id` is the engine's handle on that specific playback: it is what
+/// `set_play_gain` retunes and what a targeted `stop_media` ends, and it is the
+/// only way to address one of the four concurrent overlay slots on a direction.
+/// Carried separately from the duration because the two answer different
+/// questions and an overlay generally has a handle but no useful duration.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PlayMediaOutcome {
+    /// The engine's handle on this playback, when it assigned one.
+    pub play_id: Option<u64>,
+    /// Played duration in milliseconds, when the engine reported one.  Always
+    /// absent for an HTTP source at accept time — the length is not known until
+    /// the body has arrived.
+    pub duration_ms: Option<u64>,
+}
 
 /// Native JSON-over-TCP control client for `siphon-rtp`.
 pub struct SiphonRtpClient {
@@ -403,7 +450,14 @@ impl SiphonRtpClient {
     }
 
     /// Inject an audio prompt; returns the engine-reported duration in ms.
-    #[allow(clippy::too_many_arguments)]
+    ///
+    /// `overlay` mixes the prompt **under** the party's live egress instead of
+    /// replacing it (up to four concurrent overlays per direction, each with its
+    /// own `play_id`); `gain_decibels` sets the playout level relative to the
+    /// source's own, clamped engine-side to −60..=+12 dB.
+    ///
+    /// Returns the `play_id` alongside the duration so a caller can retune the
+    /// playback with [`SiphonRtpClient::set_play_gain`] or stop just this one.
     #[allow(clippy::too_many_arguments)]
     pub async fn play_media(
         &self,
@@ -414,8 +468,10 @@ impl SiphonRtpClient {
         start_pos_ms: Option<u64>,
         duration_ms: Option<u64>,
         to_tag: Option<&str>,
+        overlay: bool,
+        gain_decibels: Option<i32>,
         wait: bool,
-    ) -> Result<Option<u64>, RtpEngineError> {
+    ) -> Result<PlayMediaOutcome, RtpEngineError> {
         let result = self
             .request(Command::PlayMedia {
                 call_id: call_id.to_string(),
@@ -424,6 +480,8 @@ impl SiphonRtpClient {
                 repeat_times,
                 start_pos_ms,
                 duration_ms,
+                overlay,
+                gain_decibels,
                 to_tag: to_tag.map(str::to_string),
             })
             .await?;
@@ -441,7 +499,10 @@ impl SiphonRtpClient {
         // Fire-and-forget, or an engine that didn't assign a play_id: return on
         // accept, exactly as before.
         let (true, Some(play_id)) = (wait, play_id) else {
-            return Ok(accept_duration);
+            return Ok(PlayMediaOutcome {
+                play_id,
+                duration_ms: accept_duration,
+            });
         };
 
         // Block until the prompt ends. Register the waiter keyed by play_id (the
@@ -452,20 +513,44 @@ impl SiphonRtpClient {
         let (sender, receiver) = oneshot::channel::<(PlayEndReason, Option<u64>)>();
         self.play_pending.insert(play_id, sender);
         let deadline = Duration::from_millis(self.play_timeout_ms.max(1));
+        // Every outcome still reports the play_id: the caller may want to stop or
+        // retune a playback that merely failed to *complete* (an overlay ended
+        // early is still a live slot from the controller's point of view).
+        let outcome = |duration_ms| PlayMediaOutcome {
+            play_id: Some(play_id),
+            duration_ms,
+        };
         match tokio::time::timeout(deadline, receiver).await {
             // Prompt played out in full.
-            Ok(Ok((PlayEndReason::Completed, played_ms))) => Ok(played_ms.or(accept_duration)),
+            Ok(Ok((PlayEndReason::Completed, played_ms))) => {
+                Ok(outcome(played_ms.or(accept_duration)))
+            }
             // Ended early (stopped / superseded) — didn't play out; the script decides.
-            Ok(Ok((PlayEndReason::Stopped | PlayEndReason::Superseded, _))) => Ok(None),
-            // Engine reported an aborted playback.
+            Ok(Ok((PlayEndReason::Stopped | PlayEndReason::Superseded, _))) => Ok(outcome(None)),
+            // Engine reported an aborted playback — this is also how a bounded
+            // HTTP source reports a fetch that failed, since that play never
+            // produced audio.
             Ok(Ok((PlayEndReason::Error, _))) => {
                 warn!(call_id, play_id, "siphon-rtp play_media aborted (engine error)");
-                Ok(None)
+                Ok(outcome(None))
+            }
+            // A reason this build does not know. `PlayEndReason` is
+            // `#[non_exhaustive]` upstream precisely because the safe reading of
+            // an unknown reason is the documented one — the playback ended — so
+            // this reports "did not complete" rather than inventing a duration.
+            Ok(Ok((reason, _))) => {
+                warn!(
+                    call_id,
+                    play_id,
+                    ?reason,
+                    "siphon-rtp play_media ended for a reason this build does not know"
+                );
+                Ok(outcome(None))
             }
             // Connection dropped (sender cleared on disconnect) — treat as not completed.
             Ok(Err(_)) => {
                 warn!(call_id, play_id, "siphon-rtp play_media: connection lost before completion");
-                Ok(None)
+                Ok(outcome(None))
             }
             // Fallback timeout — no PlayFinished within play_timeout_ms.
             Err(_) => {
@@ -476,17 +561,52 @@ impl SiphonRtpClient {
                     timeout_ms = self.play_timeout_ms,
                     "siphon-rtp play_media: no completion within fallback timeout"
                 );
-                Ok(None)
+                Ok(outcome(None))
             }
         }
     }
 
-    /// Stop any prompt playing on the monologue selected by `from_tag`.
-    pub async fn stop_media(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
+    /// Stop prompt playback on the monologue selected by `from_tag`.
+    ///
+    /// `play_id` targets one playback (an individual overlay slot); `None` stops
+    /// everything playing on the leg.
+    pub async fn stop_media(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        play_id: Option<u64>,
+    ) -> Result<(), RtpEngineError> {
         expect_ok(
             self.request(Command::StopMedia {
                 call_id: call_id.to_string(),
                 from_tag: from_tag.to_string(),
+                play_id,
+            })
+            .await?,
+        )
+    }
+
+    /// Retune the playout gain of a playback that is already running — how a
+    /// controller ducks a music bed under a prompt and lifts it again.
+    ///
+    /// `play_id` is the handle the playback's accept returned.  The engine
+    /// answers an error when no playback on the call holds that id, so a stale
+    /// handle surfaces rather than silently doing nothing.
+    pub async fn set_play_gain(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        play_id: u64,
+        gain_decibels: i32,
+        to_tag: Option<&str>,
+    ) -> Result<(), RtpEngineError> {
+        expect_ok(
+            self.request(Command::SetPlayGain {
+                call_id: call_id.to_string(),
+                from_tag: from_tag.to_string(),
+                play_id,
+                gain_decibels,
+                to_tag: to_tag.map(str::to_string),
             })
             .await?,
         )
@@ -697,6 +817,7 @@ impl SiphonRtpClient {
         ws_uri: &str,
         direction: WsTeeDirection,
         channels: Option<u8>,
+        sample_rate: Option<u32>,
     ) -> Result<(), RtpEngineError> {
         expect_ok(
             self.request(Command::AttachWsTee {
@@ -705,6 +826,7 @@ impl SiphonRtpClient {
                 ws_uri: ws_uri.to_string(),
                 direction: proto_ws_tee_direction(direction),
                 channels,
+                sample_rate,
             })
             .await?,
         )
@@ -957,8 +1079,10 @@ impl SiphonRtpClientSet {
         start_pos_ms: Option<u64>,
         duration_ms: Option<u64>,
         to_tag: Option<&str>,
+        overlay: bool,
+        gain_decibels: Option<i32>,
         wait: bool,
-    ) -> Result<Option<u64>, RtpEngineError> {
+    ) -> Result<PlayMediaOutcome, RtpEngineError> {
         self.select(call_id)
             .play_media(
                 call_id,
@@ -968,14 +1092,35 @@ impl SiphonRtpClientSet {
                 start_pos_ms,
                 duration_ms,
                 to_tag,
+                overlay,
+                gain_decibels,
                 wait,
             )
             .await
     }
 
     /// Stop a prompt via the affinity-bound instance.
-    pub async fn stop_media(&self, call_id: &str, from_tag: &str) -> Result<(), RtpEngineError> {
-        self.select(call_id).stop_media(call_id, from_tag).await
+    pub async fn stop_media(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        play_id: Option<u64>,
+    ) -> Result<(), RtpEngineError> {
+        self.select(call_id).stop_media(call_id, from_tag, play_id).await
+    }
+
+    /// Retune a running playback's gain via the affinity-bound instance.
+    pub async fn set_play_gain(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        play_id: u64,
+        gain_decibels: i32,
+        to_tag: Option<&str>,
+    ) -> Result<(), RtpEngineError> {
+        self.select(call_id)
+            .set_play_gain(call_id, from_tag, play_id, gain_decibels, to_tag)
+            .await
     }
 
     /// Inject DTMF via the affinity-bound instance.
@@ -1087,9 +1232,10 @@ impl SiphonRtpClientSet {
         ws_uri: &str,
         direction: WsTeeDirection,
         channels: Option<u8>,
+        sample_rate: Option<u32>,
     ) -> Result<(), RtpEngineError> {
         self.select(call_id)
-            .attach_ws_tee(call_id, from_tag, ws_uri, direction, channels)
+            .attach_ws_tee(call_id, from_tag, ws_uri, direction, channels, sample_rate)
             .await
     }
 
@@ -1190,6 +1336,11 @@ fn unexpected_result(context: &str, result: CmdResult) -> RtpEngineError {
 }
 
 /// A short, stable tag for a [`CmdResult`] variant, for error messages.
+///
+/// `CmdResult` is `#[non_exhaustive]` upstream, so the wildcard is forced.  It
+/// yields a named placeholder rather than being silently absorbed — the caller
+/// is building "unexpected `{kind}` response to {context}", and an empty kind
+/// would turn a real protocol violation into an unreadable error.
 fn result_kind(result: &CmdResult) -> &'static str {
     match result {
         CmdResult::Ok { .. } => "ok",
@@ -1200,6 +1351,7 @@ fn result_kind(result: &CmdResult) -> &'static str {
         CmdResult::Load { .. } => "load",
         CmdResult::NodeInfo { .. } => "node_info",
         CmdResult::Checkpoint { .. } => "checkpoint",
+        _ => "unrecognised",
     }
 }
 
@@ -1317,15 +1469,52 @@ fn convert_event(event: Event) -> RtpEngineEvent {
             frames_sent,
             frames_dropped,
         }),
+        Event::BeepDetected {
+            call_id,
+            from_tag,
+            to_tag,
+            frequency_hz,
+            duration_ms,
+            offset_ms,
+        } => RtpEngineEvent::BeepDetected(BeepDetectedEvent {
+            call_id,
+            from_tag,
+            to_tag,
+            frequency_hz,
+            duration_ms,
+            offset_ms,
+        }),
         Event::Unknown => RtpEngineEvent::Unknown {
             event: "unknown".to_string(),
             call_id: None,
             from_tag: None,
         },
+        // `Event` is `#[non_exhaustive]` upstream, so a build newer than this one
+        // can push a variant this one has no arm for. Surfaced through `Unknown`
+        // (which the dispatcher logs) rather than dropped — the correlation ids
+        // are unreachable behind the wildcard, but the fact that an unmodelled
+        // event arrived is exactly what tells an operator siphon is behind the
+        // engine. A serde-level `Event::Unknown` (an event tag the *proto* did
+        // not recognise) is the arm above; this is a tag it did.
+        other => {
+            debug!(?other, "siphon-rtp event not modelled by this build");
+            RtpEngineEvent::Unknown {
+                event: "unmodelled".to_string(),
+                call_id: None,
+                from_tag: None,
+            }
+        }
     }
 }
 
 /// Map the proto tee end-reason onto siphon's own enum.
+///
+/// `WsTeeEndReason` is `#[non_exhaustive]` upstream. The wildcard maps to
+/// [`WsTeeEndReason::TransportError`] rather than a silent
+/// [`WsTeeEndReason::Detached`]: `Detached` is the *only* orderly end, and the
+/// dispatcher keys its WARN-when-unexpected logging on that distinction, so
+/// treating an unknown reason as orderly would hide a dead stream on a live
+/// call — the exact failure this event exists to surface.
 fn ws_tee_end_reason_from_proto(reason: ProtoWsTeeEndReason) -> WsTeeEndReason {
     match reason {
         ProtoWsTeeEndReason::Detached => WsTeeEndReason::Detached,
@@ -1333,6 +1522,7 @@ fn ws_tee_end_reason_from_proto(reason: ProtoWsTeeEndReason) -> WsTeeEndReason {
         ProtoWsTeeEndReason::ServerStopped => WsTeeEndReason::ServerStopped,
         ProtoWsTeeEndReason::CallEnded => WsTeeEndReason::CallEnded,
         ProtoWsTeeEndReason::TransportError => WsTeeEndReason::TransportError,
+        _ => WsTeeEndReason::TransportError,
     }
 }
 
@@ -2120,9 +2310,15 @@ mod tests {
             ws_barge_in: true,
             ws_vad_threshold: Some(2_000_000),
             ws_vad_hangover_ms: Some(300),
+            ws_sample_rate: Some(24_000),
+            ws_vad_engine: Some(WsVadEngine::Neural),
+            ws_vad_min_speech_ms: Some(80),
+            beep_detection: true,
+            beep_cadence_guard_ms: Some(3_000),
             ws_tee: Some("wss://asr.invalid/tee".into()),
             ws_tee_direction: Some(WsTeeDirection::Callee),
             ws_tee_channels: Some(1),
+            ws_tee_sample_rate: Some(16_000),
             carry_received_from: true,
             received_from: Some("198.51.100.7".parse().unwrap()),
             rtcp_mux: vec!["require".into()],
@@ -2146,15 +2342,229 @@ mod tests {
             ws_barge_in: true,
             ws_vad_threshold: Some(2_000_000),
             ws_vad_hangover_ms: Some(300),
+            ws_sample_rate: Some(24_000),
+            ws_vad_engine: Some(ProtoWsVadEngine::Neural),
+            ws_vad_min_speech_ms: Some(80),
+            beep_detection: true,
+            beep_cadence_guard_ms: Some(3_000),
             ws_tee: Some("wss://asr.invalid/tee".into()),
             ws_tee_direction: Some(ProtoWsTeeDirection::Callee),
             ws_tee_channels: Some(1),
+            ws_tee_sample_rate: Some(16_000),
             received_from: Some("198.51.100.7".parse().unwrap()),
             rtcp_mux: vec!["require".into()],
             text_events: true,
         };
 
         assert_eq!(profile_flags_from_ng(&ng), expected);
+    }
+
+    /// Each new 0.3.0 profile field must reach the **wire**, not merely the
+    /// struct.  All six carry `skip_serializing_if`, so a field siphon forgot to
+    /// populate is indistinguishable from one it deliberately left unset when
+    /// you compare structs — only the emitted JSON tells them apart.
+    #[test]
+    fn new_profile_fields_reach_the_json_wire() {
+        let ng = NgFlags {
+            ws_uri: Some("wss://ai.invalid/stream".into()),
+            ws_vad: true,
+            ws_sample_rate: Some(16_000),
+            ws_vad_engine: Some(WsVadEngine::Neural),
+            ws_vad_min_speech_ms: Some(80),
+            beep_detection: true,
+            beep_cadence_guard_ms: Some(3_000),
+            ws_tee: Some("wss://asr.invalid/tee".into()),
+            ws_tee_sample_rate: Some(48_000),
+            ..NgFlags::default()
+        };
+
+        let json = serde_json::to_value(profile_flags_from_ng(&ng)).expect("serialize profile");
+
+        assert_eq!(json["ws_sample_rate"], 16_000);
+        assert_eq!(json["ws_vad_engine"], "neural");
+        assert_eq!(json["ws_vad_min_speech_ms"], 80);
+        assert_eq!(json["beep_detection"], true);
+        assert_eq!(json["beep_cadence_guard_ms"], 3_000);
+        assert_eq!(json["ws_tee_sample_rate"], 48_000);
+    }
+
+    /// The mirror of the test above: an unset field must be *absent* from the
+    /// wire, not present as a zero/null.  This is what keeps the default profile
+    /// serialising to `{}` and an older engine seeing a byte-identical command.
+    #[test]
+    fn unset_profile_fields_are_omitted_from_the_wire() {
+        let json =
+            serde_json::to_value(profile_flags_from_ng(&NgFlags::default())).expect("serialize");
+
+        for field in [
+            "ws_sample_rate",
+            "ws_vad_engine",
+            "ws_vad_min_speech_ms",
+            "beep_detection",
+            "beep_cadence_guard_ms",
+            "ws_tee_sample_rate",
+        ] {
+            assert!(
+                json.get(field).is_none(),
+                "{field} must be omitted when unset, got {:?}",
+                json.get(field)
+            );
+        }
+        assert_eq!(json, serde_json::json!({}), "default profile must be empty");
+    }
+
+    /// `energy` is the engine's own default, so siphon must still emit it
+    /// explicitly when a profile names it — otherwise a profile that pinned the
+    /// cheap detector would be indistinguishable from one that expressed no
+    /// preference, and a future change of engine default would silently move it.
+    #[test]
+    fn ws_vad_engine_energy_is_emitted_not_elided() {
+        let ng = NgFlags {
+            ws_vad_engine: Some(WsVadEngine::Energy),
+            ..NgFlags::default()
+        };
+        let json = serde_json::to_value(profile_flags_from_ng(&ng)).expect("serialize");
+        assert_eq!(json["ws_vad_engine"], "energy");
+    }
+
+    #[test]
+    fn beep_detected_event_converts_field_for_field() {
+        let converted = convert_event(Event::BeepDetected {
+            call_id: "call-beep-1".into(),
+            from_tag: "callee-tag".into(),
+            to_tag: Some("caller-tag".into()),
+            frequency_hz: 1_000.5,
+            duration_ms: 420,
+            offset_ms: 7_300,
+        });
+
+        let RtpEngineEvent::BeepDetected(beep) = converted else {
+            panic!("expected a BeepDetected event");
+        };
+        assert_eq!(beep.call_id, "call-beep-1");
+        assert_eq!(beep.from_tag, "callee-tag");
+        assert_eq!(beep.to_tag.as_deref(), Some("caller-tag"));
+        assert!((beep.frequency_hz - 1_000.5).abs() < f32::EPSILON);
+        assert_eq!(beep.duration_ms, 420);
+        // The offset of the *tone*, not of the event — the event trails it by
+        // the cadence guard, so this must be carried through untouched.
+        assert_eq!(beep.offset_ms, 7_300);
+    }
+
+    /// A `to_tag`-less beep (the common single-leg case, where the field is
+    /// skipped on the wire) must still convert.
+    #[test]
+    fn beep_detected_event_without_to_tag_converts() {
+        let converted = convert_event(Event::BeepDetected {
+            call_id: "call-beep-2".into(),
+            from_tag: "callee-tag".into(),
+            to_tag: None,
+            frequency_hz: 425.0,
+            duration_ms: 250,
+            offset_ms: 1_200,
+        });
+
+        let RtpEngineEvent::BeepDetected(beep) = converted else {
+            panic!("expected a BeepDetected event");
+        };
+        assert!(beep.to_tag.is_none());
+    }
+
+    /// Both new play sources must reach the wire under the tagged shape the
+    /// engine reads (`{"source": "...", ...}`).
+    #[test]
+    fn tone_and_http_play_sources_reach_the_wire() {
+        let tone = serde_json::to_value(proto_play_source(&PlayMediaSource::Tone(
+            "425/1000,0/4000*inf".into(),
+        )))
+        .expect("serialize tone");
+        assert_eq!(tone["source"], "tone");
+        assert_eq!(tone["tone"], "425/1000,0/4000*inf");
+
+        let preset =
+            serde_json::to_value(proto_play_source(&PlayMediaSource::Tone("ringback_eu".into())))
+                .expect("serialize preset");
+        assert_eq!(preset["source"], "tone");
+        assert_eq!(preset["tone"], "ringback_eu");
+
+        let http = serde_json::to_value(proto_play_source(&PlayMediaSource::Http(
+            "https://prompts.invalid/welcome.wav".into(),
+        )))
+        .expect("serialize http");
+        assert_eq!(http["source"], "http");
+        assert_eq!(http["url"], "https://prompts.invalid/welcome.wav");
+    }
+
+    /// `set_play_gain` addresses a running playback by its `play_id`; the wire
+    /// shape is what the engine matches on.
+    #[test]
+    fn set_play_gain_command_wire_shape() {
+        let json = serde_json::to_value(Command::SetPlayGain {
+            call_id: "call-gain".into(),
+            from_tag: "leg-a".into(),
+            play_id: 4,
+            gain_decibels: -18,
+            to_tag: None,
+        })
+        .expect("serialize set_play_gain");
+
+        assert_eq!(json["play_id"], 4);
+        assert_eq!(json["gain_decibels"], -18);
+        assert!(json.get("to_tag").is_none(), "unset to_tag must be omitted");
+    }
+
+    /// An overlay play and a targeted stop both travel by `play_id`.
+    #[test]
+    fn overlay_and_targeted_stop_wire_shape() {
+        let play = serde_json::to_value(Command::PlayMedia {
+            call_id: "call-overlay".into(),
+            from_tag: "leg-a".into(),
+            source: ProtoPlayMediaSource::Tone {
+                tone: "ringback_eu".into(),
+            },
+            repeat_times: None,
+            start_pos_ms: None,
+            duration_ms: None,
+            overlay: true,
+            gain_decibels: Some(-12),
+            to_tag: None,
+        })
+        .expect("serialize play_media");
+        assert_eq!(play["overlay"], true);
+        assert_eq!(play["gain_decibels"], -12);
+
+        let stop = serde_json::to_value(Command::StopMedia {
+            call_id: "call-overlay".into(),
+            from_tag: "leg-a".into(),
+            play_id: Some(4),
+        })
+        .expect("serialize stop_media");
+        assert_eq!(stop["play_id"], 4);
+
+        // A supersede play and an untargeted stop must stay byte-identical to
+        // what a pre-0.3.0 engine saw.
+        let plain_stop = serde_json::to_value(Command::StopMedia {
+            call_id: "call-overlay".into(),
+            from_tag: "leg-a".into(),
+            play_id: None,
+        })
+        .expect("serialize stop_media");
+        assert!(plain_stop.get("play_id").is_none());
+    }
+
+    /// The WS tee's wire rate is a distinct knob from the takeover bridge's.
+    #[test]
+    fn attach_ws_tee_carries_sample_rate() {
+        let json = serde_json::to_value(Command::AttachWsTee {
+            call_id: "call-tee".into(),
+            from_tag: "leg-a".into(),
+            ws_uri: "wss://asr.invalid/tee".into(),
+            direction: ProtoWsTeeDirection::Both,
+            channels: Some(2),
+            sample_rate: Some(16_000),
+        })
+        .expect("serialize attach_ws_tee");
+        assert_eq!(json["sample_rate"], 16_000);
     }
 
     /// `carry_received_from` is siphon-side policy, not a wire field: on its own
@@ -2567,10 +2977,13 @@ mod tests {
         let (event_tx, _event_rx) = channel();
         let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         let played = client
-            .play_media("call-play", "tag-a", &play_source(), None, None, None, None, true)
+            .play_media("call-play", "tag-a", &play_source(), None, None, None, None, false, None, true)
             .await
             .unwrap();
-        assert_eq!(played, Some(1234));
+        assert_eq!(played.duration_ms, Some(1234));
+        // The handle must survive alongside the duration so a caller can still
+        // stop or retune the playback it just started.
+        assert_eq!(played.play_id, Some(7));
     }
 
     #[tokio::test]
@@ -2580,10 +2993,10 @@ mod tests {
         let (event_tx, _event_rx) = channel();
         let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         let played = client
-            .play_media("call-play", "tag-a", &play_source(), None, None, None, None, true)
+            .play_media("call-play", "tag-a", &play_source(), None, None, None, None, false, None, true)
             .await
             .unwrap();
-        assert_eq!(played, None);
+        assert_eq!(played.duration_ms, None);
     }
 
     #[tokio::test]
@@ -2595,12 +3008,12 @@ mod tests {
         let client = SiphonRtpClient::new(address, None, 2000, 5_000, event_tx);
         let played = tokio::time::timeout(
             Duration::from_millis(500),
-            client.play_media("call-play", "tag-a", &play_source(), None, None, None, None, false),
+            client.play_media("call-play", "tag-a", &play_source(), None, None, None, None, false, None, false),
         )
         .await
         .expect("play_media(wait=false) must return on accept, not block")
         .unwrap();
-        assert_eq!(played, None);
+        assert_eq!(played.duration_ms, None);
     }
 
     #[tokio::test]
@@ -2613,12 +3026,12 @@ mod tests {
         let client = SiphonRtpClient::new(address, None, 2000, 100, event_tx);
         let played = tokio::time::timeout(
             Duration::from_millis(2000),
-            client.play_media("call-play", "tag-a", &play_source(), None, None, None, None, true),
+            client.play_media("call-play", "tag-a", &play_source(), None, None, None, None, false, None, true),
         )
         .await
         .expect("play_media must give up at the fallback timeout, not hang")
         .unwrap();
-        assert_eq!(played, None);
+        assert_eq!(played.duration_ms, None);
     }
 
     #[tokio::test]

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -16,7 +16,9 @@ use pyo3::types::PyDict;
 use tracing::{debug, warn};
 
 use crate::rtpengine::client::PlayMediaSource;
-use crate::rtpengine::profile::{NgFlags, ProfileRegistry, WsTeeDirection};
+use crate::rtpengine::profile::{
+    validate_ws_sample_rate, NgFlags, ProfileRegistry, WsTeeDirection, WsVadEngine,
+};
 use crate::rtpengine::MediaBackend;
 use crate::rtpengine::RtpEngineError;
 use crate::rtpengine::session::{MediaSession, MediaSessionStore};
@@ -78,19 +80,28 @@ impl PyRtpEngine {
     }
 }
 
-/// Validate exactly-one of ``file``/``blob``/``db_id`` and build a [`PlayMediaSource`].
+/// Validate exactly-one of ``file``/``blob``/``db_id``/``tone``/``url`` and
+/// build a [`PlayMediaSource`].
 fn resolve_play_media_source(
     file: Option<String>,
     blob: Option<Vec<u8>>,
     db_id: Option<u64>,
+    tone: Option<String>,
+    url: Option<String>,
 ) -> PyResult<PlayMediaSource> {
-    let count = [file.is_some(), blob.is_some(), db_id.is_some()]
-        .iter()
-        .filter(|present| **present)
-        .count();
+    let count = [
+        file.is_some(),
+        blob.is_some(),
+        db_id.is_some(),
+        tone.is_some(),
+        url.is_some(),
+    ]
+    .iter()
+    .filter(|present| **present)
+    .count();
     if count != 1 {
         return Err(pyo3::exceptions::PyValueError::new_err(
-            "play_media requires exactly one of file=, blob=, or db_id="
+            "play_media requires exactly one of file=, blob=, db_id=, tone=, or url="
                 .to_string(),
         ));
     }
@@ -103,7 +114,52 @@ fn resolve_play_media_source(
     if let Some(id) = db_id {
         return Ok(PlayMediaSource::DbId(id));
     }
+    if let Some(spec) = tone {
+        return Ok(PlayMediaSource::Tone(validate_tone(spec)?));
+    }
+    if let Some(location) = url {
+        return Ok(PlayMediaSource::Http(validate_http_url(location)?));
+    }
     unreachable!("count == 1 guaranteed one branch above")
+}
+
+/// Reject an empty tone spec before it reaches the engine.
+///
+/// The engine tells a **preset name** from a **cadence spec** by the `/` (a
+/// preset never contains one; a cadence spec is never valid without one), so
+/// both forms are accepted verbatim — siphon deliberately does not keep its own
+/// copy of the preset table, which would go stale against the engine's the first
+/// time a preset is added.  Only the one thing that is wrong under either
+/// reading is caught here.
+fn validate_tone(spec: String) -> PyResult<String> {
+    if spec.trim().is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "play_media tone= must be a preset name (e.g. \"ringback_eu\") or a \
+             cadence spec (e.g. \"425/1000,0/4000*inf\"), not an empty string"
+                .to_string(),
+        ));
+    }
+    Ok(spec)
+}
+
+/// Reject a URL scheme the engine will not fetch.
+///
+/// The **engine** performs this fetch from its own network position, bounded by
+/// its own connect / first-byte / deadline / size / redirect caps and run off
+/// the media path, so a URL that never answers ends the *playback* (a
+/// play-finished `error`) and never stalls the leg.  siphon deliberately does
+/// not fetch it here: doing so would put an unbounded third-party HTTP
+/// round-trip on the call-setup path, which is the failure mode this design
+/// avoids.  What is checked here is only the part the engine would reject
+/// outright.
+fn validate_http_url(url: String) -> PyResult<String> {
+    let lowered = url.trim().to_ascii_lowercase();
+    if !(lowered.starts_with("http://") || lowered.starts_with("https://")) {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "play_media url= must be an http:// or https:// URL, got {url:?}"
+        )));
+    }
+    Ok(url)
 }
 
 /// Default profile name when none is specified.
@@ -233,6 +289,94 @@ fn resolve_ws_uri(
     profile_ws_uri.map(|uri| uri.to_string())
 }
 
+/// The 0.3.0 media knobs a script can override for **one call**, on top of
+/// whatever its `media.profiles` entry set.
+///
+/// Same model as the existing per-call `ws_uri=`: `None` means "leave the
+/// profile's value alone", so passing nothing emits exactly the command a
+/// pre-override build did.  These are the knobs whose right value genuinely
+/// varies per call rather than per deployment — arming beep detection only on
+/// the leg being transferred, or matching the wire rate to the model a
+/// particular AI backend expects.
+#[derive(Debug, Clone, Copy, Default)]
+struct MediaOverrides {
+    beep_detection: Option<bool>,
+    beep_cadence_guard_ms: Option<u32>,
+    ws_sample_rate: Option<u32>,
+    ws_tee_sample_rate: Option<u32>,
+    ws_vad_min_speech_ms: Option<u32>,
+    ws_vad_engine: Option<WsVadEngine>,
+}
+
+impl MediaOverrides {
+    /// Parse the raw keyword values, rejecting anything the engine would refuse.
+    ///
+    /// The two sample rates are validated here rather than at the engine: the
+    /// engine *fails the offer* on a bad rate instead of clamping, so a script
+    /// that passed one would get a call that answers and never carries media.
+    fn parse(
+        beep_detection: Option<bool>,
+        beep_cadence_guard_ms: Option<u32>,
+        ws_sample_rate: Option<u32>,
+        ws_tee_sample_rate: Option<u32>,
+        ws_vad_min_speech_ms: Option<u32>,
+        ws_vad_engine: Option<&str>,
+    ) -> PyResult<Self> {
+        for (field, rate) in [
+            ("ws_sample_rate", ws_sample_rate),
+            ("ws_tee_sample_rate", ws_tee_sample_rate),
+        ] {
+            if let Some(rate) = rate {
+                validate_ws_sample_rate(rate).map_err(|reason| {
+                    pyo3::exceptions::PyValueError::new_err(format!("{field} {reason}"))
+                })?;
+            }
+        }
+
+        let ws_vad_engine = match ws_vad_engine {
+            None => None,
+            Some(value) => Some(WsVadEngine::parse(value).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "ws_vad_engine must be one of {}, got {value:?}",
+                    WsVadEngine::VALUES.join(" / ")
+                ))
+            })?),
+        };
+
+        Ok(Self {
+            beep_detection,
+            beep_cadence_guard_ms,
+            ws_sample_rate,
+            ws_tee_sample_rate,
+            ws_vad_min_speech_ms,
+            ws_vad_engine,
+        })
+    }
+
+    /// Overlay the set values onto the profile's flags.
+    fn apply(self, flags: &mut NgFlags) -> PyResult<()> {
+        if let Some(value) = self.beep_detection {
+            flags.beep_detection = value;
+        }
+        if let Some(value) = self.beep_cadence_guard_ms {
+            flags.beep_cadence_guard_ms = Some(value);
+        }
+        if let Some(value) = self.ws_sample_rate {
+            flags.ws_sample_rate = Some(value);
+        }
+        if let Some(value) = self.ws_tee_sample_rate {
+            flags.ws_tee_sample_rate = Some(value);
+        }
+        if let Some(value) = self.ws_vad_min_speech_ms {
+            flags.ws_vad_min_speech_ms = Some(value);
+        }
+        if let Some(value) = self.ws_vad_engine {
+            flags.ws_vad_engine = Some(value);
+        }
+        Ok(())
+    }
+}
+
 /// Apply the per-call WebSocket URI and `received_from` address to a profile's
 /// resolved flags, and reject flags the configured backend cannot honour.
 ///
@@ -246,12 +390,14 @@ fn finalise_flags(
     mut flags: NgFlags,
     backend: &MediaBackend,
     ws_uri: Option<String>,
+    overrides: MediaOverrides,
     source_ip: Option<&str>,
     profile_name: &str,
 ) -> PyResult<NgFlags> {
     if let Some(uri) = ws_uri {
         flags.ws_uri = Some(uri);
     }
+    overrides.apply(&mut flags)?;
     if flags.carry_received_from {
         match source_ip.and_then(|ip| ip.parse::<std::net::IpAddr>().ok()) {
             Some(address) => flags.received_from = Some(address),
@@ -439,13 +585,42 @@ impl PyRtpEngine {
     ///             ``{from_tag}``, ``{from_user}`` and ``{to_user}``
     ///             placeholders. The resolved URI is recorded on the media
     ///             session, so a later ``answer`` reuses it automatically.
-    #[pyo3(signature = (request, profile=None, ws_uri=None))]
+    ///     beep_detection: Arm the record-tone ("voicemail beep") detector on this
+    ///             leg for this call, overriding the profile. Arming it on the leg
+    ///             toward the callee is what watches the party that might be a
+    ///             machine; the tone arrives as ``@rtpengine.on_beep``, once per
+    ///             leg per call. ``siphon-rtp`` backend only.
+    ///     beep_cadence_guard_ms: How long the detector waits after a candidate
+    ///             tone to rule out a cadenced ringback/busy tone. **Also the
+    ///             detection latency** — the event trails the tone by this long.
+    ///             Unset uses the engine default (4500 ms).
+    ///     ws_sample_rate: L16 wire rate in Hz for the ``ws_uri`` bridge,
+    ///             independent of the leg's codec rate and applied both ways.
+    ///             Must be a multiple of 1000 within 8000-48000 (the engine fails
+    ///             the offer rather than clamping, so it is checked here).
+    ///     ws_tee_sample_rate: L16 wire rate in Hz for the ``ws_tee`` copy. Same
+    ///             range rule; send-only, so it never changes what the call hears.
+    ///     ws_vad_engine: Which uplink VAD to run — ``"energy"`` (cheap; any loud
+    ///             sound reads as speech) or ``"neural"`` (answers "is this
+    ///             speech", so it does not turn-start on noise).
+    ///     ws_vad_min_speech_ms: **Leading** minimum continuous-speech run before
+    ///             the speech-start edge (and barge-in) fires — distinct from the
+    ///             trailing hangover. Rounded up to whole ptime frames and added
+    ///             to turn-start latency, so 60-120 ms is the useful range.
+    #[pyo3(signature = (request, profile=None, ws_uri=None, beep_detection=None, beep_cadence_guard_ms=None, ws_sample_rate=None, ws_tee_sample_rate=None, ws_vad_engine=None, ws_vad_min_speech_ms=None))]
+    #[allow(clippy::too_many_arguments)]
     fn offer<'py>(
         &self,
         python: Python<'py>,
         request: &Bound<'py, PyAny>,
         profile: Option<&str>,
         ws_uri: Option<&str>,
+        beep_detection: Option<bool>,
+        beep_cadence_guard_ms: Option<u32>,
+        ws_sample_rate: Option<u32>,
+        ws_tee_sample_rate: Option<u32>,
+        ws_vad_engine: Option<&str>,
+        ws_vad_min_speech_ms: Option<u32>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let profile_name = profile.unwrap_or(DEFAULT_PROFILE);
         let entry = self.registry.get(profile_name).ok_or_else(|| {
@@ -484,10 +659,19 @@ impl PyRtpEngine {
             }
             None => None,
         };
+        let overrides = MediaOverrides::parse(
+            beep_detection,
+            beep_cadence_guard_ms,
+            ws_sample_rate,
+            ws_tee_sample_rate,
+            ws_vad_min_speech_ms,
+            ws_vad_engine,
+        )?;
         let flags = finalise_flags(
             flags,
             &self.client,
             resolved_ws_uri.clone(),
+            overrides,
             source_ip.as_deref(),
             profile_name,
         )?;
@@ -592,7 +776,21 @@ impl PyRtpEngine {
     ///             backend only). When omitted, the URI recorded by the matching
     ///             ``offer`` is reused, then the resolved profile's own —
     ///             the same precedence as ``profile``.
-    #[pyo3(signature = (reply, profile=None, call=None, ws_uri=None))]
+    ///     beep_detection: Arm the record-tone ("voicemail beep") detector on this
+    ///             leg for this call, overriding the profile. Delivered as
+    ///             ``@rtpengine.on_beep``, once per leg per call. ``siphon-rtp``
+    ///             backend only.
+    ///     beep_cadence_guard_ms: Cadence guard for the beep detector, and also
+    ///             its detection latency. Unset uses the engine default (4500 ms).
+    ///     ws_sample_rate: L16 wire rate in Hz for the ``ws_uri`` bridge. Must be
+    ///             a multiple of 1000 within 8000-48000.
+    ///     ws_tee_sample_rate: L16 wire rate in Hz for the ``ws_tee`` copy. Same
+    ///             range rule; send-only.
+    ///     ws_vad_engine: ``"energy"`` or ``"neural"`` uplink VAD.
+    ///     ws_vad_min_speech_ms: Leading minimum continuous-speech run before the
+    ///             speech-start edge fires (60-120 ms is the useful range).
+    #[pyo3(signature = (reply, profile=None, call=None, ws_uri=None, beep_detection=None, beep_cadence_guard_ms=None, ws_sample_rate=None, ws_tee_sample_rate=None, ws_vad_engine=None, ws_vad_min_speech_ms=None))]
+    #[allow(clippy::too_many_arguments)]
     fn answer<'py>(
         &self,
         python: Python<'py>,
@@ -600,6 +798,12 @@ impl PyRtpEngine {
         profile: Option<&str>,
         call: Option<&Bound<'py, PyAny>>,
         ws_uri: Option<&str>,
+        beep_detection: Option<bool>,
+        beep_cadence_guard_ms: Option<u32>,
+        ws_sample_rate: Option<u32>,
+        ws_tee_sample_rate: Option<u32>,
+        ws_vad_engine: Option<&str>,
+        ws_vad_min_speech_ms: Option<u32>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let message = extract_message(reply)?;
 
@@ -659,10 +863,19 @@ impl PyRtpEngine {
         // A reply carries no source address of its own; when the script passed
         // `call=`, that object does.
         let source_ip = call.and_then(|object| extract_source_ip(object));
+        let overrides = MediaOverrides::parse(
+            beep_detection,
+            beep_cadence_guard_ms,
+            ws_sample_rate,
+            ws_tee_sample_rate,
+            ws_vad_min_speech_ms,
+            ws_vad_engine,
+        )?;
         let flags = finalise_flags(
             flags,
             &self.client,
             resolved_ws_uri,
+            overrides,
             source_ip.as_deref(),
             &profile_name,
         )?;
@@ -734,7 +947,21 @@ impl PyRtpEngine {
     /// Returns:
     ///     The answer SDP as ``str`` on success, or ``None`` when the offer had
     ///     no encodable codec and it was auto-rejected with a 488.
-    #[pyo3(signature = (call, profile=None, auto_reject=true, ws_uri=None))]
+    ///     beep_detection: Arm the record-tone ("voicemail beep") detector on this
+    ///             leg for this call, overriding the profile. Delivered as
+    ///             ``@rtpengine.on_beep``, once per leg per call. ``siphon-rtp``
+    ///             backend only.
+    ///     beep_cadence_guard_ms: Cadence guard for the beep detector, and also
+    ///             its detection latency. Unset uses the engine default (4500 ms).
+    ///     ws_sample_rate: L16 wire rate in Hz for the ``ws_uri`` bridge. Must be
+    ///             a multiple of 1000 within 8000-48000.
+    ///     ws_tee_sample_rate: L16 wire rate in Hz for the ``ws_tee`` copy. Same
+    ///             range rule; send-only.
+    ///     ws_vad_engine: ``"energy"`` or ``"neural"`` uplink VAD.
+    ///     ws_vad_min_speech_ms: Leading minimum continuous-speech run before the
+    ///             speech-start edge fires (60-120 ms is the useful range).
+    #[pyo3(signature = (call, profile=None, auto_reject=true, ws_uri=None, beep_detection=None, beep_cadence_guard_ms=None, ws_sample_rate=None, ws_tee_sample_rate=None, ws_vad_engine=None, ws_vad_min_speech_ms=None))]
+    #[allow(clippy::too_many_arguments)]
     fn answer_local<'py>(
         &self,
         python: Python<'py>,
@@ -742,6 +969,12 @@ impl PyRtpEngine {
         profile: Option<&str>,
         auto_reject: bool,
         ws_uri: Option<&str>,
+        beep_detection: Option<bool>,
+        beep_cadence_guard_ms: Option<u32>,
+        ws_sample_rate: Option<u32>,
+        ws_tee_sample_rate: Option<u32>,
+        ws_vad_engine: Option<&str>,
+        ws_vad_min_speech_ms: Option<u32>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let message = extract_message(call)?;
         let (call_id, from_tag, offer_sdp_bytes) = extract_offer_params(&message)?;
@@ -780,10 +1013,19 @@ impl PyRtpEngine {
             }
             None => None,
         };
+        let overrides = MediaOverrides::parse(
+            beep_detection,
+            beep_cadence_guard_ms,
+            ws_sample_rate,
+            ws_tee_sample_rate,
+            ws_vad_min_speech_ms,
+            ws_vad_engine,
+        )?;
         let flags = finalise_flags(
             flags,
             &self.client,
             resolved_ws_uri.clone(),
+            overrides,
             source_ip.as_deref(),
             &profile_name,
         )?;
@@ -902,7 +1144,8 @@ impl PyRtpEngine {
 
     /// Send a `play media` command — inject an audio prompt into the call.
     ///
-    /// Exactly one of ``file``, ``blob``, or ``db_id`` must be supplied.
+    /// Exactly one of ``file``, ``blob``, ``db_id``, ``tone`` or ``url`` must be
+    /// supplied.
     ///
     /// Per rtpengine semantics, ``from-tag`` selects the monologue whose
     /// outgoing audio is replaced by the prompt — the peer of that monologue
@@ -920,6 +1163,24 @@ impl PyRtpEngine {
     ///     file: Absolute path to an audio file on the rtpengine host.
     ///     blob: Raw audio bytes to play (e.g. TTS output).
     ///     db_id: Reference to a prompt stored in rtpengine's prompt DB.
+    ///     tone: A synthesised call-progress tone — no audio file to provision.
+    ///           Either a preset name (``"ringback_eu"``, ``"busy_na"``,
+    ///           ``"dial_uk"``, …) or an explicit cadence spec in the engine's
+    ///           tone grammar (``"425/1000,0/4000*inf"`` = 425 Hz one second on,
+    ///           four seconds off, forever). The two are told apart by the
+    ///           ``/``. Rendered at the leg's codec rate, so never resampled.
+    ///           Native **siphon-rtp** backend only.
+    ///     url: An ``http://`` / ``https://`` WAV the **engine** fetches from its
+    ///          own network position. The fetch is bounded engine-side (connect,
+    ///          first-byte, overall deadline, size cap, redirect cap) and runs
+    ///          off the media path, so a URL that never answers ends the
+    ///          *playback*, never the leg — it comes back as a play that
+    ///          produced no audio rather than a stalled call. The accept carries
+    ///          no duration (the length is unknown until the body arrives).
+    ///          Native **siphon-rtp** backend only.
+    ///     gain_decibels: Playout gain in whole decibels relative to the
+    ///           source's own level, clamped engine-side to −60..=+12. Native
+    ///           **siphon-rtp** backend only.
     ///     repeat: Number of times to repeat the prompt (default: 1).
     ///     start_ms: Offset into the file at which to start (milliseconds).
     ///     duration_ms: Cap on playback length (milliseconds).
@@ -937,7 +1198,7 @@ impl PyRtpEngine {
     ///     The played duration in milliseconds if the engine reports one, else
     ///     ``None`` (also ``None`` when the prompt was stopped / superseded before
     ///     it finished, or the fallback timeout elapsed).
-    #[pyo3(signature = (target, file=None, blob=None, db_id=None, repeat=None, start_ms=None, duration_ms=None, to_tag=None, wait=true))]
+    #[pyo3(signature = (target, file=None, blob=None, db_id=None, tone=None, url=None, repeat=None, start_ms=None, duration_ms=None, gain_decibels=None, to_tag=None, wait=true))]
     #[allow(clippy::too_many_arguments)]
     fn play_media<'py>(
         &self,
@@ -946,20 +1207,23 @@ impl PyRtpEngine {
         file: Option<String>,
         blob: Option<Vec<u8>>,
         db_id: Option<u64>,
+        tone: Option<String>,
+        url: Option<String>,
         repeat: Option<u64>,
         start_ms: Option<u64>,
         duration_ms: Option<u64>,
+        gain_decibels: Option<i32>,
         to_tag: Option<String>,
         wait: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let source = resolve_play_media_source(file, blob, db_id)?;
+        let source = resolve_play_media_source(file, blob, db_id, tone, url)?;
 
         let (call_id, from_tag) = resolve_call_from_tag(target)?;
 
         let client = Arc::clone(&self.client);
 
         pyo3_async_runtimes::tokio::future_into_py(python, async move {
-            let duration = client
+            let outcome = client
                 .play_media(
                     &call_id,
                     &from_tag,
@@ -968,6 +1232,9 @@ impl PyRtpEngine {
                     start_ms,
                     duration_ms,
                     to_tag.as_deref(),
+                    // Superseding playback — `play_overlay` is the additive twin.
+                    false,
+                    gain_decibels,
                     wait,
                 )
                 .await
@@ -976,30 +1243,185 @@ impl PyRtpEngine {
                         "rtpengine.play_media failed: {error}"
                     ))
                 })?;
-            debug!(call_id = %call_id, duration_ms = ?duration, "rtpengine play_media");
-            Ok(duration)
+            debug!(
+                call_id = %call_id,
+                duration_ms = ?outcome.duration_ms,
+                "rtpengine play_media"
+            );
+            Ok(outcome.duration_ms)
         })
     }
 
-    /// Send a `stop media` command — stop any prompt currently playing on the
-    /// monologue selected by the SIP object's From-tag.
-    #[pyo3(signature = (target,))]
+    /// Start an **overlay** playback — mix audio *under* the party's live egress
+    /// instead of replacing it, and return its ``play_id`` handle.
+    ///
+    /// The additive twin of :meth:`play_media`. Where ``play_media`` answers
+    /// "how long did it play", this answers "which playback is it", because that
+    /// is what an overlay is for: a music bed you will duck with
+    /// :meth:`set_play_gain` and stop individually with
+    /// ``stop_media(target, play_id=...)``.
+    ///
+    /// Up to **four** overlays run concurrently per direction, each with its own
+    /// ``play_id`` and its own completion. Starting a fifth is rejected rather
+    /// than displacing one — a script that lost a playback it believes is
+    /// running has no way to notice. An overlay never supersedes anything,
+    /// including another overlay.
+    ///
+    /// Returns immediately on the engine's accept (an overlay is background
+    /// audio; there is no ``wait``). Native **siphon-rtp** backend only.
+    ///
+    /// ```python,ignore
+    /// bed = await rtpengine.play_overlay(call, file="/prompts/hold.wav", repeat=0)
+    /// await rtpengine.play_media(call, file="/prompts/agent.wav")
+    /// await rtpengine.set_play_gain(call, bed, -18)   # duck the bed
+    /// await rtpengine.stop_media(call, play_id=bed)
+    /// ```
+    ///
+    /// Args:
+    ///     target: Request, Reply, or Call object.
+    ///     file / blob / db_id / tone / url: exactly one, as for
+    ///         :meth:`play_media`.
+    ///     repeat: Number of times to repeat.
+    ///     start_ms: Offset into the source at which to start.
+    ///     duration_ms: Hard playout cap — the only bound, short of a stop, on
+    ///         an endless (``*inf``) tone.
+    ///     gain_decibels: Playout gain relative to the source's own level,
+    ///         clamped engine-side to −60..=+12.
+    ///     to_tag: Optional peer tag for MPTY scoping.
+    ///
+    /// Returns:
+    ///     The ``play_id`` of the started overlay, or ``None`` if the engine
+    ///     assigned none.
+    #[pyo3(signature = (target, file=None, blob=None, db_id=None, tone=None, url=None, repeat=None, start_ms=None, duration_ms=None, gain_decibels=None, to_tag=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn play_overlay<'py>(
+        &self,
+        python: Python<'py>,
+        target: &Bound<'py, PyAny>,
+        file: Option<String>,
+        blob: Option<Vec<u8>>,
+        db_id: Option<u64>,
+        tone: Option<String>,
+        url: Option<String>,
+        repeat: Option<u64>,
+        start_ms: Option<u64>,
+        duration_ms: Option<u64>,
+        gain_decibels: Option<i32>,
+        to_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let source = resolve_play_media_source(file, blob, db_id, tone, url)?;
+
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
+
+        let client = Arc::clone(&self.client);
+
+        pyo3_async_runtimes::tokio::future_into_py(python, async move {
+            let outcome = client
+                .play_media(
+                    &call_id,
+                    &from_tag,
+                    &source,
+                    repeat,
+                    start_ms,
+                    duration_ms,
+                    to_tag.as_deref(),
+                    true,
+                    gain_decibels,
+                    // An overlay is background audio: blocking until it drains
+                    // would defeat the point (and an endless tone never drains).
+                    false,
+                )
+                .await
+                .map_err(|error| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "rtpengine.play_overlay failed: {error}"
+                    ))
+                })?;
+            debug!(
+                call_id = %call_id,
+                play_id = ?outcome.play_id,
+                "rtpengine play_overlay"
+            );
+            Ok(outcome.play_id)
+        })
+    }
+
+    /// Send a `stop media` command — stop prompt playback on the monologue
+    /// selected by the SIP object's From-tag.
+    ///
+    /// ``play_id`` stops one specific playback (an individual overlay slot, from
+    /// :meth:`play_overlay`); omitting it stops everything playing on the leg.
+    /// A ``play_id`` is native **siphon-rtp** only — the other backends have no
+    /// handle on an individual playback, and are refused rather than widened
+    /// into "stop everything", which would kill playbacks the script meant to
+    /// keep running.
+    #[pyo3(signature = (target, play_id=None))]
     fn stop_media<'py>(
         &self,
         python: Python<'py>,
         target: &Bound<'py, PyAny>,
+        play_id: Option<u64>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let (call_id, from_tag) = resolve_call_from_tag(target)?;
 
         let client = Arc::clone(&self.client);
 
         pyo3_async_runtimes::tokio::future_into_py(python, async move {
-            client.stop_media(&call_id, &from_tag).await.map_err(|error| {
+            client.stop_media(&call_id, &from_tag, play_id).await.map_err(|error| {
                 pyo3::exceptions::PyRuntimeError::new_err(format!(
                     "rtpengine.stop_media failed: {error}"
                 ))
             })?;
-            debug!(call_id = %call_id, "rtpengine stop_media");
+            debug!(call_id = %call_id, play_id = ?play_id, "rtpengine stop_media");
+            Ok(true)
+        })
+    }
+
+    /// Retune the playout gain of a playback that is already running — how a
+    /// script ducks a music bed under a prompt and lifts it again afterwards.
+    ///
+    /// A separate verb rather than a field on :meth:`play_media` because
+    /// ``play_media`` is a *start*: reusing it would mean "start another
+    /// playback", not "change this one".
+    ///
+    /// The engine answers an error when no playback on the call holds that
+    /// ``play_id``, so a stale handle raises rather than silently doing nothing.
+    /// Native **siphon-rtp** backend only.
+    ///
+    /// Args:
+    ///     target: Request, Reply, or Call object.
+    ///     play_id: The running playback to retune, from :meth:`play_overlay`.
+    ///     gain_decibels: New gain in whole decibels, clamped engine-side to
+    ///         −60..=+12.
+    ///     to_tag: Optional peer tag for MPTY scoping.
+    #[pyo3(signature = (target, play_id, gain_decibels, to_tag=None))]
+    fn set_play_gain<'py>(
+        &self,
+        python: Python<'py>,
+        target: &Bound<'py, PyAny>,
+        play_id: u64,
+        gain_decibels: i32,
+        to_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let (call_id, from_tag) = resolve_call_from_tag(target)?;
+
+        let client = Arc::clone(&self.client);
+
+        pyo3_async_runtimes::tokio::future_into_py(python, async move {
+            client
+                .set_play_gain(&call_id, &from_tag, play_id, gain_decibels, to_tag.as_deref())
+                .await
+                .map_err(|error| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "rtpengine.set_play_gain failed: {error}"
+                    ))
+                })?;
+            debug!(
+                call_id = %call_id,
+                play_id,
+                gain_decibels,
+                "rtpengine set_play_gain"
+            );
             Ok(true)
         })
     }
@@ -1314,7 +1736,12 @@ impl PyRtpEngine {
     ///         stereo, ``1`` mixes them to mono.  Only meaningful with
     ///         ``direction="both"``; a single-leg tee is always mono.  ``None``
     ///         (default) leaves the engine's choice: 2 for both legs, 1 for one.
-    #[pyo3(signature = (target, ws_uri, direction="both", channels=None))]
+    ///     sample_rate: L16 wire sample rate in Hz, independent of the legs'
+    ///         codec rates — the engine resamples the teed copy into it. Must be
+    ///         a multiple of 1000 within 8000–48000; the engine *fails* the
+    ///         attach on anything else rather than clamping, so it is checked
+    ///         here first. ``None`` (default) leaves the engine's choice.
+    #[pyo3(signature = (target, ws_uri, direction="both", channels=None, sample_rate=None))]
     fn attach_ws_tee<'py>(
         &self,
         python: Python<'py>,
@@ -1322,6 +1749,7 @@ impl PyRtpEngine {
         ws_uri: String,
         direction: &str,
         channels: Option<u8>,
+        sample_rate: Option<u32>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let (call_id, from_tag) = resolve_call_from_tag(target)?;
 
@@ -1342,11 +1770,22 @@ impl PyRtpEngine {
             }
         }
 
+        // Same reason as `channels`: the engine fails the attach on a bad rate
+        // rather than clamping, so catching it here gives the script the precise
+        // rule instead of a generic engine rejection.
+        if let Some(rate) = sample_rate {
+            validate_ws_sample_rate(rate).map_err(|reason| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "rtpengine.attach_ws_tee sample_rate {reason}"
+                ))
+            })?;
+        }
+
         let client = Arc::clone(&self.client);
 
         pyo3_async_runtimes::tokio::future_into_py(python, async move {
             client
-                .attach_ws_tee(&call_id, &from_tag, &ws_uri, direction, channels)
+                .attach_ws_tee(&call_id, &from_tag, &ws_uri, direction, channels, sample_rate)
                 .await
                 .map_err(|error| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
@@ -1359,6 +1798,7 @@ impl PyRtpEngine {
                 ws_uri = %ws_uri,
                 direction = %direction.as_str(),
                 ?channels,
+                ?sample_rate,
                 "rtpengine attach_ws_tee"
             );
             Ok(true)
@@ -1643,6 +2083,73 @@ def make_decorator(call_id, from_tag):
 
         // Support both `@on_ws_tee_started` (bare) and
         // `@on_ws_tee_started(call_id=...)` forms.
+        match func_or_none {
+            Some(func) => decorator.call1((func.bind(python),)),
+            None => Ok(decorator),
+        }
+    }
+
+    /// Register a handler for **record-tone (voicemail beep)** events.
+    ///
+    /// Fires when the engine hears the short single tone an answering machine
+    /// plays before it starts recording, on a leg whose media profile set
+    /// ``beep_detection``.  This is the *media* half of answering-machine
+    /// detection: a script can abort an attended transfer here instead of
+    /// bridging the caller into a voicemail box.
+    ///
+    /// Arm it **per leg** — the profile used toward the callee is what watches
+    /// the party that might be a machine.  It fires **once per leg per call**
+    /// (the engine drops the detector after the first tone, so a handler never
+    /// has to de-duplicate, and there is no mid-call re-arm).
+    ///
+    /// ``offset_ms`` is how much decoded audio was seen on the leg before the
+    /// tone **started** — the offset of the tone itself, *not* of this event.
+    /// The event trails it by roughly the profile's ``beep_cadence_guard_ms``
+    /// (4500 ms by default), which is the detector's cadence guard *and* its
+    /// detection latency.
+    ///
+    /// Delivered by the native **siphon-rtp** backend only.
+    ///
+    /// ```python,ignore
+    /// @rtpengine.on_beep
+    /// def machine(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    ///     log.info(f"{call_id}: answering machine ({frequency_hz:.0f} Hz)")
+    ///     b2bua.terminate(call_id, "Answering machine detected")
+    /// ```
+    ///
+    /// Args:
+    ///     func_or_none: When applied directly (``@rtpengine.on_beep``) this is
+    ///         the function.  When called with keyword filters the return value
+    ///         is a decorator.
+    ///     call_id: Optional engine call-id filter.
+    ///     from_tag: Optional from-tag filter.
+    #[pyo3(signature = (func_or_none=None, *, call_id=None, from_tag=None))]
+    fn on_beep<'py>(
+        &self,
+        python: Python<'py>,
+        func_or_none: Option<Py<PyAny>>,
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let code = r#"
+def make_decorator(call_id, from_tag):
+    import asyncio
+    import _siphon_registry
+    def decorator(fn):
+        is_async = asyncio.iscoroutinefunction(fn)
+        metadata = {"call_id": call_id, "from_tag": from_tag}
+        _siphon_registry.register("rtpengine.on_beep", None, fn, is_async, metadata)
+        return fn
+    return decorator
+"#;
+        let globals = PyDict::new(python);
+        python.run(&std::ffi::CString::new(code)?, Some(&globals), None)?;
+        let make_decorator = globals.get_item("make_decorator")?.ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("failed to build on_beep decorator")
+        })?;
+        let decorator = make_decorator.call1((call_id, from_tag))?;
+
+        // Support both `@on_beep` (bare) and `@on_beep(call_id=...)` forms.
         match func_or_none {
             Some(func) => decorator.call1((func.bind(python),)),
             None => Ok(decorator),
@@ -2041,6 +2548,8 @@ mod tests {
             Some("/tmp/a.wav".to_string()),
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
         assert!(matches!(source, PlayMediaSource::File(ref path) if path == "/tmp/a.wav"));
@@ -2053,6 +2562,8 @@ mod tests {
             None,
             Some(vec![0x00, 0xff]),
             None,
+            None,
+            None,
         )
         .unwrap();
         assert!(matches!(source, PlayMediaSource::Blob(ref bytes) if bytes == &[0x00, 0xff]));
@@ -2061,14 +2572,173 @@ mod tests {
     #[test]
     fn resolve_play_media_source_db_id() {
         pyo3::Python::initialize();
-        let source = resolve_play_media_source(None, None, Some(7)).unwrap();
+        let source = resolve_play_media_source(None, None, Some(7), None, None).unwrap();
         assert!(matches!(source, PlayMediaSource::DbId(7)));
+    }
+
+    #[test]
+    fn resolve_play_media_source_tone_preset_and_cadence() {
+        pyo3::Python::initialize();
+        // Both forms are accepted verbatim — the engine tells them apart by the
+        // `/`, and siphon deliberately keeps no copy of the preset table, which
+        // would go stale the first time the engine adds a preset.
+        let preset =
+            resolve_play_media_source(None, None, None, Some("ringback_eu".to_string()), None)
+                .unwrap();
+        assert!(matches!(preset, PlayMediaSource::Tone(ref t) if t == "ringback_eu"));
+
+        let cadence = resolve_play_media_source(
+            None,
+            None,
+            None,
+            Some("425/1000,0/4000*inf".to_string()),
+            None,
+        )
+        .unwrap();
+        assert!(matches!(cadence, PlayMediaSource::Tone(ref t) if t == "425/1000,0/4000*inf"));
+    }
+
+    #[test]
+    fn resolve_play_media_source_empty_tone_rejected() {
+        pyo3::Python::initialize();
+        let error =
+            resolve_play_media_source(None, None, None, Some("   ".to_string()), None).unwrap_err();
+        Python::attach(|py| {
+            assert!(error.value(py).to_string().contains("tone="));
+        });
+    }
+
+    #[test]
+    fn resolve_play_media_source_http_url() {
+        pyo3::Python::initialize();
+        for url in [
+            "http://prompts.invalid/a.wav",
+            "https://prompts.invalid/a.wav",
+            // Scheme match is case-insensitive, but the URL is passed through
+            // unchanged — the engine, not siphon, is what fetches it.
+            "HTTPS://prompts.invalid/a.wav",
+        ] {
+            let source =
+                resolve_play_media_source(None, None, None, None, Some(url.to_string())).unwrap();
+            assert!(matches!(source, PlayMediaSource::Http(ref got) if got == url));
+        }
+    }
+
+    #[test]
+    fn resolve_play_media_source_non_http_url_rejected() {
+        pyo3::Python::initialize();
+        for url in ["file:///etc/passwd", "ftp://host/a.wav", "prompts/a.wav"] {
+            let error =
+                resolve_play_media_source(None, None, None, None, Some(url.to_string()))
+                    .unwrap_err();
+            Python::attach(|py| {
+                assert!(
+                    error.value(py).to_string().contains("http://"),
+                    "error must state the accepted schemes for {url}"
+                );
+            });
+        }
+    }
+
+    /// The new sources join the same exactly-one rule as the old ones, so a
+    /// script cannot send an ambiguous command.
+    #[test]
+    fn resolve_play_media_source_tone_and_url_are_mutually_exclusive() {
+        pyo3::Python::initialize();
+        let error = resolve_play_media_source(
+            None,
+            None,
+            None,
+            Some("ringback_eu".to_string()),
+            Some("https://prompts.invalid/a.wav".to_string()),
+        )
+        .unwrap_err();
+        Python::attach(|py| {
+            assert!(error.value(py).to_string().contains("exactly one"));
+        });
+
+        let with_file = resolve_play_media_source(
+            Some("/tmp/a.wav".to_string()),
+            None,
+            None,
+            Some("ringback_eu".to_string()),
+            None,
+        )
+        .unwrap_err();
+        Python::attach(|py| {
+            assert!(with_file.value(py).to_string().contains("exactly one"));
+        });
+    }
+
+    /// A per-call override must reach the flags, and a bad one must raise rather
+    /// than reach an engine that would fail the whole offer.
+    #[test]
+    fn media_overrides_apply_and_validate() {
+        pyo3::Python::initialize();
+
+        let overrides = MediaOverrides::parse(
+            Some(true),
+            Some(3_000),
+            Some(16_000),
+            Some(48_000),
+            Some(80),
+            Some("neural"),
+        )
+        .unwrap();
+        let mut flags = NgFlags::default();
+        overrides.apply(&mut flags).unwrap();
+        assert!(flags.beep_detection);
+        assert_eq!(flags.beep_cadence_guard_ms, Some(3_000));
+        assert_eq!(flags.ws_sample_rate, Some(16_000));
+        assert_eq!(flags.ws_tee_sample_rate, Some(48_000));
+        assert_eq!(flags.ws_vad_min_speech_ms, Some(80));
+        assert_eq!(flags.ws_vad_engine, Some(WsVadEngine::Neural));
+
+        // Nothing set → the profile is left exactly as it was.
+        let mut untouched = NgFlags {
+            beep_detection: true,
+            ws_sample_rate: Some(24_000),
+            ..NgFlags::default()
+        };
+        MediaOverrides::default().apply(&mut untouched).unwrap();
+        assert!(untouched.beep_detection);
+        assert_eq!(untouched.ws_sample_rate, Some(24_000));
+
+        // An explicit `beep_detection=False` must be able to turn OFF a profile
+        // that had it on — the reason the field is `Option<bool>` and not `bool`.
+        let mut disarmed = NgFlags {
+            beep_detection: true,
+            ..NgFlags::default()
+        };
+        MediaOverrides::parse(Some(false), None, None, None, None, None)
+            .unwrap()
+            .apply(&mut disarmed)
+            .unwrap();
+        assert!(!disarmed.beep_detection);
+    }
+
+    #[test]
+    fn media_overrides_reject_bad_values() {
+        pyo3::Python::initialize();
+
+        let bad_rate =
+            MediaOverrides::parse(None, None, Some(44_100), None, None, None).unwrap_err();
+        let bad_tee_rate =
+            MediaOverrides::parse(None, None, None, Some(96_000), None, None).unwrap_err();
+        let bad_engine =
+            MediaOverrides::parse(None, None, None, None, None, Some("telepathy")).unwrap_err();
+
+        Python::attach(|py| {
+            assert!(bad_rate.value(py).to_string().contains("ws_sample_rate"));
+            assert!(bad_tee_rate.value(py).to_string().contains("ws_tee_sample_rate"));
+            assert!(bad_engine.value(py).to_string().contains("ws_vad_engine"));
+        });
     }
 
     #[test]
     fn resolve_play_media_source_none_rejected() {
         pyo3::Python::initialize();
-        let error = resolve_play_media_source(None, None, None).unwrap_err();
+        let error = resolve_play_media_source(None, None, None, None, None).unwrap_err();
         Python::attach(|py| {
             assert!(error.value(py).to_string().contains("exactly one"));
         });
@@ -2081,12 +2751,16 @@ mod tests {
             Some("/tmp/a.wav".to_string()),
             Some(vec![0x00]),
             None,
+            None,
+            None,
         )
         .unwrap_err();
         let error_file_and_db = resolve_play_media_source(
             Some("/tmp/a.wav".to_string()),
             None,
             Some(1),
+            None,
+            None,
         )
         .unwrap_err();
         Python::attach(|py| {

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -491,10 +491,14 @@ class _CacheNamespace:
 class _RtpEngineNamespace:
     """RTPEngine media proxy operations (stub)."""
 
-    async def offer(self, request, profile=None):
+    async def offer(self, request, profile=None, ws_uri=None, beep_detection=None,
+                    beep_cadence_guard_ms=None, ws_sample_rate=None, ws_tee_sample_rate=None,
+                    ws_vad_engine=None, ws_vad_min_speech_ms=None):
         raise NotImplementedError("rtpengine.offer() not available — no media.rtpengine in config")
 
-    async def answer(self, reply, profile=None):
+    async def answer(self, reply, profile=None, call=None, ws_uri=None, beep_detection=None,
+                     beep_cadence_guard_ms=None, ws_sample_rate=None, ws_tee_sample_rate=None,
+                     ws_vad_engine=None, ws_vad_min_speech_ms=None):
         raise NotImplementedError("rtpengine.answer() not available — no media.rtpengine in config")
 
     async def delete(self, request):
@@ -512,11 +516,19 @@ class _RtpEngineNamespace:
     async def unsubscribe(self, call_id, from_tag, to_tag):
         raise NotImplementedError("rtpengine.unsubscribe() not available — no media.rtpengine in config")
 
-    async def attach_ws_tee(self, target, ws_uri, direction="both", channels=None):
+    async def attach_ws_tee(self, target, ws_uri, direction="both", channels=None, sample_rate=None):
         raise NotImplementedError("rtpengine.attach_ws_tee() not available — no media.rtpengine in config")
 
     async def detach_ws_tee(self, target):
         raise NotImplementedError("rtpengine.detach_ws_tee() not available — no media.rtpengine in config")
+
+    async def play_overlay(self, target, file=None, blob=None, db_id=None, tone=None, url=None,
+                           repeat=None, start_ms=None, duration_ms=None, gain_decibels=None,
+                           to_tag=None):
+        raise NotImplementedError("rtpengine.play_overlay() not available — no media.rtpengine in config")
+
+    async def set_play_gain(self, target, play_id, gain_decibels, to_tag=None):
+        raise NotImplementedError("rtpengine.set_play_gain() not available — no media.rtpengine in config")
 
     def on_dtmf(self, func_or_none=None, *, call_id=None, from_tag=None):
         """Register a handler for inbound DTMF events from rtpengine.
@@ -590,6 +602,38 @@ class _RtpEngineNamespace:
             is_async = _asyncio.iscoroutinefunction(fn)
             metadata = {"call_id": call_id, "from_tag": from_tag}
             _registry.register("rtpengine.on_text", None, fn, is_async, metadata)
+            return fn
+        if func_or_none is not None:
+            return decorator(func_or_none)
+        return decorator
+
+    def on_beep(self, func_or_none=None, *, call_id=None, from_tag=None):
+        """Register a handler for record-tone ("voicemail beep") events.
+
+        Fires when the engine hears the short tone an answering machine plays
+        before it starts recording, on a leg whose media profile set
+        ``beep_detection`` — the media half of answering-machine detection.
+
+        Arm it per leg (the profile used toward the callee watches the party
+        that might be a machine). Fires once per leg per call; there is no
+        mid-call re-arm.
+
+        ``offset_ms`` is the offset of the *tone*, not of the event: the event
+        trails it by roughly the profile's ``beep_cadence_guard_ms``.
+
+        Usage:
+            @rtpengine.on_beep
+            def handle_any(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+                ...
+
+            @rtpengine.on_beep(call_id="abc")
+            def handle_specific(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+                ...
+        """
+        def decorator(fn):
+            is_async = _asyncio.iscoroutinefunction(fn)
+            metadata = {"call_id": call_id, "from_tag": from_tag}
+            _registry.register("rtpengine.on_beep", None, fn, is_async, metadata)
             return fn
         if func_or_none is not None:
             return decorator(func_or_none)

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -154,6 +154,15 @@ pub enum HandlerKind {
         call_id: Option<String>,
         from_tag: Option<String>,
     },
+    /// `@rtpengine.on_beep` — a record tone (the "voicemail beep") was detected
+    /// on a leg armed with `beep_detection`, the media half of
+    /// answering-machine detection. Fires once per leg per call.
+    ///
+    /// ``call_id`` and ``from_tag`` are optional filters.
+    RtpEngineOnBeep {
+        call_id: Option<String>,
+        from_tag: Option<String>,
+    },
     /// Open extension point for handler kinds owned by host extensions.
     /// The string is the registry key the extension wrote (e.g.
     /// `"audit.sink"`); siphon-core does not interpret it. Per-handler
@@ -316,6 +325,21 @@ impl ScriptState {
             .iter()
             .filter(|h| match &h.kind {
                 HandlerKind::RtpEngineOnWsTeeEnded { call_id: filter_cid, from_tag: filter_ftag } => {
+                    filter_cid.as_deref().map_or(true, |v| v == call_id)
+                        && filter_ftag.as_deref().map_or(true, |v| v == from_tag)
+                }
+                _ => false,
+            })
+            .collect()
+    }
+
+    /// Return all `RtpEngineOnBeep` handlers whose optional call-id/from-tag
+    /// filters match the event.  `None` filters match everything.
+    pub fn beep_handlers(&self, call_id: &str, from_tag: &str) -> Vec<&HandlerEntry> {
+        self.handlers
+            .iter()
+            .filter(|h| match &h.kind {
+                HandlerKind::RtpEngineOnBeep { call_id: filter_cid, from_tag: filter_ftag } => {
                     filter_cid.as_deref().map_or(true, |v| v == call_id)
                         && filter_ftag.as_deref().map_or(true, |v| v == from_tag)
                 }
@@ -1196,6 +1220,17 @@ fn extract_handlers(
                     .and_then(|v| v.extract().ok());
                 HandlerKind::RtpEngineOnText { call_id, from_tag }
             }
+            "rtpengine.on_beep" => {
+                let call_id: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("call_id").ok())
+                    .and_then(|v| v.extract().ok());
+                let from_tag: Option<String> = metadata
+                    .as_ref()
+                    .and_then(|meta| meta.get_item("from_tag").ok())
+                    .and_then(|v| v.extract().ok());
+                HandlerKind::RtpEngineOnBeep { call_id, from_tag }
+            }
             "rtpengine.on_ws_tee_ended" => {
                 let call_id: Option<String> = metadata
                     .as_ref()
@@ -1903,6 +1938,48 @@ async def specific_text(call_id, from_tag, to_tag, text, direction):
                 HandlerKind::RtpEngineOnText { call_id: Some(c), .. } if c == "abc"
             ))
             .expect("filtered text handler registered");
+        assert!(specific.is_async);
+    }
+
+    #[test]
+    fn rtpengine_on_beep_decorator_registers_and_filters() {
+        // Same (call_id, from_tag) filter shape as the sibling rtpengine hooks.
+        // The from-tag names the leg the tone was heard *on*, which is what makes
+        // a per-leg filter meaningful: a transfer arms detection on the callee
+        // leg only and wants events from that leg alone.
+        let source = r#"
+from siphon import rtpengine
+
+@rtpengine.on_beep
+def any_beep(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    pass
+
+@rtpengine.on_beep(call_id="abc", from_tag="ftag1")
+async def specific_beep(call_id, from_tag, to_tag, frequency_hz, duration_ms, offset_ms):
+    pass
+"#;
+        let state = compile_temp_script(source).unwrap();
+        assert_eq!(state.handlers.len(), 2);
+
+        // Catch-all everywhere, plus the filtered one on an exact match only.
+        assert_eq!(state.beep_handlers("xyz", "other").len(), 1);
+        assert_eq!(state.beep_handlers("abc", "ftag1").len(), 2);
+        assert_eq!(state.beep_handlers("abc", "wrong").len(), 1);
+        assert_eq!(state.beep_handlers("wrong", "ftag1").len(), 1);
+
+        // A beep handler is not picked up by the other rtpengine hooks, and they
+        // are not picked up by it.
+        assert_eq!(state.ws_tee_started_handlers("abc", "ftag1").len(), 0);
+        assert_eq!(state.dtmf_handlers("abc", "ftag1").len(), 0);
+
+        let specific = state
+            .handlers
+            .iter()
+            .find(|h| matches!(
+                &h.kind,
+                HandlerKind::RtpEngineOnBeep { call_id: Some(c), .. } if c == "abc"
+            ))
+            .expect("filtered beep handler registered");
         assert!(specific.is_async);
     }
 

--- a/tests/integration/siphon_rtp_tests.rs
+++ b/tests/integration/siphon_rtp_tests.rs
@@ -230,7 +230,7 @@ async fn attach_ws_tee_emits_the_documented_wire_shape() {
     // `direction` does not, so the engine always receives an explicit leg
     // selection rather than relying on its own default.
     backend
-        .attach_ws_tee("c", "f", "ws://h/s", WsTeeDirection::Both, None)
+        .attach_ws_tee("c", "f", "ws://h/s", WsTeeDirection::Both, None, None)
         .await
         .unwrap();
     let body = records.recv().await.expect("attach recorded");
@@ -242,7 +242,7 @@ async fn attach_ws_tee_emits_the_documented_wire_shape() {
 
     // Explicit non-default direction + channels are carried verbatim.
     backend
-        .attach_ws_tee("c", "f", "wss://h/s", WsTeeDirection::Caller, Some(1))
+        .attach_ws_tee("c", "f", "wss://h/s", WsTeeDirection::Caller, Some(1), None)
         .await
         .unwrap();
     let body = records.recv().await.expect("explicit attach recorded");
@@ -331,7 +331,7 @@ async fn ws_tee_is_rejected_by_backends_that_cannot_stream() {
         MediaBackend::RtpEngine(RtpEngineSet::new(vec![(ng, 500, 1)]).await.unwrap().into());
 
     let error = backend
-        .attach_ws_tee("c", "f", "ws://h/s", WsTeeDirection::Both, None)
+        .attach_ws_tee("c", "f", "ws://h/s", WsTeeDirection::Both, None, None)
         .await
         .expect_err("rtpengine cannot stream a websocket tee");
     let text = error.to_string();


### PR DESCRIPTION
Moves the native media contract from 0.2.0 to 0.3.0 and wires up the surface it adds. A 0.x minor
is a semver-breaking range, so this only ever moves on purpose.

## What is now reachable

| profile field | what it does |
|---|---|
| `ws_sample_rate` / `ws_tee_sample_rate` | target rate for the WebSocket bridge / tee, independent of the leg's codec rate — an 8 kHz call can stream at 16 kHz |
| `ws_vad_engine` | `energy` (default) or `neural`, an embedded speech classifier that answers "is this speech" rather than "is this loud" |
| `ws_vad_min_speech_ms` | a *leading* minimum continuous-speech run before barge-in, distinct from the existing trailing hangover — without it breathing, hum and uncancelled echo start a turn |
| `beep_detection` / `beep_cadence_guard_ms` | answering-machine beep detection, surfaced as `@rtpengine.on_beep` |

Plus `set_play_gain`, and `Tone` / `Http` play sources — a call-progress tone needs no audio file
shipped or provisioned, and a prompt can be served over HTTPS.

All of it is native-backend-only, so rtpengine and rtpproxy reject these fields at config load
naming profile/direction/field. A flag the engine never sees is worse than an error.

## Two corrections to what the contract was assumed to be

**1. The compile-error tripwire no longer covers enums.** 0.3.0 marked `Command`, `CmdResult`,
`Event`, `PlayEndReason`, `PlayMediaSource`, `WsTeeEndReason` and `ProtoError`
`#[non_exhaustive]` — 0.2.0 had none. So `Event::BeepDetected` produced **no** compile error; a
forced wildcard arm swallows it silently. The property still holds for `ProfileFlags`, which is a
struct and was deliberately left exhaustive, and that is what surfaced the six new fields.

Mitigation in this PR: every forced wildcard **names or refuses** the unknown rather than
absorbing it. Notably `ws_tee_end_reason_from_proto` maps an unknown reason to `TransportError`,
not `Detached` — `Detached` is the only orderly end and the dispatcher's WARN keys on exactly
that, so defaulting there would silently reclassify a dead stream as a clean one.

**2. `overlay`, `gain_decibels`, `StopMedia.play_id` and `AttachWsTee.sample_rate` are new in
0.3.0**, not pre-existing. Verified against the vendored 0.2.0: `StopMedia { call_id, from_tag }`
with no `play_id`, and `PlayMedia` with neither `overlay` nor `gain_decibels`. Only the `play_id`
*correlation handle* — on the accept and on `PlayFinished` — was already there.

## Design decision worth review

`play_media` returns a duration; `set_play_gain` needs a `play_id`. Rather than change
`play_media`'s return type (the scripting API is the SemVer contract), this adds
**`rtpengine.play_overlay(...) -> play_id`** as an additive twin:

- `play_media` — replace the egress, tell me how long it played
- `play_overlay` — mix under the live audio, here is your handle

Non-breaking, and each return type is unambiguous.

## Where the HTTP fetch happens

Engine-side, bounded there (connect / first-byte / deadline / size / redirect caps, off the media
path). siphon deliberately does **not** fetch: a controller-side fetch would put an unbounded
third-party round-trip on call setup. siphon validates the scheme; the typed failure is the
existing `PlayFinished{reason: error}`.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo test` **4049 passed** ·
SDK **632 passed** (+30).

Tests assert **emitted JSON**, not structs — all six new fields carry `skip_serializing_if`, so a
field siphon never populates is indistinguishable at struct level from one it does. Coverage
includes: unset fields absent and a default profile still serialising to `{}`; `ws_vad_engine:
energy` emitted rather than elided; field-exact `BeepDetected` conversion with and without
`to_tag`; the capability gate on all three backends both ways; and boundary rates accepted with
bad ones refused.

Not run: the 16-row SIPp perf baseline and the memory-leak pair — held for the maintainer as
usual.
