### PR TITLE
build(release): ship the http extension in the official artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,9 @@ tasks/
 sipp/
 tests/
 .python-version
+# The patterns above anchor at the context root, so siphon-bin's own build
+# artifacts need their own entries now that the image builds that package.
+# .cargo/ is excluded because the image writes its own patch config there and a
+# developer's local copy must not shadow it.
+siphon-bin/target/
+siphon-bin/.cargo/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,6 +242,33 @@ jobs:
       - name: Clippy (--features full)
         run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features full -- -D warnings
 
+      # The release composition, and the one leg that is NOT a bit-rot guard.
+      # Everything above resolves siphon-sip from git, so it can be green against
+      # a lib many commits behind this branch. This leg patches siphon-sip to the
+      # in-tree source — exactly what release.yaml and the root Dockerfile do —
+      # and so answers the question the others cannot: does THIS branch still
+      # compile the binary the project actually ships?
+      #
+      # It matters because the release build now needs siphon-http to compile
+      # against the release tree. siphon-http touches a two-type surface
+      # (siphon::script::{ScriptHandle, HandlerHandle}); break it here and
+      # without this leg the first failure would land halfway through a release
+      # cut. `--features ui` mirrors the artifacts; `http` is already default.
+      #
+      # Kept last on purpose: the pin writes a .cargo config into siphon-bin and
+      # must not leak into the unpatched legs above.
+      # Invoked by relative path rather than with a working-directory override:
+      # this job defaults every step into siphon-bin/, and the script locates the
+      # repo root from its own path, so it works from wherever it is called.
+      - name: Pin siphon-sip to this checkout
+        run: ../scripts/pin-siphon-sip-to-tree.sh
+
+      - name: Build (patched to this tree — the released composition)
+        run: PYO3_PYTHON=python3.14 cargo build --features ui
+
+      - name: Clippy (patched to this tree — the released composition)
+        run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features ui -- -D warnings
+
   # ── Python SDK tests ──────────────────────────────────────────────────
   sdk-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,10 +70,42 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # siphon-bin is a separate, excluded workspace with its own target dir, so
+      # it needs its own cache entry — the default only covers the root one.
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            siphon-bin
 
-      - name: Build release binary
-        run: PYO3_PYTHON=python3.14 cargo build --release --target ${{ matrix.target }}
+      # The released binary is the siphon-bin composition, not the plain
+      # siphon-sip one: same `siphon` artifact, same CLI, same siphon.yaml, plus
+      # the `http` namespace (siphon-bin's default feature) and the `ui`
+      # dashboard (an explicit passthrough to siphon-sip's own feature).
+      #
+      # Pinning first is what makes the release contain THIS tag's lib rather
+      # than whatever siphon-bin/Cargo.lock's pinned SHA of main happens to be;
+      # the script asserts the patch actually applied, because cargo downgrades
+      # an unused [patch] to a warning and would otherwise build the git copy.
+      # ci.yaml runs the same composition on PRs so drift fails there instead of
+      # halfway through a release cut.
+      - name: Pin siphon-sip to this checkout
+        run: scripts/pin-siphon-sip-to-tree.sh
+
+      - name: Build release binary (siphon-bin — http + ui)
+        working-directory: siphon-bin
+        run: PYO3_PYTHON=python3.14 cargo build --release --target ${{ matrix.target }} --features ui
+
+      # Stage it where the packaging steps below already look. Everything in
+      # Cargo.toml's [package.metadata.deb] / [package.metadata.generate-rpm]
+      # then keeps working untouched: the binary asset resolves, and every other
+      # asset path (siphon.yaml, scripts/, dist/) stays relative to the root
+      # manifest. Moving that metadata into siphon-bin/ would mean rewriting
+      # every asset path as ../ for no gain.
+      - name: Stage the binary for packaging
+        run: |
+          install -D siphon-bin/target/${{ matrix.target }}/release/siphon \
+                     target/${{ matrix.target }}/release/siphon
 
       - name: Build .deb package
         if: matrix.target == 'x86_64-unknown-linux-gnu'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   - Typed refusals throughout — `bad_request`, `conflict`, `not_found` (no
     route), `unsupported_verb`, `unavailable` — each separately actionable, and
     a refused originate registers no channel and places nothing on the wire.
+- **`ui` and `sctp` cargo features on `siphon-bin`**, forwarding to the
+  `siphon-sip` features of the same name. Previously an extension build had no
+  way to turn either on, so composing extensions meant giving up the operator
+  dashboard and SCTP transport. The official artifacts build with `ui`.
+- **Release-cut now runs the security-advisory gate over the `siphon-bin`
+  composition too**, not just the `siphon-sip` graph. The released binary is
+  built from that composition, so the extension crates and their dependency
+  trees reach operators; an open advisory in one of them would previously have
+  left the gate green.
 
 ### Changed
 - **`hangup` on an un-answered call siphon originated now CANCELs** instead of
@@ -112,7 +121,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `answer()` and `answer_local()`, the same way `ws_uri=` already was — so beep
   detection can be armed on one leg of one call without a second profile.
 
-### Changed
 - The native media control contract moved from 0.2.0 to 0.3.0. The JSON wire is
   unchanged (every new field is optional and omitted when unset, and a default
   profile still serialises to `{}`), so an unset knob emits exactly the command
@@ -151,12 +159,41 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `TransferOutcomePayload` + `TransferStage`, `CallEvent::transfer_outcome()` /
   `CallEvent::is_transfer_final()` and the TypeScript `isTransferFinal()`.
 
-### Changed
 - **`siphon-control-proto`'s `SipEvent` is now `#[non_exhaustive]`.** The
   server's event set grows, and without it every addition breaks any downstream
   `match` with an arm per variant. A wildcard arm is now required once, and
   every future event is purely additive. Consumers matching `SipEvent`
   exhaustively need to add `_ => {}`.
+- **The official artifacts now ship the `http` extension.** The container image,
+  the `.deb`, the `.rpm` and the release tarball are built from the
+  extension-composing `siphon-bin` package instead of the plain `siphon-sip`
+  one, so the scriptable `http` namespace (inbound `@http.route` handlers plus
+  the Rust-backed `http.Client`) is compiled in. Previously it was reachable
+  only by building `siphon-bin` yourself, which is a real barrier for anyone
+  installing from a package or running the image. It is the one module with no
+  deployment prerequisite, so it costs an operator nothing to carry.
+
+  Nothing changes for an existing deployment: the artifact is still a binary
+  called `siphon` with the same CLI and the same `siphon.yaml`, the embedded
+  `ui` dashboard is still compiled in, and a module that is compiled in but has
+  no `extensions:` entry registers nothing and costs nothing at runtime. To
+  start using it, add `extensions: { http: /etc/siphon/http.yaml }` — `siphon.yaml`
+  now carries a commented reference block for the section. `smpp` and `sigtran`
+  keep their deployment prerequisites and still need a `siphon-bin` build.
+
+  `cargo install siphon-sip` is unaffected and still installs the SIP core with
+  no extensions; the published crate is byte-identical to 1.6.0.
+- **`.deb` maintainer address** is now `maintainers@siphon-sip.org` rather than
+  a personal one.
+
+### Fixed
+- **A `siphon-bin` build reports the SIPhon version again.** It announced its
+  own package version (`0.1.0`) in the startup banner, the `User-Agent`/`Server`
+  headers and `/admin/health`, which broke the lockstep guarantee that the
+  crate, the binary, the image and the SDK all carry one number. It now inherits
+  the `siphon-sip` version it was built against. This matters more than it did
+  before, because that build is now what the official artifacts ship.
+
 
 ## [1.6.0] — 2026-08-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 # --- Debian packaging (cargo-deb) ---
 [package.metadata.deb]
-maintainer = "SIPhon Contributors <mvdvlies@gmail.com>"
+maintainer = "SIPhon Contributors <maintainers@siphon-sip.org>"
 section = "net"
 priority = "optional"
 extended-description = """\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 # SIPhon container image.
 #
+# What it builds: the `siphon-bin` package, NOT the root `siphon-sip` one. Both
+# produce an artifact called `siphon` with the same CLI and the same
+# siphon.yaml, but siphon-bin additionally composes the opt-in extension crates,
+# so the official image ships the scriptable `http` namespace (siphon-bin's
+# default feature) alongside the `ui` dashboard. smpp/sigtran stay off — see
+# siphon-bin/Dockerfile for an image with those compiled in.
+#
+# The siphon-sip git dep is patched to this checkout (see the builder stage), so
+# an image built at tag vX.Y.Z contains that tag's lib. Without the patch cargo
+# would resolve the SHA pinned in siphon-bin/Cargo.lock and the image would
+# silently drift from the release.
+#
 # Python: free-threaded CPython 3.14t (PEP 703) installed via uv. Siphon's
 # Rust hot loop calls into embedded Python on every SIP request — the
 # persistent-attach optimization in src/server.rs (PyGILState_Ensure +
@@ -18,7 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         libssl-dev \
         xz-utils \
+        git \
     && rm -rf /var/lib/apt/lists/*
+# git is load-bearing: siphon-bin reaches the extension crates through git
+# dependencies, and cargo shells out to git to fetch them.
 # NOTE: the default build excludes SIP/Diameter-over-SCTP (the `sctp` Cargo
 # feature is off by default), so libsctp-dev is not needed. To build an
 # SCTP-capable image, add `libsctp-dev` here, `libsctp1` to the runtime stage,
@@ -61,6 +76,15 @@ RUN cargo install cargo-chef
 WORKDIR /build
 
 # ── Plan dependencies ────────────────────────────────────────────────────────
+# The recipe is taken from the ROOT siphon-sip package, not from siphon-bin.
+# That is deliberate. Once siphon-sip is patched to a path dependency (below),
+# the chain siphon-bin -> siphon-http -> siphon-sip runs THROUGH first-party
+# source, and cargo-chef cannot cache-separate that: cooking siphon-bin's graph
+# would need the real siphon-sip source present, which would invalidate the
+# cooked layer on every src/ edit and defeat the point. Cooking siphon-sip's own
+# dependency graph instead keeps the expensive third-party bulk (tokio, pyo3,
+# axum, reqwest, hickory, rustls, …) cached behind a layer that only moves when
+# Cargo.toml/Cargo.lock move.
 FROM chef AS planner
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
@@ -73,18 +97,37 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Build dependencies (cached until Cargo.toml/lock change) ─────────────────
 FROM chef AS builder
+# One target dir shared by the cook below and the siphon-bin build further down.
+# Without this they are /build/target and /build/siphon-bin/target, the cooked
+# artifacts are invisible to the build that needs them, and the whole dependency
+# graph compiles from scratch.
+ENV CARGO_TARGET_DIR=/build/target
 COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --release --features ui --recipe-path recipe.json
 
-# Build the real binary. The embedded operator web UI (`ui` feature) is compiled
-# in by default in the image — it's an EXPERIMENTAL dashboard, served only when
-# `admin.ui.enabled` is set in siphon.yaml. `ui/` is a single self-contained HTML
-# file baked in by rust-embed (no Node/build step). Drop `--features ui` on both
-# the cook and build lines to produce a leaner image without it.
+# Build the real binary — the siphon-bin composition (see the file header).
+# Two features are in play and they are different kinds of thing:
+#   `http`  — a siphon-bin DEFAULT feature, so it needs no flag here. Compiles
+#             in the scriptable `http` namespace; it stays inert until
+#             siphon.yaml carries an `extensions.http` entry.
+#   `ui`    — a passthrough to siphon-sip's own feature, hence explicit. The
+#             EXPERIMENTAL operator dashboard, served only when
+#             `admin.ui.enabled` is set. `ui/` is a single self-contained HTML
+#             file baked in by rust-embed (no Node/build step).
+# Drop `--features ui` on both the cook and build lines for a leaner image; add
+# `--features smpp` / `sigtran` (plus their system deps) to compile in more.
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 COPY benches/ benches/
 COPY ui/ ui/
+COPY siphon-bin/ siphon-bin/
+COPY scripts/ scripts/
+# Repoint siphon-sip at this checkout, so the image contains the lib from the
+# tree it was built from rather than the main-branch SHA pinned in
+# siphon-bin/Cargo.lock. The script asserts the patch actually applied — cargo
+# treats an unused [patch] as a warning and would otherwise build the git copy.
+RUN scripts/pin-siphon-sip-to-tree.sh
+WORKDIR /build/siphon-bin
 RUN cargo build --release --features ui
 
 # ── Runtime stage ────────────────────────────────────────────────────────────
@@ -109,7 +152,7 @@ RUN PY_BIN=$(find /opt/python -type f -name python3.14t -perm -u+x | head -n1) &
     echo "$PY_PREFIX/lib" > /etc/ld.so.conf.d/python3.14t.conf && \
     ldconfig
 
-# SIPhon binary
+# SIPhon binary (built from siphon-bin, so `http` is compiled in — see header)
 COPY --from=builder /build/target/release/siphon /usr/local/bin/siphon
 
 # Default scripts and config

--- a/README.md
+++ b/README.md
@@ -158,9 +158,17 @@ cargo install siphon-sip --features sctp
 
 Protocol extensions that aren't part of the core SIP datapath live in their own
 crates and are composed into a drop-in `siphon` binary by the separate
-[`siphon-bin`](siphon-bin/) package, each behind its own off-by-default cargo
-feature. The plain `cargo install siphon-sip` binary is unaffected; build the
-extension binary only if you need one:
+[`siphon-bin`](siphon-bin/) package.
+
+**`http` ships in the official artifacts** — the container image, the `.deb`,
+the `.rpm` and the release tarball are all built from `siphon-bin`, so the
+scriptable `http` namespace (inbound `@http.route` handlers plus a Rust-backed
+`http.Client`) is already compiled in and needs only an `extensions.http` entry.
+It is the one module with no deployment prerequisite.
+
+`smpp` and `sigtran` each carry one, so they stay off-by-default; build the
+binary yourself if you need them. `cargo install siphon-sip` is the SIP core
+alone, with no extensions:
 
 ```bash
 # SMPP 3.4 (scriptable `smpp` namespace: @smpp.on_pdu / @smpp.on_bind)
@@ -180,9 +188,13 @@ Point siphon at each extension's config from `siphon.yaml`:
 
 ```yaml
 extensions:
+  http: /etc/siphon/http.yaml
   smpp: /etc/siphon/smpp.yaml
   sigtran: /etc/siphon/sigtran.yaml
 ```
+
+A module that is compiled in but absent from this map is inert — it registers
+nothing and costs nothing at runtime.
 
 If `extensions.smpp` is present but the binary was built without `--features
 smpp`, it is skipped with a loud warning (same contract as `sctp`).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,40 +1,52 @@
 # Extensions (SMPP, HTTP, SIGTRAN)
 
 SIPhon's core speaks SIP. Protocol functionality **beyond SIP** — SMPP, HTTP and
-SIGTRAN/SS7 today — is provided by **opt-in extension modules**. They
-are not part of the default binary: you enable a module at build time and
-configure it through the `extensions:` block in `siphon.yaml`. Each module adds
-a scriptable Python namespace your routing scripts can use, alongside the
-built-in `proxy`, `registrar`, `cache`, and friends.
+SIGTRAN/SS7 today — is provided by **extension modules**: each one adds a
+scriptable Python namespace your routing scripts can use, alongside the built-in
+`proxy`, `registrar`, `cache`, and friends, and each is configured through the
+`extensions:` block in `siphon.yaml`.
 
-## How extensions work
+Which modules a given `siphon` binary can run is fixed when that binary is
+compiled. The official artifacts ship one of them.
 
-- **Not in the standard binary.** `cargo install siphon-sip`, and the default
-  container image, contain no extensions at all.
-- **Enabled at build.** An extension-capable build is produced by the
+## What's in the binary you have
+
+- **`http` is in the official artifacts.** The container image, the `.deb`, the
+  `.rpm` and the release tarball are all built from the
   [`siphon-bin`](https://github.com/siphon-project/siphon-sip/tree/main/siphon-bin)
-  package. It is a drop-in `siphon` binary — same CLI, same `siphon.yaml`, plus
-  the modules.
-- **`http` is on by default there.** A bare `cargo build -p siphon-bin` gets you
-  the `http` namespace. It is the one module with no deployment prerequisite —
-  no libsctp, no upstream SMSC bind, nothing to provision — and the one most
-  scripts reach for. Every other module is opt-in (`--features smpp`,
-  `--features sigtran`, or `--features full` for all of them), and features are
-  additive, so `--features smpp` gives you http **and** smpp. Drop HTTP with
-  `--no-default-features`.
+  package with `http` compiled in, so the `http` namespace is there and needs
+  only configuration. It is the module with no deployment prerequisite — no
+  libsctp, no upstream SMSC bind, nothing to provision — and the one most
+  scripts reach for.
+- **`cargo install siphon-sip` gets you a plain binary.** The crate is the SIP
+  core on its own, with no extensions. Extension crates depend on `siphon-sip`,
+  so the crate cannot depend back on them.
+- **`smpp` and `sigtran` need a `siphon-bin` build.** They stay opt-in because
+  each carries a deployment prerequisite. Build with `--features smpp`,
+  `--features sigtran`, or `--features full`; features are additive on top of
+  the default, so `--features smpp` gives you http **and** smpp. Drop HTTP with
+  `--no-default-features`. `siphon-bin/Dockerfile` builds a container image on
+  the same basis.
+- **Same binary either way.** `siphon-bin` produces an artifact called `siphon`
+  with the same CLI and the same `siphon.yaml` — it is a drop-in for the plain
+  one, and reports the same version.
 - **Configured in `siphon.yaml`.** An `extensions:` map points each enabled
   module at its own config file:
 
   ```yaml
   extensions:
+    http: /etc/siphon/http.yaml
     smpp: /etc/siphon/smpp.yaml
     sigtran: /etc/siphon/sigtran.yaml
   ```
 
+  A module that is compiled in but absent from this map is inert — it registers
+  nothing and costs nothing at runtime.
+
 - **Loud on mismatch.** If `extensions.smpp` is configured but the running
-  binary was *not* built with that feature, siphon logs a warning and skips the
-  module — it never silently ignores configuration. (This mirrors the optional
-  `sctp` transport feature.)
+  binary was *not* built with that feature, siphon says so on stderr at startup
+  and carries on without the module — it never silently ignores configuration.
+  (This mirrors the optional `sctp` transport feature.)
 
 ## SMPP (SMS, SMPP 3.4)
 
@@ -130,10 +142,13 @@ mutual TLS); the client is pooled reqwest.
     You do **not** need to declare an `http.servers` listener to use the client —
     an `http.yaml` with only a `clients:` block is enough.
 
-### 1. Build with the feature
+### 1. Check you have an HTTP-capable binary
+
+Nothing to do if you are on an official artifact — the image, deb, rpm and
+tarball all ship `http`. Building yourself, it is the default feature:
 
 ```bash
-cargo build -p siphon-bin --release --features http
+cargo build -p siphon-bin --release          # http is already in
 ```
 
 ### 2. Point siphon at the HTTP config

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -75,6 +75,14 @@ if [ "${ADVISORY_OK:-0}" != "1" ]; then
     || die "cargo-deny not installed — 'cargo install cargo-deny' (or set ADVISORY_OK=1 to skip)"
   cargo deny --all-features check advisories \
     || die "cargo-deny found an open advisory — bump the affected crate (cargo update -p <crate>) or add a reviewed ignore in deny.toml, then re-cut (or set ADVISORY_OK=1 to skip)"
+
+  # ...and the same for siphon-bin. The released binary is that composition, so
+  # its extension crates and their dependency trees ship to operators even
+  # though they are absent from the siphon-sip graph checked above. Without this
+  # a release could carry an open advisory in, say, siphon-http's tree and the
+  # gate above would be perfectly green.
+  cargo deny --manifest-path siphon-bin/Cargo.toml check advisories \
+    || die "cargo-deny found an open advisory in the siphon-bin composition (the graph the released binary is built from) — bump the affected crate or add a reviewed ignore in siphon-bin/deny.toml, then re-cut (or set ADVISORY_OK=1 to skip)"
 fi
 
 # ── Performance + memory-leak baseline (manual, per project policy) ─────────

--- a/scripts/pin-siphon-sip-to-tree.sh
+++ b/scripts/pin-siphon-sip-to-tree.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Point siphon-bin's siphon-sip dependency at this checkout, and prove it took.
+#
+# Every official artifact — container image, .deb, .rpm, release tarball — is
+# built from the siphon-bin package rather than the plain siphon-sip one, so
+# that the scriptable `http` namespace is compiled in. But siphon-bin git-deps
+# siphon-sip at branch=main and its Cargo.lock pins a SHA, so without this the
+# artifact released as vX.Y.Z would contain whatever `main` happened to be
+# instead of that tag's lib. Release and image builds both run this first.
+#
+# One [patch] entry covers the whole graph: siphon-bin and every extension crate
+# are required to spell the repo URL byte-identically (cargo does not follow
+# GitHub's rename redirect and would otherwise resolve two separate copies of
+# siphon-sip), so patching that single source catches siphon-http's edge too.
+#
+# The config is written here and never committed — the siphon-bin CI legs build
+# against the git deps deliberately, as a bit-rot guard, and a committed patch
+# would void that.
+#
+# Running this locally DOES rewrite the tracked siphon-bin/Cargo.lock, because
+# re-resolving is the only way to make the patch bite (see below). That is
+# invisible in CI, where checkouts are throwaway, but it dirties a local tree —
+# and cut-release.sh refuses to cut with a dirty tree. Undo with:
+#     git checkout siphon-bin/Cargo.lock && rm -rf siphon-bin/.cargo
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$REPO_ROOT/siphon-bin"
+
+mkdir -p .cargo
+{
+    echo '[patch."https://github.com/siphon-project/siphon-sip"]'
+    echo 'siphon-sip = { path = ".." }'
+} > .cargo/config.toml
+
+# A [patch] is IGNORED when Cargo.lock already pins that dependency: cargo says
+# "patch ... was not used in the crate graph" as a WARNING and cheerfully builds
+# the git copy. Re-resolving this one package is what makes the patch bite.
+cargo update -p siphon-sip
+
+# And because the failure mode above is a warning rather than an error, assert
+# the outcome instead of trusting it. A git-sourced siphon-sip in the graph here
+# means the artifact would not be built from this tree — which is the entire
+# bug this script exists to prevent, and it would be invisible in the log noise.
+if cargo tree --invert siphon-sip | grep -q 'siphon-sip v.*(https://'; then
+    echo "error: siphon-sip resolved from git, not from $REPO_ROOT." >&2
+    echo "       The [patch] did not apply, so this build would not be the released tree." >&2
+    cargo tree --invert siphon-sip >&2
+    exit 1
+fi
+
+echo "siphon-sip pinned to $REPO_ROOT:"
+cargo tree --invert siphon-sip

--- a/siphon-bin/.gitignore
+++ b/siphon-bin/.gitignore
@@ -1,1 +1,7 @@
 /target
+# Written on the fly by the release workflow and the root Dockerfile to point
+# the siphon-sip git dep at the in-tree source, so an artifact built at tag
+# vX.Y.Z contains that tag's lib rather than whatever `main` happened to be.
+# Deliberately never committed: the siphon-bin CI legs build against the git
+# deps on purpose, and a committed patch would silently void that guard.
+/.cargo/

--- a/siphon-bin/Cargo.toml
+++ b/siphon-bin/Cargo.toml
@@ -38,6 +38,14 @@ http = ["dep:siphon-http"] # HTTP/HTTPS — inbound routes + Rust-backed `http.C
 sigtran = ["dep:siphon-sigtran"]
 full = ["smpp", "http", "sigtran"] # convenience aggregate: every extension module
 
+# Passthroughs to siphon-sip's own optional features. Not extension modules —
+# they gate functionality inside the lib, and without a passthrough here there
+# is no way to turn them on from a siphon-bin build at all. Deliberately kept
+# out of `default` and out of `full` (which is the *extension* aggregate): the
+# official artifacts pass `--features ui` explicitly.
+ui = ["siphon-sip/ui"] # embedded operator web dashboard, served behind `admin.ui.enabled`
+sctp = ["siphon-sip/sctp"] # SIP + Diameter over SCTP; needs libsctp at build + runtime
+
 [dependencies]
 # Single-source rule: every crate here that depends on siphon-sip MUST use a
 # byte-identical git URL + ref, or cargo keys two separate `siphon-sip` sources

--- a/siphon-bin/Dockerfile
+++ b/siphon-bin/Dockerfile
@@ -1,9 +1,15 @@
 # SIPhon container image WITH opt-in extension modules (SMPP, HTTP, SIGTRAN).
 #
-# This builds the `siphon-bin` package — a drop-in `siphon` binary that composes
-# optional extension crates behind cargo features. It is SEPARATE from the root
-# Dockerfile (which builds the plain siphon-sip binary): siphon-bin git-deps the
-# published siphon-sip lib + the extension crates, so the build context is just
+# NOT the official image. The published ghcr.io image is built from the ROOT
+# Dockerfile, which also builds siphon-bin but patches siphon-sip to the
+# in-tree source and adds the pieces an operator image wants: the `ui`
+# dashboard, a baked siphon.yaml + default scripts, and the Python packages
+# scripts commonly import. Reach for THIS file when you want smpp or sigtran
+# compiled in, which the official image does not carry.
+#
+# It builds the `siphon-bin` package — a drop-in `siphon` binary that composes
+# optional extension crates behind cargo features — against the *published*
+# siphon-sip lib + extension crates via git deps, so the build context is just
 # this package directory (no root tree needed).
 #
 # Build (context = this directory). FEATURES defaults to the package's own

--- a/siphon-bin/src/main.rs
+++ b/siphon-bin/src/main.rs
@@ -51,7 +51,13 @@ fn main() {
         std::process::exit(1);
     });
 
-    let mut builder = SiphonServer::builder().product("SIPhon", env!("CARGO_PKG_VERSION"));
+    // No `.product(...)` on purpose. The builder defaults to "SIPhon" plus
+    // siphon-sip's own CARGO_PKG_VERSION, which is the version this binary
+    // must report: the project versions the crate, the binary, the image and
+    // the SDK in lockstep off the git tag, and this package carries its own
+    // unrelated 0.1.0. Setting the product here would announce that 0.1.0 in
+    // the startup banner, the User-Agent/Server headers and /admin/health.
+    let mut builder = SiphonServer::builder();
     builder = ext::register_all(builder, &config);
     builder.config_path(&cli.config).run();
 }

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -1371,3 +1371,27 @@ log:
 #     slow_consumer: drop_oldest    # drop_oldest | disconnect
 #     reattach_grace_secs: 10       # window for a reconnecting app to `resync`
 #     handoff_deadline_ms: 3000     # default deadline before the parked call degrades
+
+# ---------------------------------------------------------------------------
+# Extensions — protocols beyond SIP
+# ---------------------------------------------------------------------------
+# Each entry names a module and points at that module's own config file. A
+# module contributes a scriptable Python namespace on top of the built-in
+# proxy / registrar / cache / … set, and does nothing at all until it appears
+# here: compiled in but unconfigured costs nothing at runtime.
+#
+# What the official artifacts (container image, deb, rpm, tarball) ship:
+#   http     — HTTP/HTTPS. Inbound routes via @http.route plus a Rust-backed
+#              http.Client for outbound calls. Compiled in, ready to configure.
+#   smpp     — SMPP 3.4 (SMS). NOT compiled in; needs a siphon-bin build.
+#   sigtran  — SIGTRAN/SS7: M3UA/M2PA/SUA over SCTP, MTP3, SCCP GTT, and
+#              MAP/CAP/INAP termination. NOT compiled in; needs a siphon-bin
+#              build plus libsctp. See docs/extensions.md.
+#
+# Configuring a module the running binary was NOT built with is not silently
+# ignored — siphon says so on stderr at startup and carries on without it.
+#
+# extensions:
+#   http: /etc/siphon/http.yaml
+#   smpp: /etc/siphon/smpp.yaml
+#   sigtran: /etc/siphon/sigtran.yaml


### PR DESCRIPTION
The `http` extension is only reachable today by building `siphon-bin` yourself. The official artifacts — the GHCR image, the `.deb`, the `.rpm`, the tarball — are all built from `siphon-sip`, which carries no extensions, so anyone installing from a package or running the image has no way to get it.

It cannot be fixed by adding a dependency. `siphon-http` depends on `siphon-sip` (for `siphon::script::{ScriptHandle, HandlerHandle}`), so the reverse edge is a cargo cycle, and `siphon-http` is git-only so a crates.io crate could never reference it regardless. That cycle is why `siphon-bin/` exists.

So this changes what the artifacts compile rather than moving any code: every official artifact is now built from `siphon-bin`, which already has `http` as a default feature. The binary is named `siphon` on purpose — same CLI, same `siphon.yaml`, same ENTRYPOINT — so it is a drop-in that gained a capability. `cargo install siphon-sip` is untouched and still installs the SIP core alone; no file under `src/` changes and the published crate is byte-identical.

Scope is `http` + `ui` only. `smpp` and `sigtran` each carry a deployment prerequisite and still need a `siphon-bin` build.

## Building the tagged tree, not `main`

`siphon-bin` git-deps `siphon-sip` at `branch = main` with a lockfile pinning a SHA, so a `vX.Y.Z` build would otherwise contain whatever `main` was. `scripts/pin-siphon-sip-to-tree.sh` writes an ephemeral `[patch]` redirecting that source to the checkout — one entry covers `siphon-http`'s edge too, since the single-source rule guarantees byte-identical URLs.

The subtlety worth flagging for review: **a `[patch]` that the lockfile already pins is ignored, and cargo reports that as a warning, not an error.** The first build during development compiled against `main` while looking perfectly successful. The script therefore re-resolves and then asserts the result, failing the build if any `siphon-sip` in the graph still has a git source. That guard was tested in both directions.

The config is written rather than committed, so the existing `siphon-bin` CI legs keep building against the git deps as the deliberate bit-rot guard. A new leg builds the patched composition, which is the freshness check that job's own comment says it lacks — and it matters now, because the release build requires `siphon-http` to compile against the release tree. Without it, that failure would land halfway through a release cut.

## Also here

- **`ui` and `sctp` passthrough features on `siphon-bin`.** There was previously no way to enable either from an extension build, so composing extensions meant giving up the dashboard and SCTP transport.
- **Version identity fixed.** `siphon-bin` announced its own `0.1.0` in the startup banner, the `User-Agent`/`Server` headers and `/admin/health`, breaking lockstep versioning. Dropping its `.product()` call inherits the `siphon-sip` version. This matters more now that this build is what ships.
- **Release advisory gate extended to the `siphon-bin` graph.** The released binary now contains the extension crates' dependency trees, which the root `cargo deny` never sees; an open advisory in one would have left the gate green.
- **`.deb` maintainer** moved off a personal address to `maintainers@siphon-sip.org`.
- Packaging metadata is untouched: the built binary is staged into the root target dir, so every asset path in `[package.metadata.deb]` / `[package.metadata.generate-rpm]` stays valid.

## Verification

Against the built container image: `SIPhon v1.6.0` in the banner (not `0.1.0`), `@http.route` returning `HTTP/1.1 200 OK`, the `ui` dashboard serving at `/`, `/admin/health` ok, `httpx`/`redis`/`prometheus_client` still importable, baked config and scripts present. The build log shows the pin asserting, then `Compiling siphon-sip v1.6.0 (/build)` → `siphon-http v1.0.2` → `siphon-bin`.

Also: 10/10 SIPp calls through the composed binary with zero retransmits and zero unexpected messages; a `.deb` built through the exact CI sequence whose `/usr/bin/siphon` carries both `siphon_http` and `ui`; 4025 tests passing; clippy `--all-targets --all-features` clean; `docker build --check` clean.

The SIP datapath is unchanged — no `src/` file is touched, and a compiled-in but unconfigured extension registers nothing and costs nothing at runtime.

## Note on cargo-chef

Once `siphon-sip` is a path dep the chain `siphon-bin → siphon-http → siphon-sip` runs through first-party source and cannot be cache-separated. The recipe is now taken from the root package and both stages share one `CARGO_TARGET_DIR`, so the third-party bulk still caches while the three first-party crates compile in the final layer.

Intended for a 1.6.1 patch release.
