### PR TITLE
feat(b2bua): originate — a call siphon places itself

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -579,6 +579,66 @@ jobs:
             rtpengine-real.log
             *.log
 
+  # ── Control-plane `originate` (a call siphon places itself) ─────────────
+  # No inbound call anywhere: a control application dials siphon's control
+  # WebSocket and places a call under a channel id IT chose.
+  #
+  # The two halves of the acceptance criteria live on opposite sides of the
+  # rail, so both have to pass:
+  #   * the UAS asserts the outbound identity actually reached the wire (From +
+  #     display, P-Asserted-Identity, custom header, the caller-supplied offer,
+  #     no To-tag) and then holds `180 Ringing` for two seconds;
+  #   * the app asserts its accept came back during that ring rather than after
+  #     the answer, that the reply echoes its own id, that a duplicate id is
+  #     refused `conflict`, and that hangup produces the `StasisEnd`.
+  #
+  # The app prints one ORIGINATE-VERDICT line; the grep below fails the job on
+  # `"pass": false` AND on a verdict that never appeared (the app never
+  # connecting at all looks like success to `--exit-code-from` alone only if it
+  # exits 0, which it does not — but the grep is the belt to that braces).
+  sipp-originate:
+    runs-on: ubuntu-latest
+    needs: rust-tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build siphon-originate image
+        run: docker compose -f sipp/docker-compose.yaml --profile originate build siphon-originate
+
+      - name: Start siphon (control listener) + the UAS
+        run: docker compose -f sipp/docker-compose.yaml --profile originate up -d --wait siphon-originate
+
+      - name: Originate under a caller-supplied id, ring, answer, bridge-free hangup
+        run: docker compose -f sipp/docker-compose.yaml --profile originate up --abort-on-container-exit --exit-code-from originate-app sipp-originate-uas originate-app
+
+      - name: Assert the control app's verdict
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs originate-app > originate-app.log 2>&1 || true
+          grep -q 'ORIGINATE-VERDICT' originate-app.log || { echo "no verdict — the control app never completed"; exit 1; }
+          if grep -q '"pass": false' originate-app.log; then
+            echo "originate acceptance checks failed:"; grep 'ORIGINATE-VERDICT' originate-app.log; exit 1
+          fi
+          grep 'ORIGINATE-VERDICT' originate-app.log
+
+      - name: Collect logs
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml logs siphon-originate > siphon-originate.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile originate down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-originate-logs
+          path: |
+            siphon-originate.log
+            originate-app.log
+            *.log
+
   # ── B2BUA A-leg INVITE authentication ──────────────────────────────────
   # siphon challenges the CALLER from @b2bua.on_invite. With a @b2bua handler
   # registered the dispatcher routes INVITE to the B2BUA path and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **`originate` — a call siphon places itself.** Both the control-plane verb
+  (`module: "sip"`, `verb: "originate"`) and the in-process
+  `b2bua.originate(...)`. Until now a call could only ever be a *reaction*:
+  `call.dial()` builds a B-leg off an INVITE that already arrived, and
+  `proxy.send_request()` is a one-shot request/response with no dialog you can
+  later answer, transfer or tear down. So click-to-dial, callbacks and outbound
+  notification had no primitive at all, and an application driving a transfer
+  could not place the leg it wanted to transfer *to*. An originated call is a
+  `CallActor` whose A-leg is a UAC dialog siphon owns end to end: it ACKs the 2xx
+  (RFC 3261 §13.2.2.4), ACKs a final non-2xx on the INVITE's own branch
+  (§17.1.1.3), CANCELs rather than answering a response when abandoned before
+  answer (§9.1 — a UAC has no business sending one to the party it is calling),
+  and tears down through the same funnel every other B2BUA call uses.
+  - **The channel id is supplied by the caller, never minted by siphon.** An
+    application stages its per-call context — routing, media plan, its own state
+    — keyed on an id it chose before anything reaches the network; returning an
+    id instead would force a round-trip a well-built controller has designed out.
+    Reusing a **live** id answers the new `conflict` error code (distinct from
+    `bad_request`: the frame is fine, the id collides, and retrying the same one
+    can never succeed); the id is free again once the call is gone.
+  - **The accept is the local action, not the far-end outcome.** The reply comes
+    back as soon as the INVITE is on the wire, while the callee is still ringing
+    — so ringback or a prompt can start during ring, and one ringing phone never
+    serialises a connection's command stream. Ringing, answer and hangup arrive
+    afterwards as `ChannelStateChange` / `StasisEnd` events on the supplied id,
+    and `StasisEnd` now carries the SIP cause (`code` + `response`) for a leg
+    that was rejected, which is the only way a controller can learn *why* when
+    there is no A-leg the response was relayed to.
+  - **Full outbound identity**: From URI and display name, To URI and display
+    name, `P-Asserted-Identity` (RFC 3325 §9.1), RFC 3323 §4.1 / TS 24.607 CLIR
+    via `privacy: "restricted"` (applied last, so a custom header cannot undo
+    it), a `next_hop` that steers egress without reshaping the R-URI, and
+    arbitrary custom headers. Dialog-defining headers are refused rather than
+    applied — overwriting one would leave the leg unaddressable for its own ACK.
+  - **Media**: either the caller's own SDP offer (any backend, or none), or
+    `media: true`, which sends the INVITE offerless and answers the callee's 2xx
+    offer locally on the media backend with the answer riding on the ACK. The
+    resulting session is keyed on the leg's SIP Call-ID, so `play` / `dtmf` /
+    `hold` / `stream_start` work against an originated leg exactly as they do
+    against an inbound-anchored one. A backend that cannot do it is refused at
+    the command (`unsupported_verb`), never connected as a mute call.
+  - Typed refusals throughout — `bad_request`, `conflict`, `not_found` (no
+    route), `unsupported_verb`, `unavailable` — each separately actionable, and
+    a refused originate registers no channel and places nothing on the wire.
+
+### Changed
+- **`hangup` on an un-answered call siphon originated now CANCELs** instead of
+  sending a final non-2xx. The response path is correct for an inbound call
+  parked under control; on a call siphon placed, siphon is the UAC.
+- Two new stable control-plane error codes, `conflict` and `invalid_state`,
+  mirrored into `siphon-control-proto` and the TypeScript SDK so a client parses
+  them as the refusals they are rather than a transport error.
+
 ## [1.6.0] — 2026-08-20
 
 ### Added

--- a/docs/reference/call.md
+++ b/docs/reference/call.md
@@ -14,6 +14,40 @@ async def bridge(call):
 
 ::: siphon_sdk.call.Call
 
+## Placing a call: `b2bua.originate`
+
+Every handler above is driven by a call that arrived. `b2bua.originate()` creates
+one from nothing — click-to-dial, callbacks, outbound notification — so it works
+from a timer or an event callback, where no `Call` object exists at all.
+
+It returns as soon as the INVITE is on the wire, with the new leg's SIP Call-ID;
+it does **not** wait for the callee. Ringing and answer come back through the
+ordinary handlers (`@b2bua.on_answer`, `@b2bua.on_failure`, `@b2bua.on_bye`), and
+the returned Call-ID is the handle for `b2bua.terminate()` / `b2bua.refer()`.
+
+```python
+from siphon import b2bua, timer
+
+@timer.every(seconds=60)
+def reminders():
+    for number in due_numbers():
+        b2bua.originate(
+            to=f"sip:{number}@carrier.example",
+            from_uri="sip:+14035550100@siphon.example",
+            from_display="Reminders",
+            media=True,          # siphon anchors the leg on the media backend
+            timeout=30,          # CANCELled if nobody answers in 30 s
+        )
+```
+
+Exactly one media plan is required — an INVITE with no offer and no way to answer
+the callee's would connect a call with no audio: `sdp=` (your own offer, any
+backend) or `media=True` (siphon anchors it; `siphon-rtp` backend). The full
+argument set and its failure modes are below; the out-of-process twin is the
+control plane's [`originate` verb](control-plane.md#placing-a-call-originate).
+
+::: siphon_sdk.mock_module.MockB2bua.originate
+
 ## `MediaHandle`
 
 Returned by `call.media` — controls RTP anchoring for the call.

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -206,6 +206,7 @@ chunk, so logs join Homer and billing with no mapping table.
 
 | verb | module | args | notes |
 |---|---|---|---|
+| `originate` | sip | `{channel, to, from?, from_display?, to_display?, next_hop?, p_asserted_identity?, privacy?, headers?, sdp \| media, profile?, ws_uri?, timeout?, on_lost?, vars?}` | place an outbound call under a **caller-supplied** channel id; returns as soon as the INVITE is on the wire |
 | `answer` | sip | `{code, reason?, body?, content_type?}` | UAS 2xx to the parked A-leg |
 | `progress` | sip | `{code, reason?, body?, content_type?}` | 1xx / early media |
 | `reject` | sip | `{code, reason?}` | final non-2xx + tear down |
@@ -294,10 +295,95 @@ answers `bad_request`; a decision for a call with no pending REFER (already
 decided, timed out, or gone) answers `not_found`. A REFER on an **uncontrolled**
 call is unaffected — it still runs the Python `@b2bua.on_refer` path.
 
-`bridge` / `originate` verbs arrive in later phases over the same envelope. The
-client SDK facade methods for the media verbs and the transfer verbs land
-alongside them (until then, reach the verbs through the generic
-`command(verb, args)` escape hatch).
+## Placing a call: `originate`
+
+Every verb above acts on a call that already arrived. `originate` is the one that
+creates one — the primitive under click-to-dial, callbacks, outbound
+notification and the dial half of a transfer:
+
+```json
+{ "id":"c-7", "type":"command", "module":"sip", "verb":"originate",
+  "args": { "channel": "cb-7f3a",
+            "to": "sip:+15551000001@carrier.example",
+            "from": "sip:+15550000001@example.com",
+            "from_display": "Callback",
+            "p_asserted_identity": "sip:+15550000001@example.com",
+            "privacy": "allowed",
+            "headers": { "X-Campaign": "reminder" },
+            "media": true,
+            "timeout": 30 } }
+```
+
+```json
+{ "id":"c-7", "type":"reply", "status":"ok",
+  "result": { "channel":"cb-7f3a", "call_id":"<uuid>",
+              "sip_call_id":"<cid>", "state":"calling" } }
+```
+
+**The channel id is yours.** `args.channel` is required and siphon never mints
+one: a controller stages its per-call context — routing, media plan, its own
+state — keyed on an id it chose *before* anything reaches the network, and an API
+that returned the id instead would force a round-trip that a well-built
+controller has designed out. Reusing the id of a **live** channel answers
+`conflict` (distinguishable from `bad_request`: the frame is fine, the id just
+collides, and retrying the same one can never succeed). Once the call is gone the
+id is free again.
+
+**The reply is the local action, not the outcome.** It comes back as soon as the
+INVITE is on the wire, while the callee is still ringing — which is what lets you
+start ringback or a prompt during ring, and what stops one ringing phone
+serialising the connection's whole command stream. What happens next arrives as
+events on your id:
+
+| event | payload | when |
+|---|---|---|
+| `ChannelStateChange` | `{state:"ringing"\|"progress", code, early_media, sdp?}` | a 1xx from the callee (`progress` when it carried SDP) |
+| `ChannelStateChange` | `{state:"answered", code, sdp?}` | the callee answered; siphon has ACKed |
+| `StasisEnd` | `{reason:"rejected", code, response}` | the callee rejected it — the SIP cause, since there is no A-leg it was relayed to |
+| `StasisEnd` | `{reason:"bye"}` / `{reason:"ring timeout"}` / `{reason:<hangup reason>}` | the call ended |
+
+**Media.** Exactly one plan is required, because an INVITE with no offer and no
+way to answer the callee's leaves its 2xx unanswerable (RFC 3261 §13.2.2.4) — a
+connected call with no audio:
+
+- `sdp` — your own offer, carried verbatim. Works on any backend, or none.
+- `media: true` — siphon anchors the leg on the media backend: the INVITE goes
+  out offerless, the callee offers in its 2xx and siphon answers it locally with
+  the answer on the ACK. The session is keyed on the leg's SIP Call-ID, so
+  `play` / `dtmf` / `hold` / `stream_start` all work against it exactly as they do
+  for an inbound-anchored channel. `profile` (default `rtp_passthrough`) and
+  `ws_uri` shape it. Requires the `siphon-rtp` backend — anything else answers
+  `unsupported_verb` at the command rather than connecting a mute call.
+
+**Identity.** `from` / `from_display` / `to_display` / `p_asserted_identity`
+(RFC 3325 §9.1) and arbitrary `headers` all land on the INVITE. `privacy:
+"restricted"` anonymises From and asserts `Privacy: id` while keeping the real
+identity in `P-Asserted-Identity` for the trusted next hop (RFC 3323 §4.1 /
+TS 24.607) — applied last, so a custom header cannot undo it. Dialog-defining
+headers in `headers` (Via, From, To, Call-ID, CSeq, Contact, Max-Forwards,
+Content-Length, Route, Record-Route) are ignored: the stack owns them, and
+overwriting one would leave the leg unaddressable for its own ACK / BYE.
+
+**Ending it.** `hangup` works on an originated channel like any other: a BYE once
+answered, and a CANCEL (RFC 3261 §9.1) while it is still ringing — never a SIP
+response, which a UAC has no business sending to the party it is calling. The
+same CANCEL fires when `timeout` (default 30 s, `0` to disable) elapses unanswered.
+
+Refusals are typed and separately actionable: `bad_request` (missing/contradictory
+args, unparseable URI, bad `privacy`), `conflict` (the id is in use), `not_found`
+(no route to the target), `unsupported_verb` (the backend cannot serve the media
+plan), `unavailable` (the B2BUA is not running, or the commanding connection has
+gone — nothing would own the call).
+
+In-process, the same primitive is
+[`b2bua.originate(...)`](call.md#placing-a-call-b2buaoriginate), which returns the
+new leg's SIP Call-ID and drives the ordinary `@b2bua.on_answer` / `on_failure` /
+`on_bye` handlers.
+
+The `bridge` verb — joining two legs this process already owns — arrives in a
+later phase over the same envelope. The client SDK facade methods for the media,
+transfer and originate verbs land alongside it (until then, reach the verbs
+through the generic `command(verb, args)` escape hatch).
 
 The complete wire reference, both connection modes end to end, and two
 low-level example clients (one Python, one TypeScript) that drive calls with no

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -590,6 +590,8 @@ class MockB2bua:
         - ``@b2bua.on_cancel`` — unanswered call cancelled (RFC 3261 §9)
 
     Imperative:
+        - ``b2bua.originate(to=...)`` — place an outbound call with no inbound
+          INVITE behind it (records onto ``originates`` for test assertions)
         - ``b2bua.terminate(call_id)`` — end a call by SIP Call-ID from any
           context (records onto ``terminates`` for test assertions)
         - ``b2bua.refer(call_id, target)`` — transfer a call by SIP Call-ID
@@ -601,11 +603,140 @@ class MockB2bua:
         self.terminates: list[dict] = []
         # Records b2bua.refer(...) calls for test assertions.
         self.refers: list[dict] = []
+        # Records b2bua.originate(...) calls for test assertions.
+        self.originates: list[dict] = []
+        # Sequence counter for the mock's synthetic originated Call-IDs.
+        self._originate_seq = 0
 
     def clear(self) -> None:
         """Reset recorded imperative calls (called by ``reset()``)."""
         self.terminates.clear()
         self.refers.clear()
+        self.originates.clear()
+        self._originate_seq = 0
+
+    def originate(
+        self,
+        to: str,
+        from_uri: Optional[str] = None,
+        from_display: Optional[str] = None,
+        to_display: Optional[str] = None,
+        next_hop: Optional[str] = None,
+        p_asserted_identity: Optional[str] = None,
+        privacy: Optional[str] = None,
+        headers: Optional[dict] = None,
+        sdp: Optional[str] = None,
+        media: bool = False,
+        profile: Optional[str] = None,
+        ws_uri: Optional[str] = None,
+        timeout: int = 30,
+    ) -> str:
+        """Place an outbound call siphon owns, with no inbound INVITE behind it.
+
+        The primitive under click-to-dial, callbacks and outbound notification.
+        Unlike ``call.dial()`` (which builds a B-leg off a call that already
+        arrived), this creates a call from nothing.
+
+        **Asynchronous.** Returns as soon as the INVITE is on the wire, with the
+        new leg's SIP Call-ID — it does not wait for the callee. Ringing and
+        answer arrive through the ordinary handlers: ``@b2bua.on_answer`` fires
+        with ``(call, reply)``, ``@b2bua.on_failure`` with
+        ``(call, code, reason)``, ``@b2bua.on_bye`` on teardown. Feed the
+        returned Call-ID to ``b2bua.terminate()`` / ``b2bua.refer()``.
+
+        Exactly one media plan is required — an INVITE with no offer and no way
+        to answer the callee's would connect a call with no audio:
+
+        * ``sdp="v=0..."`` — your own offer, carried verbatim (any backend);
+        * ``media=True`` — siphon anchors the leg on the configured media
+          backend (siphon-rtp), so ``rtpengine.play_media()``, DTMF and the
+          WebSocket tee all work against it.
+
+        Args:
+            to: called party — the Request-URI and the To URI.
+            from_uri: calling identity (From URI). Defaults to siphon's own
+                advertised address.
+            from_display: From display name.
+            to_display: To display name.
+            next_hop: route the INVITE here while the R-URI keeps the called
+                party's shape (IMS edge / trunk steering).
+            p_asserted_identity: ``P-Asserted-Identity`` for a trusted next hop.
+            privacy: ``"allowed"`` or ``"restricted"``. Restricted anonymises
+                From and asserts ``Privacy: id``, keeping the real identity in
+                ``P-Asserted-Identity``.
+            headers: dict of extra headers applied last. Dialog-defining headers
+                (Via/From/To/Call-ID/CSeq/Contact/Route/…) are ignored.
+            sdp: your own SDP offer.
+            media: True to have siphon anchor the leg on the media backend.
+            profile: media profile for ``media=True`` (default
+                ``"rtp_passthrough"``).
+            ws_uri: per-call WebSocket bridge URI for ``media=True``.
+            timeout: ring timeout in seconds; the call is CANCELled when it
+                elapses. 0 disables it.
+
+        Returns:
+            str: the new leg's SIP Call-ID.
+
+        Raises:
+            ValueError: no media plan, both media plans, or an unrecognised
+                ``privacy`` value. Live siphon also raises for unparseable URIs,
+                no route, and a media plan the backend cannot serve — never a
+                silent ``None`` for a call that was never placed.
+
+        In the mock, records the full argument set on ``originates`` and returns
+        a synthetic Call-ID. Inspect via ``siphon.get_b2bua().originates``.
+
+        Usage::
+
+            @timer.every(seconds=60)
+            def reminders():
+                for number in due_numbers():
+                    b2bua.originate(
+                        to=f"sip:{number}@carrier.example",
+                        from_uri="sip:+14035550100@siphon.example",
+                        media=True,
+                    )
+        """
+        if sdp is not None and media:
+            raise ValueError(
+                "b2bua.originate takes either sdp= (your own offer) or "
+                "media=True (siphon anchors the leg), not both"
+            )
+        if sdp is not None and not sdp.strip():
+            raise ValueError("b2bua.originate sdp= must not be empty")
+        if sdp is None and not media:
+            raise ValueError(
+                "b2bua.originate needs a media plan: sdp= (your own offer) or "
+                "media=True (siphon anchors the leg)"
+            )
+        if privacy is not None and privacy not in (
+            "allowed", "allow", "present", "presented",
+            "restricted", "restrict", "private", "anonymous",
+        ):
+            raise ValueError(
+                'b2bua.originate privacy= must be "allowed" or "restricted", '
+                f"got '{privacy}'"
+            )
+
+        self._originate_seq += 1
+        call_id = f"b2b-originate-{self._originate_seq}"
+        self.originates.append({
+            "call_id": call_id,
+            "to": to,
+            "from_uri": from_uri,
+            "from_display": from_display,
+            "to_display": to_display,
+            "next_hop": next_hop,
+            "p_asserted_identity": p_asserted_identity,
+            "privacy": privacy,
+            "headers": dict(headers) if headers else {},
+            "sdp": sdp,
+            "media": media,
+            "profile": profile,
+            "ws_uri": ws_uri,
+            "timeout": timeout,
+        })
+        return call_id
 
     def terminate(self, call_id: str, reason: str = "Normal Clearing") -> bool:
         """Imperatively end a B2BUA call by its SIP Call-ID.

--- a/sdk/tests/test_b2bua_originate.py
+++ b/sdk/tests/test_b2bua_originate.py
@@ -1,0 +1,156 @@
+"""Tests for b2bua.originate() — a call siphon places itself.
+
+Unlike call.dial() (a B-leg off a call that already arrived), originate creates a
+call from nothing: click-to-dial, callbacks, outbound notification. It returns as
+soon as the INVITE is on the wire; ringing and answer arrive later through the
+ordinary @b2bua.* handlers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from siphon_sdk.testing import SipTestHarness
+
+
+@pytest.fixture
+def harness():
+    h = SipTestHarness(local_domains=["example.com"])
+    yield h
+    h.reset()
+    h.close()
+
+
+class TestB2buaOriginate:
+    def test_returns_a_call_id_and_records_the_target(self, harness):
+        import siphon
+
+        call_id = siphon.b2bua.originate(
+            to="sip:+14035551212@carrier.example",
+            media=True,
+        )
+        assert isinstance(call_id, str) and call_id
+        placed = harness.b2bua.originates[-1]
+        assert placed["call_id"] == call_id
+        assert placed["to"] == "sip:+14035551212@carrier.example"
+        assert placed["media"] is True
+        assert placed["timeout"] == 30
+
+    def test_carries_the_full_outbound_identity(self, harness):
+        import siphon
+
+        siphon.b2bua.originate(
+            to="sip:+14035551212@carrier.example",
+            to_display="Callee",
+            from_uri="sip:+14035550100@siphon.example",
+            from_display="Reminders",
+            p_asserted_identity="sip:+14035550100@siphon.example",
+            privacy="restricted",
+            next_hop="sip:gw.carrier.example:5060",
+            headers={"X-Campaign": "reminder"},
+            media=True,
+            profile="voice_ai",
+            ws_uri="ws://ai.invalid/{call_id}",
+            timeout=45,
+        )
+        placed = harness.b2bua.originates[-1]
+        assert placed["from_uri"] == "sip:+14035550100@siphon.example"
+        assert placed["from_display"] == "Reminders"
+        assert placed["to_display"] == "Callee"
+        assert placed["p_asserted_identity"] == "sip:+14035550100@siphon.example"
+        assert placed["privacy"] == "restricted"
+        assert placed["next_hop"] == "sip:gw.carrier.example:5060"
+        assert placed["headers"] == {"X-Campaign": "reminder"}
+        assert placed["profile"] == "voice_ai"
+        assert placed["ws_uri"] == "ws://ai.invalid/{call_id}"
+        assert placed["timeout"] == 45
+
+    def test_a_caller_supplied_offer_is_carried_verbatim(self, harness):
+        import siphon
+
+        offer = "v=0\r\no=- 1 1 IN IP4 198.51.100.10\r\n"
+        siphon.b2bua.originate(to="sip:1@carrier.example", sdp=offer)
+        placed = harness.b2bua.originates[-1]
+        assert placed["sdp"] == offer
+        assert placed["media"] is False
+
+    def test_no_media_plan_is_a_hard_error(self, harness):
+        # An INVITE with no offer and no anchor cannot answer the callee's own
+        # offer, so it would connect a call with no audio.
+        import siphon
+
+        with pytest.raises(ValueError, match="media plan"):
+            siphon.b2bua.originate(to="sip:1@carrier.example")
+        assert harness.b2bua.originates == []
+
+    def test_both_media_plans_is_a_hard_error(self, harness):
+        import siphon
+
+        with pytest.raises(ValueError, match="not both"):
+            siphon.b2bua.originate(
+                to="sip:1@carrier.example", sdp="v=0\r\n", media=True
+            )
+        assert harness.b2bua.originates == []
+
+    def test_empty_offer_is_a_hard_error(self, harness):
+        import siphon
+
+        with pytest.raises(ValueError, match="must not be empty"):
+            siphon.b2bua.originate(to="sip:1@carrier.example", sdp="   ")
+
+    def test_unknown_privacy_value_is_a_hard_error(self, harness):
+        # Guessing at a privacy setting is how identities leak.
+        import siphon
+
+        with pytest.raises(ValueError, match="privacy"):
+            siphon.b2bua.originate(
+                to="sip:1@carrier.example", media=True, privacy="maybe"
+            )
+        assert harness.b2bua.originates == []
+
+    def test_originate_from_a_timer_handler(self, harness):
+        # The real shape: an outbound reminder campaign driven by a timer, with
+        # no inbound call anywhere in the picture — nothing about originate
+        # needs a `call` object or an inbound INVITE in scope.
+        from siphon_sdk.mock_module import get_registry
+
+        harness.load_source(
+            """
+from siphon import b2bua, timer
+
+@timer.every(seconds=60)
+def reminders():
+    b2bua.originate(
+        to="sip:+14035551212@carrier.example",
+        from_uri="sip:+14035550100@siphon.example",
+        media=True,
+    )
+"""
+        )
+        handlers = get_registry().handlers.get("timer.every", [])
+        assert len(handlers) == 1
+        _filter, fn, _is_async, _metadata = handlers[0]
+        fn()
+
+        assert len(harness.b2bua.originates) == 1
+        assert harness.b2bua.originates[0]["to"] == "sip:+14035551212@carrier.example"
+
+    def test_returned_call_id_drives_terminate(self, harness):
+        # The Call-ID originate returns is the handle for every other imperative
+        # verb — that is what makes it useful without a `call` object in scope.
+        import siphon
+
+        call_id = siphon.b2bua.originate(to="sip:1@carrier.example", media=True)
+        assert siphon.b2bua.terminate(call_id, reason="campaign done") is True
+        assert harness.b2bua.terminates[-1] == {
+            "call_id": call_id,
+            "reason": "campaign done",
+        }
+
+    def test_reset_drains_recorded_originates(self, harness):
+        import siphon
+
+        siphon.b2bua.originate(to="sip:1@carrier.example", media=True)
+        assert harness.b2bua.originates
+        harness.reset()
+        assert harness.b2bua.originates == []

--- a/siphon-control-sdk/siphon-control-proto/src/lib.rs
+++ b/siphon-control-sdk/siphon-control-proto/src/lib.rs
@@ -126,6 +126,11 @@ pub enum ControlErrorCode {
     NotFound,
     /// The frame or its arguments were malformed.
     BadRequest,
+    /// The caller-supplied identifier is already in use (an `originate` reusing
+    /// a live channel id). The fix is a different id — never a retry.
+    Conflict,
+    /// The target exists but is in the wrong state for this verb.
+    InvalidState,
     /// The command exceeded a rate limit.
     RateLimited,
     /// An originate was denied by the toll-fraud gates.
@@ -503,6 +508,27 @@ mod tests {
             serde_json::to_string(&ControlErrorCode::UnsupportedVersion).unwrap(),
             "\"unsupported_version\""
         );
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::Conflict).unwrap(),
+            "\"conflict\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::InvalidState).unwrap(),
+            "\"invalid_state\""
+        );
+    }
+
+    #[test]
+    fn originate_error_codes_round_trip_from_the_wire() {
+        // The server can emit these; a client that cannot parse them would
+        // surface a transport error instead of the real refusal.
+        for (wire, expected) in [
+            ("\"conflict\"", ControlErrorCode::Conflict),
+            ("\"invalid_state\"", ControlErrorCode::InvalidState),
+        ] {
+            let parsed: ControlErrorCode = serde_json::from_str(wire).unwrap();
+            assert_eq!(parsed, expected);
+        }
     }
 
     #[test]

--- a/siphon-control-sdk/siphon-control-proto/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-proto/src/sip.rs
@@ -16,6 +16,10 @@ use serde::{Deserialize, Serialize};
 /// siphon-rtp-only, so a non-siphon-rtp backend answers them `unsupported_verb`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SipVerb {
+    /// Place an outbound call under a caller-supplied channel id. Returns as
+    /// soon as the INVITE is on the wire; ringing/answer/hangup arrive as
+    /// events on that id.
+    Originate,
     /// Send a UAS 2xx to the parked A-leg.
     Answer,
     /// Send a UAS 1xx / early media.
@@ -58,6 +62,7 @@ impl SipVerb {
     /// The exact wire token for this verb.
     pub const fn as_str(self) -> &'static str {
         match self {
+            SipVerb::Originate => "originate",
             SipVerb::Answer => "answer",
             SipVerb::Progress => "progress",
             SipVerb::Reject => "reject",
@@ -218,6 +223,7 @@ mod tests {
 
     #[test]
     fn sip_verb_wire_tokens() {
+        assert_eq!(SipVerb::Originate.as_str(), "originate");
         assert_eq!(SipVerb::Answer.as_str(), "answer");
         assert_eq!(SipVerb::Route.as_str(), "route");
         assert_eq!(SipVerb::SetHeader.as_str(), "set_header");

--- a/siphon-control-sdk/typescript/src/errors.ts
+++ b/siphon-control-sdk/typescript/src/errors.ts
@@ -14,6 +14,8 @@ export type ControlErrorCode =
   | "forbidden"
   | "not_found"
   | "bad_request"
+  | "conflict"
+  | "invalid_state"
   | "rate_limited"
   | "originate_denied"
   | "unsupported_verb"

--- a/sipp/control/originate_app.py
+++ b/sipp/control/originate_app.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Control application driving the `originate` acceptance test.
+
+It stands in for a real out-of-process controller: it dials siphon's inbound
+control WebSocket, says `hello`, and then places a call with an id **it** chose.
+Everything it asserts is a property of the verb's contract, not of this app:
+
+  1. **The id is the caller's.** The reply's `channel` is byte-identical to the
+     id sent in `args.channel`; nothing was minted for us to look up. A second
+     `originate` reusing that live id is refused `conflict` — distinguishable
+     from `bad_request`, because retrying the same id can never succeed.
+
+  2. **The accept is not the outcome.** The reply lands while the callee is
+     still ringing. The UAS deliberately holds `180 Ringing` for a couple of
+     seconds; the app records a monotonic timestamp for the reply and for the
+     `answered` event and fails the run unless reply < ringing < answered. A
+     synchronous originate would serialise this connection's whole command
+     stream behind one ringing phone.
+
+  3. **The identity crossed the wire.** The UAS scenario matches on the From,
+     To, P-Asserted-Identity and custom header this app asked for, so a
+     parameter that was accepted but never applied fails the run there.
+
+  4. **Events correlate by the supplied id.** Every event carries `channel`
+     equal to the id, so the app never needs a mapping table.
+
+  5. **Hangup means hangup.** The app sends `hangup` on the answered call and
+     requires the `StasisEnd` that follows.
+
+One `ORIGINATE-VERDICT <json>` line is printed at the end. The CI step greps for
+it and fails on `"pass": false`; a verdict that never appears is also a failure,
+which is what catches the app never connecting at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+
+import websockets
+
+CONTROL_URL = os.environ.get("CONTROL_URL", "ws://172.20.0.150:9092/control/ws")
+CONTROL_TOKEN = os.environ.get("CONTROL_TOKEN", "originate-test-token")
+SUBPROTOCOL = "siphon-control.v1"
+
+# The id this app chose before anything touched the network. Everything the app
+# does afterwards is keyed on it.
+CHANNEL_ID = os.environ.get("ORIGINATE_CHANNEL", "cb-0001")
+
+# The callee (the SIPp UAS) and the identity the call must present.
+TARGET = os.environ.get("ORIGINATE_TO", "sip:+15551000001@172.20.0.151:5060")
+FROM_URI = os.environ.get("ORIGINATE_FROM", "sip:+15550000001@originate.test")
+FROM_DISPLAY = "Callback"
+ASSERTED = os.environ.get("ORIGINATE_PAI", "sip:+15550000001@originate.test")
+CUSTOM_HEADER = ("X-Originate-Test", "acceptance")
+
+# A plain G.711 offer, so the test needs no media backend at all — the media
+# plan under test here is "the controller supplied the offer".
+OFFER_SDP = (
+    "v=0\r\n"
+    "o=- 3141592653 3141592653 IN IP4 172.20.0.152\r\n"
+    "s=originate\r\n"
+    "c=IN IP4 172.20.0.152\r\n"
+    "t=0 0\r\n"
+    "m=audio 40000 RTP/AVP 0 101\r\n"
+    "a=rtpmap:0 PCMU/8000\r\n"
+    "a=rtpmap:101 telephone-event/8000\r\n"
+    "a=sendrecv\r\n"
+)
+
+OVERALL_TIMEOUT_SECS = float(os.environ.get("ORIGINATE_TIMEOUT", "30"))
+
+
+class Session:
+    """One control connection, with request/reply correlation."""
+
+    def __init__(self, socket) -> None:
+        self._socket = socket
+        self._next_id = 0
+        self._replies: dict[str, dict] = {}
+        self._events: list[dict] = []
+        self._event_waiters: list[asyncio.Future] = []
+
+    async def command(self, verb: str, args: dict, module: str | None = "sip",
+                      target: dict | None = None) -> dict:
+        """Send one command and return its correlated reply frame."""
+        self._next_id += 1
+        request_id = f"c-{self._next_id}"
+        frame = {"id": request_id, "type": "command", "verb": verb, "args": args}
+        if module is not None:
+            frame["module"] = module
+        if target is not None:
+            frame["target"] = target
+        await self._socket.send(json.dumps(frame))
+        while request_id not in self._replies:
+            await self._pump()
+        return self._replies.pop(request_id)
+
+    async def wait_event(self, predicate, timeout: float) -> dict:
+        """Wait for the first event matching ``predicate``."""
+        deadline = time.monotonic() + timeout
+        while True:
+            for index, event in enumerate(self._events):
+                if predicate(event):
+                    return self._events.pop(index)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("no matching event before the deadline")
+            await self._pump(remaining)
+
+    async def _pump(self, timeout: float = OVERALL_TIMEOUT_SECS) -> None:
+        raw = await asyncio.wait_for(self._socket.recv(), timeout)
+        frame = json.loads(raw)
+        stamped = dict(frame)
+        stamped["_at"] = time.monotonic()
+        if frame.get("type") == "reply":
+            self._replies[frame["id"]] = stamped
+        elif frame.get("type") == "event":
+            print(f"event {frame.get('event')} {json.dumps(frame.get('payload'))}",
+                  flush=True)
+            self._events.append(stamped)
+
+
+def fail(checks: list, name: str, detail: str) -> None:
+    checks.append({"check": name, "pass": False, "detail": detail})
+
+
+def ok(checks: list, name: str, detail: str = "") -> None:
+    checks.append({"check": name, "pass": True, "detail": detail})
+
+
+async def run() -> bool:
+    checks: list[dict] = []
+
+    headers = {"Authorization": f"Bearer {CONTROL_TOKEN}"}
+    # websockets renamed extra_headers -> additional_headers in 14.0.
+    try:
+        connector = websockets.connect(
+            CONTROL_URL, subprotocols=[SUBPROTOCOL], additional_headers=headers
+        )
+    except TypeError:
+        connector = websockets.connect(
+            CONTROL_URL, subprotocols=[SUBPROTOCOL], extra_headers=headers
+        )
+
+    async with connector as socket:
+        session = Session(socket)
+
+        hello = await session.command(
+            "hello", {"app": "originate-app", "protocol": 1}, module=None
+        )
+        if hello.get("status") != "ok":
+            fail(checks, "hello", json.dumps(hello))
+            return verdict(checks)
+        ok(checks, "hello")
+
+        # --- 1 + 2: place the call under our own id, and time the accept ----
+        sent_at = time.monotonic()
+        reply = await session.command("originate", {
+            "channel": CHANNEL_ID,
+            "to": TARGET,
+            "from": FROM_URI,
+            "from_display": FROM_DISPLAY,
+            "p_asserted_identity": ASSERTED,
+            "headers": {CUSTOM_HEADER[0]: CUSTOM_HEADER[1]},
+            "sdp": OFFER_SDP,
+            "timeout": 20,
+        })
+        accepted_at = reply.get("_at", time.monotonic())
+        if reply.get("status") != "ok":
+            fail(checks, "originate_accepted", json.dumps(reply))
+            return verdict(checks)
+        result = reply.get("result", {})
+        if result.get("channel") != CHANNEL_ID:
+            fail(checks, "caller_supplied_id",
+                 f"reply channel {result.get('channel')!r} != {CHANNEL_ID!r}")
+        else:
+            ok(checks, "caller_supplied_id", CHANNEL_ID)
+        if result.get("state") != "calling":
+            fail(checks, "accept_state", json.dumps(result))
+        else:
+            ok(checks, "accept_state", "calling")
+        if not result.get("sip_call_id"):
+            fail(checks, "sip_call_id_returned", json.dumps(result))
+        else:
+            ok(checks, "sip_call_id_returned", result["sip_call_id"])
+
+        # --- 1b: a duplicate id is refused, and distinguishably so ----------
+        duplicate = await session.command("originate", {
+            "channel": CHANNEL_ID,
+            "to": TARGET,
+            "sdp": OFFER_SDP,
+        })
+        code = (duplicate.get("error") or {}).get("code")
+        if duplicate.get("status") == "error" and code == "conflict":
+            ok(checks, "duplicate_id_is_conflict", code)
+        else:
+            fail(checks, "duplicate_id_is_conflict", json.dumps(duplicate))
+
+        # --- 4: ringing arrives as an event on our id -----------------------
+        ringing = await session.wait_event(
+            lambda event: event.get("event") == "ChannelStateChange"
+            and (event.get("payload") or {}).get("state") in ("ringing", "progress"),
+            OVERALL_TIMEOUT_SECS,
+        )
+        if ringing.get("channel") != CHANNEL_ID:
+            fail(checks, "ringing_correlates", json.dumps(ringing))
+        else:
+            ok(checks, "ringing_correlates",
+               f"code={(ringing.get('payload') or {}).get('code')}")
+        ringing_at = ringing.get("_at", time.monotonic())
+
+        # --- 2: the accept came back before the far end did anything --------
+        answered = await session.wait_event(
+            lambda event: event.get("event") == "ChannelStateChange"
+            and (event.get("payload") or {}).get("state") == "answered",
+            OVERALL_TIMEOUT_SECS,
+        )
+        answered_at = answered.get("_at", time.monotonic())
+        if answered.get("channel") != CHANNEL_ID:
+            fail(checks, "answered_correlates", json.dumps(answered))
+        else:
+            ok(checks, "answered_correlates",
+               f"code={(answered.get('payload') or {}).get('code')}")
+
+        # The whole point of an asynchronous originate: the reply is the local
+        # action, and it must land while the callee is still ringing.
+        if accepted_at < ringing_at < answered_at:
+            ok(checks, "accept_precedes_answer",
+               f"accept +{accepted_at - sent_at:.3f}s, "
+               f"ringing +{ringing_at - sent_at:.3f}s, "
+               f"answered +{answered_at - sent_at:.3f}s")
+        else:
+            fail(checks, "accept_precedes_answer",
+                 f"accept={accepted_at - sent_at:.3f} ringing={ringing_at - sent_at:.3f} "
+                 f"answered={answered_at - sent_at:.3f}")
+        # A synchronous originate would have blocked for the UAS's ring hold, so
+        # the accept would be no faster than the answer. Require real slack.
+        if answered_at - accepted_at < 1.0:
+            fail(checks, "accept_is_not_the_outcome",
+                 f"only {answered_at - accepted_at:.3f}s between accept and answer")
+        else:
+            ok(checks, "accept_is_not_the_outcome",
+               f"{answered_at - accepted_at:.3f}s of ring after the accept")
+
+        # --- 5: hang the answered call up, and require the StasisEnd --------
+        hangup = await session.command(
+            "hangup", {"reason": "acceptance test done"},
+            target={"channel": CHANNEL_ID},
+        )
+        if hangup.get("status") != "ok":
+            fail(checks, "hangup_accepted", json.dumps(hangup))
+        else:
+            ok(checks, "hangup_accepted")
+
+        ended = await session.wait_event(
+            lambda event: event.get("event") == "StasisEnd", OVERALL_TIMEOUT_SECS
+        )
+        if ended.get("channel") != CHANNEL_ID:
+            fail(checks, "stasis_end_correlates", json.dumps(ended))
+        else:
+            ok(checks, "stasis_end_correlates",
+               json.dumps(ended.get("payload")))
+
+        # --- and the id is free again once the call is gone -----------------
+        reused = await session.command("originate", {
+            "channel": CHANNEL_ID,
+            "to": "sip:+15559999999@172.20.0.253:5060",
+            "sdp": OFFER_SDP,
+            "timeout": 1,
+        })
+        reused_code = (reused.get("error") or {}).get("code")
+        if reused.get("status") == "ok" or reused_code != "conflict":
+            ok(checks, "id_is_free_after_teardown", reused_code or "ok")
+        else:
+            fail(checks, "id_is_free_after_teardown", json.dumps(reused))
+
+    return verdict(checks)
+
+
+def verdict(checks: list[dict]) -> bool:
+    passed = all(check["pass"] for check in checks)
+    print("ORIGINATE-VERDICT " + json.dumps({"pass": passed, "checks": checks}),
+          flush=True)
+    return passed
+
+
+async def main() -> int:
+    try:
+        passed = await asyncio.wait_for(run(), OVERALL_TIMEOUT_SECS * 2)
+    except Exception as error:  # noqa: BLE001 — the verdict is the report
+        print("ORIGINATE-VERDICT " + json.dumps({
+            "pass": False,
+            "checks": [{"check": "run", "pass": False, "detail": repr(error)}],
+        }), flush=True)
+        return 1
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/sipp/control/originate_noop.py
+++ b/sipp/control/originate_noop.py
@@ -1,0 +1,10 @@
+"""No-op script for the `originate` acceptance test.
+
+The control application places every call over the control rail, so nothing here
+routes anything. It exists because a running siphon loads a script, and it is
+deliberately empty so the test proves the control-plane path and nothing else.
+"""
+
+from siphon import log
+
+log.info("originate acceptance test: no in-process routing, control app drives")

--- a/sipp/control/siphon-originate.yaml
+++ b/sipp/control/siphon-originate.yaml
@@ -1,0 +1,40 @@
+# siphon config for the `originate` acceptance test
+# (sipp/control/originate_app.py + sipp/originate_uas.xml).
+#
+# There is no inbound call anywhere in this test: the control application dials
+# siphon's control WebSocket and places a call itself. So there is no B2BUA
+# script route to configure — the script only exists because a running siphon
+# wants one, and it registers no handlers.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "originate.test"
+    - "172.20.0.150"
+
+advertised_address: "172.20.0.150"
+
+script:
+  path: "/etc/siphon/scripts/originate_noop.py"
+
+control:
+  listen: "0.0.0.0:9092"
+  apps:
+    - name: "originate-app"
+      token: "originate-test-token"
+      # Inbound persistent mode: the app dials siphon and holds one socket.
+      # An originate has no inbound call to dial the app *for*, so per-call
+      # connect cannot apply to it.
+      per_call_connect: false
+      on_lost: "hangup"
+  limits:
+    event_queue_depth: 256
+    slow_consumer: drop_oldest
+    reattach_grace_secs: 5
+    handoff_deadline_ms: 3000
+
+log:
+  level: info

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -5074,6 +5074,94 @@ services:
     profiles:
       - rtpproxy-real
 
+  # ── Control-plane `originate` (a call siphon places itself) ───────────────
+  # Requires the "originate" profile.
+  #
+  # IP assignments:
+  #   172.20.0.150 — siphon (control listener on :9092, SIP on :5060)
+  #   172.20.0.151 — SIPp UAS (the callee)
+  #   172.20.0.152 — the control application
+  #
+  # There is no inbound call: the control app dials siphon's control WebSocket
+  # and places one with a channel id it chose. The UAS asserts the outbound
+  # identity reached the wire and holds `180 Ringing` for two seconds; the app
+  # asserts its accept came back long before the answer did, and that a
+  # duplicate id is refused `conflict`.
+  #
+  # Usage:
+  #   docker compose -f sipp/docker-compose.yaml --profile originate \
+  #     up --abort-on-container-exit --exit-code-from originate-app \
+  #     siphon-originate sipp-originate-uas originate-app
+
+  siphon-originate:
+    build:
+      context: ..
+    container_name: siphon-originate-test
+    volumes:
+      - ./control/siphon-originate.yaml:/etc/siphon/siphon.yaml:ro
+      - ./control:/etc/siphon/scripts:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.150
+    healthcheck:
+      # The control listener is what this test needs up, so probe that rather
+      # than SIP: a siphon that answers OPTIONS but never bound :9092 would
+      # otherwise look healthy and the app would fail on connect.
+      test: ["CMD-SHELL", "python3 -c \"import socket; socket.create_connection(('127.0.0.1',9092),2).close()\""]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 8s
+    profiles:
+      - originate
+
+  # The callee. Asserts the From / P-Asserted-Identity / custom header / offer
+  # the app asked for, then rings for 2 s before answering.
+  sipp-originate-uas:
+    image: ctaloi/sipp:latest
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.151
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/originate_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "40"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - originate
+
+  originate-app:
+    image: python:3.12-slim
+    container_name: originate-app
+    depends_on:
+      siphon-originate:
+        condition: service_healthy
+      sipp-originate-uas:
+        condition: service_started
+    volumes:
+      - ./control:/app:ro
+    working_dir: /app
+    # websockets is not in the base image; install then run.
+    command: ["sh", "-c", "pip install --quiet --no-cache-dir websockets && exec python3 originate_app.py"]
+    environment:
+      CONTROL_URL: "ws://172.20.0.150:9092/control/ws"
+      CONTROL_TOKEN: "originate-test-token"
+      ORIGINATE_TO: "sip:+15551000001@172.20.0.151:5060"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.152
+    profiles:
+      - originate
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:

--- a/sipp/originate_uas.xml
+++ b/sipp/originate_uas.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  UAS side of the `originate` acceptance test.
+
+  The call under test has NO inbound leg: the control application placed it, so
+  this INVITE is siphon acting as a UAC from nothing. Two things are asserted
+  here that the control app cannot see from its side of the rail:
+
+    1. The outbound identity the app asked for actually reached the wire — the
+       From URI + display name, the P-Asserted-Identity (RFC 3325 §9.1), the
+       custom header, and the caller-supplied SDP offer. A parameter that was
+       accepted by the verb but never applied to the INVITE fails right here.
+
+    2. The ring hold. `180 Ringing` goes out immediately and the answer is held
+       for two seconds, which is what gives the control app a window to prove
+       its accept came back long before the callee did anything.
+
+  Flow: recv INVITE -> 180 -> (2 s) -> 200 -> recv ACK -> recv BYE -> 200.
+-->
+<scenario name="originate UAS">
+
+  <!-- The INVITE siphon originated. Every regexp below is an assertion: an
+       unmatched one fails the call, which fails the run. -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <!-- RFC 3261 §8.1.1.3: the calling identity the app supplied, display
+           name and all. -->
+      <ereg regexp='"Callback" &lt;sip:\+15550000001@originate\.test&gt;'
+            search_in="hdr" header="From:" check_it="true" assign_to="from_ok" />
+      <!-- RFC 3325 §9.1: the asserted identity for the trusted next hop. -->
+      <ereg regexp="sip:\+15550000001@originate\.test"
+            search_in="hdr" header="P-Asserted-Identity:"
+            check_it="true" assign_to="pai_ok" />
+      <!-- An arbitrary custom header the app asked for. -->
+      <ereg regexp="acceptance"
+            search_in="hdr" header="X-Originate-Test:"
+            check_it="true" assign_to="custom_ok" />
+      <!-- The called party, in the Request-URI and in To. -->
+      <ereg regexp="sip:\+15551000001@"
+            search_in="hdr" header="To:" check_it="true" assign_to="to_ok" />
+      <!-- RFC 3261 §12.1.2: a UAC's initial INVITE carries no To-tag. -->
+      <ereg regexp="tag="
+            search_in="hdr" header="To:" check_it_inverse="true"
+            assign_to="to_untagged" />
+      <!-- The controller's own SDP offer, carried verbatim. -->
+      <ereg regexp="m=audio 40000 RTP/AVP"
+            search_in="msg" check_it="true" assign_to="offer_ok" />
+      <!-- siphon must be reachable for the in-dialog BYE (RFC 3261 §12.2.1.1). -->
+      <ereg regexp="sip:"
+            search_in="hdr" header="Contact:" check_it="true" assign_to="contact_ok" />
+      <!-- Reference the assigned vars so SIPp does not reject them as unused;
+           the pass/fail gate is check_it on the eregs above. -->
+      <log message="originate INVITE assertions: from=[$from_ok] pai=[$pai_ok] custom=[$custom_ok] to=[$to_ok] untagged=[$to_untagged] offer=[$offer_ok] contact=[$contact_ok]" />
+    </action>
+  </recv>
+
+  <!-- Ring immediately: the control app times its accept against this. -->
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:callee@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Hold the answer. A synchronous originate would still be blocked here, so
+       this pause is what makes the "accept is not the outcome" check real. -->
+  <pause milliseconds="2000" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:callee@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=callee 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <!-- RFC 3261 §13.2.2.4: the UAC ACKs the 2xx. Not optional — an originate
+       that never ACKs leaves the callee retransmitting until the dialog dies. -->
+  <recv request="ACK" rtd="true" />
+
+  <!-- The control app's `hangup` on an answered call is an in-dialog BYE. -->
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -479,6 +479,28 @@ impl Leg {
         }
     }
 
+    /// Create the single leg of a call **siphon itself placed** (`originate`).
+    ///
+    /// Siphon is the UAC on this leg — there is no inbound INVITE and no caller
+    /// to bridge to — so it carries an *outbound* dialog ([`Dialog::new_outbound`])
+    /// while still occupying the A-leg slot: the A-leg is "the leg the call
+    /// starts from", and every teardown / in-dialog path
+    /// ([`crate::b2bua::actor::CallActor::request_direction`], the framework BYE
+    /// builder, the media safety-net) keys on it. `local_tag` is our From-tag
+    /// (RFC 3261 §8.1.1.3) and `branch` the INVITE's own Via branch.
+    pub fn new_originating_leg(
+        call_id: String,
+        local_tag: String,
+        target_uri: String,
+        branch: String,
+        transport: TransportInfo,
+    ) -> Self {
+        Self {
+            side: LegSide::A,
+            ..Self::new_b_leg(call_id, local_tag, target_uri, branch, transport)
+        }
+    }
+
     /// Create a new B-leg for an outbound INVITE.
     pub fn new_b_leg(
         call_id: String,
@@ -571,6 +593,17 @@ pub struct LegRegistry {
     /// B-leg path, which ACKs (wrong for a non-INVITE, RFC 3261 §17.1.2) and
     /// reasons about legs that do not exist on a single-leg call.
     originated_refers: DashMap<String, OriginatedRefer>,
+    /// Via branch → internal call ID for an INVITE **siphon originated**
+    /// (`originate`).
+    ///
+    /// Kept apart from [`Self::by_branch`] for the same reason
+    /// [`Self::originated_refers`] is: a response matched there runs
+    /// `handle_b2bua_response`, which relays the far end's provisionals/finals
+    /// to an A-leg and reasons about B-legs. An originated call *is* the A-leg
+    /// and has no B-leg, so relaying its own 180 back at the peer we are calling
+    /// is exactly wrong. This index gives the response path a first, explicit
+    /// hook (checked before the leg-branch lookup) into the UAC-side handler.
+    originated_calls: DashMap<String, String>,
 }
 
 /// A REFER siphon sent on one of its own legs, awaiting a response.
@@ -600,7 +633,32 @@ impl LegRegistry {
             by_call_id: DashMap::new(),
             by_branch: DashMap::new(),
             originated_refers: DashMap::new(),
+            originated_calls: DashMap::new(),
         }
+    }
+
+    /// Record a siphon-originated INVITE branch so its responses reach the
+    /// UAC-side handler instead of the B-leg relay machinery.
+    pub fn register_originated_call(&self, branch: &str, internal_id: &str) {
+        self.originated_calls
+            .insert(branch.to_string(), internal_id.to_string());
+    }
+
+    /// The internal call id of the originate this branch belongs to, if any.
+    pub fn lookup_originated_call(&self, branch: &str) -> Option<String> {
+        self.originated_calls.get(branch).map(|entry| entry.clone())
+    }
+
+    /// Drop the originate branch index entry of a call that is gone.
+    pub fn clear_originated_calls(&self, internal_id: &str) {
+        self.originated_calls
+            .retain(|_, id| id.as_str() != internal_id);
+    }
+
+    /// Number of tracked originate branches (leak-test accessor).
+    #[cfg(test)]
+    pub fn originated_call_count(&self) -> usize {
+        self.originated_calls.len()
     }
 
     /// Record a siphon-originated REFER so its response can be matched.
@@ -666,6 +724,10 @@ impl LegRegistry {
         // entry would leak one per abandoned transfer.
         self.originated_refers
             .retain(|_, refer| refer.call_id.as_str() != internal_id);
+        // ...and the originate branch, for the same reason: one entry per placed
+        // call would otherwise never drain.
+        self.originated_calls
+            .retain(|_, id| id.as_str() != internal_id);
     }
 
     /// Number of registered calls (unique internal IDs in Call-ID map).
@@ -915,6 +977,28 @@ pub struct CallActor {
     /// instead of the 408 timeout teardown. Cleared once the controller acts
     /// (answer/progress transitions the state) or the call is torn down.
     pub handoff_pending: bool,
+    /// True when siphon *placed* this call (`originate`) rather than receiving
+    /// an INVITE for it. The A-leg is then a UAC dialog siphon owns, so every
+    /// path that would answer the A-leg with a SIP *response* is wrong for it:
+    /// an un-answered originate is abandoned with a CANCEL (RFC 3261 §9.1), not
+    /// a 408/503 sent to the peer we are calling.
+    pub originated: bool,
+    /// The media anchor an originated call asked for, when it went out with no
+    /// offer. Read on the callee's 2xx to answer its offer locally and carry the
+    /// answer on the ACK (RFC 3261 §13.2.2.4). `None` for a call originated with
+    /// a controller-supplied offer, and for every inbound call.
+    pub originate_anchor: Option<OriginateAnchor>,
+}
+
+/// The media plan of an offerless originate, resolved when the callee's 2xx
+/// arrives. Names a profile in the media registry rather than carrying resolved
+/// engine flags, so the actor layer stays free of media types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OriginateAnchor {
+    /// Media profile whose `answer` flags the local anchor uses.
+    pub profile: String,
+    /// Per-call WebSocket bridge URI (templated), overriding the profile's.
+    pub ws_uri: Option<String>,
 }
 
 impl CallActor {
@@ -954,6 +1038,8 @@ impl CallActor {
             control_app: None,
             on_control_loss: None,
             handoff_pending: false,
+            originated: false,
+            originate_anchor: None,
         }
     }
 
@@ -1779,6 +1865,40 @@ impl CallActorStore {
         self.registry.clear_originated_refers(call_id);
     }
 
+    /// Mark a call as one siphon *placed* (`originate`) and index its INVITE's
+    /// Via branch so the response path routes to the UAC-side handler.
+    pub fn mark_originated(&self, call_id: &str, branch: &str) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            call.originated = true;
+        }
+        self.registry.register_originated_call(branch, call_id);
+    }
+
+    /// Whether this call was placed by siphon (`originate`).
+    pub fn is_originated(&self, call_id: &str) -> bool {
+        self.calls.get(call_id).is_some_and(|call| call.originated)
+    }
+
+    /// The internal call id of the originate whose INVITE carried `branch`.
+    pub fn lookup_originated_call(&self, branch: &str) -> Option<String> {
+        self.registry.lookup_originated_call(branch)
+    }
+
+    /// Record the media anchor an offerless originate must apply to the
+    /// callee's 2xx offer.
+    pub fn set_originate_anchor(&self, call_id: &str, anchor: OriginateAnchor) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            call.originate_anchor = Some(anchor);
+        }
+    }
+
+    /// The media anchor plan of an originated call, if it went out offerless.
+    pub fn originate_anchor(&self, call_id: &str) -> Option<OriginateAnchor> {
+        self.calls
+            .get(call_id)
+            .and_then(|call| call.originate_anchor.clone())
+    }
+
     /// Get a call by internal ID.
     pub fn get_call(&self, call_id: &str) -> Option<dashmap::mapref::one::Ref<'_, String, CallActor>> {
         self.calls.get(call_id)
@@ -2147,6 +2267,9 @@ impl CallActorStore {
             // would transfer is gone. Cleared here rather than left to age out,
             // so an abandoned transfer does not leak an entry per call.
             self.registry.clear_originated_refers(call_id);
+            // Likewise the originate branch index: one entry per placed call,
+            // dropped with the call so it can never outlive it.
+            self.registry.clear_originated_calls(call_id);
             // Clean up A-leg registry entries
             self.registry.remove_call_id(&call.a_leg.dialog.call_id);
             self.registry.remove_branch(&call.a_leg.branch);
@@ -2194,6 +2317,24 @@ impl CallActorStore {
     pub fn remove_call_after_cancel(&self, call_id: &str) -> bool {
         let mut captured = false;
         if let Some(call) = self.calls.get(call_id) {
+            // A call siphon placed (`originate`) carries its pending INVITE on
+            // the A-leg, not a B-leg, so the loop below would capture nothing
+            // and a 2xx racing our CANCEL would be dropped — leaving the callee
+            // retransmitting a 200 for a dialog nobody ever ACKs or BYEs
+            // (RFC 3261 §9.1 glare, §13.2.2.4, §15).
+            if call.originated
+                && matches!(call.state, CallState::Calling | CallState::Ringing)
+                && call.a_leg_invite.is_some()
+            {
+                self.zombie_cancelled.insert(
+                    call.a_leg.dialog.call_id.clone(),
+                    ZombieCancelledLeg {
+                        leg: call.a_leg.clone(),
+                        byed: false,
+                    },
+                );
+                captured = true;
+            }
             for (index, b_leg) in call.b_legs.iter().enumerate() {
                 let pending = matches!(
                     call.b_leg_status.get(index),
@@ -4377,5 +4518,124 @@ mod tests {
         assert!(!terminated.contains_key("cid-2"));
         assert!(terminated.contains_key("cid-3"));
         assert!(terminated.contains_key("cid-4"));
+    }
+}
+
+#[cfg(test)]
+mod originate_tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn transport() -> TransportInfo {
+        TransportInfo {
+            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)), 5060),
+            connection_id: ConnectionId::default(),
+            transport: Transport::Udp,
+            local_addr: None,
+        }
+    }
+
+    fn originating_leg() -> Leg {
+        Leg::new_originating_leg(
+            "orig-call@siphon.invalid".to_string(),
+            "sip-from-tag".to_string(),
+            "sip:+14035551212@carrier.example".to_string(),
+            "z9hG4bK-orig1".to_string(),
+            transport(),
+        )
+    }
+
+    #[test]
+    fn originating_leg_is_an_a_leg_with_an_outbound_dialog() {
+        let leg = originating_leg();
+        assert_eq!(leg.side, LegSide::A);
+        // Outbound dialog: our tag is the local (From) tag, the remote tag is
+        // still unknown, and the target URI is the R-URI we INVITE.
+        assert_eq!(leg.dialog.local_tag, "sip-from-tag");
+        assert!(leg.dialog.remote_tag.is_none());
+        assert_eq!(
+            leg.dialog.target_uri.as_deref(),
+            Some("sip:+14035551212@carrier.example")
+        );
+        assert_eq!(leg.dialog.local_cseq, 1);
+        assert!(!leg.is_tracking_leg());
+    }
+
+    #[test]
+    fn a_fresh_call_is_not_originated() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(originating_leg());
+        assert!(!store.is_originated(&call_id));
+    }
+
+    #[test]
+    fn mark_originated_flags_the_call_and_indexes_the_branch() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(originating_leg());
+        store.mark_originated(&call_id, "z9hG4bK-orig1");
+
+        assert!(store.is_originated(&call_id));
+        assert_eq!(
+            store.lookup_originated_call("z9hG4bK-orig1").as_deref(),
+            Some(call_id.as_str())
+        );
+        assert!(store.lookup_originated_call("z9hG4bK-someone-else").is_none());
+    }
+
+    #[test]
+    fn removing_the_call_drains_the_originate_branch_index() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(originating_leg());
+        store.mark_originated(&call_id, "z9hG4bK-orig1");
+        assert_eq!(store.registry.originated_call_count(), 1);
+
+        store.remove_call(&call_id);
+        assert_eq!(store.registry.originated_call_count(), 0);
+        assert!(store.lookup_originated_call("z9hG4bK-orig1").is_none());
+    }
+
+    /// Steady-state leak guard for the originate branch index: a batch of
+    /// complete place-then-tear-down cycles must return every store to the
+    /// length it started at.
+    #[test]
+    fn originate_cycles_drain_every_store_to_baseline() {
+        let store = CallActorStore::new();
+        let baseline = (store.count(), store.registry.originated_call_count());
+
+        for index in 0..200 {
+            let leg = Leg::new_originating_leg(
+                format!("orig-{index}@siphon.invalid"),
+                format!("tag-{index}"),
+                "sip:+14035551212@carrier.example".to_string(),
+                format!("z9hG4bK-orig-{index}"),
+                transport(),
+            );
+            let call_id = store.create_call(leg);
+            store.mark_originated(&call_id, &format!("z9hG4bK-orig-{index}"));
+            store.remove_call(&call_id);
+        }
+
+        assert_eq!(
+            (store.count(), store.registry.originated_call_count()),
+            baseline,
+            "originate must not retain per-call state after teardown"
+        );
+    }
+
+    #[test]
+    fn an_originated_call_routes_its_own_in_dialog_requests_to_the_a_leg() {
+        // RFC 3261 §12: the far end's BYE carries our dialog Call-ID, and its
+        // From-tag is the tag it assigned (our `remote_tag`). A single-leg
+        // originated call must resolve that to the A-leg, never to "no dialog".
+        let mut actor = CallActor::new(originating_leg());
+        actor.a_leg.dialog.remote_tag = Some("peer-tag".to_string());
+        assert_eq!(
+            actor.request_direction("orig-call@siphon.invalid", Some("peer-tag")),
+            Some(LegSide::A)
+        );
+        assert_eq!(
+            actor.request_direction("some-other-call@elsewhere", Some("peer-tag")),
+            None
+        );
     }
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -53,6 +53,15 @@ pub use registry::{
     Ownership, PushOutcome, SlowConsumerPolicy,
 };
 
+/// Push an event to the control channel owning `sip_call_id`, if the call is
+/// controlled. A no-op when the control plane is not installed. Signalling-path
+/// helper — never blocks, never panics.
+pub fn notify_channel_event(sip_call_id: &str, event: &str, payload: serde_json::Value) {
+    if let Some(bus) = ControlBus::global() {
+        bus.forward_channel_event(sip_call_id, event, payload);
+    }
+}
+
 /// The resolved target of an adapter command. The substrate resolves + ownership
 /// -checks a `{channel}` target before handing the command to the adapter, so an
 /// adapter never sees a channel its connection does not own.
@@ -62,6 +71,21 @@ pub enum ResolvedTarget {
     Channel(ChannelRef),
     /// No addressable resource (module-level verb).
     None,
+}
+
+/// The authenticated connection a command arrived on.
+///
+/// Carried alongside the resolved target because a verb that *creates* a
+/// resource (`originate`) has no target to resolve ownership from and must
+/// still register what it creates to exactly one owner — the connection that
+/// asked for it. Server-authoritative: the substrate fills this in from the
+/// authenticated socket, it is never read off the frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOrigin {
+    /// The application the connection authenticated as.
+    pub app: String,
+    /// The originating connection id.
+    pub conn_id: u64,
 }
 
 /// A command handed to an adapter, with its target already resolved +
@@ -74,6 +98,8 @@ pub struct AdapterCommand {
     pub args: serde_json::Value,
     /// The resolved, ownership-checked target.
     pub target: ResolvedTarget,
+    /// The authenticated connection this command came in on.
+    pub origin: CommandOrigin,
 }
 
 /// Introspection schema for one adapter (`describe`).
@@ -331,6 +357,10 @@ async fn dispatch(
             verb: verb.to_string(),
             args,
             target: resolved,
+            origin: CommandOrigin {
+                app: app.to_string(),
+                conn_id,
+            },
         })
         .await
 }

--- a/src/control/protocol.rs
+++ b/src/control/protocol.rs
@@ -83,6 +83,15 @@ pub enum ControlErrorCode {
     NotFound,
     /// The frame or its arguments were malformed.
     BadRequest,
+    /// The caller-supplied identifier is already in use (an `originate` reusing
+    /// a live channel id). Distinct from `bad_request`: the frame is well
+    /// formed, the id just collides, and the fix is a different id — never a
+    /// retry of the same one.
+    Conflict,
+    /// The target resource exists and is addressable, but is in the wrong state
+    /// for this verb (bridging a leg that has not answered). Distinct from
+    /// `not_found` (no such leg) and from `conflict` (id already taken).
+    InvalidState,
     /// The command exceeded a rate limit.
     RateLimited,
     /// An originate was denied by the toll-fraud gates.
@@ -352,5 +361,33 @@ mod tests {
             serde_json::to_string(&ControlErrorCode::UnsupportedVersion).unwrap(),
             "\"unsupported_version\""
         );
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::Conflict).unwrap(),
+            "\"conflict\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ControlErrorCode::InvalidState).unwrap(),
+            "\"invalid_state\""
+        );
+    }
+
+    #[test]
+    fn each_originate_failure_cause_has_its_own_code() {
+        // Requirement: unknown leg / duplicate id / wrong state / backend can't
+        // are four *distinguishable* wire codes, never one bucket.
+        let codes = [
+            ControlErrorCode::NotFound,
+            ControlErrorCode::Conflict,
+            ControlErrorCode::InvalidState,
+            ControlErrorCode::UnsupportedVerb,
+        ];
+        let rendered: Vec<String> = codes
+            .iter()
+            .map(|code| serde_json::to_string(code).unwrap_or_default())
+            .collect();
+        let mut unique = rendered.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), codes.len(), "codes collide on the wire: {rendered:?}");
     }
 }

--- a/src/control/registry.rs
+++ b/src/control/registry.rs
@@ -578,6 +578,52 @@ impl ControlBus {
         self.apps.get(app).and_then(|fanout| fanout.get(conn_id))
     }
 
+    /// The live connection that issued a command, so an adapter verb that
+    /// *creates* a channel (`originate`) can register it to the same owner the
+    /// command came in on — server-authoritative, never client-asserted, and
+    /// the same exactly-one-owner rule every offered channel follows.
+    /// `None` once the connection has gone (a command racing its own socket
+    /// close), which the adapter answers `unavailable` rather than leaking an
+    /// ownerless channel.
+    pub fn connection_for_command(&self, app: &str, conn_id: u64) -> Option<Arc<ConnHandle>> {
+        self.connection(app, conn_id)
+    }
+
+    /// Whether a channel id is already registered. Read by `originate` before
+    /// it places anything on the wire so a caller-supplied id that collides is
+    /// rejected as `conflict` — never silently re-pointed at a second call,
+    /// which would strand the first.
+    pub fn channel_exists(&self, channel_id: &str) -> bool {
+        self.channels.contains_key(channel_id)
+    }
+
+    /// Push an event to whichever channel owns `sip_call_id`, if any.
+    ///
+    /// The by-Call-ID twin of [`publish_to_channel`](Self::publish_to_channel),
+    /// for signalling-path callers (the B2BUA response handler) that hold the
+    /// SIP Call-ID and not the channel id. Idempotent no-op — never panics,
+    /// never blocks — when the call is uncontrolled (the common case), the
+    /// channel is orphaned, or its connection is gone. Adds and removes no
+    /// per-call state of its own. Returns whether an event was queued.
+    pub fn forward_channel_event(
+        &self,
+        sip_call_id: &str,
+        event: &str,
+        payload: serde_json::Value,
+    ) -> bool {
+        let Some(channel_id) = self.channel_id_for_sip_call_id(sip_call_id) else {
+            return false;
+        };
+        let (app, call_actor_id) = match self.channels.get(&channel_id) {
+            Some(entry) => (entry.app.clone(), entry.call_actor_id.clone()),
+            None => return false,
+        };
+        self.publish_to_channel(
+            &channel_id,
+            EventFrame::new(event, &channel_id, &app, &call_actor_id, sip_call_id, payload),
+        )
+    }
+
     /// Register a controlled channel to an owning connection.
     #[allow(clippy::too_many_arguments)]
     pub fn register_channel(
@@ -718,6 +764,26 @@ impl ControlBus {
     /// the channel. Idempotent — a no-op when the call is not controlled.
     /// Called from every B2BUA teardown junction, guarded internally.
     pub fn on_call_terminated(&self, sip_call_id: &str, reason: &str) {
+        self.on_call_terminated_with_cause(sip_call_id, reason, None, None);
+    }
+
+    /// [`on_call_terminated`](Self::on_call_terminated) carrying the SIP cause
+    /// that ended the call.
+    ///
+    /// A leg siphon *placed* (`originate`) can die on a final non-2xx —
+    /// `486 Busy Here`, `603 Decline` — and the controller has no other way to
+    /// learn which: there is no A-leg the response was relayed to and no reply
+    /// frame it belongs to (RFC 3261 §8.1.3.4 leaves the meaning to the code +
+    /// reason phrase, so both are surfaced). `code`/`response` ride alongside
+    /// `reason` in the `StasisEnd` payload and are omitted when absent, so an
+    /// ordinary BYE-driven teardown emits exactly the frame it emitted before.
+    pub fn on_call_terminated_with_cause(
+        &self,
+        sip_call_id: &str,
+        reason: &str,
+        code: Option<u16>,
+        response: Option<&str>,
+    ) {
         let Some(channel_id) = self.channel_id_for_sip_call_id(sip_call_id) else {
             return;
         };
@@ -725,6 +791,15 @@ impl ControlBus {
             Some(entry) => (entry.app.clone(), entry.call_actor_id.clone()),
             None => return,
         };
+        let mut payload = serde_json::json!({ "reason": reason });
+        if let Some(object) = payload.as_object_mut() {
+            if let Some(code) = code {
+                object.insert("code".to_string(), serde_json::json!(code));
+            }
+            if let Some(response) = response {
+                object.insert("response".to_string(), serde_json::json!(response));
+            }
+        }
         self.publish_to_channel(
             &channel_id,
             EventFrame::new(
@@ -733,11 +808,11 @@ impl ControlBus {
                 &app,
                 &call_actor_id,
                 sip_call_id,
-                serde_json::json!({ "reason": reason }),
+                payload,
             ),
         );
         self.remove_channel(&channel_id);
-        debug!(%channel_id, %sip_call_id, reason, "control plane: StasisEnd + channel removed");
+        debug!(%channel_id, %sip_call_id, reason, ?code, "control plane: StasisEnd + channel removed");
     }
 
     /// Forward an in-band DTMF digit (detected by the media engine on a
@@ -1566,5 +1641,117 @@ mod tests {
         }
         assert_eq!(conn.events.depth(), 4);
         assert_eq!(conn.events.dropped_count(), 996);
+    }
+
+    // --- originate support -------------------------------------------------
+
+    #[test]
+    fn channel_exists_is_the_duplicate_id_gate() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        assert!(!bus.channel_exists("cb-1"));
+        bus.register_channel("cb-1", &conn, "call-uuid", "sipcid", "hangup", HashMap::new());
+        assert!(bus.channel_exists("cb-1"));
+        bus.remove_channel("cb-1");
+        assert!(!bus.channel_exists("cb-1"), "the id must be free again after teardown");
+    }
+
+    #[test]
+    fn connection_for_command_resolves_only_a_live_owner() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        assert_eq!(
+            bus.connection_for_command("ivr-app", conn.id).map(|c| c.id),
+            Some(conn.id)
+        );
+        assert!(bus.connection_for_command("ivr-app", conn.id + 99).is_none());
+        assert!(bus.connection_for_command("other-app", conn.id).is_none());
+        bus.unregister_connection(&conn);
+        assert!(
+            bus.connection_for_command("ivr-app", conn.id).is_none(),
+            "a closed connection must never be handed a new channel to own"
+        );
+    }
+
+    #[test]
+    fn forward_channel_event_reaches_the_owner_by_sip_call_id() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("cb-1", &conn, "call-uuid", "sipcid@host", "hangup", HashMap::new());
+
+        assert!(bus.forward_channel_event(
+            "sipcid@host",
+            "ChannelStateChange",
+            serde_json::json!({ "state": "ringing", "code": 180 }),
+        ));
+        let frames = futures_executor_block_on_recv(&conn);
+        let event = frames
+            .iter()
+            .find_map(|frame| match frame {
+                OutboundFrame::Event(event) if event.event == "ChannelStateChange" => Some(event),
+                _ => None,
+            })
+            .expect("ChannelStateChange must be queued");
+        assert_eq!(event.channel.as_deref(), Some("cb-1"));
+        assert_eq!(event.sip_call_id.as_deref(), Some("sipcid@host"));
+        assert_eq!(event.payload["state"], "ringing");
+
+        // An uncontrolled call is a silent no-op, never a panic.
+        assert!(!bus.forward_channel_event("nobody@host", "ChannelStateChange", serde_json::json!({})));
+    }
+
+    #[test]
+    fn stasis_end_carries_the_sip_cause_when_one_is_known() {
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("cb-1", &conn, "call-uuid", "sipcid@host", "hangup", HashMap::new());
+
+        bus.on_call_terminated_with_cause("sipcid@host", "rejected", Some(486), Some("Busy Here"));
+        let frames = futures_executor_block_on_recv(&conn);
+        let event = frames
+            .iter()
+            .find_map(|frame| match frame {
+                OutboundFrame::Event(event) if event.event == "StasisEnd" => Some(event),
+                _ => None,
+            })
+            .expect("StasisEnd must be queued");
+        assert_eq!(event.payload["reason"], "rejected");
+        assert_eq!(event.payload["code"], 486);
+        assert_eq!(event.payload["response"], "Busy Here");
+        assert!(!bus.channel_exists("cb-1"), "the channel must drain with the call");
+    }
+
+    #[test]
+    fn stasis_end_without_a_cause_is_byte_identical_to_the_legacy_frame() {
+        // Regression guard: adding the cause must not change the frame an
+        // ordinary BYE-driven teardown emits.
+        let bus = test_bus(16, SlowConsumerPolicy::DropOldest);
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("cb-1", &conn, "call-uuid", "sipcid@host", "hangup", HashMap::new());
+        bus.on_call_terminated("sipcid@host", "bye");
+        let frames = futures_executor_block_on_recv(&conn);
+        let event = frames
+            .iter()
+            .find_map(|frame| match frame {
+                OutboundFrame::Event(event) if event.event == "StasisEnd" => Some(event),
+                _ => None,
+            })
+            .expect("StasisEnd must be queued");
+        assert_eq!(event.payload, serde_json::json!({ "reason": "bye" }));
+    }
+
+    /// Drain a connection's queue without an async runtime: the queue is
+    /// already populated by the synchronous `try_push_event`, so one poll is
+    /// enough.
+    fn futures_executor_block_on_recv(conn: &Arc<ConnHandle>) -> Vec<OutboundFrame> {
+        conn.events.close();
+        let mut frames = Vec::new();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        runtime.block_on(async {
+            frames = conn.events.recv_many().await;
+        });
+        frames
     }
 }

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -8,10 +8,12 @@
 //! the callee's answer / ACK / BYE-200 arrive later as events. A command against
 //! a dead/unknown call returns a typed `not_found`, never hangs.
 
+use std::collections::HashMap;
+
 use futures_util::future::BoxFuture;
 
 use super::protocol::{ControlErrorCode, ControlResult};
-use super::registry::ChannelRef;
+use super::registry::{ChannelRef, ControlBus};
 use super::{AdapterCommand, AdapterSchema, ControlAdapter, ResolvedTarget, VerbSchema};
 
 /// The SIP adapter (`module() == "sip"`).
@@ -34,7 +36,10 @@ impl ControlAdapter for SipControlAdapter {
         // Media verbs bind to the async MediaBackend, so they run on the async
         // path; every other verb is a synchronous decision over the B2BUA rail.
         Box::pin(async move {
-            if is_media_verb(&command.verb) {
+            if command.verb == "originate" {
+                // Module-level: it creates the channel rather than addressing one.
+                originate(command)
+            } else if is_media_verb(&command.verb) {
                 apply_media_verb(command).await
             } else {
                 apply_sip(command)
@@ -46,6 +51,7 @@ impl ControlAdapter for SipControlAdapter {
         AdapterSchema {
             module: "sip".to_string(),
             verbs: vec![
+                verb("originate", "Place an outbound call under a caller-supplied channel id and return as soon as the INVITE is on the wire (args: channel, to, from, from_display, to_display, next_hop, p_asserted_identity, privacy, headers, sdp | media, profile, ws_uri, timeout, on_lost, vars)"),
                 verb("answer", "Send a UAS 2xx to the parked A-leg (args: code, reason, body, content_type)"),
                 verb("progress", "Send a UAS 1xx / early media (args: code, reason, body, content_type)"),
                 verb("reject", "Send a final non-2xx and tear the call down (args: code, reason)"),
@@ -439,6 +445,237 @@ async fn stream_stop(channel: &ChannelRef) -> ControlResult {
     }
 }
 
+/// `originate` — place an outbound call the controller owns from the moment it
+/// is accepted.
+///
+/// **The channel id comes from the caller, never from siphon.** A controller
+/// stages its per-call context — routing, media plan, its own state — keyed on
+/// an id it chose *before* anything reaches the network; minting the id here and
+/// returning it would force a round-trip that a well-built controller has
+/// designed out, and would leave a window where the call exists and the
+/// controller cannot name it. A collision with a live channel is a `conflict`,
+/// never a silent re-point (which would strand the first call).
+///
+/// **Asynchronous by construction.** The reply is the *local* action — "the
+/// INVITE is on the wire" — and returns before the callee has done anything.
+/// Ringing (`ChannelStateChange`), answer (`ChannelStateChange{state:answered}`)
+/// and hangup (`StasisEnd`, with the SIP cause) arrive later as events on the
+/// supplied id. A synchronous originate that blocked to answer-or-timeout would
+/// serialise this connection's whole command stream behind one ringing phone and
+/// make ringback or a prompt during ring impossible.
+///
+/// The channel is registered **before** the INVITE is dialed (the two-phase
+/// [`crate::dispatcher::b2bua_originate_prepare`] / `..._dial` split), so a
+/// callee that answers instantly cannot beat its own `StasisStart`.
+fn originate(command: AdapterCommand) -> ControlResult {
+    let Some(bus) = ControlBus::global() else {
+        return ControlResult::error(
+            ControlErrorCode::Unavailable,
+            "control plane is not installed",
+        );
+    };
+    originate_with_bus(&bus, command)
+}
+
+/// [`originate`] with the bus injected, so the id-collision and ownership rules
+/// are testable without a process-global control plane.
+fn originate_with_bus(bus: &std::sync::Arc<ControlBus>, command: AdapterCommand) -> ControlResult {
+    let args = &command.args;
+    let Some(channel_id) = args.get("channel").and_then(|value| value.as_str()) else {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "originate requires args.channel — the caller-supplied channel id this call is addressed by",
+        );
+    };
+    if channel_id.trim().is_empty() {
+        return ControlResult::error(
+            ControlErrorCode::BadRequest,
+            "originate args.channel must not be empty",
+        );
+    }
+    let Some(to) = args.get("to").and_then(|value| value.as_str()) else {
+        return ControlResult::error(ControlErrorCode::BadRequest, "originate requires args.to");
+    };
+
+    let media = match parse_originate_media(args) {
+        Ok(media) => media,
+        Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
+    };
+    let privacy = match parse_privacy(args.get("privacy")) {
+        Ok(privacy) => privacy,
+        Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
+    };
+    let headers = parse_extra_headers(args.get("headers"));
+    let timeout_secs = args
+        .get("timeout")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(30) as u32;
+    let vars: HashMap<String, String> = args
+        .get("vars")
+        .and_then(|value| value.as_object())
+        .map(|object| {
+            object
+                .iter()
+                .filter_map(|(key, value)| value.as_str().map(|v| (key.clone(), v.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+    let on_lost = args
+        .get("on_lost")
+        .and_then(|value| value.as_str())
+        .unwrap_or("hangup")
+        .to_string();
+
+    if bus.channel_exists(channel_id) {
+        return ControlResult::error(
+            ControlErrorCode::Conflict,
+            format!("channel '{channel_id}' is already in use — pick a different id"),
+        );
+    }
+    // Resolve the owner up front: a channel with no live owner would be
+    // unaddressable and would leak, so a command racing its own socket close
+    // must fail before anything is placed on the wire.
+    let Some(conn) = bus.connection_for_command(&command.origin.app, command.origin.conn_id) else {
+        return ControlResult::error(
+            ControlErrorCode::Unavailable,
+            "the commanding connection is gone — nothing would own the originated call",
+        );
+    };
+
+    let params = crate::dispatcher::OriginateParams {
+        to: to.to_string(),
+        to_display: string_arg(args, "to_display"),
+        from: string_arg(args, "from"),
+        from_display: string_arg(args, "from_display"),
+        next_hop: string_arg(args, "next_hop"),
+        p_asserted_identity: string_arg(args, "p_asserted_identity"),
+        privacy,
+        headers,
+        timeout_secs,
+        media,
+    };
+
+    let prepared = match crate::dispatcher::b2bua_originate_prepare(params) {
+        Ok(prepared) => prepared,
+        Err(error) => return originate_error(error),
+    };
+
+    // Own it before it rings: register under the caller's id, then dial.
+    bus.register_channel(
+        channel_id,
+        &conn,
+        &prepared.internal_call_id,
+        &prepared.sip_call_id,
+        &on_lost,
+        vars,
+    );
+    if !crate::dispatcher::b2bua_originate_dial(&prepared) {
+        bus.remove_channel(channel_id);
+        return ControlResult::error(
+            ControlErrorCode::Unavailable,
+            "the originated call vanished before its INVITE could be sent",
+        );
+    }
+
+    ControlResult::Ok(serde_json::json!({
+        "channel": channel_id,
+        "call_id": prepared.internal_call_id,
+        "sip_call_id": prepared.sip_call_id,
+        "state": "calling",
+    }))
+}
+
+/// Read an optional non-empty string argument.
+fn string_arg(args: &serde_json::Value, name: &str) -> Option<String> {
+    args.get(name)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+}
+
+/// Parse the media plan: exactly one of `args.sdp` (a controller-supplied
+/// offer) or `args.media: true` (siphon anchors the leg on the media backend).
+///
+/// Neither is a `bad_request` rather than a default, because an INVITE with no
+/// offer and no plan to answer the callee's leaves its 2xx un-answerable
+/// (RFC 3261 §13.2.2.4) — a connected call with no audio, which is the exact
+/// hollow success this rail refuses to produce.
+fn parse_originate_media(
+    args: &serde_json::Value,
+) -> Result<crate::dispatcher::OriginateMedia, String> {
+    let sdp = args.get("sdp").and_then(|value| value.as_str());
+    let anchor = args
+        .get("media")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    match (sdp, anchor) {
+        (Some(_), true) => Err(
+            "originate takes either args.sdp (your own offer) or args.media=true (siphon anchors the leg), not both"
+                .to_string(),
+        ),
+        (Some(sdp), false) if sdp.trim().is_empty() => {
+            Err("originate args.sdp must not be empty".to_string())
+        }
+        (Some(sdp), false) => Ok(crate::dispatcher::OriginateMedia::Offer(sdp.to_string())),
+        (None, true) => Ok(crate::dispatcher::OriginateMedia::Anchor {
+            profile: args
+                .get("profile")
+                .and_then(|value| value.as_str())
+                .unwrap_or("rtp_passthrough")
+                .to_string(),
+            ws_uri: args
+                .get("ws_uri")
+                .and_then(|value| value.as_str())
+                .map(|value| value.to_string()),
+        }),
+        (None, false) => Err(
+            "originate requires a media plan: args.sdp (your own offer) or args.media=true (siphon anchors the leg)"
+                .to_string(),
+        ),
+    }
+}
+
+/// Parse the optional `privacy` argument (RFC 3323 §4.1 / TS 24.607). An
+/// unrecognised value is a typed error, never a silent "present the CLI" —
+/// guessing at a privacy setting is how identities leak.
+fn parse_privacy(
+    value: Option<&serde_json::Value>,
+) -> Result<Option<crate::sip::privacy::CallerIdPresentation>, String> {
+    match value {
+        None => Ok(None),
+        Some(value) if value.is_null() => Ok(None),
+        Some(value) => match value.as_str() {
+            Some(text) => crate::sip::privacy::CallerIdPresentation::parse(text)
+                .map(Some)
+                .ok_or_else(|| {
+                    format!("originate args.privacy must be \"allowed\" or \"restricted\", got '{text}'")
+                }),
+            None => Err("originate args.privacy must be a string".to_string()),
+        },
+    }
+}
+
+/// Map an [`crate::dispatcher::OriginateError`] onto its own wire code, so a
+/// caller can tell a bad URI from no route from a backend that cannot do it.
+fn originate_error(error: crate::dispatcher::OriginateError) -> ControlResult {
+    use crate::dispatcher::OriginateError;
+    let message = error.to_string();
+    match error {
+        OriginateError::InvalidUri { .. } => {
+            ControlResult::error(ControlErrorCode::BadRequest, message)
+        }
+        // No reachable destination for the target: the request was well formed
+        // and the resource simply is not there to be called.
+        OriginateError::Unroutable(_) => ControlResult::error(ControlErrorCode::NotFound, message),
+        OriginateError::Unsupported(_) => {
+            ControlResult::error(ControlErrorCode::UnsupportedVerb, message)
+        }
+        OriginateError::Unavailable(_) | OriginateError::BuildFailed(_) => {
+            ControlResult::error(ControlErrorCode::Unavailable, message)
+        }
+    }
+}
+
 /// Fetch a clone of the stored A-leg INVITE Arc for a controlled call.
 fn stored_invite(call_actor_id: &str) -> Option<std::sync::Arc<std::sync::Mutex<crate::sip::message::SipMessage>>> {
     let store = crate::b2bua::actor::global_call_store()?;
@@ -526,17 +763,28 @@ fn reject(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
 
 fn hangup(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
     let reason = args.get("reason").and_then(|v| v.as_str());
-    let answered = crate::b2bua::actor::global_call_store()
+    let (answered, originated) = crate::b2bua::actor::global_call_store()
         .and_then(|store| {
-            store
-                .get_call(&channel.call_actor_id)
-                .map(|call| matches!(call.state, crate::b2bua::actor::CallState::Answered))
+            store.get_call(&channel.call_actor_id).map(|call| {
+                (
+                    matches!(call.state, crate::b2bua::actor::CallState::Answered),
+                    call.originated,
+                )
+            })
         })
-        .unwrap_or(false);
+        .unwrap_or((false, false));
 
     let ok = if answered {
         // Answered: BYE both legs via the full teardown funnel (Rf/Ro/CDR/media).
         crate::dispatcher::b2bua_terminate_call(&channel.sip_call_id, reason)
+    } else if originated {
+        // A call siphon placed that has not answered: abandon it with a CANCEL on
+        // our own INVITE (RFC 3261 §9.1). The arm below sends a final *response*,
+        // which a UAC has no business sending to the party it is calling.
+        crate::dispatcher::b2bua_cancel_originated_call(
+            &channel.sip_call_id,
+            Some(reason.unwrap_or("cancelled")),
+        )
     } else {
         // Unanswered/parked: send a final non-2xx and tear down (no B-leg to CANCEL
         // in Phase 1's single-CallActor model).
@@ -850,9 +1098,323 @@ mod tests {
         }
     }
 
+    fn test_origin() -> crate::control::CommandOrigin {
+        crate::control::CommandOrigin {
+            app: "ivr-app".to_string(),
+            conn_id: 1,
+        }
+    }
+
+    fn originate_command(args: serde_json::Value) -> AdapterCommand {
+        AdapterCommand {
+            verb: "originate".to_string(),
+            args,
+            target: ResolvedTarget::None,
+            origin: test_origin(),
+        }
+    }
+
+    /// Run `originate` against a fresh bus with a live owning connection, so a
+    /// test exercises the argument rules rather than the "no control plane"
+    /// short-circuit.
+    fn originate_args(args: serde_json::Value) -> ControlResult {
+        let bus = test_bus();
+        let conn = bus.register_connection("ivr-app");
+        let mut command = originate_command(args);
+        command.origin.conn_id = conn.id;
+        originate_with_bus(&bus, command)
+    }
+
     #[test]
     fn module_is_sip() {
         assert_eq!(SipControlAdapter::new().module(), "sip");
+    }
+
+    // --- originate ---------------------------------------------------------
+
+    #[test]
+    fn originate_without_a_channel_id_is_bad_request() {
+        // The id is the caller's to choose; siphon never mints one, so its
+        // absence is a malformed command rather than a defaulted call.
+        let result = originate_args(serde_json::json!({ "to": "sip:1@carrier.example", "media": true }));
+        match result {
+            ControlResult::Error { code, ref message } => {
+                assert_eq!(code, ControlErrorCode::BadRequest);
+                assert!(message.contains("args.channel"), "message was: {message}");
+            }
+            other => panic!("expected bad_request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn originate_with_an_empty_channel_id_is_bad_request() {
+        let result = originate_args(serde_json::json!({
+            "channel": "   ",
+            "to": "sip:1@carrier.example",
+            "media": true,
+        }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn originate_without_a_target_is_bad_request() {
+        let result = originate_args(serde_json::json!({ "channel": "cb-1", "media": true }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn originate_without_a_media_plan_is_bad_request() {
+        // An INVITE with no offer and no anchor cannot answer the callee's 2xx
+        // offer (RFC 3261 §13.2.2.4) — that would connect a call with no audio.
+        let result = originate_args(serde_json::json!({
+            "channel": "cb-1",
+            "to": "sip:1@carrier.example",
+        }));
+        match result {
+            ControlResult::Error { code, ref message } => {
+                assert_eq!(code, ControlErrorCode::BadRequest);
+                assert!(message.contains("media plan"), "message was: {message}");
+            }
+            other => panic!("expected bad_request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn originate_with_both_media_plans_is_bad_request() {
+        let result = originate_args(serde_json::json!({
+            "channel": "cb-1",
+            "to": "sip:1@carrier.example",
+            "sdp": "v=0\r\n",
+            "media": true,
+        }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    #[test]
+    fn originate_with_a_bad_privacy_value_is_bad_request() {
+        let result = originate_args(serde_json::json!({
+            "channel": "cb-1",
+            "to": "sip:1@carrier.example",
+            "media": true,
+            "privacy": "maybe",
+        }));
+        assert!(matches!(
+            result,
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+    }
+
+    fn test_bus() -> std::sync::Arc<ControlBus> {
+        use crate::config::ControlAppConfig;
+        let (command_tx, _rx) = flume::unbounded();
+        ControlBus::new(
+            command_tx,
+            vec![ControlAppConfig {
+                name: "ivr-app".to_string(),
+                token: "tok".to_string(),
+                per_call_connect: false,
+                connect_url: None,
+                on_lost: Some("hangup".to_string()),
+            }],
+            64,
+            crate::control::SlowConsumerPolicy::DropOldest,
+            10,
+            3000,
+        )
+    }
+
+    #[test]
+    fn originate_rejects_a_duplicate_caller_supplied_id_with_conflict() {
+        // The caller owns the id, so a collision has to be told apart from a
+        // malformed command: retrying the same id can never succeed, and
+        // silently re-pointing it at a second call would strand the first.
+        let bus = test_bus();
+        let conn = bus.register_connection("ivr-app");
+        bus.register_channel("cb-1", &conn, "call-uuid", "sipcid@host", "hangup", HashMap::new());
+
+        let mut command = originate_command(serde_json::json!({
+            "channel": "cb-1",
+            "to": "sip:1@carrier.example",
+            "media": true,
+        }));
+        command.origin.conn_id = conn.id;
+        let result = originate_with_bus(&bus, command);
+        match result {
+            ControlResult::Error { code, ref message } => {
+                assert_eq!(code, ControlErrorCode::Conflict, "message was: {message}");
+                assert!(message.contains("cb-1"), "message was: {message}");
+            }
+            other => panic!("expected conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn originate_from_a_dead_connection_is_unavailable() {
+        // Nothing would own the resulting channel, so it must fail before an
+        // INVITE goes out — an ownerless channel is a leak with a live call
+        // behind it.
+        let bus = test_bus();
+        let mut command = originate_command(serde_json::json!({
+            "channel": "cb-ghost",
+            "to": "sip:1@carrier.example",
+            "media": true,
+        }));
+        command.origin.conn_id = 99;
+        assert!(matches!(
+            originate_with_bus(&bus, command),
+            ControlResult::Error { code: ControlErrorCode::Unavailable, .. }
+        ));
+        assert!(
+            !bus.channel_exists("cb-ghost"),
+            "a refused originate must register no channel"
+        );
+    }
+
+    #[test]
+    fn a_refused_originate_registers_no_channel() {
+        // The dispatcher is not running in this process, so prepare fails; the
+        // caller's id must be left free for a retry.
+        let bus = test_bus();
+        let conn = bus.register_connection("ivr-app");
+        let mut command = originate_command(serde_json::json!({
+            "channel": "cb-2",
+            "to": "sip:1@carrier.example",
+            "media": true,
+        }));
+        command.origin.conn_id = conn.id;
+        let result = originate_with_bus(&bus, command);
+        assert!(matches!(result, ControlResult::Error { .. }), "got {result:?}");
+        assert!(!bus.channel_exists("cb-2"));
+    }
+
+    #[test]
+    fn originate_without_a_control_bus_is_unavailable_not_a_hollow_ok() {
+        // No process-global bus in the unit-test process: the command must
+        // answer, and must not answer "ok" for a call nothing would own.
+        let result = originate(originate_command(serde_json::json!({
+            "channel": "cb-1",
+            "to": "sip:1@carrier.example",
+            "media": true,
+        })));
+        assert!(
+            matches!(result, ControlResult::Error { code: ControlErrorCode::Unavailable, .. }),
+            "got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn originate_dispatches_through_apply_as_a_module_level_verb() {
+        // No channel target: `originate` creates the channel rather than
+        // addressing one, so it must not be rejected for a missing target.
+        let adapter = SipControlAdapter::new();
+        let result = adapter
+            .apply(originate_command(serde_json::json!({
+                "channel": "cb-1", "to": "sip:1@carrier.example", "media": true
+            })))
+            .await;
+        match result {
+            ControlResult::Error { code, ref message } => {
+                assert_ne!(
+                    code,
+                    ControlErrorCode::BadRequest,
+                    "originate must not be rejected for the missing channel target: {message}"
+                );
+            }
+            other => panic!("expected an error from the un-booted stack, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_originate_media_variants() {
+        use crate::dispatcher::OriginateMedia;
+        assert_eq!(
+            parse_originate_media(&serde_json::json!({ "sdp": "v=0\r\n" })),
+            Ok(OriginateMedia::Offer("v=0\r\n".to_string()))
+        );
+        assert_eq!(
+            parse_originate_media(&serde_json::json!({ "media": true })),
+            Ok(OriginateMedia::Anchor {
+                profile: "rtp_passthrough".to_string(),
+                ws_uri: None,
+            })
+        );
+        assert_eq!(
+            parse_originate_media(&serde_json::json!({
+                "media": true, "profile": "voice_ai", "ws_uri": "ws://ai.invalid/{call_id}",
+            })),
+            Ok(OriginateMedia::Anchor {
+                profile: "voice_ai".to_string(),
+                ws_uri: Some("ws://ai.invalid/{call_id}".to_string()),
+            })
+        );
+        assert!(parse_originate_media(&serde_json::json!({})).is_err());
+        assert!(parse_originate_media(&serde_json::json!({ "sdp": "" })).is_err());
+        assert!(parse_originate_media(&serde_json::json!({ "sdp": "v=0", "media": true })).is_err());
+    }
+
+    #[test]
+    fn parse_privacy_variants() {
+        use crate::sip::privacy::CallerIdPresentation;
+        assert_eq!(parse_privacy(None), Ok(None));
+        assert_eq!(parse_privacy(Some(&serde_json::Value::Null)), Ok(None));
+        assert_eq!(
+            parse_privacy(Some(&serde_json::json!("restricted"))),
+            Ok(Some(CallerIdPresentation::Restricted))
+        );
+        assert_eq!(
+            parse_privacy(Some(&serde_json::json!("allowed"))),
+            Ok(Some(CallerIdPresentation::Allowed))
+        );
+        assert!(parse_privacy(Some(&serde_json::json!("sideways"))).is_err());
+        assert!(parse_privacy(Some(&serde_json::json!(1))).is_err());
+    }
+
+    #[test]
+    fn originate_error_maps_each_cause_to_its_own_code() {
+        use crate::dispatcher::OriginateError;
+        // Requirement: unknown target / bad argument / backend-cannot / stack-down
+        // must each be separately actionable on the wire.
+        assert!(matches!(
+            originate_error(OriginateError::InvalidUri {
+                field: "to",
+                detail: "nope".to_string()
+            }),
+            ControlResult::Error { code: ControlErrorCode::BadRequest, .. }
+        ));
+        assert!(matches!(
+            originate_error(OriginateError::Unroutable("no route".to_string())),
+            ControlResult::Error { code: ControlErrorCode::NotFound, .. }
+        ));
+        assert!(matches!(
+            originate_error(OriginateError::Unsupported("no answer_local".to_string())),
+            ControlResult::Error { code: ControlErrorCode::UnsupportedVerb, .. }
+        ));
+        assert!(matches!(
+            originate_error(OriginateError::Unavailable("down".to_string())),
+            ControlResult::Error { code: ControlErrorCode::Unavailable, .. }
+        ));
+        assert!(matches!(
+            originate_error(OriginateError::BuildFailed("bad".to_string())),
+            ControlResult::Error { code: ControlErrorCode::Unavailable, .. }
+        ));
+    }
+
+    #[test]
+    fn string_arg_treats_empty_as_absent() {
+        let args = serde_json::json!({ "from": "", "from_display": "Support", "x": 7 });
+        assert_eq!(string_arg(&args, "from"), None);
+        assert_eq!(string_arg(&args, "from_display"), Some("Support".to_string()));
+        assert_eq!(string_arg(&args, "x"), None);
+        assert_eq!(string_arg(&args, "missing"), None);
     }
 
     #[test]
@@ -901,6 +1463,7 @@ mod tests {
             verb: "answer".to_string(),
             args: serde_json::json!({}),
             target: ResolvedTarget::None,
+            origin: test_origin(),
         });
         assert!(matches!(
             result,
@@ -914,6 +1477,7 @@ mod tests {
             verb: "teleport".to_string(),
             args: serde_json::json!({}),
             target: ResolvedTarget::Channel(channel()),
+            origin: test_origin(),
         });
         assert!(matches!(
             result,
@@ -954,6 +1518,7 @@ mod tests {
                     verb: verb.to_string(),
                     args,
                     target: ResolvedTarget::Channel(channel()),
+                    origin: test_origin(),
                 })
                 .await;
             assert!(
@@ -1108,6 +1673,7 @@ mod tests {
             verb: "remove_header".to_string(),
             args: serde_json::json!({ "name": "X-Foo" }),
             target: ResolvedTarget::Channel(channel()),
+            origin: test_origin(),
         });
         assert!(matches!(
             result,
@@ -1277,6 +1843,7 @@ mod tests {
             verb: "route".to_string(),
             args: serde_json::json!({ "targets": ["sip:1@carrier.example"] }),
             target: ResolvedTarget::Channel(channel()),
+            origin: test_origin(),
         });
         assert!(matches!(
             result,
@@ -1381,6 +1948,7 @@ mod tests {
             verb: "accept_refer".to_string(),
             args: serde_json::json!({}),
             target: ResolvedTarget::Channel(channel()),
+            origin: test_origin(),
         });
         assert!(matches!(
             result,
@@ -1412,6 +1980,7 @@ mod tests {
             verb: "reject_refer".to_string(),
             args: serde_json::json!({}),
             target: ResolvedTarget::Channel(channel()),
+            origin: test_origin(),
         });
         assert!(matches!(
             result,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -5342,6 +5342,16 @@ fn handle_response(
         return;
     }
 
+    // A response to an INVITE *siphon originated*. Checked before the leg-branch
+    // lookup for the same reason: `handle_b2bua_response` relays what it gets to
+    // an A-leg and reasons about B-legs, and an originated call has neither — it
+    // *is* the A-leg, so relaying its own 180 would put it back on the wire at
+    // the party we are calling.
+    if let Some(internal_call_id) = state.call_actors.lookup_originated_call(&branch) {
+        handle_originated_call_response(&internal_call_id, &message, status_code, state);
+        return;
+    }
+
     // Check if this response belongs to a B2BUA call
     if let Some(call_id) = state.call_actors.call_id_for_branch(&branch) {
         handle_b2bua_response(&call_id, &branch, &mut message, status_code, inbound.remote_addr, state);
@@ -12018,6 +12028,24 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
         return;
     }
 
+    // A call siphon *placed* (`originate`) that nobody answered in time. siphon
+    // is the UAC here, so there is no A-leg transaction to answer 408: the
+    // correct give-up is to CANCEL the INVITE (RFC 3261 §9.1). Taking the path
+    // below would instead aim a 408 *response* at the party being called.
+    let originated = state
+        .call_actors
+        .get_call(call_id)
+        .map(|call| (call.originated, call.a_leg.dialog.call_id.clone()));
+    if let Some((true, sip_call_id)) = originated {
+        warn!(
+            call_id = %call_id,
+            %sip_call_id,
+            "originate: ring timeout — CANCELling the INVITE"
+        );
+        b2bua_cancel_originated_call(&sip_call_id, Some("ring timeout"));
+        return;
+    }
+
     // Snapshot everything needed, then drop the DashMap ref before the CANCEL
     // sends, Python, and the A-leg response.
     let (a_leg, a_leg_invite, a_leg_local_addr, cancel_targets, handle_txs) =
@@ -17643,6 +17671,27 @@ fn control_notify_terminated(sip_call_id: &str, reason: &str) {
     }
 }
 
+/// [`control_notify_terminated`] carrying the SIP cause. Used by the originate
+/// paths, where the controller has no other way to learn *why* the leg it
+/// placed died — there is no A-leg the callee's final was relayed to.
+fn control_notify_terminated_with_cause(
+    sip_call_id: &str,
+    reason: &str,
+    code: Option<u16>,
+    response: Option<&str>,
+) {
+    if let Some(bus) = crate::control::ControlBus::global() {
+        bus.on_call_terminated_with_cause(sip_call_id, reason, code, response);
+    }
+}
+
+/// Push a lifecycle event to the control channel owning `sip_call_id`, if the
+/// call is controlled. A no-op when control is not configured / the call is
+/// uncontrolled — never blocks the signalling path.
+fn control_notify_channel_event(sip_call_id: &str, event: &str, payload: serde_json::Value) {
+    crate::control::notify_channel_event(sip_call_id, event, payload);
+}
+
 /// Forward an in-band DTMF digit the media engine detected on a controlled
 /// B2BUA call's leg to the owning control connection as a `ChannelDtmfReceived`
 /// event, so an external IVR / AI app collects digits off the event stream.
@@ -18482,6 +18531,1056 @@ pub fn b2bua_progress_call(
     content_type: Option<&str>,
 ) -> bool {
     b2bua_send_uas_response(internal_call_id, invite, code, reason, body, content_type, false)
+}
+
+// ---------------------------------------------------------------------------
+// originate — a call siphon places itself (no inbound INVITE)
+// ---------------------------------------------------------------------------
+
+/// The media plan of an [`OriginateParams`] — how the originated INVITE gets an
+/// offer/answer. There is deliberately no "neither" variant: an INVITE with no
+/// offer and no plan to answer the callee's would leave a 2xx un-answerable
+/// (RFC 3261 §13.2.2.4 requires the answer in the ACK when the INVITE carried
+/// no offer), i.e. a connected call with no media.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OriginateMedia {
+    /// The controller supplied the SDP offer; it rides on the INVITE verbatim
+    /// and the callee's answer arrives in the 2xx (RFC 3264 §5). Works on every
+    /// media backend, and on none at all.
+    Offer(String),
+    /// siphon anchors the leg on the configured media backend: the INVITE goes
+    /// out **offerless**, the callee's 2xx carries the offer, and siphon answers
+    /// it locally (`answer_local`) with the answer riding on the ACK — RFC 3261
+    /// §13.2.2.4 / RFC 3264 §5, the delayed-offer half of RFC 3725's 3PCC flows.
+    /// The resulting media session is keyed on this leg's SIP Call-ID, so every
+    /// media verb (`play` / `dtmf` / `hold` / `stream_start`) resolves against it
+    /// exactly as it does for an inbound-anchored channel.
+    Anchor {
+        /// Media profile whose `answer` flags the local anchor uses.
+        profile: String,
+        /// Per-call WebSocket bridge URI (templated), overriding the profile's.
+        ws_uri: Option<String>,
+    },
+}
+
+/// Everything an [`b2bua_originate_prepare`] needs. Every field is applied to
+/// the INVITE that goes on the wire — none is decorative.
+#[derive(Debug, Clone)]
+pub struct OriginateParams {
+    /// Called party — the Request-URI and the To URI (RFC 3261 §8.1.1.1/§8.1.1.2).
+    pub to: String,
+    /// Optional To display name.
+    pub to_display: Option<String>,
+    /// Calling identity — the From URI (RFC 3261 §8.1.1.3). Defaults to
+    /// `sip:<advertised-host>` when absent.
+    pub from: Option<String>,
+    /// Optional From display name.
+    pub from_display: Option<String>,
+    /// Route the INVITE here instead of resolving the Request-URI — the R-URI
+    /// still carries the called party's shape (IMS edge / trunk steering).
+    pub next_hop: Option<String>,
+    /// `P-Asserted-Identity` for a trusted next hop (RFC 3325 §9.1).
+    pub p_asserted_identity: Option<String>,
+    /// Calling-identity presentation (RFC 3323 §4.1 / TS 24.607). `Restricted`
+    /// anonymises From and asserts `Privacy: id`, keeping the real identity in
+    /// `P-Asserted-Identity` for the trusted next hop.
+    pub privacy: Option<crate::sip::privacy::CallerIdPresentation>,
+    /// Arbitrary custom headers, applied last.
+    pub headers: Vec<(String, String)>,
+    /// Ring timeout in seconds; `0` disables it (the orphan sweep stays the
+    /// backstop). The call is CANCELled (RFC 3261 §9.1) when it elapses.
+    pub timeout_secs: u32,
+    /// The media plan.
+    pub media: OriginateMedia,
+}
+
+/// Why an originate was refused. Each variant maps to its own control-plane
+/// error code — a caller must be able to tell "your URI is wrong" from "no
+/// route" from "this backend cannot do that".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OriginateError {
+    /// The dispatcher is not running (headless / shutting down).
+    Unavailable(String),
+    /// A supplied URI did not parse.
+    InvalidUri {
+        /// Which argument.
+        field: &'static str,
+        /// Parser detail.
+        detail: String,
+    },
+    /// No wire destination could be resolved for the target / next hop.
+    Unroutable(String),
+    /// The configured backend cannot serve the requested media plan.
+    Unsupported(String),
+    /// The INVITE could not be built (should not happen; surfaced, never panicked).
+    BuildFailed(String),
+}
+
+impl std::fmt::Display for OriginateError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OriginateError::Unavailable(detail) => write!(formatter, "{detail}"),
+            OriginateError::InvalidUri { field, detail } => {
+                write!(formatter, "invalid {field}: {detail}")
+            }
+            OriginateError::Unroutable(detail) => write!(formatter, "{detail}"),
+            OriginateError::Unsupported(detail) => write!(formatter, "{detail}"),
+            OriginateError::BuildFailed(detail) => write!(formatter, "{detail}"),
+        }
+    }
+}
+
+/// A staged originate: the call exists in the store and is addressable, but its
+/// INVITE has **not** left the socket yet.
+///
+/// The two-phase split exists so the control plane can register the channel
+/// under the caller-supplied id *before* anything is on the wire. Dialing first
+/// would open a window where a fast callee's `180`/`200` arrives with no channel
+/// registered and its event is dropped on the floor — an outcome the controller
+/// could never recover from, since a missed `answered` looks identical to a call
+/// that never answered.
+#[derive(Debug)]
+pub struct PreparedOriginate {
+    /// The internal `CallActor` id.
+    pub internal_call_id: String,
+    /// The originated leg's SIP Call-ID (CDR / HEP / media-session join key).
+    pub sip_call_id: String,
+    /// Our From-tag on the originated dialog.
+    pub from_tag: String,
+    invite: SipMessage,
+    destination: SocketAddr,
+    transport: Transport,
+    timeout_secs: u32,
+}
+
+/// Stage a call siphon places: build the INVITE, create the `CallActor` whose
+/// A-leg is the outbound (UAC) dialog, and index the INVITE's branch so its
+/// responses reach [`handle_originated_call_response`]. Nothing is sent — call
+/// [`b2bua_originate_dial`] to put it on the wire.
+pub fn b2bua_originate_prepare(
+    params: OriginateParams,
+) -> Result<PreparedOriginate, OriginateError> {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return Err(OriginateError::Unavailable(
+            "b2bua is not running — nothing to originate from".to_string(),
+        ));
+    };
+    let state = &control.state;
+
+    let target_uri = parse_uri_standalone(&params.to).map_err(|error| {
+        OriginateError::InvalidUri {
+            field: "to",
+            detail: error.to_string(),
+        }
+    })?;
+    for (field, value) in [
+        ("from", params.from.as_deref()),
+        ("next_hop", params.next_hop.as_deref()),
+        ("p_asserted_identity", params.p_asserted_identity.as_deref()),
+    ] {
+        if let Some(value) = value {
+            parse_uri_standalone(value).map_err(|error| OriginateError::InvalidUri {
+                field,
+                detail: error.to_string(),
+            })?;
+        }
+    }
+
+    // Validate the media plan against the *configured* backend before anything
+    // is created: a plan this deployment cannot serve must fail visibly at the
+    // command, never as a connected call with no audio.
+    if let OriginateMedia::Anchor { profile, .. } = &params.media {
+        originate_validate_anchor(profile, state)?;
+    }
+
+    // Resolve the wire destination. `next_hop` steers egress without touching
+    // the R-URI (the called party's shape is preserved on the wire) — the same
+    // split `call.dial(next_hop=…)` and `proxy.send_request(next_hop=…)` make.
+    let routing_uri = params.next_hop.as_deref().unwrap_or(&params.to);
+    let relay_target = resolve_target(routing_uri, &state.dns_resolver).ok_or_else(|| {
+        OriginateError::Unroutable(format!("cannot resolve a destination for '{routing_uri}'"))
+    })?;
+    let destination = relay_target.address;
+    let transport = relay_target.transport.unwrap_or(Transport::Udp);
+
+    let sip_call_id = crate::b2bua::actor::generate_call_id();
+    let from_tag = crate::b2bua::actor::generate_tag();
+    let branch = TransactionKey::generate_branch();
+    let (via_host, via_port) = (state.via_host(&transport), state.via_port(&transport));
+
+    let contact = build_b_leg_contact(&via_host, via_port, transport, None, None);
+    let invite = build_originate_invite(
+        &params,
+        target_uri,
+        OriginateIdentity {
+            sip_call_id: &sip_call_id,
+            from_tag: &from_tag,
+            branch: &branch,
+            via_host: &via_host,
+            via_port,
+            transport,
+            contact: &contact,
+            user_agent: state
+                .user_agent_header
+                .as_deref()
+                .or(state.server_header.as_deref()),
+        },
+    )?;
+
+    let mut leg = crate::b2bua::actor::Leg::new_originating_leg(
+        sip_call_id.clone(),
+        from_tag.clone(),
+        params.to.clone(),
+        branch.clone(),
+        LegTransport {
+            remote_addr: destination,
+            connection_id: ConnectionId::default(),
+            transport,
+            local_addr: None,
+        },
+    );
+    leg.dialog.local_contact = Some(contact);
+    leg.dialog.local_from_uri = invite.headers.from().cloned();
+    leg.dialog.remote_to_uri = invite.headers.to().cloned();
+    if !invite.body.is_empty() {
+        leg.last_sdp = Some(invite.body.clone());
+    }
+
+    let internal_call_id = state.call_actors.create_call(leg);
+    state
+        .call_actors
+        .set_a_leg_invite(&internal_call_id, Arc::new(Mutex::new(invite.clone())));
+    state.call_actors.mark_originated(&internal_call_id, &branch);
+    if let OriginateMedia::Anchor { profile, ws_uri } = &params.media {
+        state.call_actors.set_originate_anchor(
+            &internal_call_id,
+            crate::b2bua::actor::OriginateAnchor {
+                profile: profile.clone(),
+                ws_uri: ws_uri.clone(),
+            },
+        );
+    }
+
+    // The event channel every leg actor on this call shares. An originated call
+    // has no B-leg today, but the store's teardown paths expect the pair to
+    // exist, and a later bridge dials one.
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel::<CallEvent>(64);
+    if let Some(mut call) = state.call_actors.get_call_mut(&internal_call_id) {
+        call.event_tx = Some(event_tx);
+    }
+    state
+        .call_event_receivers
+        .insert(internal_call_id.clone(), event_rx);
+
+    info!(
+        call_id = %internal_call_id,
+        %sip_call_id,
+        target = %params.to,
+        %destination,
+        %transport,
+        "B2BUA: originate staged"
+    );
+    Ok(PreparedOriginate {
+        internal_call_id,
+        sip_call_id,
+        from_tag,
+        invite,
+        destination,
+        transport,
+        timeout_secs: params.timeout_secs,
+    })
+}
+
+/// The dialog identity + local socket identity an originate INVITE advertises.
+/// Grouped so [`build_originate_invite`] stays a pure, testable function rather
+/// than a nine-argument one.
+struct OriginateIdentity<'a> {
+    sip_call_id: &'a str,
+    from_tag: &'a str,
+    branch: &'a str,
+    via_host: &'a str,
+    via_port: u16,
+    transport: Transport,
+    contact: &'a str,
+    user_agent: Option<&'a str>,
+}
+
+/// Build the INVITE an originate puts on the wire. Pure — no state, no I/O — so
+/// the identity rules that matter (From/To shape, PAI, CLIR ordering, the
+/// reserved-header guard, offer vs offerless body) are unit-testable.
+fn build_originate_invite(
+    params: &OriginateParams,
+    target_uri: SipUri,
+    identity: OriginateIdentity<'_>,
+) -> Result<SipMessage, OriginateError> {
+    let from_uri = params
+        .from
+        .clone()
+        .unwrap_or_else(|| format!("sip:{}", identity.via_host));
+    let from_header = match params.from_display.as_deref().filter(|d| !d.is_empty()) {
+        Some(display) => format!("\"{display}\" <{from_uri}>;tag={}", identity.from_tag),
+        None => format!("<{from_uri}>;tag={}", identity.from_tag),
+    };
+    // RFC 3261 §12.1.2: the UAC's To carries no tag until the callee assigns one.
+    let to_header = match params.to_display.as_deref().filter(|d| !d.is_empty()) {
+        Some(display) => format!("\"{display}\" <{}>", params.to),
+        None => format!("<{}>", params.to),
+    };
+
+    let mut builder = SipMessageBuilder::new()
+        .request(Method::Invite, target_uri)
+        .via(format!(
+            "SIP/2.0/{} {}:{};branch={}",
+            identity.transport, identity.via_host, identity.via_port, identity.branch
+        ))
+        .from(from_header)
+        .to(to_header)
+        .call_id(identity.sip_call_id.to_string())
+        .cseq("1 INVITE".to_string())
+        .header("Max-Forwards", "70".to_string())
+        .header("Contact", identity.contact.to_string())
+        .header("Allow", crate::sip::SUPPORTED_METHODS.to_string());
+    if let Some(user_agent) = identity.user_agent {
+        builder = builder.header("User-Agent", user_agent.to_string());
+    }
+    if let Some(ref asserted) = params.p_asserted_identity {
+        builder = builder.header("P-Asserted-Identity", format!("<{asserted}>"));
+    }
+    let builder = match &params.media {
+        OriginateMedia::Offer(sdp) => builder
+            .content_type("application/sdp".to_string())
+            .content_length(sdp.len())
+            .body(sdp.as_bytes().to_vec()),
+        // Offerless: the callee offers in its 2xx and we answer in the ACK.
+        OriginateMedia::Anchor { .. } => builder.content_length(0),
+    };
+    let mut invite = builder
+        .build()
+        .map_err(|error| OriginateError::BuildFailed(format!("cannot build INVITE: {error}")))?;
+
+    // Custom headers last, so a caller can shape anything the framework set
+    // above short of the dialog-defining ones it must not touch.
+    for (name, value) in &params.headers {
+        if is_originate_reserved_header(name) {
+            warn!(
+                sip_call_id = %identity.sip_call_id,
+                header = %name,
+                "originate: ignoring a dialog-defining header supplied in args.headers"
+            );
+            continue;
+        }
+        invite.headers.set(name, value.clone());
+    }
+
+    // CLIR last of all — anonymisation is the final identity step, or a custom
+    // From / P-Asserted-Identity header set after it would undo it
+    // (RFC 3323 §4.1 / TS 24.607).
+    if params.privacy == Some(crate::sip::privacy::CallerIdPresentation::Restricted) {
+        crate::sip::privacy::restrict_calling_identity(&mut invite);
+    }
+    Ok(invite)
+}
+
+/// Headers an `originate` caller must not set: the dialog identity and framing
+/// the stack owns (RFC 3261 §8.1.1). Setting them from `args.headers` would
+/// desynchronise the stored dialog from the wire — the leg would be
+/// unaddressable for its own ACK / BYE.
+fn is_originate_reserved_header(name: &str) -> bool {
+    [
+        "via",
+        "from",
+        "to",
+        "call-id",
+        "cseq",
+        "contact",
+        "max-forwards",
+        "content-length",
+        "route",
+        "record-route",
+    ]
+    .contains(&name.trim().to_ascii_lowercase().as_str())
+}
+
+/// Gate an [`OriginateMedia::Anchor`] plan against the configured backend +
+/// profile registry. Pure enough to unit-test through
+/// [`originate_anchor_rejection`]; returns the typed refusal the caller
+/// surfaces verbatim.
+fn originate_validate_anchor(
+    profile: &str,
+    state: &DispatcherState,
+) -> Result<(), OriginateError> {
+    let Some(backend) = state.rtpengine_set.as_ref() else {
+        return Err(OriginateError::Unsupported(
+            "originate media anchoring requires a media backend (media.backend), none configured"
+                .to_string(),
+        ));
+    };
+    let Some(registry) = state.rtpengine_profiles.as_ref() else {
+        return Err(OriginateError::Unsupported(
+            "originate media anchoring requires media profiles, none configured".to_string(),
+        ));
+    };
+    originate_anchor_rejection(backend.kind(), registry.get(profile).is_some(), profile)
+        .map_or(Ok(()), Err)
+}
+
+/// The refusal an anchor plan draws, if any — split out so both gates (backend
+/// kind, profile existence) are testable without a `DispatcherState`.
+fn originate_anchor_rejection(
+    kind: crate::config::MediaBackendKind,
+    profile_known: bool,
+    profile: &str,
+) -> Option<OriginateError> {
+    // `answer_local` is the siphon-rtp native verb; rtpengine / rtpproxy have no
+    // equivalent, so an anchored originate on them must fail here rather than
+    // connect a call whose 2xx offer nothing can answer.
+    if !matches!(kind, crate::config::MediaBackendKind::SiphonRtp) {
+        return Some(OriginateError::Unsupported(format!(
+            "originate media anchoring requires the siphon-rtp media backend; media.backend is {}",
+            kind.as_str()
+        )));
+    }
+    if !profile_known {
+        return Some(OriginateError::Unsupported(format!(
+            "unknown media profile '{profile}' for originate"
+        )));
+    }
+    None
+}
+
+/// Put a staged originate on the wire: arm the RFC 3261 §17.1.1.2 retransmit
+/// schedule (UDP), send the INVITE, and arm the ring timeout. Returns `false`
+/// (never panics) when the call was torn down between prepare and dial.
+pub fn b2bua_originate_dial(prepared: &PreparedOriginate) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let state = &control.state;
+    if state
+        .call_actors
+        .get_call(&prepared.internal_call_id)
+        .is_none()
+    {
+        return false;
+    }
+    // The send path may spawn (TCP/TLS connect) and the caller may be on a
+    // non-tokio thread (the control command consumer, an async-pool loop).
+    let _enter = control.runtime.enter();
+
+    let data = Bytes::from(prepared.invite.to_bytes());
+    arm_b2bua_retransmit(
+        &prepared.invite,
+        &data,
+        prepared.transport,
+        prepared.destination,
+        udp_egress_source(prepared.transport, prepared.destination, None),
+        state,
+    );
+    let relay_target = RelayTarget {
+        address: prepared.destination,
+        transport: Some(prepared.transport),
+        server_name: None,
+    };
+    send_to_target(
+        data,
+        &relay_target,
+        prepared.transport,
+        ConnectionId::default(),
+        None,
+        state,
+    );
+    set_b2bua_answer_deadline(&prepared.internal_call_id, prepared.timeout_secs, state);
+    debug!(
+        call_id = %prepared.internal_call_id,
+        sip_call_id = %prepared.sip_call_id,
+        destination = %prepared.destination,
+        "B2BUA: originate INVITE sent"
+    );
+    true
+}
+
+/// Stage **and** dial in one step, for the in-process `b2bua.originate()`
+/// surface (there is no channel to register between the two phases there).
+pub fn b2bua_originate(params: OriginateParams) -> Result<PreparedOriginate, OriginateError> {
+    let prepared = b2bua_originate_prepare(params)?;
+    if !b2bua_originate_dial(&prepared) {
+        return Err(OriginateError::Unavailable(
+            "originate was staged but the call vanished before dialling".to_string(),
+        ));
+    }
+    Ok(prepared)
+}
+
+/// Handle a response to an INVITE **siphon originated**.
+///
+/// The UAC-side twin of [`handle_b2bua_response`]. Nothing here is relayed:
+/// there is no A-leg to forward to — this call *is* the A-leg — so the response
+/// is turned into control-plane events and the local dialog transitions the
+/// RFC 3261 §17.1.1 client transaction owes the callee:
+///
+/// * **1xx** — record the early dialog's remote tag/target (§12.1.2) and surface
+///   `ChannelStateChange`. `100 Trying` never reaches here (absorbed upstream).
+/// * **2xx** — confirm the dialog (§13.2.2.4): capture the remote tag, Contact
+///   and reversed Record-Route as the route set, ACK (carrying the local media
+///   answer when the INVITE went out offerless), mark the call answered.
+/// * **3xx-6xx** — ACK the final (§17.1.1.3, on the INVITE's own branch), then
+///   tear the call down with the cause the callee gave.
+fn handle_originated_call_response(
+    internal_call_id: &str,
+    message: &SipMessage,
+    status_code: u16,
+    state: &DispatcherState,
+) {
+    let Some((mut leg, sip_call_id, already_answered)) =
+        state.call_actors.get_call(internal_call_id).map(|call| {
+            (
+                call.a_leg.clone(),
+                call.a_leg.dialog.call_id.clone(),
+                matches!(call.state, CallState::Answered),
+            )
+        })
+    else {
+        warn!(call_id = %internal_call_id, "originate: response for a call that is gone");
+        return;
+    };
+
+    // A response to our CANCEL shares the INVITE's top Via branch (RFC 3261
+    // §9.1); it is not the callee's answer and needs nothing here.
+    let cseq_method = message
+        .headers
+        .cseq()
+        .and_then(|cseq| cseq.split_whitespace().nth(1).map(str::to_string))
+        .unwrap_or_default();
+    if !cseq_method.eq_ignore_ascii_case("INVITE") {
+        debug!(
+            call_id = %internal_call_id,
+            status = status_code,
+            method = %cseq_method,
+            "originate: absorbing a non-INVITE response on the originate branch"
+        );
+        return;
+    }
+
+    if (100..200).contains(&status_code) {
+        // RFC 3261 §12.1.2: the first provisional with a To-tag opens the early
+        // dialog; record its identity so a CANCEL/BYE has a target before answer.
+        let remote_tag = crate::b2bua::actor::extract_to_tag(message);
+        if let Some(mut call) = state.call_actors.get_call_mut(internal_call_id) {
+            // §12.1.2 sets the remote target once from the dialog-creating
+            // response; a downstream fork puts several early dialogs on this one
+            // branch, so later provisionals must not overwrite the first's
+            // target. The confirming 2xx below refreshes both to the winner.
+            if call.a_leg.dialog.remote_tag.is_none() {
+                call.a_leg.dialog.remote_tag = remote_tag.clone();
+            }
+            if call.a_leg.dialog.remote_contact.is_none() {
+                if let Some(contact) = message.headers.get("Contact") {
+                    call.a_leg.dialog.remote_contact =
+                        Some(crate::b2bua::actor::extract_contact_uri(contact));
+                }
+            }
+        }
+        let early_media = !message.body.is_empty();
+        state
+            .call_actors
+            .set_state(internal_call_id, CallState::Ringing);
+        let phase = if early_media { "progress" } else { "ringing" };
+        control_notify_channel_event(
+            &sip_call_id,
+            "ChannelStateChange",
+            serde_json::json!({
+                "state": phase,
+                "code": status_code,
+                "early_media": early_media,
+                "sdp": originate_body_text(message),
+            }),
+        );
+        debug!(
+            call_id = %internal_call_id,
+            status = status_code,
+            early_media,
+            "originate: provisional"
+        );
+        return;
+    }
+
+    if (200..300).contains(&status_code) {
+        // A retransmitted 200 (our ACK was lost) must be re-ACKed and nothing
+        // else — the dialog is already confirmed and the controller has already
+        // been told (RFC 3261 §13.2.2.4).
+        if already_answered {
+            originate_ack_2xx(&leg, message, None, state);
+            return;
+        }
+
+        // Confirm the dialog from the 2xx (RFC 3261 §12.1.2).
+        let remote_tag = crate::b2bua::actor::extract_to_tag(message);
+        let remote_contact = message
+            .headers
+            .get("Contact")
+            .map(|contact| crate::b2bua::actor::extract_contact_uri(contact));
+        // §12.1.2: the UAC's route set is the Record-Route of the 2xx, reversed.
+        let route_set: Vec<String> = message
+            .headers
+            .get_all("Record-Route")
+            .map(|values| {
+                values
+                    .iter()
+                    .flat_map(|value| value.split(','))
+                    .map(|entry| entry.trim().to_string())
+                    .filter(|entry| !entry.is_empty())
+                    .rev()
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Anchor the media before the ACK is built: an offerless originate owes
+        // the callee its answer *in* the ACK, so the engine round-trip has to
+        // complete first. A failure is loud and terminal — a connected call with
+        // no answer would be a call with no audio.
+        let anchor_answer = match state.call_actors.originate_anchor(internal_call_id) {
+            Some(anchor) => {
+                match originate_anchor_2xx(
+                    &sip_call_id,
+                    remote_tag.as_deref().unwrap_or_default(),
+                    message,
+                    &anchor,
+                    state,
+                ) {
+                    Ok(answer) => Some(answer),
+                    Err(reason) => {
+                        error!(
+                            call_id = %internal_call_id,
+                            %sip_call_id,
+                            %reason,
+                            "originate: media anchor failed on the callee's answer — ACK + BYE"
+                        );
+                        // ACK (the 2xx must be acknowledged either way, §13.2.2.4)
+                        // then release the dialog we cannot carry audio for (§15).
+                        originate_ack_2xx(&leg, message, None, state);
+                        if let Some(tag) = remote_tag.clone() {
+                            leg.dialog.remote_tag = Some(tag);
+                        }
+                        leg.dialog.remote_contact = remote_contact.clone();
+                        leg.dialog.local_cseq = leg.dialog.local_cseq.saturating_add(1);
+                        if let Some(bye) = build_b2bua_bye(&leg, state) {
+                            send_b2bua_to_bleg(
+                                bye,
+                                leg.transport.transport,
+                                leg.transport.remote_addr,
+                                leg.transport.local_addr,
+                                state,
+                            );
+                        }
+                        control_notify_terminated_with_cause(
+                            &sip_call_id,
+                            "media_failed",
+                            Some(status_code),
+                            Some(&reason),
+                        );
+                        state.call_actors.remove_call(internal_call_id);
+                        state.call_event_receivers.remove(internal_call_id);
+                        return;
+                    }
+                }
+            }
+            None => None,
+        };
+
+        if let Some(mut call) = state.call_actors.get_call_mut(internal_call_id) {
+            call.a_leg.dialog.remote_tag = remote_tag.clone();
+            if remote_contact.is_some() {
+                call.a_leg.dialog.remote_contact = remote_contact.clone();
+            }
+            if !route_set.is_empty() {
+                call.a_leg.dialog.route_set = route_set;
+            }
+            if !message.body.is_empty() {
+                call.a_leg.last_sdp = Some(message.body.clone());
+            }
+            // The INVITE used CSeq 1; every later in-dialog request (BYE,
+            // re-INVITE) must exceed it (RFC 3261 §12.2.1.1).
+            call.a_leg.dialog.local_cseq = 2;
+            leg = call.a_leg.clone();
+        }
+        state
+            .call_actors
+            .set_state(internal_call_id, CallState::Answered);
+        originate_ack_2xx(&leg, message, anchor_answer.as_deref(), state);
+        if crate::cdr::auto_emit_enabled() {
+            cdr_mark_answer(state, internal_call_id, status_code);
+        }
+        control_notify_channel_event(
+            &sip_call_id,
+            "ChannelStateChange",
+            serde_json::json!({
+                "state": "answered",
+                "code": status_code,
+                "sdp": originate_body_text(message),
+            }),
+        );
+        originate_fire_answer_handlers(internal_call_id, &leg, message, state);
+        info!(call_id = %internal_call_id, %sip_call_id, status = status_code, "originate: answered");
+        return;
+    }
+
+    // Final non-2xx. RFC 3261 §17.1.1.3: the INVITE client transaction ACKs it
+    // on the INVITE's own Via branch — without that the callee retransmits its
+    // final on Timer G until Timer H.
+    let reason_phrase = match &message.start_line {
+        StartLine::Response(status_line) => status_line.reason_phrase.clone(),
+        StartLine::Request(_) => String::new(),
+    };
+    let (via_host, via_port) = b_leg_sent_by(leg.transport.local_addr, state, &leg.transport.transport);
+    let ack = build_b2bua_ack_for_non2xx(
+        message,
+        &leg.branch,
+        leg.dialog.target_uri.as_deref(),
+        leg.transport.transport,
+        &via_host,
+        via_port,
+    );
+    send_b2bua_to_bleg(
+        ack,
+        leg.transport.transport,
+        leg.transport.remote_addr,
+        leg.transport.local_addr,
+        state,
+    );
+
+    warn!(
+        call_id = %internal_call_id,
+        %sip_call_id,
+        status = status_code,
+        "originate: rejected by the callee"
+    );
+    if crate::cdr::auto_emit_enabled() {
+        cdr_finalize_b2bua_fail(state, internal_call_id, status_code);
+    }
+    originate_fire_failure_handlers(internal_call_id, &leg, status_code, &reason_phrase, state);
+    control_notify_terminated_with_cause(
+        &sip_call_id,
+        "rejected",
+        Some(status_code),
+        Some(&reason_phrase),
+    );
+    originate_delete_media(&sip_call_id, state);
+    state.call_actors.remove_call(internal_call_id);
+    state.call_event_receivers.remove(internal_call_id);
+}
+
+/// The response body as text, for a control event payload. `None` for an empty
+/// or non-UTF-8 body — the rail is JSON text, so a binary body is reported by
+/// its absence rather than mangled.
+fn originate_body_text(message: &SipMessage) -> Option<String> {
+    if message.body.is_empty() {
+        return None;
+    }
+    std::str::from_utf8(&message.body).ok().map(str::to_string)
+}
+
+/// ACK a 2xx on an originated dialog (RFC 3261 §13.2.2.4), optionally carrying
+/// the local media answer to an offer the callee made in that 2xx.
+fn originate_ack_2xx(
+    leg: &crate::b2bua::actor::Leg,
+    response: &SipMessage,
+    answer_sdp: Option<&str>,
+    state: &DispatcherState,
+) {
+    let (via_host, via_port) =
+        b_leg_sent_by(leg.transport.local_addr, state, &leg.transport.transport);
+    let Some(mut ack) = build_b2bua_ack_for_2xx(response, leg.transport.transport, &via_host, via_port)
+    else {
+        return;
+    };
+    if let Some(sdp) = answer_sdp {
+        ack.headers.set("Content-Type", "application/sdp".to_string());
+        ack.body = sdp.as_bytes().to_vec();
+        ack.headers.set("Content-Length", ack.body.len().to_string());
+    }
+    send_b2bua_to_bleg(
+        ack,
+        leg.transport.transport,
+        leg.transport.remote_addr,
+        leg.transport.local_addr,
+        state,
+    );
+}
+
+/// Answer the callee's 2xx offer locally on the media backend and record the
+/// media session under this leg's SIP Call-ID, so every media verb resolves
+/// against it through [`b2bua_media_target`].
+///
+/// Returns the answer SDP for the ACK, or a short human reason on failure —
+/// never a silent no-op, because an offerless INVITE with no answer is a
+/// connected call with no audio.
+fn originate_anchor_2xx(
+    sip_call_id: &str,
+    remote_tag: &str,
+    response: &SipMessage,
+    anchor: &crate::b2bua::actor::OriginateAnchor,
+    state: &DispatcherState,
+) -> Result<String, String> {
+    let backend = state
+        .rtpengine_set
+        .as_ref()
+        .ok_or_else(|| "no media backend configured".to_string())?;
+    let registry = state
+        .rtpengine_profiles
+        .as_ref()
+        .ok_or_else(|| "no media profiles configured".to_string())?;
+    let entry = registry
+        .get(&anchor.profile)
+        .ok_or_else(|| format!("unknown media profile '{}'", anchor.profile))?;
+    let mut flags = entry.answer.clone();
+
+    let offer_sdp = std::str::from_utf8(&response.body)
+        .map_err(|_| "the callee's 2xx body is not valid UTF-8 SDP".to_string())?
+        .to_string();
+    if offer_sdp.trim().is_empty() {
+        return Err("the callee answered with no SDP offer — nothing to anchor".to_string());
+    }
+
+    // ws_uri precedence: explicit per-call arg → the profile's own → none.
+    let template = anchor.ws_uri.clone().or_else(|| flags.ws_uri.clone());
+    if let Some(template) = template {
+        let context = crate::script::api::rtpengine::WsUriContext {
+            call_id: sip_call_id,
+            from_tag: remote_tag,
+            from_user: None,
+            to_user: None,
+        };
+        flags.ws_uri = Some(
+            crate::script::api::rtpengine::expand_ws_uri(&template, &context)
+                .map_err(|error| format!("ws_uri templating failed: {error:?}"))?,
+        );
+    }
+    let unsupported = backend.unsupported_flags(&flags);
+    if !unsupported.is_empty() {
+        return Err(format!(
+            "media profile '{}' sets {} which the {} backend cannot honour",
+            anchor.profile,
+            unsupported.join(", "),
+            backend.kind().as_str()
+        ));
+    }
+
+    // The offerer here is the *callee* (it offered in its 2xx), so the engine's
+    // monologue is keyed on the callee's tag — the same "key on the offerer's
+    // tag" convention the inbound answer-first anchor uses.
+    let answer = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(backend.answer_local(
+            sip_call_id,
+            remote_tag,
+            &offer_sdp,
+            &flags,
+        ))
+    })
+    .map_err(|error| format!("answer_local failed: {error}"))?;
+
+    if let Some(sessions) = state.rtpengine_sessions.as_ref() {
+        sessions.insert(crate::rtpengine::session::MediaSession {
+            rtpengine_call_id: sip_call_id.to_string(),
+            call_id: sip_call_id.to_string(),
+            from_tag: remote_tag.to_string(),
+            to_tag: None,
+            profile: anchor.profile.clone(),
+            ws_uri: flags.ws_uri.clone(),
+            created_at: std::time::Instant::now(),
+        });
+    }
+    Ok(answer)
+}
+
+/// Drop any media session anchored for an originated call that failed before it
+/// could be torn down the ordinary way.
+fn originate_delete_media(sip_call_id: &str, state: &DispatcherState) {
+    if let (Some(backend), Some(sessions)) = (&state.rtpengine_set, &state.rtpengine_sessions) {
+        if let Some(session) = sessions.remove(sip_call_id) {
+            let backend = Arc::clone(backend);
+            tokio::spawn(async move {
+                if let Err(error) = backend.delete(session.rtpengine_id(), &session.from_tag).await {
+                    if !error.is_call_not_found() {
+                        warn!(call_id = %session.call_id, "originate: media delete failed: {error}");
+                    }
+                }
+            });
+        }
+    }
+}
+
+/// Fire `@b2bua.on_answer(call, reply)` for an originated call, so an in-process
+/// script driving `b2bua.originate()` sees the answer through the same handler
+/// an inbound-driven call uses.
+fn originate_fire_answer_handlers(
+    internal_call_id: &str,
+    leg: &crate::b2bua::actor::Leg,
+    response: &SipMessage,
+    state: &DispatcherState,
+) {
+    let engine_state = state.engine.state();
+    let handlers = engine_state.handlers_for(&HandlerKind::B2buaAnswer);
+    if handlers.is_empty() {
+        return;
+    }
+    let Some(invite_arc) = state
+        .call_actors
+        .get_call(internal_call_id)
+        .and_then(|call| call.a_leg_invite.clone())
+    else {
+        return;
+    };
+    let response_arc = Arc::new(std::sync::Mutex::new(response.clone()));
+    let py_call = PyCall::new(
+        internal_call_id.to_string(),
+        Arc::clone(&invite_arc),
+        leg.transport.remote_addr.ip().to_string(),
+        format!("{}", leg.transport.transport).to_lowercase(),
+    );
+    let py_reply = PyReply::new(Arc::clone(&response_arc)).with_a_leg(Arc::clone(&invite_arc));
+    Python::attach(|python| {
+        let call_obj = match Py::new(python, py_call) {
+            Ok(obj) => obj,
+            Err(error) => {
+                error!("failed to create PyCall for originate on_answer: {error}");
+                return;
+            }
+        };
+        let reply_obj = match Py::new(python, py_reply) {
+            Ok(obj) => obj,
+            Err(error) => {
+                error!("failed to create PyReply for originate on_answer: {error}");
+                return;
+            }
+        };
+        for handler in &handlers {
+            let callable = handler.callable.bind(python);
+            match callable.call1((call_obj.bind(python), reply_obj.bind(python))) {
+                Ok(returned) => {
+                    if handler.is_async {
+                        if let Err(error) = run_coroutine(python, &returned) {
+                            error!("async originate on_answer handler error: {error}");
+                        }
+                    }
+                }
+                Err(error) => error!("originate on_answer handler error: {error}"),
+            }
+        }
+    });
+}
+
+/// Fire `@b2bua.on_failure(call, code, reason)` for an originated call the
+/// callee rejected.
+fn originate_fire_failure_handlers(
+    internal_call_id: &str,
+    leg: &crate::b2bua::actor::Leg,
+    status_code: u16,
+    reason: &str,
+    state: &DispatcherState,
+) {
+    let engine_state = state.engine.state();
+    let handlers = engine_state.handlers_for(&HandlerKind::B2buaFailure);
+    if handlers.is_empty() {
+        return;
+    }
+    let Some(invite_arc) = state
+        .call_actors
+        .get_call(internal_call_id)
+        .and_then(|call| call.a_leg_invite.clone())
+    else {
+        return;
+    };
+    let py_call = PyCall::new(
+        internal_call_id.to_string(),
+        invite_arc,
+        leg.transport.remote_addr.ip().to_string(),
+        format!("{}", leg.transport.transport).to_lowercase(),
+    );
+    Python::attach(|python| {
+        let call_obj = match Py::new(python, py_call) {
+            Ok(obj) => obj,
+            Err(error) => {
+                error!("failed to create PyCall for originate on_failure: {error}");
+                return;
+            }
+        };
+        for handler in &handlers {
+            let callable = handler.callable.bind(python);
+            match callable.call1((call_obj.bind(python), status_code, reason)) {
+                Ok(returned) => {
+                    if handler.is_async {
+                        if let Err(error) = run_coroutine(python, &returned) {
+                            error!("async originate on_failure handler error: {error}");
+                        }
+                    }
+                }
+                Err(error) => error!("originate on_failure handler error: {error}"),
+            }
+        }
+    });
+}
+
+/// Abandon an originated call that has not been answered: CANCEL the INVITE
+/// (RFC 3261 §9.1 — same Via branch and CSeq sequence as the request it
+/// cancels), stop retransmitting it, emit `StasisEnd`, and tear the call down.
+///
+/// This is what `hangup` means on an un-answered leg siphon placed. The
+/// inbound-call path answers its A-leg with a final non-2xx there, which is
+/// exactly wrong here: siphon is the UAC, and sending a *response* to the party
+/// it is calling is not a thing (RFC 3261 §8.1 — a UAC answers nothing).
+/// Returns `false`, never panics, when the call is already gone.
+pub fn b2bua_cancel_originated_call(sip_call_id: &str, reason: Option<&str>) -> bool {
+    let Some(control) = B2BUA_CONTROL.get() else {
+        return false;
+    };
+    let state = &control.state;
+    let Some(internal_call_id) = state.call_actors.find_by_sip_call_id(sip_call_id) else {
+        return false;
+    };
+    let _enter = control.runtime.enter();
+
+    let staged = match state.call_actors.get_call(&internal_call_id) {
+        Some(call) => call.a_leg_invite.clone().map(|invite| {
+            (
+                invite,
+                call.a_leg.transport.transport,
+                call.a_leg.transport.remote_addr,
+                call.a_leg.transport.local_addr,
+                call.a_leg.branch.clone(),
+            )
+        }),
+        None => return false,
+    };
+    let Some((invite_arc, transport, destination, local_addr, branch)) = staged else {
+        return false;
+    };
+
+    // Stop the INVITE's own retransmit schedule first: we are giving up on it,
+    // and `arm_b2bua_retransmit` disarms it again when the CANCEL is armed —
+    // this also covers a leg whose CANCEL cannot be built.
+    state.b2bua_retransmits.disarm_branch(&branch);
+    let cancel = match invite_arc.lock() {
+        Ok(invite) => build_cancel_from_invite(&invite),
+        Err(_) => {
+            error!(call_id = %internal_call_id, "originate cancel: stored INVITE mutex poisoned");
+            None
+        }
+    };
+    if let Some(cancel) = cancel {
+        send_b2bua_to_bleg(cancel, transport, destination, local_addr, state);
+    }
+
+    if crate::cdr::auto_emit_enabled() {
+        cdr_finalize_b2bua_fail(state, &internal_call_id, 487);
+    }
+    control_notify_terminated(sip_call_id, reason.unwrap_or("cancelled"));
+    // Keep the leg alive as a zombie so a 2xx that raced our CANCEL is still
+    // ACKed + BYEd (RFC 3261 §9.1 glare) rather than left ringing on the callee.
+    if state.call_actors.remove_call_after_cancel(&internal_call_id) {
+        schedule_zombie_cancelled_cleanup(state.call_actors.clone());
+    }
+    state.call_event_receivers.remove(&internal_call_id);
+    true
 }
 
 /// Arm the RFC 3262 §3 retransmit task for a reliable provisional response.
@@ -26666,6 +27765,298 @@ a=rtpmap:8 PCMA/8000\r\n";
         assert_eq!(
             response.headers.call_id().unwrap(),
             "refer-call@example.com"
+        );
+    }
+}
+
+#[cfg(test)]
+mod originate_tests {
+    use super::*;
+
+    fn params(media: OriginateMedia) -> OriginateParams {
+        OriginateParams {
+            to: "sip:+14035551212@carrier.example".to_string(),
+            to_display: None,
+            from: None,
+            from_display: None,
+            next_hop: None,
+            p_asserted_identity: None,
+            privacy: None,
+            headers: Vec::new(),
+            timeout_secs: 30,
+            media,
+        }
+    }
+
+    fn identity<'a>() -> OriginateIdentity<'a> {
+        OriginateIdentity {
+            sip_call_id: "b2b-originate-1",
+            from_tag: "sft-1",
+            branch: "z9hG4bK-orig-1",
+            via_host: "198.51.100.10",
+            via_port: 5060,
+            transport: Transport::Udp,
+            contact: "<sip:198.51.100.10:5060;transport=udp>",
+            user_agent: Some("siphon"),
+        }
+    }
+
+    fn build(params: &OriginateParams) -> SipMessage {
+        let uri = parse_uri_standalone(&params.to).expect("target parses");
+        build_originate_invite(params, uri, identity()).expect("invite builds")
+    }
+
+    #[test]
+    fn originate_invite_carries_the_uac_dialog_identity() {
+        let invite = build(&params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        }));
+
+        match &invite.start_line {
+            StartLine::Request(line) => {
+                assert_eq!(line.method, Method::Invite);
+                assert_eq!(line.request_uri.to_string(), "sip:+14035551212@carrier.example");
+            }
+            other => panic!("expected a request line, got {other:?}"),
+        }
+        assert_eq!(invite.headers.call_id().unwrap(), "b2b-originate-1");
+        assert_eq!(invite.headers.cseq().unwrap(), "1 INVITE");
+        // RFC 3261 §8.1.1.3: the UAC's From carries the tag it chose.
+        assert!(invite.headers.from().unwrap().contains(";tag=sft-1"));
+        // RFC 3261 §12.1.2: no To-tag until the callee assigns one.
+        assert!(!invite.headers.to().unwrap().contains("tag="));
+        assert_eq!(
+            invite.headers.get("Via").unwrap(),
+            "SIP/2.0/UDP 198.51.100.10:5060;branch=z9hG4bK-orig-1"
+        );
+        assert_eq!(invite.headers.get("Max-Forwards").unwrap(), "70");
+        assert_eq!(
+            invite.headers.get("Contact").unwrap(),
+            "<sip:198.51.100.10:5060;transport=udp>"
+        );
+        assert!(invite.headers.has("Allow"));
+        assert_eq!(invite.headers.get("User-Agent").unwrap(), "siphon");
+    }
+
+    #[test]
+    fn originate_defaults_the_from_uri_to_our_own_advertised_address() {
+        let invite = build(&params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        }));
+        assert!(
+            invite.headers.from().unwrap().contains("sip:198.51.100.10"),
+            "from was: {:?}",
+            invite.headers.from()
+        );
+    }
+
+    #[test]
+    fn originate_applies_the_full_calling_identity() {
+        let mut params = params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        });
+        params.from = Some("sip:+14035550100@siphon.example".to_string());
+        params.from_display = Some("Reminders".to_string());
+        params.to_display = Some("Callee".to_string());
+        params.p_asserted_identity = Some("sip:+14035550100@siphon.example".to_string());
+        let invite = build(&params);
+
+        let from = invite.headers.from().unwrap();
+        assert!(from.starts_with("\"Reminders\" <sip:+14035550100@siphon.example>"), "from was {from}");
+        assert!(from.contains(";tag=sft-1"));
+        assert!(invite.headers.to().unwrap().starts_with("\"Callee\" <sip:+14035551212@carrier.example>"));
+        // RFC 3325 §9.1: PAI is a name-addr for the trusted next hop.
+        assert_eq!(
+            invite.headers.get("P-Asserted-Identity").unwrap(),
+            "<sip:+14035550100@siphon.example>"
+        );
+    }
+
+    #[test]
+    fn originate_with_restricted_privacy_anonymises_from_and_asserts_privacy_id() {
+        // RFC 3323 §4.1 / TS 24.607: the real identity stays in PAI for the
+        // trusted next hop while From is anonymised.
+        let mut params = params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        });
+        params.from = Some("sip:+14035550100@siphon.example".to_string());
+        params.p_asserted_identity = Some("sip:+14035550100@siphon.example".to_string());
+        params.privacy = Some(crate::sip::privacy::CallerIdPresentation::Restricted);
+        let invite = build(&params);
+
+        let from = invite.headers.from().unwrap();
+        assert!(!from.contains("+14035550100"), "CLIR must not leak the CLI in From: {from}");
+        assert!(from.contains(";tag=sft-1"), "the dialog tag must survive CLIR: {from}");
+        assert!(invite
+            .headers
+            .get("Privacy")
+            .is_some_and(|value| value.contains("id")));
+        assert_eq!(
+            invite.headers.get("P-Asserted-Identity").unwrap(),
+            "<sip:+14035550100@siphon.example>"
+        );
+    }
+
+    #[test]
+    fn originate_privacy_runs_after_custom_headers_so_it_cannot_be_undone() {
+        // Ordering matters: a caller-supplied P-Preferred-Identity applied after
+        // the anonymisation would re-expose the CLI.
+        let mut params = params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        });
+        params.from = Some("sip:+14035550100@siphon.example".to_string());
+        params.headers = vec![(
+            "P-Preferred-Identity".to_string(),
+            "<sip:+14035550100@siphon.example>".to_string(),
+        )];
+        params.privacy = Some(crate::sip::privacy::CallerIdPresentation::Restricted);
+        let invite = build(&params);
+        assert!(
+            !invite.headers.has("P-Preferred-Identity"),
+            "CLIR must strip a P-Preferred-Identity added by the caller"
+        );
+    }
+
+    #[test]
+    fn originate_applies_custom_headers_but_never_dialog_defining_ones() {
+        let mut params = params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        });
+        params.headers = vec![
+            ("X-Campaign".to_string(), "reminder".to_string()),
+            // Every one of these would desynchronise the stored dialog from the
+            // wire, leaving the leg unaddressable for its own ACK / BYE.
+            ("Call-ID".to_string(), "hijacked".to_string()),
+            ("From".to_string(), "<sip:evil@elsewhere>".to_string()),
+            ("Via".to_string(), "SIP/2.0/UDP nowhere".to_string()),
+            ("CSeq".to_string(), "99 INVITE".to_string()),
+            ("Contact".to_string(), "<sip:nowhere>".to_string()),
+            ("Route".to_string(), "<sip:nowhere;lr>".to_string()),
+        ];
+        let invite = build(&params);
+
+        assert_eq!(invite.headers.get("X-Campaign").unwrap(), "reminder");
+        assert_eq!(invite.headers.call_id().unwrap(), "b2b-originate-1");
+        assert!(invite.headers.from().unwrap().contains(";tag=sft-1"));
+        assert!(invite.headers.get("Via").unwrap().contains("z9hG4bK-orig-1"));
+        assert_eq!(invite.headers.cseq().unwrap(), "1 INVITE");
+        assert_eq!(
+            invite.headers.get("Contact").unwrap(),
+            "<sip:198.51.100.10:5060;transport=udp>"
+        );
+        assert!(!invite.headers.has("Route"));
+    }
+
+    #[test]
+    fn originate_reserved_header_set_is_case_insensitive() {
+        for name in [
+            "Via", "via", "FROM", "To", "Call-ID", "call-id", "CSeq", "Contact", "Max-Forwards",
+            "Content-Length", "Route", "Record-Route",
+        ] {
+            assert!(is_originate_reserved_header(name), "{name} must be reserved");
+        }
+        for name in ["X-Campaign", "P-Asserted-Identity", "Subject", "Privacy", "Allow"] {
+            assert!(!is_originate_reserved_header(name), "{name} must be settable");
+        }
+    }
+
+    #[test]
+    fn a_caller_supplied_offer_rides_on_the_invite() {
+        let sdp = "v=0\r\no=- 1 1 IN IP4 198.51.100.10\r\ns=-\r\nc=IN IP4 198.51.100.10\r\nt=0 0\r\nm=audio 40000 RTP/AVP 0\r\n";
+        let invite = build(&params(OriginateMedia::Offer(sdp.to_string())));
+        assert_eq!(invite.body, sdp.as_bytes());
+        assert_eq!(invite.headers.get("Content-Type").unwrap(), "application/sdp");
+        assert_eq!(
+            invite.headers.get("Content-Length").unwrap(),
+            &sdp.len().to_string()
+        );
+    }
+
+    #[test]
+    fn an_anchored_originate_goes_out_offerless() {
+        // RFC 3261 §13.2.1: an INVITE may carry no offer; the callee then offers
+        // in its 2xx and we answer in the ACK (§13.2.2.4).
+        let invite = build(&params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        }));
+        assert!(invite.body.is_empty());
+        assert_eq!(invite.headers.get("Content-Length").unwrap(), "0");
+        assert!(!invite.headers.has("Content-Type"));
+    }
+
+    #[test]
+    fn anchor_rejection_names_the_reason_per_gate() {
+        use crate::config::MediaBackendKind;
+        // A backend with no answer_local cannot serve an offerless originate —
+        // it has to fail here, not connect a call whose 2xx nothing can answer.
+        assert!(matches!(
+            originate_anchor_rejection(MediaBackendKind::Rtpengine, true, "rtp_passthrough"),
+            Some(OriginateError::Unsupported(_))
+        ));
+        assert!(matches!(
+            originate_anchor_rejection(MediaBackendKind::Rtpproxy, true, "rtp_passthrough"),
+            Some(OriginateError::Unsupported(_))
+        ));
+        // Right backend, unknown profile.
+        match originate_anchor_rejection(MediaBackendKind::SiphonRtp, false, "nope") {
+            Some(OriginateError::Unsupported(message)) => {
+                assert!(message.contains("nope"), "message was: {message}");
+            }
+            other => panic!("expected an unsupported-profile refusal, got {other:?}"),
+        }
+        // Right backend, known profile: no refusal.
+        assert_eq!(
+            originate_anchor_rejection(MediaBackendKind::SiphonRtp, true, "rtp_passthrough"),
+            None
+        );
+    }
+
+    #[test]
+    fn originate_error_renders_each_cause_distinctly() {
+        assert_eq!(
+            OriginateError::InvalidUri {
+                field: "to",
+                detail: "bad".to_string()
+            }
+            .to_string(),
+            "invalid to: bad"
+        );
+        assert_eq!(
+            OriginateError::Unroutable("no route to 'sip:x'".to_string()).to_string(),
+            "no route to 'sip:x'"
+        );
+    }
+
+    #[test]
+    fn originate_body_text_only_surfaces_text_bodies() {
+        let raw = concat!(
+            "SIP/2.0 200 OK\r\n",
+            "Via: SIP/2.0/UDP 198.51.100.10:5060;branch=z9hG4bK-orig-1\r\n",
+            "From: <sip:a@siphon.example>;tag=sft-1\r\n",
+            "To: <sip:b@carrier.example>;tag=peer\r\n",
+            "Call-ID: b2b-originate-1\r\n",
+            "CSeq: 1 INVITE\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        );
+        let mut response = crate::sip::parser::parse_sip_message_bytes(raw.as_bytes()).unwrap();
+        assert_eq!(originate_body_text(&response), None);
+
+        response.body = b"v=0\r\n".to_vec();
+        assert_eq!(originate_body_text(&response), Some("v=0\r\n".to_string()));
+
+        response.body = vec![0xff, 0xfe];
+        assert_eq!(
+            originate_body_text(&response),
+            None,
+            "a non-UTF-8 body is reported by its absence, never mangled onto a JSON rail"
         );
     }
 }

--- a/src/script/api/b2bua.rs
+++ b/src/script/api/b2bua.rs
@@ -54,6 +54,129 @@ impl PyB2buaControl {
     /// silent no-op (no handler-return to act on). Returns True if the call was
     /// found and the REFER emitted, False if the Call-ID is unknown / already
     /// gone. Never raises (except on a malformed `replaces` dict).
+    /// Place an outbound call siphon owns, with no inbound INVITE behind it —
+    /// the primitive under click-to-dial, callbacks and outbound notification.
+    ///
+    /// Returns immediately with the new leg's **SIP Call-ID** as soon as the
+    /// INVITE is on the wire; it does *not* wait for the callee. Ringing and
+    /// answer arrive later through the ordinary handlers — `@b2bua.on_answer`
+    /// fires with `(call, reply)` when the callee answers, `@b2bua.on_failure`
+    /// with `(call, code, reason)` when it rejects, and `@b2bua.on_bye` when
+    /// either side hangs up. Feed the returned Call-ID to `b2bua.terminate()` /
+    /// `b2bua.refer()` to drive the leg from anywhere.
+    ///
+    /// Exactly one media plan is required, because an INVITE with no offer and
+    /// no way to answer the callee's leaves a connected call with no audio:
+    ///   * `sdp="v=0..."` — your own offer, carried verbatim; or
+    ///   * `media=True` — siphon anchors the leg on the configured media
+    ///     backend (siphon-rtp), so `rtpengine.play_media()`, DTMF and the
+    ///     WebSocket tee all work against it.
+    ///
+    /// ```python
+    /// call_id = b2bua.originate(
+    ///     to="sip:+14035551212@carrier.example",
+    ///     from_uri="sip:+14035550100@siphon.example",
+    ///     from_display="Reminders",
+    ///     media=True,
+    ///     headers={"X-Campaign": "reminder"},
+    ///     timeout=30,
+    /// )
+    /// ```
+    ///
+    /// Raises `ValueError` when the target/identity URIs do not parse, no route
+    /// exists, the media plan is not one the configured backend can serve, or
+    /// the B2BUA is not running — never a silent `None` for a call that was
+    /// never placed.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        to,
+        from_uri=None,
+        from_display=None,
+        to_display=None,
+        next_hop=None,
+        p_asserted_identity=None,
+        privacy=None,
+        headers=None,
+        sdp=None,
+        media=false,
+        profile=None,
+        ws_uri=None,
+        timeout=30,
+    ))]
+    fn originate(
+        &self,
+        to: &str,
+        from_uri: Option<&str>,
+        from_display: Option<&str>,
+        to_display: Option<&str>,
+        next_hop: Option<&str>,
+        p_asserted_identity: Option<&str>,
+        privacy: Option<&str>,
+        headers: Option<&Bound<'_, pyo3::types::PyDict>>,
+        sdp: Option<&str>,
+        media: bool,
+        profile: Option<&str>,
+        ws_uri: Option<&str>,
+        timeout: u32,
+    ) -> PyResult<String> {
+        use pyo3::exceptions::PyValueError;
+
+        let media_plan = match (sdp, media) {
+            (Some(_), true) => {
+                return Err(PyValueError::new_err(
+                    "b2bua.originate takes either sdp= (your own offer) or media=True (siphon anchors the leg), not both",
+                ));
+            }
+            (Some(sdp), false) if sdp.trim().is_empty() => {
+                return Err(PyValueError::new_err("b2bua.originate sdp= must not be empty"));
+            }
+            (Some(sdp), false) => crate::dispatcher::OriginateMedia::Offer(sdp.to_string()),
+            (None, true) => crate::dispatcher::OriginateMedia::Anchor {
+                profile: profile.unwrap_or("rtp_passthrough").to_string(),
+                ws_uri: ws_uri.map(str::to_string),
+            },
+            (None, false) => {
+                return Err(PyValueError::new_err(
+                    "b2bua.originate needs a media plan: sdp= (your own offer) or media=True (siphon anchors the leg)",
+                ));
+            }
+        };
+
+        let privacy = match privacy {
+            None => None,
+            Some(value) => Some(
+                crate::sip::privacy::CallerIdPresentation::parse(value).ok_or_else(|| {
+                    PyValueError::new_err(format!(
+                        "b2bua.originate privacy= must be \"allowed\" or \"restricted\", got '{value}'"
+                    ))
+                })?,
+            ),
+        };
+
+        let mut extra_headers = Vec::new();
+        if let Some(headers) = headers {
+            for (key, value) in headers.iter() {
+                extra_headers.push((key.to_string(), value.to_string()));
+            }
+        }
+
+        let params = crate::dispatcher::OriginateParams {
+            to: to.to_string(),
+            to_display: to_display.map(str::to_string),
+            from: from_uri.map(str::to_string),
+            from_display: from_display.map(str::to_string),
+            next_hop: next_hop.map(str::to_string),
+            p_asserted_identity: p_asserted_identity.map(str::to_string),
+            privacy,
+            headers: extra_headers,
+            timeout_secs: timeout,
+            media: media_plan,
+        };
+        crate::dispatcher::b2bua_originate(params)
+            .map(|placed| placed.sip_call_id)
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
     #[pyo3(signature = (call_id, target, replaces=None))]
     fn refer(
         &self,

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -191,6 +191,103 @@ class _B2buaNamespace:
             return False
         return control.terminate(call_id, reason)
 
+    def originate(
+        self,
+        to,
+        from_uri=None,
+        from_display=None,
+        to_display=None,
+        next_hop=None,
+        p_asserted_identity=None,
+        privacy=None,
+        headers=None,
+        sdp=None,
+        media=False,
+        profile=None,
+        ws_uri=None,
+        timeout=30,
+    ):
+        """Place an outbound call siphon owns, with no inbound INVITE behind it.
+
+        The primitive under click-to-dial, callbacks and outbound notification:
+        unlike ``call.dial()`` (which builds a B-leg off a call that already
+        arrived), this creates a call from nothing.
+
+        **Asynchronous.** It returns as soon as the INVITE is on the wire, with
+        the new leg's SIP Call-ID — it does not wait for the callee. Ringing and
+        answer arrive through the ordinary handlers: ``@b2bua.on_answer`` fires
+        with ``(call, reply)``, ``@b2bua.on_failure`` with ``(call, code,
+        reason)``, ``@b2bua.on_bye`` on teardown. Feed the returned Call-ID to
+        ``b2bua.terminate()`` / ``b2bua.refer()`` to drive the leg from anywhere.
+
+        Exactly one media plan is required — an INVITE with no offer and no way
+        to answer the callee's would connect a call with no audio:
+
+        * ``sdp="v=0..."`` — your own offer, carried verbatim (any backend);
+        * ``media=True`` — siphon anchors the leg on the configured media
+          backend (siphon-rtp), so ``rtpengine.play_media()``, DTMF and the
+          WebSocket tee all work against it.
+
+        Args:
+            to: called party — the Request-URI and the To URI.
+            from_uri: calling identity (From URI). Defaults to siphon's own
+                advertised address.
+            from_display: From display name.
+            to_display: To display name.
+            next_hop: route the INVITE here while the R-URI keeps the called
+                party's shape (IMS edge / trunk steering).
+            p_asserted_identity: ``P-Asserted-Identity`` for a trusted next hop.
+            privacy: ``"allowed"`` or ``"restricted"``. Restricted anonymises
+                From and asserts ``Privacy: id``, keeping the real identity in
+                ``P-Asserted-Identity``.
+            headers: dict of extra headers applied last. Dialog-defining headers
+                (Via/From/To/Call-ID/CSeq/Contact/…) are ignored — the stack owns
+                them.
+            sdp: your own SDP offer.
+            media: True to have siphon anchor the leg on the media backend.
+            profile: media profile for ``media=True`` (default
+                ``"rtp_passthrough"``).
+            ws_uri: per-call WebSocket bridge URI for ``media=True``.
+            timeout: ring timeout in seconds; the call is CANCELled when it
+                elapses. 0 disables it.
+
+        Returns:
+            str: the new leg's SIP Call-ID.
+
+        Raises:
+            ValueError: the URIs do not parse, no route exists, the media plan
+                is not one the configured backend can serve, or the B2BUA is not
+                running. Never a silent None for a call that was never placed.
+
+        Usage:
+            @timer.every(seconds=60)
+            def reminders():
+                for number in due_numbers():
+                    b2bua.originate(
+                        to=f"sip:{number}@carrier.example",
+                        from_uri="sip:+14035550100@siphon.example",
+                        media=True,
+                    )
+        """
+        control = object.__getattribute__(self, "__dict__").get("_control")
+        if control is None:
+            raise ValueError("b2bua.originate requires a running siphon B2BUA")
+        return control.originate(
+            to,
+            from_uri,
+            from_display,
+            to_display,
+            next_hop,
+            p_asserted_identity,
+            privacy,
+            headers,
+            sdp,
+            media,
+            profile,
+            ws_uri,
+            timeout,
+        )
+
     def refer(self, call_id, target, replaces=None):
         """Imperatively send an outbound REFER on a live B2BUA call by SIP Call-ID.
 


### PR DESCRIPTION
Every call siphon has handled until now was a *reaction*: `call.dial` builds a B-leg off an
inbound INVITE, and `proxy.send_request` is one-shot with no dialog you can later answer, bridge
or transfer. There was no way to place a call. That is what blocks a callback, a click-to-dial,
or an application driving a transfer.

**`bridge` is deliberately not in this PR.** It is a genuinely separate change — 3PCC
re-negotiation across two already-answered dialogs, a media re-anchor across two `CallActor`s,
and glare. Half of it would have been worse than none.

## The caller-supplied id

`args.channel` is **required**; siphon never mints one. An application stages its per-call
context before anything reaches the network, keyed by an id it chose, and an API that mints and
returns one forces a round-trip that design has removed.

Registration happens **before** the dial — `b2bua_originate_prepare` and `b2bua_originate_dial`
are two phases precisely so a callee that answers instantly cannot beat its own channel
registration and have its answer event dropped.

A duplicate live id returns a new typed **`conflict`**: retrying the same id can never succeed,
so it must be distinguishable from `bad_request`. The id frees again on teardown. A refused
originate registers no channel and puts nothing on the wire.

## The async contract

The reply reports the local action only. Measured on the wire:
`accept +0.000s, ringing +0.041s, answered +2.006s`.

## The call model

An originated call is a `CallActor` whose A-leg is a UAC dialog (`Leg::new_originating_leg`,
side A, `Dialog::new_outbound`). Its INVITE branch lives in a **separate** registry index
(`originated_calls`), checked before the leg-branch lookup — the precedent the outbound-REFER
index already set, and for the same reason: `handle_b2bua_response` relays to an A-leg and
reasons about B-legs, and an originated call *is* the A-leg.

It ACKs the 2xx (RFC 3261 §13.2.2.4), ACKs a final non-2xx on the INVITE's own branch (§17.1.1.3),
and **CANCELs** when abandoned (§9.1) rather than answering — the inbound path would otherwise aim
a `408`/`603` *response* at the party being called.

## Media

Exactly one plan is required, and neither is a default:

- `sdp` — a verbatim offer, any backend
- `media: true` — offerless INVITE, then `answer_local` on the callee's 2xx offer, answered on the ACK

Keyed on the leg's SIP Call-ID, so `play` / `dtmf` / `hold` / `stream_start` work unchanged.
Supplying neither is `bad_request`: an unanswerable 2xx is a connected call with no audio, which
is worse than a refused command.

## Mutation check — all three caught

| mutation | result |
|---|---|
| reply blocked 4 s (i.e. a synchronous originate) | `accept_precedes_answer` and `accept_is_not_the_outcome` both fail (`accept=4.001 ringing=0.553 answered=2.555`) |
| `p_asserted_identity` accepted but not wired onto the INVITE | UAS: `Failed regexp match: header P-Asserted-Identity: not found`, exit 255 |
| duplicate-id gate removed | `originate_rejects_a_duplicate_caller_supplied_id_with_conflict` fails |

## Verification

`cargo test` **4064 passed** · `cargo clippy --all-targets --all-features -- -D warnings` clean ·
control SDK 36 tests + clippy clean · SDK **612 passed** (+9) · `mkdocs build --strict` clean ·
the SIPp acceptance test run end to end locally, both containers exit 0, all 12 checks pass.

New CI job `sipp-originate`, new compose profile `originate` (172.20.0.150–152).

## Flagged, not fixed

**A `487` to our CANCEL is not ACKed** — it falls through unmatched and the callee retransmits to
Timer H. This is identical to every CANCELled B2BUA leg today (`zombie_cancelled` covers only 2xx
glare), so it is not a regression introduced here, but it costs more on outbound traffic where
CANCEL is routine rather than exceptional. Fixing it means touching shared dispatch while other
changes are in flight there, so it is raised rather than done.

**The feature-readiness matrix has no control-plane section**, so there was nothing to update
without inventing one that would collide with concurrent work.
