### PR TITLE
test(ci): functional coverage for the external control rail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -786,6 +786,111 @@ jobs:
             originate-app.log
             *.log
 
+  # ── Control plane: the external application rail ────────────────────────
+  # An out-of-process application drives real calls over a real WebSocket. Five
+  # cases against one siphon, both connection modes at once (per-call-connect,
+  # which siphon dials, and persistent-inbound, which dials siphon), because
+  # ownership round-robin and `resync` only exist in the second.
+  #
+  # Each SIPp scenario is the decider for its own step. What the SIP wire cannot
+  # show is asserted on the recorded frames afterwards, and that half is not
+  # optional: the media step below passes on the wire AND in the application's
+  # own reply even when the verb was accepted and never performed — only the
+  # media engine's record catches that.
+  #
+  # The `grep` patterns carry the space in `"key": "value"` because that is what
+  # `json.dumps` writes; without it they match nothing.
+  sipp-control:
+    runs-on: ubuntu-latest
+    needs: build-image
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
+
+      # --force-recreate keeps the set coherent: the persistent app dials siphon
+      # once at start-up and holds its sockets for life, so an app reused across
+      # a recreated siphon would be connected to nothing.
+      - name: Start siphon, both control applications and the media engine
+        run: docker compose -f sipp/docker-compose.yaml --profile control up -d --force-recreate --wait mock-control-rtp control-app-edge siphon-control control-app-ivr
+
+      - name: Deferred handover — siphon parks the INVITE, the app answers it
+        run: docker compose -f sipp/docker-compose.yaml --profile control up --abort-on-container-exit --exit-code-from sipp-control-handover-uac sipp-control-handover-uac
+
+      - name: Handoff deadline — the controller never acts, siphon applies its default
+        run: docker compose -f sipp/docker-compose.yaml --profile control up --abort-on-container-exit --exit-code-from sipp-control-deadline-uac sipp-control-deadline-uac
+
+      - name: Media verbs on an answer-first channel
+        run: docker compose -f sipp/docker-compose.yaml --profile control up --abort-on-container-exit --exit-code-from sipp-control-media-uac sipp-control-media-uac
+
+      - name: Exactly-one-owner dispatch across several app connections
+        run: docker compose -f sipp/docker-compose.yaml --profile control up --abort-on-container-exit --exit-code-from sipp-control-owner-uac sipp-control-owner-uac
+
+      - name: Resync — the owner drops, reconnects in the grace window, re-claims
+        run: docker compose -f sipp/docker-compose.yaml --profile control up --abort-on-container-exit --exit-code-from sipp-control-resync-uac sipp-control-resync-uac
+
+      - name: Assert the recorded control frames
+        if: always()
+        run: |
+          docker compose -f sipp/docker-compose.yaml logs control-app-edge > control-app-edge.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs control-app-ivr > control-app-ivr.log 2>&1 || true
+          docker compose -f sipp/docker-compose.yaml logs mock-control-rtp > mock-control-rtp.log 2>&1 || true
+          fail=0
+          assert_verdict() {
+            local case="$1" log="$2" line
+            line="$(grep 'CONTROL-VERDICT' "$log" 2>/dev/null | grep "\"case\": \"$case\"" || true)"
+            if [ -z "$line" ]; then
+              echo "no CONTROL-VERDICT for case '$case' — the control app never completed it"
+              fail=1
+              return
+            fi
+            if echo "$line" | grep -q '"pass": false'; then
+              echo "control-plane case '$case' failed:"
+              echo "$line"
+              fail=1
+              return
+            fi
+            echo "ok: control case '$case'"
+          }
+          assert_performed() {
+            local verb="$1"
+            if ! grep -q "\"command\": \"$verb\"" mock-control-rtp.log; then
+              echo "the media engine never received '$verb' — the verb was accepted but never performed"
+              fail=1
+              return
+            fi
+            echo "ok: media engine performed '$verb'"
+          }
+          assert_verdict handover control-app-edge.log
+          assert_verdict deadline control-app-ivr.log
+          assert_verdict media    control-app-edge.log
+          assert_verdict owner    control-app-ivr.log
+          assert_verdict resync   control-app-ivr.log
+          assert_performed play_media
+          assert_performed stop_media
+          exit $fail
+
+      - name: Collect logs
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml logs siphon-control > siphon-control.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile control down --remove-orphans
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-control-logs
+          path: |
+            siphon-control.log
+            control-app-edge.log
+            control-app-ivr.log
+            mock-control-rtp.log
+            *.log
+
   # ── B2BUA A-leg INVITE authentication ──────────────────────────────────
   # siphon challenges the CALLER from @b2bua.on_invite. With a @b2bua handler
   # registered the dispatcher routes INVITE to the B2BUA path and

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -8,6 +8,7 @@
 #   ./scripts/run-tests.sh --call       # Also run call scenarios (UAC+UAS)
 #   ./scripts/run-tests.sh --rtpengine  # Also run B2BUA + RTPEngine tests
 #   ./scripts/run-tests.sh --rtpproxy   # Also run classic rtpproxy media test
+#   ./scripts/run-tests.sh --control    # Also run the external control-plane (app rail) tests
 #   ./scripts/run-tests.sh --b2bua     # Also run B2BUA call/session-timer/cancel/failure tests
 set -euo pipefail
 
@@ -33,6 +34,7 @@ RUN_PRESENCE=false
 RUN_RTPENGINE=false
 RUN_RTPPROXY=false
 RUN_VOICE_AI=false
+RUN_CONTROL=false
 RUN_REFER_SINGLE_LEG=false
 RUN_REINVITE=false
 RUN_REOFFER=false
@@ -62,6 +64,7 @@ for arg in "$@"; do
     --rtpengine)  RUN_RTPENGINE=true;  SELECTED_MODES+=("$arg") ;;
     --rtpproxy)   RUN_RTPPROXY=true;   SELECTED_MODES+=("$arg") ;;
     --voice-ai)   RUN_VOICE_AI=true;   SELECTED_MODES+=("$arg") ;;
+    --control)    RUN_CONTROL=true;    SELECTED_MODES+=("$arg") ;;
     --refer-single-leg) RUN_REFER_SINGLE_LEG=true; SELECTED_MODES+=("$arg") ;;
     --reinvite)   RUN_REINVITE=true;   SELECTED_MODES+=("$arg") ;;
     --reoffer)    RUN_REOFFER=true;    SELECTED_MODES+=("$arg") ;;
@@ -82,7 +85,7 @@ for arg in "$@"; do
       echo
       echo "Scenario modes (pick at most ONE per run):"
       echo "  --ipsec --charging --call --presence --rtpengine --rtpproxy --reinvite"
-      echo "  --voice-ai --refer-single-leg --reoffer"
+      echo "  --voice-ai --refer-single-leg --reoffer --control"
       echo "  --b2bua --b2bua-auth --b2bua-invite-auth --gateway --auto100 --http-auth"
       echo "  --wedge --banscan"
       echo "  --security --rfc4475 --webrtc"
@@ -193,6 +196,106 @@ if [[ "$RUN_VOICE_AI" == true ]]; then
   run_sipp docker compose -f "$COMPOSE_FILE" --profile voice-ai up \
     --abort-on-container-exit --exit-code-from sipp-voice-ai-uac sipp-voice-ai-uac
   docker compose -f "$COMPOSE_FILE" --profile voice-ai rm -sf sipp-voice-ai-uac 2>/dev/null || true
+fi
+
+# ── Step 7a1: External control plane — the application rail (optional) ────
+# Five cases against one siphon, both connection modes at once. Each SIPp
+# scenario is the decider for its own step (--exit-code-from), and the parts the
+# SIP wire cannot show — which connection was given the call, whether a media
+# verb was performed or merely accepted, what `resync` handed back — are
+# asserted on the mock application's and mock media engine's recorded frames.
+if [[ "$RUN_CONTROL" == true ]]; then
+  CONTROL_LOG_DIR="$(mktemp -d)"
+
+  # NOTE on the greps below: the app and the engine both emit `json.dumps`
+  # output, which writes `"key": "value"` WITH a space after the colon. A pattern
+  # written without the space matches nothing and the assertion passes
+  # vacuously — which is the whole failure mode these asserts exist to avoid.
+  control_dump_logs() {
+    docker compose -f "$COMPOSE_FILE" logs control-app-edge > "$CONTROL_LOG_DIR/control-app-edge.log" 2>&1 || true
+    docker compose -f "$COMPOSE_FILE" logs control-app-ivr > "$CONTROL_LOG_DIR/control-app-ivr.log" 2>&1 || true
+    docker compose -f "$COMPOSE_FILE" logs mock-control-rtp > "$CONTROL_LOG_DIR/mock-control-rtp.log" 2>&1 || true
+    docker compose -f "$COMPOSE_FILE" logs siphon-control > "$CONTROL_LOG_DIR/siphon-control.log" 2>&1 || true
+  }
+
+  # A case that never ran prints no verdict at all, and that is a failure too —
+  # it is what catches an application that was never reached.
+  assert_control_verdict() {
+    local case="$1" log="$CONTROL_LOG_DIR/$2" line
+    line="$(grep 'CONTROL-VERDICT' "$log" 2>/dev/null | grep "\"case\": \"$case\"" || true)"
+    if [[ -z "$line" ]]; then
+      echo "FAILED: no CONTROL-VERDICT for case '$case' in $log — the control app never completed it"
+      exit 1
+    fi
+    if grep -q '"pass": false' <<<"$line"; then
+      echo "FAILED: control-plane case '$case':"
+      echo "$line"
+      exit 1
+    fi
+    echo "  ✓ control case '$case': $line"
+  }
+
+  # The difference between a media verb siphon *accepted* and one it *performed*
+  # is invisible to SIPp; the engine's own record is the only witness.
+  assert_engine_performed() {
+    local verb="$1" log="$CONTROL_LOG_DIR/mock-control-rtp.log"
+    if ! grep -q "\"command\": \"$verb\"" "$log"; then
+      echo "FAILED: the media engine never received '$verb' — the verb was accepted but never performed"
+      exit 1
+    fi
+    echo "  ✓ media engine performed '$verb'"
+  }
+
+  echo "=== SIPp control-plane tests (external application rail) ==="
+  # --force-recreate: the persistent app dials siphon once at start-up and holds
+  # its sockets for life, so a re-run that recreates siphon (a rebuilt image)
+  # while reusing a running app leaves that app connected to nothing. Recreating
+  # the set together keeps the stack coherent. The app's healthcheck catches the
+  # case too — it heartbeats only while it can actually take a call — but a
+  # loud "unhealthy" is still a re-run someone has to debug.
+  docker compose -f "$COMPOSE_FILE" --profile control up -d --force-recreate --wait \
+    mock-control-rtp control-app-edge siphon-control control-app-ivr
+
+  echo "--- deferred handover: siphon parks the INVITE, the app answers it ---"
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile control up \
+    --abort-on-container-exit --exit-code-from sipp-control-handover-uac sipp-control-handover-uac
+  docker compose -f "$COMPOSE_FILE" --profile control rm -sf sipp-control-handover-uac 2>/dev/null || true
+  control_dump_logs
+  assert_control_verdict handover control-app-edge.log
+
+  echo "--- handoff deadline: the controller never acts, siphon applies its default ---"
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile control up \
+    --abort-on-container-exit --exit-code-from sipp-control-deadline-uac sipp-control-deadline-uac
+  docker compose -f "$COMPOSE_FILE" --profile control rm -sf sipp-control-deadline-uac 2>/dev/null || true
+  control_dump_logs
+  assert_control_verdict deadline control-app-ivr.log
+
+  echo "--- media verbs on an answer-first channel (accepted AND performed) ---"
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile control up \
+    --abort-on-container-exit --exit-code-from sipp-control-media-uac sipp-control-media-uac
+  docker compose -f "$COMPOSE_FILE" --profile control rm -sf sipp-control-media-uac 2>/dev/null || true
+  control_dump_logs
+  assert_control_verdict media control-app-edge.log
+  assert_engine_performed play_media
+  assert_engine_performed stop_media
+
+  echo "--- exactly-one-owner dispatch across several app connections ---"
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile control up \
+    --abort-on-container-exit --exit-code-from sipp-control-owner-uac sipp-control-owner-uac
+  docker compose -f "$COMPOSE_FILE" --profile control rm -sf sipp-control-owner-uac 2>/dev/null || true
+  control_dump_logs
+  assert_control_verdict owner control-app-ivr.log
+
+  # Last of the persistent-app cases on purpose: it drops one of the app's
+  # sockets, so anything queued behind it would be running with fewer.
+  echo "--- resync: the owner drops, reconnects in the grace window, re-claims ---"
+  run_sipp docker compose -f "$COMPOSE_FILE" --profile control up \
+    --abort-on-container-exit --exit-code-from sipp-control-resync-uac sipp-control-resync-uac
+  docker compose -f "$COMPOSE_FILE" --profile control rm -sf sipp-control-resync-uac 2>/dev/null || true
+  control_dump_logs
+  assert_control_verdict resync control-app-ivr.log
+
+  echo "Control-plane logs: $CONTROL_LOG_DIR"
 fi
 
 # ── Step 7a2: Single-leg cold transfer (optional) ─────────────────────────

--- a/sipp/control/control_app.py
+++ b/sipp/control/control_app.py
@@ -1,0 +1,620 @@
+"""Mock control-plane application for the functional test stack.
+
+The out-of-process half of siphon's application rail. It stands in for a real
+controller: it speaks `siphon-control.v1` over a WebSocket, drives a scripted
+sequence of verbs against whatever call is handed to it, and **records every
+frame it sent and received** as one JSON line on stdout.
+
+That recording is the point. Most of what this rail does is invisible to SIPp:
+a call answered by the controller and a call answered by an in-process script
+look identical on the wire, and a media verb that was *accepted* looks identical
+to one that was *performed*. So the SIPp scenarios assert the SIP side, this app
+asserts the rail side, and the two together are the acceptance criteria. It is
+the control-plane analogue of sipp/siphon-rtp/mock_siphon_rtp.py, which does the
+same job for the media rail.
+
+Both connection modes are supported, because they are genuinely different code
+paths in siphon and a given app can only reach one of them:
+
+  * ``CONTROL_MODE=outbound`` — per-call-connect, the multi-pod default. This
+    app runs the WebSocket **server** and siphon dials it once per handed-over
+    call. There is no ``hello``; the first frame on a fresh socket is
+    ``StasisStart`` and that socket owns exactly that one call.
+  * ``CONTROL_MODE=inbound`` — persistent. This app dials siphon's
+    ``control.listen`` with ``CONTROL_CONNECTIONS`` sockets, each saying
+    ``hello``, and siphon round-robins handed-over calls across them. Only this
+    mode has the concepts the exactly-one-owner and ``resync`` cases test.
+
+Which behaviour to run for a call is read off the ``vars.case`` seeded by
+``call.handover(vars=…)`` in the routing script, so the compose profile drives
+every case through one long-running app rather than one container per case.
+
+Output contract (both greppable, both with `json.dumps`'s ``"key": "value"``
+spacing — a pattern written without the space matches nothing and passes
+vacuously):
+
+  CONTROL-FRAME   {"dir": "recv"|"send", "conn": "<label>", "frame": {…}}
+  CONTROL-VERDICT {"case": "<case>", "pass": true|false, "checks": […]}
+
+A case that never runs prints no verdict at all, which the runner treats as a
+failure — that is what catches the app never being reached.
+
+There is deliberately no reconnect loop: a real controller has one, but here a
+socket that goes away is either the `resync` case dropping it on purpose or
+siphon having restarted, and both should be visible rather than papered over.
+Instead the ready file is a heartbeat that stops while the app cannot take a
+call, so the container reports unhealthy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pathlib
+import sys
+import time
+
+import websockets
+
+try:  # websockets >= 13
+    from websockets.asyncio.server import serve as ws_serve
+except ImportError:  # pragma: no cover — legacy fallback
+    from websockets.server import serve as ws_serve  # type: ignore[no-redef]
+
+SUBPROTOCOL = "siphon-control.v1"
+
+MODE = os.environ.get("CONTROL_MODE", "inbound")
+APP_NAME = os.environ.get("CONTROL_APP", "ivr-app")
+TOKEN = os.environ.get("CONTROL_TOKEN", "")
+CONTROL_URL = os.environ.get("CONTROL_URL", "ws://172.20.0.160:9092/control/ws")
+CONNECTIONS = int(os.environ.get("CONTROL_CONNECTIONS", "2"))
+LISTEN_HOST = os.environ.get("CONTROL_LISTEN_HOST", "0.0.0.0")
+LISTEN_PORT = int(os.environ.get("CONTROL_LISTEN_PORT", "8090"))
+READY_FILE = os.environ.get("CONTROL_READY_FILE", "/tmp/control-app-ready")
+
+# RFC 5737 TEST-NET-2 — the answer this app hands siphon for a parked call. The
+# SIPp scenarios assert this exact address in the 200 OK body, which is what
+# proves the controller's SDP reached the wire rather than something siphon
+# synthesised.
+ANSWER_MEDIA_IP = os.environ.get("CONTROL_ANSWER_IP", "198.51.100.20")
+ANSWER_SDP = (
+    "v=0\r\n"
+    f"o=- 20260101 20260101 IN IP4 {ANSWER_MEDIA_IP}\r\n"
+    "s=control-app\r\n"
+    f"c=IN IP4 {ANSWER_MEDIA_IP}\r\n"
+    "t=0 0\r\n"
+    "m=audio 41000 RTP/AVP 0\r\n"
+    "a=rtpmap:0 PCMU/8000\r\n"
+    "a=sendrecv\r\n"
+)
+
+PROMPT_FILE = os.environ.get("CONTROL_PROMPT", "/prompts/control-harness.wav")
+# Carried on the BYE's RFC 3326 Reason header, so the resync SIPp scenario can
+# tell the reattached controller's hangup apart from the on_lost teardown that
+# would fire if the grace window had lapsed instead.
+HANGUP_REASON = os.environ.get("CONTROL_HANGUP_REASON", "resync-hangup")
+
+HEARTBEAT_SECS = float(os.environ.get("CONTROL_HEARTBEAT_SECS", "2"))
+EVENT_TIMEOUT = float(os.environ.get("CONTROL_EVENT_TIMEOUT", "40"))
+COMMAND_TIMEOUT = float(os.environ.get("CONTROL_COMMAND_TIMEOUT", "10"))
+
+
+def record(direction: str, label: str, frame: dict) -> None:
+    """One JSON line per frame, so a test can assert on the actual exchange."""
+    print(
+        "CONTROL-FRAME "
+        + json.dumps({"dir": direction, "conn": label, "frame": frame}),
+        flush=True,
+    )
+
+
+def note(message: str) -> None:
+    print(f"control-app[{MODE}/{APP_NAME}]: {message}", flush=True)
+
+
+class Verdict:
+    """Accumulates one case's checks and prints the single greppable line."""
+
+    def __init__(self, case: str) -> None:
+        self.case = case
+        self.checks: list[dict] = []
+
+    def check(self, name: str, passed: bool, detail: str = "") -> bool:
+        self.checks.append({"check": name, "pass": bool(passed), "detail": detail})
+        return bool(passed)
+
+    def emit(self) -> None:
+        passed = bool(self.checks) and all(check["pass"] for check in self.checks)
+        print(
+            "CONTROL-VERDICT "
+            + json.dumps({"case": self.case, "pass": passed, "checks": self.checks}),
+            flush=True,
+        )
+
+
+class Session:
+    """One control connection: request/reply correlation + an event backlog."""
+
+    def __init__(self, socket, label: str) -> None:
+        self.socket = socket
+        self.label = label
+        self.closed = False
+        self.started_channels: set[str] = set()
+        self.commanded_channels: set[str] = set()
+        self._pending: dict[str, asyncio.Future] = {}
+        self._events: list[dict] = []
+        self._signal = asyncio.Event()
+        self._next_id = 0
+
+    async def send(self, frame: dict) -> None:
+        record("send", self.label, frame)
+        await self.socket.send(json.dumps(frame))
+
+    async def command(
+        self,
+        verb: str,
+        args: dict | None = None,
+        module: str | None = "sip",
+        target: dict | None = None,
+        timeout: float = COMMAND_TIMEOUT,
+    ) -> dict:
+        self._next_id += 1
+        request_id = f"{self.label}-{self._next_id}"
+        frame: dict = {"id": request_id, "type": "command", "verb": verb}
+        if module is not None:
+            frame["module"] = module
+        if target is not None:
+            frame["target"] = target
+            channel = target.get("channel")
+            if channel:
+                self.commanded_channels.add(channel)
+        frame["args"] = args if args is not None else {}
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        await self.send(frame)
+        return await asyncio.wait_for(future, timeout)
+
+    async def wait_event(self, predicate, timeout: float = EVENT_TIMEOUT) -> dict:
+        deadline = time.monotonic() + timeout
+        while True:
+            # Clear BEFORE scanning: an event appended after the scan re-sets the
+            # flag, so a wakeup can never be lost between the two.
+            self._signal.clear()
+            for index, event in enumerate(self._events):
+                if predicate(event):
+                    return self._events.pop(index)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"{self.label}: no matching event in {timeout}s")
+            try:
+                await asyncio.wait_for(self._signal.wait(), remaining)
+            except asyncio.TimeoutError:
+                pass
+
+    async def reader(self, on_start) -> None:
+        try:
+            async for raw in self.socket:
+                try:
+                    frame = json.loads(raw)
+                except ValueError:
+                    note(f"{self.label}: unparseable frame {raw!r}")
+                    continue
+                record("recv", self.label, frame)
+                kind = frame.get("type")
+                if kind == "reply":
+                    future = self._pending.pop(frame.get("id"), None)
+                    if future is not None and not future.done():
+                        future.set_result(frame)
+                elif kind == "event":
+                    if frame.get("event") == "StasisStart":
+                        channel = frame.get("channel")
+                        if channel:
+                            self.started_channels.add(channel)
+                        asyncio.create_task(on_start(self, frame))
+                    self._events.append(frame)
+                    self._signal.set()
+        except websockets.exceptions.ConnectionClosed:
+            pass
+        except Exception as error:  # noqa: BLE001 — a reader crash must be visible
+            note(f"{self.label}: reader stopped: {error!r}")
+        finally:
+            self.closed = True
+            self._signal.set()
+            for future in self._pending.values():
+                if not future.done():
+                    future.set_exception(ConnectionError(f"{self.label} closed"))
+
+    async def close(self) -> None:
+        self.closed = True
+        await self.socket.close()
+
+
+class App:
+    """Everything the cases need: the live sessions, and how to make another."""
+
+    def __init__(self) -> None:
+        self.sessions: list[Session] = []
+
+    async def connect_inbound(self, label: str) -> Session:
+        headers = {"Authorization": f"Bearer {TOKEN}"}
+        try:
+            connector = websockets.connect(
+                CONTROL_URL, subprotocols=[SUBPROTOCOL], additional_headers=headers
+            )
+        except TypeError:  # websockets < 14
+            connector = websockets.connect(
+                CONTROL_URL, subprotocols=[SUBPROTOCOL], extra_headers=headers
+            )
+        socket = await connector
+        session = Session(socket, label)
+        self.sessions.append(session)
+        asyncio.create_task(session.reader(self.on_stasis_start))
+        hello = await session.command(
+            "hello", {"app": APP_NAME, "protocol": 1}, module=None
+        )
+        if hello.get("status") != "ok":
+            raise RuntimeError(f"{label}: hello rejected: {json.dumps(hello)}")
+        note(f"{label}: connected + hello ok")
+        return session
+
+    async def on_stasis_start(self, session: Session, event: dict) -> None:
+        payload = event.get("payload") or {}
+        case = (payload.get("vars") or {}).get("case", "unknown")
+        handler = CASES.get(case)
+        channel = event.get("channel")
+        if handler is None:
+            note(f"{session.label}: no handler for case {case!r} — hanging up")
+            if channel:
+                await session.command(
+                    "hangup", {"reason": "unhandled case"}, target={"channel": channel}
+                )
+            return
+        note(f"{session.label}: StasisStart case={case} channel={channel}")
+        # The verdict is owned here, not by the case, so a case that raises
+        # part-way still reports the checks it had already made — otherwise the
+        # only thing left is "it threw", which does not say what broke.
+        verdict = Verdict(case)
+        try:
+            await handler(self, session, event, verdict)
+        except Exception as error:  # noqa: BLE001 — the verdict is the report
+            verdict.check("case_ran_to_completion", False, repr(error))
+        finally:
+            verdict.emit()
+
+
+# ── helpers shared by the cases ────────────────────────────────────────────
+
+
+def invite_headers(event: dict) -> dict:
+    """The StasisStart's INVITE headers as a lowercased name → value map."""
+    invite = (event.get("payload") or {}).get("invite") or {}
+    return {
+        str(name).lower(): str(value)
+        for name, value in (invite.get("headers") or [])
+    }
+
+
+def assert_sip_context(verdict: Verdict, event: dict, expected_user: str) -> None:
+    """The contract of the start event: the app gets the full SIP context and
+    the stable id triple, so it needs no mapping table to join CDR / HEP."""
+    payload = event.get("payload") or {}
+    invite = payload.get("invite") or {}
+    headers = invite_headers(event)
+
+    verdict.check(
+        "start_event_carries_the_ruri",
+        f"{expected_user}@" in str(invite.get("ruri") or ""),
+        str(invite.get("ruri")),
+    )
+    verdict.check(
+        "start_event_carries_the_invite_headers",
+        bool(headers.get("from")) and bool(headers.get("to")) and bool(headers.get("call-id")),
+        json.dumps(sorted(headers)),
+    )
+    verdict.check(
+        "sip_call_id_matches_the_invite",
+        headers.get("call-id") == event.get("sip_call_id"),
+        f"{headers.get('call-id')!r} vs {event.get('sip_call_id')!r}",
+    )
+    verdict.check(
+        "id_triple_is_complete",
+        bool(event.get("channel")) and bool(event.get("call_id")) and bool(event.get("sip_call_id")),
+        json.dumps({key: event.get(key) for key in ("channel", "call_id", "sip_call_id")}),
+    )
+    body = invite.get("body") or {}
+    verdict.check(
+        "start_event_carries_the_offer",
+        "m=audio" in str(body.get("text") or ""),
+        str(body.get("content_type")),
+    )
+    verdict.check(
+        "start_event_carries_the_source",
+        bool(payload.get("source_ip")) and payload.get("transport") == "udp",
+        json.dumps({"source_ip": payload.get("source_ip"), "transport": payload.get("transport")}),
+    )
+
+
+async def answer_with_our_sdp(session: Session, channel: str) -> dict:
+    return await session.command(
+        "answer",
+        {
+            "code": 200,
+            "reason": "OK",
+            "body": ANSWER_SDP,
+            "content_type": "application/sdp",
+        },
+        target={"channel": channel},
+    )
+
+
+def is_end(channel: str):
+    return lambda event: event.get("event") == "StasisEnd" and event.get("channel") == channel
+
+
+# ── the cases ──────────────────────────────────────────────────────────────
+
+
+async def case_handover(app: App, session: Session, event: dict, verdict: Verdict) -> None:
+    """Deferred handover: siphon holds the INVITE un-dialed, the app gets the
+    SIP context, answers, and the call completes."""
+    channel = event.get("channel") or ""
+    assert_sip_context(verdict, event, "handover")
+
+    reply = await answer_with_our_sdp(session, channel)
+    result = reply.get("result") or {}
+    verdict.check(
+        "answer_accepted",
+        reply.get("status") == "ok" and result.get("state") == "answered",
+        json.dumps(reply),
+    )
+
+    end = await session.wait_event(is_end(channel))
+    verdict.check("stasis_end_delivered", True, json.dumps(end.get("payload")))
+
+
+async def case_deadline(app: App, session: Session, event: dict, verdict: Verdict) -> None:
+    """The handoff deadline: the controller deliberately does nothing, and
+    siphon must apply its safe default rather than hang the call."""
+    channel = event.get("channel") or ""
+    parked_at = time.monotonic()
+
+    end = await session.wait_event(is_end(channel))
+    elapsed = time.monotonic() - parked_at
+
+    verdict.check(
+        "controller_sent_no_command",
+        channel not in session.commanded_channels,
+        json.dumps(sorted(session.commanded_channels)),
+    )
+    payload = end.get("payload") or {}
+    verdict.check(
+        "stasis_end_names_the_deadline",
+        payload.get("reason") == "No Controller Response",
+        json.dumps(payload),
+    )
+    # The configured deadline is 2s. Anything past ~10s means some other timer
+    # ended the call (the 408 answer timeout, a sweep), not the handoff deadline.
+    verdict.check(
+        "default_applied_within_the_deadline",
+        elapsed < 10.0,
+        f"{elapsed:.3f}s after StasisStart",
+    )
+
+
+async def case_media(app: App, session: Session, event: dict, verdict: Verdict) -> None:
+    """A media verb round trip on an answer-first (already connected) channel.
+
+    The replies here only prove the commands were *accepted*; that they were
+    *performed* is asserted on the media engine's own recorded commands, which
+    is the half SIPp cannot see.
+    """
+    channel = event.get("channel") or ""
+
+    play = await session.command("play", {"file": PROMPT_FILE}, target={"channel": channel})
+    verdict.check(
+        "play_accepted",
+        play.get("status") == "ok" and (play.get("result") or {}).get("state") == "playing",
+        json.dumps(play),
+    )
+
+    await asyncio.sleep(0.2)
+
+    stop = await session.command("stop", {}, target={"channel": channel})
+    verdict.check(
+        "stop_accepted",
+        stop.get("status") == "ok" and (stop.get("result") or {}).get("state") == "stopped",
+        json.dumps(stop),
+    )
+
+    end = await session.wait_event(is_end(channel))
+    verdict.check("stasis_end_delivered", True, json.dumps(end.get("payload")))
+
+
+async def case_owner(app: App, session: Session, event: dict, verdict: Verdict) -> None:
+    """Exactly-one-owner dispatch: with several connections of the same app up,
+    exactly one is given the call and the others cannot command it."""
+    channel = event.get("channel") or ""
+
+    others = [other for other in app.sessions if other is not session and not other.closed]
+    verdict.check(
+        "more_than_one_connection_was_up",
+        len(others) >= 1,
+        f"{len(others) + 1} live connections",
+    )
+
+    # Give any second delivery time to land before concluding there wasn't one.
+    await asyncio.sleep(0.5)
+    duplicates = [other.label for other in app.sessions
+                  if other is not session and channel in other.started_channels]
+    verdict.check(
+        "exactly_one_connection_got_the_call",
+        not duplicates,
+        json.dumps({"owner": session.label, "also_started": duplicates}),
+    )
+
+    for other in others:
+        reply = await other.command(
+            "answer", {"code": 200}, target={"channel": channel}
+        )
+        code = (reply.get("error") or {}).get("code")
+        verdict.check(
+            f"non_owner_is_forbidden[{other.label}]",
+            reply.get("status") == "error" and code == "forbidden",
+            json.dumps(reply),
+        )
+
+    reply = await answer_with_our_sdp(session, channel)
+    verdict.check(
+        "owner_can_answer",
+        reply.get("status") == "ok",
+        json.dumps(reply),
+    )
+
+    end = await session.wait_event(is_end(channel))
+    verdict.check("stasis_end_delivered", True, json.dumps(end.get("payload")))
+
+
+async def case_resync(app: App, session: Session, event: dict, verdict: Verdict) -> None:
+    """`resync` after the owning connection drops and the controller reconnects
+    inside the grace window — and the reattached connection can really drive the
+    call, not merely list it."""
+    channel = event.get("channel") or ""
+    sip_call_id = event.get("sip_call_id")
+
+    reply = await answer_with_our_sdp(session, channel)
+    verdict.check("answer_accepted", reply.get("status") == "ok", json.dumps(reply))
+
+    await asyncio.sleep(0.3)
+    note(f"{session.label}: dropping the owning socket mid-call")
+    await session.close()
+
+    # Well inside control.limits.reattach_grace_secs, so on_lost must not have
+    # fired and the call must still be there to re-claim.
+    await asyncio.sleep(1.5)
+
+    resumed = await app.connect_inbound("in-resync")
+    result = await resumed.command("resync", {}, module=None)
+    channels = ((result.get("result") or {}).get("channels")) or []
+    match = next((entry for entry in channels if entry.get("channel") == channel), None)
+    verdict.check(
+        "resync_returned_the_orphaned_call",
+        match is not None,
+        json.dumps(channels),
+    )
+    verdict.check(
+        "resync_reports_the_live_state",
+        bool(match) and match.get("state") == "answered",
+        json.dumps(match),
+    )
+    verdict.check(
+        "resync_keeps_the_id_triple",
+        bool(match) and match.get("sip_call_id") == sip_call_id,
+        json.dumps({"resync": (match or {}).get("sip_call_id"), "start": sip_call_id}),
+    )
+
+    # The real test of a reattach: the new connection can command the call.
+    hangup = await resumed.command(
+        "hangup", {"reason": HANGUP_REASON}, target={"channel": channel}
+    )
+    verdict.check(
+        "reattached_connection_can_command_the_call",
+        hangup.get("status") == "ok",
+        json.dumps(hangup),
+    )
+
+    end = await resumed.wait_event(is_end(channel))
+    verdict.check("stasis_end_delivered", True, json.dumps(end.get("payload")))
+
+
+CASES = {
+    "handover": case_handover,
+    "deadline": case_deadline,
+    "media": case_media,
+    "owner": case_owner,
+    "resync": case_resync,
+}
+
+
+# ── connection modes ───────────────────────────────────────────────────────
+
+
+async def heartbeat(is_serviceable) -> None:
+    """Refresh the ready file only while the app can actually take a call.
+
+    A one-shot ready file cannot tell a live application from one whose sockets
+    died when siphon restarted underneath it — and a controller with no live
+    connection is handed nothing, so every case would fail in a way that reads
+    like siphon's fault. The healthcheck keys on this file's mtime, so a stale
+    app goes unhealthy instead of quietly passing for the wrong reason.
+    """
+    path = pathlib.Path(READY_FILE)
+    announced = False
+    while True:
+        if is_serviceable():
+            path.write_text("ready\n", encoding="utf-8")
+            if not announced:
+                note(f"ready ({READY_FILE})")
+                announced = True
+        else:
+            path.unlink(missing_ok=True)
+            if announced:
+                note("no longer serviceable — ready file withdrawn")
+                announced = False
+        await asyncio.sleep(HEARTBEAT_SECS)
+
+
+async def run_inbound() -> None:
+    """Persistent mode: dial siphon and hold `CONTROL_CONNECTIONS` sockets."""
+    app = App()
+    for index in range(1, CONNECTIONS + 1):
+        await app.connect_inbound(f"in-{index}")
+
+    def serviceable() -> bool:
+        return sum(1 for session in app.sessions if not session.closed) >= CONNECTIONS
+
+    await heartbeat(serviceable)
+
+
+async def run_outbound() -> None:
+    """Per-call-connect mode: be the server siphon dials, once per call."""
+    app = App()
+
+    async def handler(socket) -> None:
+        label = f"out-{id(socket) & 0xffff:04x}"
+        headers = getattr(getattr(socket, "request", None), "headers", None)
+        if headers is None:  # pragma: no cover — legacy websockets
+            headers = getattr(socket, "request_headers", {})
+        presented = headers.get("Authorization") if headers is not None else None
+        if presented != f"Bearer {TOKEN}":
+            # A mock that accepts anything would hide a real auth regression.
+            note(f"{label}: rejecting dial with bad Authorization {presented!r}")
+            await socket.close(code=1008, reason="unauthorized")
+            return
+        note(f"{label}: siphon dialled in (per-call connect)")
+        session = Session(socket, label)
+        app.sessions.append(session)
+        # No `hello` in this direction — the first frame is StasisStart.
+        await session.reader(app.on_stasis_start)
+        if session in app.sessions:
+            app.sessions.remove(session)
+
+    async with ws_serve(handler, LISTEN_HOST, LISTEN_PORT, subprotocols=[SUBPROTOCOL]):
+        note(f"listening for per-call dials on {LISTEN_HOST}:{LISTEN_PORT}")
+        # Sockets here are per call, so "serviceable" is just "still accepting".
+        await heartbeat(lambda: True)
+
+
+async def main() -> int:
+    if MODE == "outbound":
+        await run_outbound()
+    elif MODE == "inbound":
+        await run_inbound()
+    else:
+        note(f"unknown CONTROL_MODE {MODE!r} (expected 'inbound' or 'outbound')")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/sipp/control/control_routes.py
+++ b/sipp/control/control_routes.py
@@ -1,0 +1,99 @@
+"""Routing script for the control-plane functional harness.
+
+The only in-process decision here is *which* control application a call is
+handed to and in what mode — everything after the handover is driven by the
+out-of-process app over the WebSocket rail (sipp/control/control_app.py).
+
+The dialled user selects the case, and the case is echoed into the handover's
+`vars` so the app knows what to do without a second channel of coordination:
+
+  handover@ — deferred handover to the per-call-connect app; the app answers.
+  media@    — answer-first (AI-park) handover; the app drives media verbs on the
+              already-connected channel.
+  deadline@ — deferred handover to an app that deliberately never acts, so the
+              configured `control.limits.handoff_deadline_ms` is what ends the
+              call. No `deadline_ms` here on purpose: the config value is what
+              this case exists to exercise.
+  owner@    — deferred handover to the persistent app, which holds several
+              connections; exactly one of them must be given the call.
+  resync@   — deferred handover to the persistent app, which answers, drops the
+              owning socket, reconnects and re-claims the call.
+
+The non-deadline cases pass a generous explicit `deadline_ms` so a slow CI box
+cannot turn a controller round trip into a spurious 503 — the deadline is a
+separate case with its own scenario.
+"""
+
+from siphon import b2bua, proxy, log
+
+# The per-call WebSocket bridge for the answer-first case. The media engine in
+# this profile is a mock that records the control commands and never dials the
+# bridge, so the address only has to be well formed (RFC 5737 TEST-NET-2).
+AI_WS_URI = "ws://198.51.100.30:9001/stream/{call_id}"
+
+PERSISTENT_APP = "ivr-app"
+PER_CALL_CONNECT_APP = "edge-app"
+
+GENEROUS_DEADLINE_MS = 20000
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    request.reply(200, "OK")
+
+
+def dialled_user(call) -> str:
+    """The R-URI userpart, or "" when the R-URI has none.
+
+    `call.ruri` is a `SipUri`, not a string — reading `.user` off it is the
+    supported way; string-splitting it raises AttributeError.
+    """
+    ruri = call.ruri
+    if ruri is None:
+        return ""
+    return ruri.user or ""
+
+
+@b2bua.on_invite
+def route(call):
+    user = dialled_user(call)
+    log.info(f"[{call.id}] control harness: INVITE for {user!r}")
+
+    if user == "handover":
+        call.handover(
+            PER_CALL_CONNECT_APP,
+            deadline_ms=GENEROUS_DEADLINE_MS,
+            vars={"case": "handover"},
+        )
+    elif user == "media":
+        call.handover(
+            PER_CALL_CONNECT_APP,
+            answer=True,
+            profile="voice_ai",
+            ws_uri=AI_WS_URI,
+            vars={"case": "media"},
+        )
+    elif user == "deadline":
+        # No deadline_ms: control.limits.handoff_deadline_ms is the thing under
+        # test, and the app handed this call never acts.
+        call.handover(PERSISTENT_APP, vars={"case": "deadline"})
+    elif user == "owner":
+        call.handover(
+            PERSISTENT_APP,
+            deadline_ms=GENEROUS_DEADLINE_MS,
+            vars={"case": "owner"},
+        )
+    elif user == "resync":
+        call.handover(
+            PERSISTENT_APP,
+            deadline_ms=GENEROUS_DEADLINE_MS,
+            vars={"case": "resync"},
+        )
+    else:
+        log.warn(f"[{call.id}] control harness: no case for {user!r}")
+        call.reject(404, "Not Found")
+
+
+@b2bua.on_bye
+def ended(call, initiator):
+    log.info(f"[{call.id}] control harness: call ended by {initiator.side}")

--- a/sipp/control/siphon-control.yaml
+++ b/sipp/control/siphon-control.yaml
@@ -1,0 +1,74 @@
+# siphon config for the control-plane (application rail) functional harness
+# (sipp/control/control_app.py + sipp/control/control_routes.py +
+# sipp/control_*_uac.xml).
+#
+# Two applications are registered on purpose, because the two connection modes
+# are different code paths in siphon and one app can only be in one of them:
+#
+#   edge-app — per-call-connect (the multi-pod default): siphon dials the app
+#              once per handed-over call and the accepting socket owns it.
+#   ivr-app  — persistent inbound: the app dials `control.listen` and siphon
+#              round-robins handed-over calls across its connections. This is
+#              the only mode where exactly-one-owner dispatch and `resync` are
+#              meaningful, so those cases run against it.
+#
+# The media backend is the mock siphon-rtp control server, which records every
+# command it is given. That is what lets the harness tell a media verb that was
+# *accepted* apart from one that was *performed* — a distinction SIPp cannot see.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "control.test"
+    - "172.20.0.160"
+
+advertised_address: "172.20.0.160"
+
+script:
+  path: "/etc/siphon/scripts/control_routes.py"
+
+media:
+  backend: siphon-rtp
+  siphon_rtp:
+    address: "172.20.0.163:8080"
+    timeout_ms: 2000
+
+  profiles:
+    # Answer-first (`call.handover(answer=True)`) anchors on this profile, which
+    # is what gives the media-verb case an already-connected channel to act on.
+    voice_ai:
+      offer: &voice_ai_flags
+        transport_protocol: "RTP/AVP"
+        ice: "remove"
+        dtls: "off"
+        replace: ["origin"]
+      answer: *voice_ai_flags
+
+control:
+  listen: "0.0.0.0:9092"
+  apps:
+    - name: "edge-app"
+      token: "edge-app-token"
+      per_call_connect: true
+      connect_url: "ws://172.20.0.161:8090/siphon"
+      on_lost: "hangup"
+    - name: "ivr-app"
+      token: "ivr-app-token"
+      per_call_connect: false
+      on_lost: "hangup"
+  limits:
+    event_queue_depth: 256
+    slow_consumer: drop_oldest
+    # Long enough for the resync case to drop its socket, wait, reconnect and
+    # re-claim; short enough that a genuinely lost controller is still cleaned
+    # up inside a test run.
+    reattach_grace_secs: 10
+    # The `deadline@` case hands over WITHOUT an explicit deadline_ms, so this
+    # is the value under test. Every other case passes a generous explicit one.
+    handoff_deadline_ms: 2000
+
+log:
+  level: info

--- a/sipp/control_deadline_uac.xml
+++ b/sipp/control_deadline_uac.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Control-plane handoff deadline:
+  INVITE -> 100 -> (controller connected, receives the call, never acts)
+         -> 503 No Controller Response -> ACK
+
+  The call is handed to an application that is genuinely there — it holds a live
+  control connection and is given the `StasisStart` — and then deliberately does
+  nothing. siphon must apply its safe default at `control.limits.handoff_deadline_ms`
+  rather than leave the INVITE parked until some unrelated timer notices.
+
+  The reason phrase is asserted, not just the code. siphon emits three different
+  503s around this path and only one of them is the deadline:
+
+    "No Controller Response"  — this case: a controller took the call and stalled
+    "No Controller Available" — nobody was connected to hand it to at all
+    "Service Unavailable"     — the control plane / app is not configured
+
+  Matching on the bare code would pass on all three, so the scenario would go
+  green on a build where the deadline never fired and the handover simply failed
+  up front. It also fails on a 408, which is the ordinary B2BUA answer timeout —
+  a different mechanism with a much longer fuse.
+-->
+<scenario name="Control-plane handoff deadline UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:deadline@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550002@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:deadline@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/control-deadline-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="180" optional="true" />
+
+  <recv response="503" rtd="true">
+    <action>
+      <ereg regexp="SIP/2\.0 503 No Controller Response"
+            search_in="msg"
+            check_it="true"
+            assign_to="deadline_default" />
+      <log message="handoff deadline applied the parked default: [$deadline_default]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK sip:deadline@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550002@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:deadline@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/control_handover_uac.xml
+++ b/sipp/control_handover_uac.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Control-plane deferred handover, happy path:
+  INVITE -> 100 -> 200 OK (the CONTROLLER's SDP) -> ACK -> BYE -> 200
+
+  There is no UAS and no in-process routing decision after the handover. siphon
+  holds this INVITE un-dialed, hands the call to the out-of-process application
+  over the control WebSocket, and the application answers it.
+
+  The assertion that matters is the answer body: the 200 OK must carry the SDP
+  the *application* supplied (RFC 5737 TEST-NET-2, 198.51.100.20), not one
+  siphon synthesised. A control rail that accepted `answer` and then answered
+  with something of its own would still complete the call here, which is exactly
+  the failure this ereg exists to catch.
+-->
+<scenario name="Control-plane handover UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:handover@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:handover@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/control-handover-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <recv response="200" rtd="true" crlf="true" rrs="true">
+    <action>
+      <ereg regexp="c=IN IP4 198\.51\.100\.20"
+            search_in="body"
+            check_it="true"
+            assign_to="controller_sdp" />
+      <!-- SIPp treats an assigned-but-unreferenced variable as a scenario
+           error, so log it. -->
+      <log message="200 OK carries the controller's answer SDP: [$controller_sdp]" />
+      <!-- RFC 3261 §12.1.1: the dialog-establishing 2xx needs a Contact for the
+           UAC's [next_url] below, and a To-tag for the in-dialog BYE. -->
+      <ereg regexp="Contact:[^\r\n]*sip:"
+            search_in="msg"
+            check_it="true"
+            assign_to="contact_present" />
+      <log message="2xx Contact present: [$contact_present]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:handover@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550001@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:handover@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/control_media_uac.xml
+++ b/sipp/control_media_uac.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Control-plane media verbs on an answer-first (AI-park) channel:
+  INVITE -> 100 -> 200 OK (engine-anchored SDP) -> ACK -> [app plays/stops] -> BYE -> 200
+
+  `call.handover(answer=True)` answers the call and anchors its media on the
+  media backend BEFORE handing over, so the application drives an
+  already-connected channel. The 200 OK therefore carries the SDP the engine
+  synthesised — asserted here on the mock's media address — rather than the
+  caller's own c= line echoed back, which is what an un-anchored answer looks
+  like.
+
+  The media verbs themselves are invisible from here: `play` and `stop` change
+  nothing on the SIP wire. This scenario only keeps the call up long enough for
+  them to happen; whether they were actually *performed* is asserted on the
+  media engine's recorded commands (see the runner / CI step).
+-->
+<scenario name="Control-plane media verbs UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:media@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550003@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:media@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/control-media-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <recv response="200" rtd="true" crlf="true" rrs="true">
+    <action>
+      <ereg regexp="c=IN IP4 203\.0\.113\.1"
+            search_in="body"
+            check_it="true"
+            assign_to="anchored" />
+      <log message="answer SDP anchored on the engine: [$anchored]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550003@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:media@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Hold the call while the application runs its play / stop round trip. -->
+  <pause milliseconds="1500" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550003@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:media@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/control_owner_uac.xml
+++ b/sipp/control_owner_uac.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Exactly-one-owner dispatch:
+  INVITE -> 100 -> 200 OK (the OWNING connection's SDP) -> ACK -> BYE -> 200
+
+  The application holds several persistent connections. Only one of them may be
+  given this call, and only that one may command it — the others must be refused
+  `forbidden`. Neither half of that is visible on the SIP wire, so the assertion
+  lives in the application's recorded frames; this scenario exists to place the
+  call, prove the owner could actually answer it, and take it back down.
+-->
+<scenario name="Control-plane exactly-one-owner UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:owner@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550004@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:owner@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/control-owner-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <recv response="200" rtd="true" crlf="true" rrs="true">
+    <action>
+      <ereg regexp="c=IN IP4 198\.51\.100\.20"
+            search_in="body"
+            check_it="true"
+            assign_to="owner_sdp" />
+      <log message="the owning connection answered: [$owner_sdp]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550004@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:owner@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550004@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:owner@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/control_resync_uac.xml
+++ b/sipp/control_resync_uac.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  `resync` after a controller reconnects inside the grace window:
+  INVITE -> 100 -> 200 OK -> ACK -> ... -> BYE (from siphon) -> 200
+
+  The owning connection answers this call and then drops its socket mid-call.
+  Inside `control.limits.reattach_grace_secs` the application reconnects, says
+  `hello`, `resync`s to re-claim what it owned, and hangs the call up over the
+  NEW connection. The BYE arriving here is what proves the reattach gave the
+  controller a call it can still drive, not just a listing.
+
+  The RFC 3326 Reason header is asserted because a BYE alone does not
+  distinguish the two ways this call can end. If the grace window had lapsed
+  instead, `on_lost: hangup` would tear the call down too — with
+  `text="control plane owner lost"`. Matching the reattached controller's own
+  hangup reason is what tells the two apart, so a build where resync silently
+  did nothing and the grace timer cleaned up cannot pass this.
+-->
+<scenario name="Control-plane resync UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:resync@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550005@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:resync@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/control-resync-uac
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <recv response="200" rtd="true" crlf="true" rrs="true">
+    <action>
+      <ereg regexp="c=IN IP4 198\.51\.100\.20"
+            search_in="body"
+            check_it="true"
+            assign_to="controller_sdp" />
+      <log message="controller answered before dropping its socket: [$controller_sdp]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+ACK [next_url] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:+15550005@control.test>;tag=[pid]SIPpTag00[call_number]
+To: <sip:resync@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+[routes]
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- The controller drops, waits, reconnects, resyncs and hangs up. -->
+  <recv request="BYE" timeout="20000">
+    <action>
+      <ereg regexp="Reason:[^\r\n]*text=&quot;resync-hangup&quot;"
+            search_in="msg"
+            check_it="true"
+            assign_to="reattached_hangup" />
+      <log message="BYE came from the reattached controller: [$reattached_hangup]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -5395,6 +5395,313 @@ services:
     profiles:
       - originate
 
+
+  # ── Control plane: the external application rail ──────────────────────────
+  # Requires the "control" profile.
+  #
+  # IP assignments:
+  #   172.20.0.160 — siphon (SIP :5060, control WebSocket :9092)
+  #   172.20.0.161 — mock control app, per-call-connect mode (WS server :8090)
+  #   172.20.0.162 — mock control app, persistent-inbound mode (2 sockets)
+  #   172.20.0.163 — mock siphon-rtp media engine (answer-first + media verbs)
+  #   172.20.0.164 — SIPp UAC, deferred handover happy path
+  #   172.20.0.165 — SIPp UAC, handoff deadline
+  #   172.20.0.166 — SIPp UAC, media verb round trip
+  #   172.20.0.167 — SIPp UAC, exactly-one-owner dispatch
+  #   172.20.0.168 — SIPp UAC, resync after a controller reconnect
+  #
+  # There is no UAS anywhere in this profile: every call is answered (or refused)
+  # by the out-of-process application over the control WebSocket, which is the
+  # whole point. Both connection modes run at once against one siphon, because
+  # they are different code paths and a given app can only be in one of them:
+  # `edge-app` is dialled per call (the multi-pod default) and `ivr-app` holds
+  # persistent inbound sockets (the only mode with round-robin ownership and
+  # `resync`).
+  #
+  # The mock app records every frame it sent and received, and the mock media
+  # engine records every command it was given — which together are what let a
+  # test assert on the actual exchange rather than on a call outcome that looks
+  # the same either way.
+  #
+  # Usage (one scenario at a time; --exit-code-from names the decider):
+  #   docker compose -f sipp/docker-compose.yaml --profile control \
+  #     up -d --wait mock-control-rtp control-app-edge siphon-control control-app-ivr
+  #   docker compose -f sipp/docker-compose.yaml --profile control \
+  #     up --abort-on-container-exit --exit-code-from sipp-control-handover-uac \
+  #     sipp-control-handover-uac
+
+  # Mock siphon-rtp — native JSON-over-TCP control on 8080. Only the answer-first
+  # (media verb) case needs it, but siphon resolves the backend at boot.
+  mock-control-rtp:
+    image: python:3.12-slim
+    container_name: mock-control-rtp
+    volumes:
+      - ./siphon-rtp:/app:ro
+    working_dir: /app
+    command: ["python3", "mock_siphon_rtp.py"]
+    environment:
+      SIPHON_RTP_PORT: "8080"
+      MOCK_MEDIA_IP: "203.0.113.1"
+      MOCK_MEDIA_PORT: "30000"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.163
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket,struct,json; s=socket.create_connection(('127.0.0.1',8080),2); b=json.dumps({'id':1,'command':'ping'}).encode(); s.sendall(struct.pack('!I',len(b))+b); h=s.recv(4); n=struct.unpack('!I',h)[0]; d=s.recv(n); s.close(); exit(0 if b'pong' in d else 1)\""]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+    profiles:
+      - control
+
+  # The per-call-connect application: siphon dials THIS, once per handed-over
+  # call. It must be listening before siphon needs it, so it starts first.
+  control-app-edge:
+    image: python:3.12-slim
+    container_name: control-app-edge
+    volumes:
+      - ./control:/app:ro
+    working_dir: /app
+    command: ["sh", "-c", "pip install --quiet --no-cache-dir websockets && exec python3 control_app.py"]
+    environment:
+      CONTROL_MODE: "outbound"
+      CONTROL_APP: "edge-app"
+      CONTROL_TOKEN: "edge-app-token"
+      CONTROL_LISTEN_PORT: "8090"
+      CONTROL_READY_FILE: "/tmp/control-app-ready"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.161
+    healthcheck:
+      # The app heartbeats this file only while it is genuinely serviceable, and
+      # the check keys on its freshness rather than its existence: an app that is
+      # up but not accepting (or, in the persistent twin below, one whose sockets
+      # died when siphon restarted under it) must read unhealthy, not ready.
+      test: ["CMD-SHELL", "test -n \"$$(find /tmp/control-app-ready -newermt '-10 seconds' 2>/dev/null)\""]
+      interval: 2s
+      timeout: 3s
+      # Few retries on purpose: start-up slack belongs in start_period, and a
+      # long retry budget here would keep reporting healthy for a minute after
+      # the app stopped being able to take a call.
+      retries: 6
+      start_period: 25s
+    profiles:
+      - control
+
+  siphon-control:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
+    build:
+      context: ..
+    container_name: siphon-control-test
+    depends_on:
+      mock-control-rtp:
+        condition: service_healthy
+      control-app-edge:
+        condition: service_healthy
+    volumes:
+      - ./control/siphon-control.yaml:/etc/siphon/siphon.yaml:ro
+      - ./control:/etc/siphon/scripts:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.160
+    healthcheck:
+      # Both rails have to be up: the control listener for the application, and
+      # SIP for the UACs. A siphon that answers OPTIONS but never bound :9092
+      # would otherwise look healthy and every case would fail on connect.
+      test: ["CMD-SHELL", "python3 -c \"import socket; socket.create_connection(('127.0.0.1',9092),2).close(); s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:control.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@control.test>;tag=hc\\r\\nTo: <sip:control.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    profiles:
+      - control
+
+  # The persistent-inbound application: it dials siphon and holds two sockets, so
+  # round-robin ownership has somewhere to go wrong.
+  control-app-ivr:
+    image: python:3.12-slim
+    container_name: control-app-ivr
+    depends_on:
+      siphon-control:
+        condition: service_healthy
+    volumes:
+      - ./control:/app:ro
+    working_dir: /app
+    command: ["sh", "-c", "pip install --quiet --no-cache-dir websockets && exec python3 control_app.py"]
+    environment:
+      CONTROL_MODE: "inbound"
+      CONTROL_APP: "ivr-app"
+      CONTROL_TOKEN: "ivr-app-token"
+      CONTROL_URL: "ws://172.20.0.160:9092/control/ws"
+      CONTROL_CONNECTIONS: "2"
+      CONTROL_READY_FILE: "/tmp/control-app-ready"
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.162
+    healthcheck:
+      # Freshness, not existence — see control-app-edge. This one matters more:
+      # this app's sockets are held for its whole life, so a siphon restart
+      # leaves it up, "ready" and unable to be handed a single call.
+      test: ["CMD-SHELL", "test -n \"$$(find /tmp/control-app-ready -newermt '-10 seconds' 2>/dev/null)\""]
+      interval: 2s
+      timeout: 3s
+      # Few retries on purpose: start-up slack belongs in start_period, and a
+      # long retry budget here would keep reporting healthy for a minute after
+      # the app stopped being able to take a call.
+      retries: 6
+      start_period: 25s
+    profiles:
+      - control
+
+  # Deferred handover, answered by the per-call-connect app.
+  sipp-control-handover-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-control:
+        condition: service_healthy
+      control-app-edge:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.164
+    entrypoint:
+      - sipp
+      - "172.20.0.160:5060"
+      - -sf
+      - /sipp/scenarios/control_handover_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - control
+
+  # Handed to a controller that is connected and deliberately never acts.
+  sipp-control-deadline-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-control:
+        condition: service_healthy
+      control-app-ivr:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.165
+    entrypoint:
+      - sipp
+      - "172.20.0.160:5060"
+      - -sf
+      - /sipp/scenarios/control_deadline_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - control
+
+  # Answer-first handover, then media verbs on the anchored channel.
+  sipp-control-media-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-control:
+        condition: service_healthy
+      control-app-edge:
+        condition: service_healthy
+      mock-control-rtp:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.166
+    entrypoint:
+      - sipp
+      - "172.20.0.160:5060"
+      - -sf
+      - /sipp/scenarios/control_media_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - control
+
+  # One call, several app connections — exactly one must own it.
+  sipp-control-owner-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-control:
+        condition: service_healthy
+      control-app-ivr:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.167
+    entrypoint:
+      - sipp
+      - "172.20.0.160:5060"
+      - -sf
+      - /sipp/scenarios/control_owner_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - control
+
+  # The owner drops its socket mid-call and re-claims the call after reconnect.
+  # Longer timeout: the scenario deliberately waits out the reconnect.
+  sipp-control-resync-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-control:
+        condition: service_healthy
+      control-app-ivr:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.168
+    entrypoint:
+      - sipp
+      - "172.20.0.160:5060"
+      - -sf
+      - /sipp/scenarios/control_resync_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "45"
+      - -timeout_error
+      - -trace_err
+    profiles:
+      - control
+
 # ── Network ────────────────────────────────────────────────────────────────
 networks:
   sipnet:


### PR DESCRIPTION
The external control rail shipped with **no functional coverage at all**. No test config enabled
a `control:` block, there was no mock control application in the test plumbing, and the runner
had no control mode. Unit tests only — nothing asserted that a real application over a real
socket could drive a real call.

That is the gap that has already produced three vacuously-passing SIPp modes in this repo. Here
it is worse: the coverage did not exist to be hollow.

## What it covers

One siphon, two apps registered, **both connection modes exercised simultaneously**:

| case | mode | what it proves |
|---|---|---|
| `handover` | per-call-connect (siphon dials the app) | the INVITE is parked un-dialed, the app receives the full SIP context and the id triple, answers, the call completes |
| `deadline` | persistent inbound | a *connected* controller that never acts still gets the parked default at `handoff_deadline_ms` |
| `media` | per-call-connect | answer-first channel, `play` + `stop` round trip |
| `owner` | persistent inbound | two connections, exactly one receives `StasisStart`, the other is refused `forbidden` |
| `resync` | persistent inbound | the owner drops mid-call, reconnects inside the grace window, `resync` re-claims — and the reattached connection can actually BYE the call |

New `control` compose profile on a fresh 172.20.0.160–168 block, `run-tests.sh --control`, and a
`sipp-control` CI job.

## Two mutations where SIPp was green and only the log assertion caught it

These are the reason the harness asserts on recorded frames rather than call outcomes.

**MC6 — siphon's `play` mutated to return `Ok` without calling the media backend.** SIPp: green.
The app's own verdict: green (`play_accepted: true`). The runner: **failed** —
`the media engine never received 'play_media' — the verb was accepted but never performed`.
That is precisely the accepted-versus-performed distinction, and nothing else in the suite would
have caught it.

**MC4a — the ownership case run with a single connection.** SIPp: green, one successful call.
The runner: **failed** — `control-plane case 'owner'`. The log assertion is the only witness.

Four more, all broken then restored: an app answering with no body (handover fails), a
120-second handoff deadline (deadline fails, zero 503s), a wrong engine media address (media
fails on the anchored-SDP match), and `reattach_grace_secs: 0` (resync fails, and the verdict
shows the call was never returned).

The grep-spacing trap was verified directly rather than assumed: `"command": "play_media"` → 1
match, `"command":"play_media"` → 0.

## End-to-end

`./scripts/run-tests.sh --control --skip-rust` → exit 0, five cases each one successful call,
five verdicts `"pass": true`, plus explicit confirmation the engine performed `play_media` and
`stop_media`. Re-run against a deliberately stale stack also passes.

No Rust touched — no `src/` entries in the diff.

## Deliberately left

`progress`/`reject`, inbound-REFER `TransferRequested` with accept/reject, the outbound-REFER
outcome events, `route`, `set_var`/`get_var`, `stream_start`/`stream_stop`, and
`on_lost: continue`/`fallback`. The mock app is a case table keyed on `vars.case`, so each of
those is a new case plus a scenario — not new plumbing.

## One harness defect found and fixed here

The persistent app dials siphon once at startup. When siphon is recreated underneath it the
sockets die, but a one-shot ready file still reported healthy — so a run reported
`handover: no controller available` and looked like a siphon bug. The ready file is now a
**heartbeat that stops while the app cannot take a call** (container goes unhealthy within ~15 s,
verified), plus `--force-recreate` in the runner and CI.

No CHANGELOG entry — pure test and CI work, exempt by project convention.
