### PR TITLE
fix(b2bua): ACK the 487 that answers a CANCEL we sent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -585,6 +585,19 @@ jobs:
         if: always()
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-cancel down sipp-b2bua-cancel-uac sipp-b2bua-cancel-uas 2>/dev/null || true
 
+      # RFC 3261 §17.1.1.3 — the CANCELled B-leg's 487 MUST be ACKed, or the
+      # callee retransmits it on Timer G to Timer H (64*T1 = 32 s, §17.2.1) on
+      # every abandoned outbound attempt.  --exit-code-from names the UAS: the
+      # A-leg gets a correct 487 either way, so reading the UAC's exit code
+      # would pass vacuously — which is exactly why the step above, which does
+      # not name a container at all, never caught this.
+      - name: B2BUA CANCEL 487 is ACKed (RFC 3261 §17.1.1.3)
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-cancel-ack up --abort-on-container-exit --exit-code-from sipp-b2bua-cancel-ack-uas sipp-b2bua-cancel-ack-uac sipp-b2bua-cancel-ack-uas
+
+      - name: Cleanup cancel-ack containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-cancel-ack down sipp-b2bua-cancel-ack-uac sipp-b2bua-cancel-ack-uas 2>/dev/null || true
+
       - name: Deregister bob (clear previous contacts)
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-failure run --rm sipp-b2bua-deregister-bob
 
@@ -600,7 +613,7 @@ jobs:
 
       - name: Teardown
         if: always()
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-session-timer --profile b2bua-cancel --profile b2bua-failure down --remove-orphans
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-session-timer --profile b2bua-cancel --profile b2bua-cancel-ack --profile b2bua-failure down --remove-orphans
 
       - name: Upload logs
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,28 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   before, because that build is now what the official artifacts ship.
 
 
+### Fixed
+- **A `487 Request Terminated` answering a CANCEL siphon sent is now ACKed
+  (RFC 3261 §17.1.1.3).** It never was, on any CANCELled B2BUA leg. The CANCEL
+  paths tear the call down as they put the CANCEL on the wire, which unregisters
+  the leg's Via branch, so the `487` that RFC 3261 §9.1 makes the ordinary
+  outcome matched nothing and fell out of the response path as an unknown
+  branch. The B2BUA registers no client transaction — it runs its own retransmit
+  schedule — so nothing generated the ACK further down either. The peer's INVITE
+  server transaction then retransmitted the `487` on Timer G until Timer H
+  (64\*T1 = 32 s, §17.2.1), holding transaction state at both ends of every
+  abandoned call. It costs most on outbound traffic, where CANCEL is routine
+  rather than exceptional: each abandoned or timed-out attempt left a peer
+  retransmitting for 32 seconds. Existing handling covered only the §9.1 glare
+  case — a 2xx that beat the CANCEL — and that path is unchanged: a 2xx is still
+  ACKed and BYEd, never reclassified. The ACK rides the INVITE's own branch and
+  Request-URI and carries the response's To-tag, so the peer's server
+  transaction matches it (§17.2.3), and it is re-sent for every retransmission
+  of the response. Fixed for both an ordinary B2BUA B-leg and a call siphon
+  placed itself (`originate`), whose pending INVITE sits on the A-leg. The proxy
+  path was never affected: it relays and forks through real client transactions,
+  whose state machine already emits the ACK and caches it for retransmits.
+
 ## [1.6.0] — 2026-08-20
 
 ### Added

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -327,6 +327,13 @@ if [[ "$RUN_B2BUA" == true ]]; then
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-cancel up --abort-on-container-exit --exit-code-from sipp-b2bua-cancel-uac sipp-b2bua-cancel-uac sipp-b2bua-cancel-uas
   docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-cancel rm -sf sipp-b2bua-cancel-uac sipp-b2bua-cancel-uas 2>/dev/null || true
 
+  echo "=== B2BUA CANCEL 487-ACK test (the CANCELled B-leg's 487 is ACKed — RFC 3261 §17.1.1.3) ==="
+  # --exit-code-from names the UAS, not the UAC: the A-leg gets a correct 487
+  # whether or not siphon ever ACKs the B-leg's, so reading the UAC's exit code
+  # would pass vacuously.  The UAS is the only side that can see the missing ACK.
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-cancel-ack up --abort-on-container-exit --exit-code-from sipp-b2bua-cancel-ack-uas sipp-b2bua-cancel-ack-uac sipp-b2bua-cancel-ack-uas
+  docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-cancel-ack rm -sf sipp-b2bua-cancel-ack-uac sipp-b2bua-cancel-ack-uas 2>/dev/null || true
+
   echo "=== B2BUA failure test (INVITE → 486 Busy) ==="
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-failure run --rm sipp-b2bua-register-failure
   run_sipp docker compose -f "$COMPOSE_FILE" --profile b2bua --profile b2bua-failure up --abort-on-container-exit --exit-code-from sipp-b2bua-failure-uac sipp-b2bua-failure-uac sipp-b2bua-failure-uas

--- a/sipp/b2bua_cancel_ack_uac.xml
+++ b/sipp/b2bua_cancel_ack_uac.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  A-leg driver for the CANCEL 487-ACK test (b2bua_cancel_ack_uas.xml).
+
+  Flow: INVITE -> provisionals -> CANCEL -> 200 (CANCEL) -> 487 (INVITE) -> ACK,
+  i.e. b2bua_cancel_uac.xml's flow exactly. This side asserts nothing new: the
+  A-leg gets a correct 487 whether or not siphon ever ACKs the B-leg's, so the
+  UAS is the deciding container of this profile.
+
+  The ONE difference from b2bua_cancel_uac.xml, and the reason this file exists
+  rather than reusing it: the trailing pause. Without it this UAC finishes its
+  scenario in well under a second and exits, `--abort-on-container-exit` tears
+  the UAS down mid-wait, and the UAS reports 0 either way — the deciding
+  container never gets to fail. Measured: with the ACK suppressed the run still
+  exited 0 until this pause was added. It must outlast the UAS's `recv ACK`
+  deadline (10 s), so the UAS times out and fails on its own terms first.
+
+  Note: we wait for 180 Ringing before sending CANCEL. CANCEL before any
+  provisional is invalid per RFC 3261 §9.1.
+-->
+<scenario name="B2BUA CANCEL 487 ACK UAC">
+
+  <!-- Send INVITE to B2BUA -->
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-cancel-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <!-- Absorb 100 Trying -->
+  <recv response="100" optional="true" />
+
+  <!-- Wait for 180 Ringing (mandatory — CANCEL is only valid after a provisional) -->
+  <recv response="180" />
+
+  <!-- Send CANCEL -->
+  <send>
+    <![CDATA[
+CANCEL sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 CANCEL
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Expect 200 OK for the CANCEL -->
+  <recv response="200" rtd="true" />
+
+  <!-- Expect 487 Request Terminated for the original INVITE -->
+  <recv response="487" />
+
+  <!-- Send ACK for the 487 -->
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Outlive the UAS's 10 s `recv ACK` deadline (see the header): this call is
+       over, but if this container exits first, --abort-on-container-exit stops
+       the UAS before it can report the missing ACK and the run passes
+       vacuously. -->
+  <pause milliseconds="14000" />
+
+</scenario>

--- a/sipp/b2bua_cancel_ack_uas.xml
+++ b/sipp/b2bua_cancel_ack_uas.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA CANCEL — the ACK for the 487 (B-leg side, RFC 3261 §17.1.1.3).
+
+  Flow: recv INVITE -> 180 Ringing -> recv CANCEL -> 200 (CANCEL) ->
+        487 Request Terminated (INVITE) -> REQUIRE the ACK.
+
+  This is the sibling of b2bua_cancel_uas.xml, and the difference is the whole
+  point of it: there the closing `recv ACK` is `optional="true"`, so that
+  scenario reports success whether or not the ACK ever arrives. Here it is
+  MANDATORY, and the container runs with -timeout_error so a missing ACK is a
+  hard failure instead of "Successful call 0 / Failed call 0" and a zero exit.
+  This UAS is therefore the deciding container of its profile.
+
+  What it pins down: RFC 3261 §17.1.1.3 requires an INVITE client transaction to
+  generate an ACK for ANY final non-2xx response, and §9.1 makes 487 the
+  ordinary final response to a CANCELled INVITE. Without that ACK this UAS's
+  server transaction retransmits the 487 on Timer G until Timer H fires
+  (64*T1 = 32 s, §17.2.1), holding transaction state at both ends of every
+  abandoned or timed-out outbound attempt.
+
+  The ACK must also be MATCHABLE, so the two things this side can check without
+  a captured-variable comparison are checked: the To-tag is the one this UAS put
+  on the 487 (the INVITE and the CANCEL both carried a tagless To, so an ACK
+  echoing SIPpTag01 can only have taken it from the 487 — RFC 3261 §17.1.1.3),
+  and the topmost Via is siphon's own sent-by bearing the §8.1.1.7 magic cookie.
+
+  Exact branch equality — the ACK for a non-2xx rides the INVITE's OWN branch,
+  not a fresh one — is asserted in Rust instead
+  (`dispatcher::tests::cancelled_leg_ack_uses_the_invite_branch_ruri_and_the_487_to_tag`).
+  Injecting a captured variable into a match regexp (`branch=[$invite_branch]`)
+  is a FATAL scenario-load error on this SIPp build; see the note in
+  b2bua_cancel_uas.xml for the outage that caused.
+
+  The matching UAC (b2bua_cancel_uac.xml) sends the INVITE at CSeq 1, so the
+  487's CSeq is hardcoded `1 INVITE` (a 487 after a CANCEL echoes the INVITE's
+  CSeq, not the CANCEL's — `[last_CSeq:]` would wrongly be `1 CANCEL`).
+-->
+<scenario name="B2BUA CANCEL 487 ACK UAS">
+
+  <!-- The B-leg INVITE siphon dials out. -->
+  <recv request="INVITE" crlf="true" />
+
+  <!-- 180 Ringing — keep ringing so the A-leg has time to CANCEL. -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- The CANCEL siphon sends once the A-leg gives up (RFC 3261 §9.1). -->
+  <recv request="CANCEL" />
+
+  <!-- 200 OK to the CANCEL (RFC 3261 §9.2 — always 200). -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- 487 Request Terminated for the INVITE. Its To-tag is the one the ACK has
+       to echo back. -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 487 Request Terminated
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+CSeq: 1 INVITE
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- THE ASSERTION. Mandatory: RFC 3261 §17.1.1.3 makes this ACK a MUST, so an
+       ACK that never comes fails the run rather than being shrugged off. -->
+  <recv request="ACK" timeout="10000">
+    <action>
+      <!-- RFC 3261 §17.1.1.3: the ACK's To — tag included — is copied from the
+           response being acknowledged. The INVITE and the CANCEL both carried a
+           tagless To, so this tag can only have come from the 487. -->
+      <ereg regexp="tag=.*SIPpTag01"
+            search_in="hdr" header="To:" check_it="true" assign_to="ack_to_tag_ok" />
+      <!-- RFC 3261 §8.1.1.7: a single Via, siphon's own, bearing the magic
+           cookie. Its branch must be the INVITE's — see the note above for why
+           that exact comparison is asserted in Rust rather than here. -->
+      <ereg regexp="branch=z9hG4bK"
+            search_in="hdr" header="Via:" check_it="true" assign_to="ack_branch_ok" />
+      <!-- Reference the assigned vars so SIPp does not reject them as unused;
+           the pass/fail gate is check_it on the eregs above. -->
+      <log message="487 ACK assertions: to_tag=[$ack_to_tag_ok] branch=[$ack_branch_ok]" />
+    </action>
+  </recv>
+
+</scenario>

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -868,6 +868,7 @@ services:
       - b2bua-update
       - b2bua-bye-glare
       - b2bua-cancel
+      - b2bua-cancel-ack
       - b2bua-early-media
       - b2bua-topology
       - b2bua-refer
@@ -914,6 +915,7 @@ services:
       - b2bua-update
       - b2bua-bye-glare
       - b2bua-cancel
+      - b2bua-cancel-ack
       - b2bua-early-media
       - b2bua-topology
       - b2bua-refer
@@ -2411,6 +2413,80 @@ services:
       - -trace_err
     profiles:
       - b2bua-cancel
+
+  # --- B2BUA CANCEL: the ACK for the 487 (RFC 3261 §17.1.1.3) ---
+  #
+  # Same call flow as the b2bua-cancel profile above and the same A-leg driver,
+  # but the B-leg UAS REQUIRES the ACK for its 487 instead of treating it as
+  # optional — so this profile, unlike that one, actually fails when siphon
+  # leaves a CANCELled leg unacknowledged and the peer retransmits to Timer H.
+  #
+  # The UAS is the deciding container: run it with
+  #   --exit-code-from sipp-b2bua-cancel-ack-uas
+  # The A-leg UAC sees a correct 487 either way, so reading the UAC's exit code
+  # here would pass vacuously.
+  #
+  # IP assignments (shared with the other b2bua profiles — one profile runs at a
+  # time, and the register helper is `run --rm` and gone before the UAS starts):
+  #   172.20.0.50 — siphon-b2bua
+  #   172.20.0.52 — B-leg UAS (the asserting side)
+  #   172.20.0.53 — A-leg UAC
+
+  sipp-b2bua-cancel-ack-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_cancel_ack_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      # Load-bearing: without it a scenario that never receives the ACK exits 0
+      # on the global timeout with "Successful call 0 / Failed call 0", and the
+      # mode passes vacuously while the defect under test is wide open.
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - b2bua-cancel-ack
+
+  sipp-b2bua-cancel-ack-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua:
+        condition: service_healthy
+      sipp-b2bua-cancel-ack-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.50:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_cancel_ack_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "40"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - b2bua-cancel-ack
 
   # ── IPsec VoLTE test ──────────────────────────────────────────────────────
   # Tests IMS REGISTER with AKA authentication and IPsec SA negotiation.

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -1466,21 +1466,38 @@ pub struct ZombieReInviteEntry {
     pub local_addr: Option<SocketAddr>,
 }
 
-/// Post-teardown state for a B-leg whose INVITE was CANCELled but might still
-/// be answered (RFC 3261 §9.1 glare): the callee put a 2xx on the wire before
-/// our CANCEL arrived. That 2xx still establishes a dialog, which the B2BUA
-/// MUST ACK (§13.2.2.4) and then BYE (§15) to release. `handle_b2bua_cancel`
-/// removes the call — unregistering the B-leg branch — so the racing 2xx would
-/// otherwise be dropped as "unknown branch"; this entry lets `handle_response`
-/// catch it and clean the dialog up.
+/// Post-teardown state for a leg whose INVITE was CANCELled but is still owed a
+/// final response.
 ///
-/// Keyed by B-leg SIP Call-ID. Auto-expires after 32 seconds (Timer H).
+/// Two outcomes reach this entry, and both would otherwise be dropped as
+/// "unknown branch" — the CANCEL paths remove the call, unregistering the leg's
+/// branch, at the moment they put the CANCEL on the wire:
+///
+///  * the **ordinary** one, a `487 Request Terminated` (RFC 3261 §9.1): every
+///    CANCELled INVITE draws a final non-2xx, and §17.1.1.3 makes ACKing it the
+///    client transaction's job. Unacknowledged, the peer's INVITE server
+///    transaction retransmits on Timer G until Timer H (64*T1 = 32 s, §17.2.1),
+///    holding transaction state on both sides for the whole window.
+///  * the **glare** one, a 2xx the callee put on the wire before our CANCEL
+///    arrived (§9.1). That 2xx still establishes a dialog, which the B2BUA MUST
+///    ACK (§13.2.2.4) and then BYE (§15) to release.
+///
+/// Keyed by the leg's SIP Call-ID. Auto-expires after 32 seconds (Timer H).
 #[derive(Debug, Clone)]
 pub struct ZombieCancelledLeg {
-    /// The cancelled B-leg's dialog + transport, used to build the ACK and BYE.
+    /// The cancelled leg's dialog + transport, used to build the ACK and BYE.
     /// `remote_tag` / `remote_contact` are filled from the racing 2xx at
     /// handling time (they were unknown when the INVITE was CANCELled).
     pub leg: Leg,
+    /// Request-URI of the INVITE that was CANCELled, captured at teardown.
+    ///
+    /// RFC 3261 §17.1.1.3 requires the ACK for a final non-2xx to carry the
+    /// same Request-URI as the INVITE it acknowledges, and by the time the
+    /// `487` lands the call — and with it the stashed INVITE — is gone. `None`
+    /// only when the INVITE could not be read back (poisoned mutex); no ACK is
+    /// built in that case, because a `sip:invalid` R-URI on the wire is worse
+    /// than none.
+    pub invite_ruri: Option<String>,
     /// Whether the BYE has already been sent. The first racing 2xx triggers
     /// ACK + BYE; later 200 OK retransmits re-ACK only (so a lost ACK still
     /// gets retried) without emitting a second BYE.
@@ -2602,10 +2619,12 @@ impl CallActorStore {
     }
 
     /// Tear down a CANCELled call, but first preserve every still-pending
-    /// B-leg (INVITE sent, no final response yet — status `Trying`/`Ringing`)
-    /// as a [`ZombieCancelledLeg`] so a 2xx that raced the CANCEL
-    /// (RFC 3261 §9.1) can still be ACKed (§13.2.2.4) and BYEd (§15) after the
-    /// call is gone. Used by `handle_b2bua_cancel` in place of `remove_call`.
+    /// leg (INVITE sent, no final response yet — status `Trying`/`Ringing`) as
+    /// a [`ZombieCancelledLeg`], so the final response the CANCEL provokes is
+    /// still answerable after the call is gone: the ordinary `487` gets its ACK
+    /// (RFC 3261 §17.1.1.3) and a 2xx that raced the CANCEL (§9.1) gets ACK
+    /// (§13.2.2.4) + BYE (§15). Used by the CANCEL paths in place of
+    /// `remove_call`.
     ///
     /// Returns true if any zombie-cancelled entries were captured (so the
     /// caller can schedule their expiry).
@@ -2614,21 +2633,24 @@ impl CallActorStore {
         if let Some(call) = self.calls.get(call_id) {
             // A call siphon placed (`originate`) carries its pending INVITE on
             // the A-leg, not a B-leg, so the loop below would capture nothing
-            // and a 2xx racing our CANCEL would be dropped — leaving the callee
-            // retransmitting a 200 for a dialog nobody ever ACKs or BYEs
-            // (RFC 3261 §9.1 glare, §13.2.2.4, §15).
+            // and the final response to our CANCEL would be dropped — leaving
+            // the callee retransmitting a 487 nobody ACKs (RFC 3261 §17.1.1.3),
+            // or a 200 for a dialog nobody ACKs or BYEs (§9.1 glare, §13.2.2.4,
+            // §15).
             if call.originated
                 && matches!(call.state, CallState::Calling | CallState::Ringing)
-                && call.a_leg_invite.is_some()
             {
-                self.zombie_cancelled.insert(
-                    call.a_leg.dialog.call_id.clone(),
-                    ZombieCancelledLeg {
-                        leg: call.a_leg.clone(),
-                        byed: false,
-                    },
-                );
-                captured = true;
+                if let Some(invite) = call.a_leg_invite.as_ref() {
+                    self.zombie_cancelled.insert(
+                        call.a_leg.dialog.call_id.clone(),
+                        ZombieCancelledLeg {
+                            leg: call.a_leg.clone(),
+                            invite_ruri: request_uri_of(invite),
+                            byed: false,
+                        },
+                    );
+                    captured = true;
+                }
             }
             for (index, b_leg) in call.b_legs.iter().enumerate() {
                 let pending = matches!(
@@ -2636,15 +2658,18 @@ impl CallActorStore {
                     Some(BLegStatus::Trying) | Some(BLegStatus::Ringing)
                 );
                 // Only legs whose INVITE actually went on the wire can answer.
-                if pending && b_leg.b_leg_invite.is_some() {
-                    self.zombie_cancelled.insert(
-                        b_leg.dialog.call_id.clone(),
-                        ZombieCancelledLeg {
-                            leg: b_leg.clone(),
-                            byed: false,
-                        },
-                    );
-                    captured = true;
+                if pending {
+                    if let Some(invite) = b_leg.b_leg_invite.as_ref() {
+                        self.zombie_cancelled.insert(
+                            b_leg.dialog.call_id.clone(),
+                            ZombieCancelledLeg {
+                                leg: b_leg.clone(),
+                                invite_ruri: request_uri_of(invite),
+                                byed: false,
+                            },
+                        );
+                        captured = true;
+                    }
                 }
             }
         }
@@ -2652,7 +2677,7 @@ impl CallActorStore {
         captured
     }
 
-    /// Resolve a racing 2xx to a CANCELled B-leg by SIP Call-ID.
+    /// Resolve a racing 2xx to a CANCELled leg by SIP Call-ID.
     ///
     /// Returns the captured leg plus a `first_2xx` flag: the first racing 2xx
     /// for a Call-ID returns `(leg, true)` so the caller sends ACK + BYE; later
@@ -2665,6 +2690,28 @@ impl CallActorStore {
             entry.byed = true;
             (entry.leg.clone(), first_2xx)
         })
+    }
+
+    /// Resolve a final non-2xx — in practice the `487 Request Terminated` that
+    /// RFC 3261 §9.1 makes the ordinary outcome of a CANCEL — to a CANCELled
+    /// leg by SIP Call-ID.
+    ///
+    /// Returns the captured leg and the CANCELled INVITE's Request-URI, so the
+    /// caller can build the ACK §17.1.1.3 requires on the INVITE's own branch.
+    ///
+    /// Unlike [`Self::zombie_cancelled_for_2xx`] there is no first-response
+    /// flag: the ACK for a final non-2xx belongs to the INVITE's client
+    /// transaction, which §17.1.1.3 has re-pass it to the transport on *every*
+    /// retransmission of the response while it sits in `Completed`. Answering
+    /// only the first would leave a peer whose ACK was lost retransmitting to
+    /// Timer H regardless — the exact stall this entry exists to end.
+    pub fn zombie_cancelled_for_non2xx(
+        &self,
+        sip_call_id: &str,
+    ) -> Option<(Leg, Option<String>)> {
+        self.zombie_cancelled
+            .get(sip_call_id)
+            .map(|entry| (entry.leg.clone(), entry.invite_ruri.clone()))
     }
 
     /// Iterate over all active calls (for session timer sweep).
@@ -2990,6 +3037,29 @@ pub fn extract_to_tag(message: &SipMessage) -> Option<String> {
                 .find(|p| p.trim().starts_with("tag="))
                 .map(|t| t.trim().trim_start_matches("tag=").to_string())
         })
+}
+
+/// The Request-URI of a stashed outbound request, as it went on the wire.
+///
+/// Read back for a leg being torn down, so an ACK built after the leg's INVITE
+/// is gone still carries the Request-URI RFC 3261 §17.1.1.3 requires it to
+/// share with the INVITE. Returns `None` on a poisoned mutex or a message that
+/// is somehow not a request — the callers treat that as "cannot build an ACK",
+/// which is the honest outcome; a placeholder R-URI on the wire is worse.
+fn request_uri_of(stashed: &Arc<Mutex<SipMessage>>) -> Option<String> {
+    let guard = match stashed.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            warn!("cancelled leg: stashed INVITE mutex poisoned, no Request-URI for its ACK");
+            return None;
+        }
+    };
+    match &guard.start_line {
+        crate::sip::message::StartLine::Request(request_line) => {
+            Some(request_line.request_uri.to_string())
+        }
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4087,6 +4157,76 @@ mod tests {
         assert!(!second, "a retransmit must not trigger a second BYE");
     }
 
+    /// The ORDINARY outcome of a CANCEL, not the glare one: the peer answers
+    /// the CANCELled INVITE `487 Request Terminated` (RFC 3261 §9.1), and
+    /// §17.1.1.3 requires an ACK for it. The call is gone by then, so the ACK
+    /// can only be built from the zombie entry — which therefore has to carry
+    /// the CANCELled INVITE's Request-URI (§17.1.1.3: the ACK's Request-URI
+    /// equals the INVITE's).
+    #[test]
+    fn store_zombie_captures_the_invite_ruri_so_the_487_can_be_acked() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+
+        let mut sent_leg = make_b_leg(0);
+        let sent_cid = sent_leg.dialog.call_id.clone();
+        let invite = crate::sip::builder::SipMessageBuilder::new()
+            .request(
+                crate::sip::message::Method::Invite,
+                crate::sip::uri::SipUri::new("198.51.100.20".to_string())
+                    .with_user("bob".to_string())
+                    .with_port(5060),
+            )
+            .via("SIP/2.0/UDP 198.51.100.10:5060;branch=z9hG4bK-bleg0".to_string())
+            .from("<sip:alice@198.51.100.10>;tag=a".to_string())
+            .to("<sip:bob@198.51.100.20>".to_string())
+            .call_id(sent_cid.clone())
+            .cseq("1 INVITE".to_string())
+            .content_length(0)
+            .build()
+            .unwrap();
+        sent_leg.b_leg_invite = Some(Arc::new(Mutex::new(invite)));
+        store.add_b_leg(&call_id, sent_leg);
+
+        // A leg whose INVITE never went on the wire draws no final response, so
+        // it is not captured and nothing is owed an ACK.
+        let unsent_leg = make_b_leg(1);
+        let unsent_cid = unsent_leg.dialog.call_id.clone();
+        store.add_b_leg(&call_id, unsent_leg);
+
+        assert!(store.remove_call_after_cancel(&call_id));
+
+        let (leg, ruri) = store
+            .zombie_cancelled_for_non2xx(&sent_cid)
+            .expect("the CANCELled leg must still resolve for its 487");
+        assert_eq!(leg.dialog.call_id, sent_cid);
+        // The ACK goes out on the INVITE's own branch (§17.1.1.3), which is the
+        // leg's branch — not a fresh one.
+        assert_eq!(leg.branch, "z9hG4bK-bleg0");
+        assert_eq!(ruri.as_deref(), Some("sip:bob@198.51.100.20:5060"));
+        assert!(store.zombie_cancelled_for_non2xx(&unsent_cid).is_none());
+
+        // §17.1.1.3 has the client transaction re-pass the ACK to the transport
+        // on EVERY retransmission of the final response while it sits in
+        // Completed — so the lookup must keep resolving, not consume the entry.
+        assert!(
+            store.zombie_cancelled_for_non2xx(&sent_cid).is_some(),
+            "a retransmitted 487 must still be ACKable"
+        );
+
+        // ...and it must not have consumed the glare path's first-2xx flag: a
+        // 487 followed by a raced 2xx (both are possible on a forked downstream)
+        // must still produce ACK + BYE for the 2xx.
+        let (_leg, first_2xx) = store
+            .zombie_cancelled_for_2xx(&sent_cid)
+            .expect("the glare entry survives a 487 lookup");
+        assert!(
+            first_2xx,
+            "ACKing a 487 must not consume the BYE the glare 2xx path owes"
+        );
+    }
+
+
     #[test]
     fn store_sweep_stale() {
         let store = CallActorStore::new();
@@ -5026,6 +5166,47 @@ mod originate_tests {
         let store = CallActorStore::new();
         let call_id = store.create_call(originating_leg());
         assert!(!store.is_originated(&call_id));
+    }
+
+    /// A call siphon placed itself carries its pending INVITE on the A-leg, so
+    /// the B-leg capture loop finds nothing — without the A-leg arm the `487
+    /// Request Terminated` its CANCEL draws (RFC 3261 §9.1) is dropped as an
+    /// unknown branch, unACKed, and the peer retransmits to Timer H (§17.2.1).
+    #[test]
+    fn cancelled_originate_is_zombified_with_its_invite_ruri_for_the_487_ack() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(originating_leg());
+        store.mark_originated(&call_id, "z9hG4bK-orig1");
+
+        let sip_call_id = "orig-call@siphon.invalid".to_string();
+        let invite = crate::sip::builder::SipMessageBuilder::new()
+            .request(
+                crate::sip::message::Method::Invite,
+                crate::sip::uri::SipUri::new("carrier.example".to_string())
+                    .with_user("+14035551212".to_string()),
+            )
+            .via("SIP/2.0/UDP 198.51.100.10:5060;branch=z9hG4bK-orig1".to_string())
+            .from("<sip:siphon@198.51.100.10>;tag=sip-from-tag".to_string())
+            .to("<sip:+14035551212@carrier.example>".to_string())
+            .call_id(sip_call_id.clone())
+            .cseq("1 INVITE".to_string())
+            .content_length(0)
+            .build()
+            .unwrap();
+        store.set_a_leg_invite(&call_id, Arc::new(Mutex::new(invite)));
+
+        assert!(
+            store.remove_call_after_cancel(&call_id),
+            "an originated call's pending A-leg must be captured"
+        );
+
+        let (leg, ruri) = store
+            .zombie_cancelled_for_non2xx(&sip_call_id)
+            .expect("the CANCELled originate must still resolve for its 487");
+        // RFC 3261 §17.1.1.3 — the ACK rides the INVITE's own branch and
+        // Request-URI.
+        assert_eq!(leg.branch, "z9hG4bK-orig1");
+        assert_eq!(ruri.as_deref(), Some("sip:+14035551212@carrier.example"));
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -5505,6 +5505,44 @@ fn handle_response(
         }
     }
 
+    // Post-CANCEL, the ORDINARY outcome: the `487 Request Terminated` the peer
+    // answers a CANCELled INVITE with (RFC 3261 §9.1). RFC 3261 §17.1.1.3 makes
+    // ACKing any final non-2xx to an INVITE the client transaction's job, and
+    // the B2BUA has no client transaction — it runs its own retransmit schedule
+    // (see the top of this function) — so nothing below generates it either.
+    // The CANCEL paths removed the call and with it the leg's branch index, so
+    // this response no longer resolves above; unanswered, the peer's INVITE
+    // server transaction retransmits on Timer G to Timer H (64*T1 = 32 s,
+    // §17.2.1), holding transaction state at both ends of every abandoned call.
+    //
+    // Matched via the same `zombie_cancelled` capture as the glare 2xx, which
+    // covers both shapes of pending leg: an ordinary B2BUA B-leg and the A-leg
+    // of a call siphon placed itself (`originate`).
+    //
+    // Gated on a CSeq of INVITE so the CANCEL's own final response — which
+    // shares the INVITE's branch (§9.1) — is never ACKed: a non-INVITE
+    // transaction takes no ACK (§17.1.2).
+    if status_code >= 300 {
+        if let Some(cseq_raw) = message.headers.get("CSeq") {
+            if cseq_raw.contains("INVITE") {
+                if let Some(sip_call_id) = message.headers.call_id() {
+                    if let Some((leg, invite_ruri)) =
+                        state.call_actors.zombie_cancelled_for_non2xx(sip_call_id)
+                    {
+                        handle_zombie_cancelled_non2xx(
+                            &leg,
+                            invite_ruri.as_deref(),
+                            &message,
+                            status_code,
+                            state,
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
     // Parse CSeq once for both transaction processing and session routing.
     let sent_by = TransactionKey::format_sent_by(&top_via.host, top_via.port);
     let client_txn_key = message.headers.get("CSeq")
@@ -17107,6 +17145,84 @@ fn handle_zombie_cancelled_2xx(
     }
 }
 
+/// ACK the final non-2xx that a CANCELled INVITE draws — in practice the
+/// `487 Request Terminated` of RFC 3261 §9.1, the ordinary end of every
+/// CANCELled leg.
+///
+/// RFC 3261 §17.1.1.3: an INVITE client transaction MUST generate an ACK for
+/// any final non-2xx response, on the INVITE's *own* branch and carrying the
+/// response's To-tag, so the peer's server transaction can match it (§17.2.3).
+/// Everything the ACK needs beyond the response itself — the branch, the
+/// INVITE's Request-URI, the socket to leave from and advertise — comes from
+/// the leg captured at CANCEL time, because the call itself is already gone.
+///
+/// Unlike the 2xx glare path there is no BYE and no first-response guard: a
+/// non-2xx establishes no dialog to release, and §17.1.1.3 has the client
+/// transaction re-pass the ACK to the transport on every retransmission of the
+/// response while it sits in `Completed`.
+fn handle_zombie_cancelled_non2xx(
+    leg: &crate::b2bua::actor::Leg,
+    invite_ruri: Option<&str>,
+    response: &SipMessage,
+    status_code: u16,
+    state: &DispatcherState,
+) {
+    let transport = leg.transport.transport;
+    let destination = leg.transport.remote_addr;
+    // The socket this leg was dialled from (flow-pinned legs) — the ACK has to
+    // leave from it and advertise it, exactly as the INVITE did, or the peer's
+    // server transaction will not match it on sent-by (§17.2.3).
+    let local_addr = leg.transport.local_addr;
+    let (via_host, via_port) = b_leg_sent_by(local_addr, state, &transport);
+
+    let Some(ack) = build_cancelled_leg_ack(leg, invite_ruri, response, &via_host, via_port) else {
+        // No Request-URI means the stashed INVITE could not be read back. Say
+        // so rather than putting a placeholder R-URI on the wire — an ACK the
+        // peer cannot match is no better than none, and this must be
+        // diagnosable when the peer keeps retransmitting.
+        error!(
+            sip_call_id = %leg.dialog.call_id,
+            status = status_code,
+            "B2BUA: cannot ACK a CANCELled leg's final response — the CANCELled \
+             INVITE's Request-URI was not captured (RFC 3261 §17.1.1.3)"
+        );
+        return;
+    };
+
+    send_b2bua_to_bleg(ack, transport, destination, local_addr, state);
+    debug!(
+        sip_call_id = %leg.dialog.call_id,
+        status = status_code,
+        branch = %leg.branch,
+        "B2BUA: ACK for the final response to a CANCELled leg (RFC 3261 §17.1.1.3)"
+    );
+}
+
+/// Build the ACK a CANCELled leg's final non-2xx is owed (RFC 3261 §17.1.1.3).
+///
+/// Pure half of [`handle_zombie_cancelled_non2xx`], split out so the invariants
+/// that actually matter are unit-testable without a `DispatcherState` fixture:
+/// the ACK rides the INVITE's **own** branch and Request-URI, and carries the
+/// **response's** To-tag — the three fields the peer's server transaction
+/// matches on (§17.2.3). `None` when the Request-URI was never captured.
+fn build_cancelled_leg_ack(
+    leg: &crate::b2bua::actor::Leg,
+    invite_ruri: Option<&str>,
+    response: &SipMessage,
+    via_host: &str,
+    via_port: u16,
+) -> Option<SipMessage> {
+    let target_uri = invite_ruri?;
+    Some(build_b2bua_ack_for_non2xx(
+        response,
+        &leg.branch,
+        Some(target_uri),
+        leg.transport.transport,
+        via_host,
+        via_port,
+    ))
+}
+
 /// Handle a BYE for a B2BUA call — bridge to the other leg.
 fn handle_b2bua_bye(
     inbound: InboundMessage,
@@ -26178,6 +26294,74 @@ a=rtpmap:8 PCMA/8000\r\n";
         // CSeq number echoes the INVITE; method becomes ACK.
         assert_eq!(ack.headers.cseq().unwrap(), "1 ACK");
         assert_eq!(ack.headers.call_id().unwrap(), "b2b-aaaa-bbbb");
+    }
+
+    /// A CANCELled leg is answered `487 Request Terminated` (RFC 3261 §9.1) and
+    /// RFC 3261 §17.1.1.3 requires an ACK for it. By then the call is torn down,
+    /// so everything the ACK needs comes from the leg captured at CANCEL time
+    /// plus the response — and it must land on the INVITE's own branch and
+    /// Request-URI, carrying the 487's To-tag, or the peer's server transaction
+    /// cannot match it (§17.2.3) and retransmits to Timer H.
+    #[test]
+    fn cancelled_leg_ack_uses_the_invite_branch_ruri_and_the_487_to_tag() {
+        let leg = crate::b2bua::actor::Leg::new_b_leg(
+            "b2b-cancelled-leg".to_string(),
+            "b-leg-from-tag".to_string(),
+            "sip:bob@198.51.100.20".to_string(),
+            "z9hG4bK-bleg-invite".to_string(),
+            crate::b2bua::actor::TransportInfo {
+                remote_addr: "198.51.100.20:5060".parse().unwrap(),
+                connection_id: ConnectionId::default(),
+                transport: Transport::Udp,
+                local_addr: None,
+            },
+        );
+
+        let response = SipMessageBuilder::new()
+            .response(487, "Request Terminated".to_string())
+            .via("SIP/2.0/UDP 198.51.100.10:5060;branch=z9hG4bK-bleg-invite".to_string())
+            .from("<sip:alice@siphon.example.org>;tag=b-leg-from-tag".to_string())
+            .to("<sip:bob@198.51.100.20>;tag=uas-487-tag".to_string())
+            .call_id("b2b-cancelled-leg".to_string())
+            .cseq("1 INVITE".to_string())
+            .content_length(0)
+            .build()
+            .unwrap();
+
+        let ack = build_cancelled_leg_ack(
+            &leg,
+            Some("sip:bob@198.51.100.20:5060"),
+            &response,
+            "198.51.100.10",
+            5060,
+        )
+        .expect("a captured Request-URI must yield an ACK");
+
+        match &ack.start_line {
+            StartLine::Request(request_line) => {
+                assert_eq!(request_line.method, Method::Ack);
+                // §17.1.1.3 — same Request-URI as the INVITE being ACKed, NOT
+                // the response's Contact (that rule is for the 2xx ACK, §13.2.2.4).
+                assert_eq!(request_line.request_uri.host, "198.51.100.20");
+                assert_eq!(request_line.request_uri.user.as_deref(), Some("bob"));
+            }
+            _ => panic!("expected an ACK request line"),
+        }
+
+        // The INVITE's own branch — the ACK for a non-2xx is part of that same
+        // client transaction (§17.1.1.3), so a fresh branch would be unmatchable.
+        assert_eq!(
+            ack.headers.via().unwrap(),
+            "SIP/2.0/UDP 198.51.100.10:5060;branch=z9hG4bK-bleg-invite"
+        );
+        // The 487's To-tag, without which the UAS cannot match the ACK (§17.2.3).
+        assert!(ack.headers.to().unwrap().contains("tag=uas-487-tag"));
+        assert_eq!(ack.headers.cseq().unwrap(), "1 ACK");
+        assert_eq!(ack.headers.call_id().unwrap(), "b2b-cancelled-leg");
+
+        // Without a captured Request-URI there is no ACK to build — the caller
+        // logs it rather than emitting a placeholder R-URI the peer would drop.
+        assert!(build_cancelled_leg_ack(&leg, None, &response, "198.51.100.10", 5060).is_none());
     }
 
     /// Regression: an outbound INVITE to an authenticating trunk draws a 401,


### PR DESCRIPTION
A `487 Request Terminated` answering a CANCEL siphon sent was never ACKed. RFC 3261 §17.1.1.3
requires an INVITE client transaction to ACK **any** final non-2xx; §9.1 makes `487` that
outcome; §17.2.1 Timer G/H means the peer retransmits it for 32 seconds. Every cancelled B2BUA
leg left a peer retransmitting and both sides holding transaction state.

Surfaced while adding `originate`, but not specific to it — it is true of every CANCELled B2BUA
leg, and it costs most on outbound traffic where CANCEL is routine rather than exceptional.

## Root cause

Every CANCEL path — inbound A-leg CANCEL, the B-leg ring-timeout, and the originated-call
cancel — tears the call down through `remove_call_after_cancel` **at the moment it puts the
CANCEL on the wire**. That reaches `LegRegistry::remove_all_for_call`, dropping both `by_branch`
and `originated_calls`.

So the `487` arrives at `handle_response` and matches nothing: the branch indexes are gone, and
the B2BUA registers no client transaction (it runs its own retransmit schedule — its own header
comment says so), so the transaction path misses too. It fell off the end at
`debug!("response for unknown branch (not ours)")`.

The pending leg **was** preserved as a `ZombieCancelledLeg` — but the only lookup consulting it
was gated `if (200..300).contains(&status_code)`, the §9.1 glare 2xx. The ordinary outcome had
no hook at all.

## Fix

`ZombieCancelledLeg` gains the INVITE's Request-URI, captured at teardown (the stashed INVITE
dies with the call), populated for both the originated A-leg and each pending B-leg. A new
`>= 300` hook runs after the 2xx block and builds the ACK on the INVITE's own branch and
Request-URI carrying the response's To-tag, so the UAS matches it (§17.2.3).

Three details worth reviewing:

- The hook is **gated on a CSeq method of INVITE**, so the CANCEL's own final response — same
  branch, §9.1 — is never ACKed (§17.2.1 puts a non-INVITE transaction outside this rule).
- It deliberately does **not** touch `byed`, so a 487 cannot consume the BYE the glare path owes.
- No Request-URI means `error!` and no ACK, rather than emitting a `sip:invalid` placeholder.

The 2xx-glare path is unchanged: the 2xx block runs first and `>= 300` excludes 2xx, so a 2xx
can never be reclassified. A unit test asserts a 487 lookup leaves `first_2xx == true` so the
ACK+BYE still fires.

## Mutation check — real containers, both ways

| | exit | UAS |
|---|---|---|
| fix disabled | **255** | `ACK 0 msgs / 1 timeout`, `Successful call 0` — SIPp aborts on the missing ACK |
| fix applied | **0** | `ACK 1`, `Successful call 1 / Failed call 0` |

## The proxy path does not share the defect

Checked, no change made. The proxy relays and forks through `new_client_transaction`, so the
`487` reaches the ICT state machine, which emits the ACK per §17.1.1.3 and caches it for
retransmits. `handle_cancel_via_session` removes only the proxy *session*, never the
transaction.

## Verification

`cargo test` **4112 passed** · `cargo clippy --all-targets --all-features -- -D warnings` clean ·
the pre-existing `b2bua-cancel` profile still exits 0, and its UAS now actually receives the ACK
(`ACK 1`) where it previously got 0 silently · the basic `b2bua` profile exits 0.

## Two things worth knowing

**The existing `b2bua-cancel` mode was green three ways over.** Its ACK receive was
`optional="true"`, it had no `-timeout_error`, and the CI step names no `--exit-code-from` at all
(the runner names the *UAC*, which gets a correct 487 regardless). That is why a 32-second stall
on every cancelled call shipped unnoticed. Left untouched here to keep the diff tight, but it
wants fixing.

**`--exit-code-from` alone was not sufficient for the new gate.** The first mutation run exited
`0` with the ACK suppressed: the UAC finished in under a second and `--abort-on-container-exit`
killed the UAS before its 10-second deadline could fire. The new scenario carries a trailing
14-second pause on the UAC specifically so the assertion can bite. Worth remembering — it is a
second way for a SIPp mode to pass vacuously, distinct from the missing `--exit-code-from`.
