### PR TITLE
fix(b2bua): keep the call alive when the transferor hangs up mid-transfer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -581,6 +581,39 @@ jobs:
         if: always()
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-terminate rm -sf sipp-b2bua-refer-terminate-uac sipp-b2bua-refer-terminate-bob-uas sipp-b2bua-refer-terminate-carol-uas 2>/dev/null || true
 
+      # Every leg is graded, NOT just the UAC. The referrer completes its own
+      # scenario cleanly even when the transfer is broken — the damage lands on
+      # the surviving leg (an unexpected BYE) and on the transfer target (a 200
+      # that is never ACKed), so `--exit-code-from` on the UAC alone reports a
+      # green run over both failures. All three scenarios self-terminate, so
+      # plain `up` returns once they have, and each exit code is then asserted.
+      - name: B2BUA REFER terminate, referrer BYEs mid-transfer (RFC 5589 §7 — survivor kept, target ACKed)
+        run: |
+          docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-referrer-bye up \
+            sipp-b2bua-refer-referrer-bye-uac \
+            sipp-b2bua-refer-referrer-bye-bob-uas \
+            sipp-b2bua-refer-referrer-bye-carol-uas
+          status=0
+          for service in uac bob-uas carol-uas; do
+            code=$(docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-referrer-bye \
+              ps -a --format '{{.Service}} {{.ExitCode}}' \
+              | awk -v s="sipp-b2bua-refer-referrer-bye-$service" '$1 == s { print $2 }')
+            echo "sipp-b2bua-refer-referrer-bye-$service exit=$code"
+            if [ "$code" != "0" ]; then status=1; fi
+          done
+          exit $status
+
+      - name: Cleanup referrer-bye containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-referrer-bye rm -sf sipp-b2bua-refer-referrer-bye-uac sipp-b2bua-refer-referrer-bye-bob-uas sipp-b2bua-refer-referrer-bye-carol-uas 2>/dev/null || true
+
+      - name: B2BUA REFER terminate attended (RFC 3891 §3 — Replaces reaches the target's INVITE)
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-attended up --abort-on-container-exit --exit-code-from sipp-b2bua-refer-attended-carol-uas sipp-b2bua-refer-attended-uac sipp-b2bua-refer-attended-bob-uas sipp-b2bua-refer-attended-carol-uas
+
+      - name: Cleanup attended containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-attended rm -sf sipp-b2bua-refer-attended-uac sipp-b2bua-refer-attended-bob-uas sipp-b2bua-refer-attended-carol-uas 2>/dev/null || true
+
       - name: B2BUA REFER terminate + REAL rtpengine (media re-anchor offer/answer/delete)
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-rtpengine-refer up --abort-on-container-exit --exit-code-from sipp-anchored-refer-uac sipp-anchored-refer-uac sipp-anchored-refer-bob-uas sipp-anchored-refer-carol-uas
 
@@ -594,7 +627,7 @@ jobs:
 
       - name: Teardown
         if: always()
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer --profile b2bua-refer-reject --profile b2bua-refer-terminate --profile b2bua-rtpengine-refer down --remove-orphans
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer --profile b2bua-refer-reject --profile b2bua-refer-terminate --profile b2bua-refer-referrer-bye --profile b2bua-refer-attended --profile b2bua-rtpengine-refer down --remove-orphans
 
       - name: Upload logs
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,43 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   a personal one.
 
 ### Fixed
+- **A blind transfer no longer kills the call when the transferor hangs up
+  first.** In a siphon-terminated `REFER` the transferor is free to end its own
+  dialog the moment the transfer is accepted (RFC 5589 §7), and real ones do —
+  a Microsoft Teams blind transfer BYEs within a few hundred milliseconds of the
+  `202`, roughly a second before the transfer target answers. That BYE was
+  treated as an ordinary bridge hangup: siphon generated a BYE at the far leg
+  (killing the very party the transfer exists to keep), deleted the media
+  session and destroyed the call actor. The target's `200 OK` then matched
+  nothing and was never ACKed, so it retransmitted to Timer B and the transfer
+  target was left in a call no one was on. Both parties dropped and the transfer
+  destination rang into nowhere. The referrer's departure is now recognised
+  while the transfer is in flight: the BYE is answered `200`, the surviving leg
+  is kept, the target is dialled through to completion and bridged, and the
+  terminating sipfrag `NOTIFY` and referrer `BYE` are skipped because the
+  implicit subscription died with the dialog (RFC 3515 §2.4.4). `@b2bua.on_bye`
+  no longer fires for that BYE either — the call is not ending, so a handler
+  that tears the call down on it can no longer undo the transfer. If the target
+  then *fails*, the now-orphaned surviving leg is released instead of being left
+  stranded.
+- **Attended transfer emits the `Replaces` it was given.** An attended `REFER`
+  carries `Refer-To: <target?Replaces=dialog>`, and RFC 3891 §3 requires that
+  dialog reference on the INVITE sent to the transfer target. siphon parsed the
+  `Replaces`, used it only to label a log line, and dropped it — so every
+  attended transfer degraded silently into a blind one and the held call it was
+  meant to take over was never replaced. The reference is now carried onto the
+  triggered INVITE, and rewritten to the dialog as the *target* sees it when
+  siphon hosts the replaced call: the referrer names it with the identifiers of
+  the leg facing itself, which on a B2BUA are meaningless at the far end and
+  would draw a `481`. A dialog siphon does not host crosses unchanged.
+- **A completed transfer no longer strands the referrer's Call-ID.** The leg the
+  transfer promoted away from left the call without its registry entry being
+  cleared, and teardown only walks the legs still attached, so the mapping
+  outlived the call permanently. A later INVITE reusing that Call-ID matched the
+  "call already exists" guard and was absorbed as a retransmission — the caller
+  got no response at all, not even a `100`. The promoted-away dialog is now
+  retired properly, so a late in-dialog request on it answers `481` like any
+  other torn-down leg.
 - **A `siphon-bin` build reports the SIPhon version again.** It announced its
   own package version (`0.1.0`) in the startup banner, the `User-Agent`/`Server`
   headers and `/admin/health`, which broke the lockstep guarantee that the

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -103,6 +103,40 @@ Alice (A-leg)            siphon 198.51.100.1            Bob (B-leg)      Carol (
      |------------------------->|                            |                |
 ```
 
+#### When the transferor hangs up first
+
+The ladder above shows siphon BYEing the referrer once the target answers, but a
+transferor is entitled to leave the moment its `REFER` is accepted (RFC 5589 §7),
+and several real ones do — a Microsoft Teams blind transfer BYEs a few hundred
+milliseconds after the `202`, well before the target picks up:
+
+```
+   Alice (referrer)              siphon                    Carol (target)
+     |  REFER / 202 / NOTIFY 100 |                            |
+     |------------------------->|  INVITE (new leg) --------->|  (ringing)
+     |  BYE                     |                            |
+     |------------------------->|                            |
+     |  200 OK                  |                            |
+     |<-------------------------|            200 OK          |
+     |     (Alice is gone)      |<---------------------------|
+     |                          |  ACK ---------------------->|
+     |                          |     Bob <== bridged ==> Carol
+```
+
+siphon treats that as the transferor leaving, **not** as the end of the call: the
+BYE is answered `200`, the surviving party stays up, and the target is dialled
+through and bridged as normal. The terminating sipfrag `NOTIFY` and the referrer
+`BYE` are simply skipped, because the implicit subscription died with the dialog
+(RFC 3515 §2.4.4).
+
+Two consequences worth knowing when you write handlers:
+
+* **`@b2bua.on_bye` does not fire for that BYE.** The call is not ending, so a
+  handler that calls `call.terminate()` on every BYE cannot accidentally undo the
+  transfer. `on_bye` fires later, when the transferred call really ends.
+* **If the target then fails**, the surviving party has nobody left to talk to,
+  so siphon releases it and tears the call down rather than stranding it.
+
 Rewrite the destination or steer egress without touching what the endpoints see:
 
 ```python
@@ -165,6 +199,16 @@ def on_refer(call):
 !!! warning "One argument, no reply"
     The handler is `def on_refer(call):` — one argument, no reply object
     (`REFER` is a request).
+
+!!! note "The `Replaces` is rewritten for the target"
+    The INVITE siphon triggers towards the transfer target carries the `Replaces`
+    naming the dialog to be taken over (RFC 3891 §3). The referrer names that
+    dialog with the identifiers of the leg facing **itself**, which on a B2BUA
+    are not the ones the target knows — so when siphon hosts the replaced call
+    the reference is rewritten to the far leg's Call-ID and tag pair before it
+    goes out. A dialog siphon does not host crosses unchanged, which is the
+    right best-effort behaviour when the replaced call never traversed this
+    node.
 
 ```text
 Alice                    siphon 198.51.100.1            Bob            Carol

--- a/sipp/b2bua_refer_attended_carol_uas.xml
+++ b/sipp/b2bua_refer_attended_carol_uas.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated, ATTENDED (RFC 3891 / RFC 5589 §7) — Carol, the
+  transfer target:
+  Receive INVITE (asserting it carries the Replaces) → 180 → 200 → ACK → BYE → 200
+
+  The assertion is the `Replaces` header on the INVITE siphon triggers. An
+  attended REFER carries `Refer-To: <target?Replaces=dialog>`; RFC 3891 §3 says
+  the INVITE sent to the target must name that dialog in a Replaces header, or
+  the target treats the call as brand new and the held dialog it was supposed to
+  take over is never replaced. siphon parsed the Replaces and then dropped it,
+  so every attended transfer degraded silently into a blind one.
+
+  This scenario uses a Replaces naming a dialog siphon does NOT host, which is
+  the pass-through case — it proves the header reaches the wire at all. The
+  rewrite applied when siphon *does* host the replaced dialog (the referrer's
+  identifiers are meaningless to the target) is covered by the unit tests on
+  `replaces_as_seen_by_peer`.
+-->
+<scenario name="B2BUA REFER attended Carol UAS">
+
+  <recv request="INVITE" crlf="true">
+    <action>
+      <!--
+        check_it: the call fails if this does not match, which covers both a
+        missing Replaces header and a mangled one. The whole triple is matched
+        in one regexp so the assertion is a single variable (SIPp rejects a
+        scenario that assigns a variable it never references, so it is logged
+        below).
+      -->
+      <ereg regexp="held-elsewhere@example\.invalid;from-tag=far-referrer-tag;to-tag=far-target-tag"
+            search_in="hdr"
+            header="Replaces:"
+            check_it="true"
+            assign_to="replaces_triple" />
+      <log message="attended transfer: target INVITE carries Replaces [$replaces_triple]" />
+      <ereg regexp="(.*)" search_in="hdr" header="Call-ID:" assign_to="dialog_callid" />
+      <ereg regexp="tag=([^;>\r\n ]+)" search_in="hdr" header="From:" assign_to="junk,remote_tag" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="From:" assign_to="junk,remote_from_uri" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="Contact:" assign_to="junk,remote_contact" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=carol 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" timeout="5000" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE [$remote_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:carol@[local_ip]>;tag=[pid]SIPpTag02[call_number]
+To: <[$remote_from_uri]>;tag=[$remote_tag]
+Call-ID: [$dialog_callid]
+CSeq: 1 BYE
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-attended-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+</scenario>

--- a/sipp/b2bua_refer_attended_uac.xml
+++ b/sipp/b2bua_refer_attended_uac.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated ATTENDED UAC scenario — Alice, the referrer:
+  INVITE → 200 → ACK
+  → REFER (X-Refer-Mode: terminate,
+           Refer-To: <carol?Replaces=dialog>) → 202
+  → NOTIFY (sipfrag 100 Trying) → 200
+  → NOTIFY (sipfrag 200 OK, terminated) → 200
+  → BYE (siphon tears down the referrer leg once carol answers) → 200
+
+  Identical to the blind terminate scenario except that the Refer-To carries an
+  escaped `Replaces` (RFC 3515 §2.4.1), which makes this an ATTENDED transfer.
+  RFC 3891 §3 requires that dialog reference to be carried onto the INVITE
+  siphon triggers towards the target — carol asserts it arrives. Without it an
+  attended transfer silently degrades to a blind one and the referrer's held
+  call is never taken over.
+
+  The Replaces here names a dialog this node does not host, so it crosses
+  verbatim; the rewrite for a dialog siphon *does* host is unit-tested.
+-->
+<scenario name="B2BUA REFER attended UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-attended-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+REFER sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 REFER
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Refer-To: <sip:carol@172.20.0.54:5060?Replaces=held-elsewhere%40example.invalid%3Bfrom-tag%3Dfar-referrer-tag%3Bto-tag%3Dfar-target-tag>
+X-Refer-Mode: terminate
+User-Agent: SIPp/b2bua-refer-attended-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="202" crlf="true" />
+
+  <!-- sipfrag NOTIFY 100 Trying (siphon-originated). -->
+  <recv request="NOTIFY" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!--
+    The final sipfrag NOTIFY (200 OK, subscription terminated) and the
+    referrer-leg BYE are two independent transactions siphon fires back to
+    back (µs apart). Over UDP there is NO cross-transaction ordering
+    guarantee (RFC 3261 §18), so either can hit the wire first. A real UAC
+    must accept both orderings — so do we. Both branches answer 200 to the
+    NOTIFY and 200 to the BYE, then the call completes.
+  -->
+
+  <!-- If the NOTIFY arrives first, branch to label 10; otherwise fall through
+       to the BYE-first ordering below. -->
+  <recv request="NOTIFY" optional="true" next="10" crlf="true" />
+
+  <!-- ===== BYE arrived before the final NOTIFY ===== -->
+  <recv request="BYE" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+  <recv request="NOTIFY" crlf="true" next="20" />
+
+  <!-- ===== NOTIFY arrived first ===== -->
+  <label id="10" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+  <recv request="BYE" crlf="true" />
+
+  <!-- ===== converge: answer whichever request (NOTIFY or BYE) was last ===== -->
+  <label id="20" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/b2bua_refer_referrer_bye_bob_uas.xml
+++ b/sipp/b2bua_refer_referrer_bye_bob_uas.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated, referrer leaves mid-transfer — Bob, the
+  surviving party:
+  Receive INVITE → 180 → 200 → ACK
+  → (the referrer REFERs and then immediately hangs up — bob must NOT be torn
+     down with it)
+  → receive the media re-INVITE once carol answers → 200 → ACK
+  → receive BYE (carol hung up) → 200
+
+  This is the leg the bug destroyed. The referrer's BYE used to be forwarded
+  across the bridge as an ordinary hangup, so bob was BYE'd roughly a second
+  before the transfer target answered — the transferred party was cut off and
+  the transfer target was left ringing into a call that no longer existed.
+
+  The assertion is the message ORDER: after the ACK the next request bob
+  accepts is the re-INVITE that re-points its media at carol (RFC 3261 §14). A
+  BYE arriving in that slot is an unexpected message and fails the call, which
+  is precisely the regression this scenario guards.
+-->
+<scenario name="B2BUA REFER referrer-BYE Bob UAS">
+
+  <recv request="INVITE" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <!--
+    The next request MUST be the media re-INVITE. Receiving a BYE here is the
+    bug: the referrer's hangup crossing the bridge onto the leg that was
+    supposed to survive the transfer.
+  -->
+  <recv request="INVITE" crlf="true" timeout="10000" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687638 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/b2bua_refer_referrer_bye_carol_uas.xml
+++ b/sipp/b2bua_refer_referrer_bye_carol_uas.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated, referrer leaves mid-transfer — Carol, the
+  transfer target:
+  Receive INVITE → 180 → (hold ringing 1.5 s, so the referrer's BYE lands
+  first) → 200 → ACK → BYE → 200
+
+  The ACK is the assertion this scenario exists for. The referrer hangs up
+  while carol is ringing; if that BYE is treated as an ordinary hangup the call
+  actor is destroyed, and carol's 200 OK then matches nothing and is never
+  ACKed — she retransmits it to Timer B and the transferred-to party never
+  learns she was answered. `recv request="ACK"` fails on exactly that.
+-->
+<scenario name="B2BUA REFER referrer-BYE Carol UAS">
+
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="(.*)" search_in="hdr" header="Call-ID:" assign_to="dialog_callid" />
+      <ereg regexp="tag=([^;>\r\n ]+)" search_in="hdr" header="From:" assign_to="junk,remote_tag" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="From:" assign_to="junk,remote_from_uri" />
+      <ereg regexp="&lt;([^>]+)>" search_in="hdr" header="Contact:" assign_to="junk,remote_contact" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!--
+    Hold the ring long enough that the referrer's BYE is processed while this
+    leg is still in flight. That ordering is the whole point of the test.
+  -->
+  <pause milliseconds="1500" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=carol 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <!-- The transfer completed and siphon owns this leg as a UAC (RFC 3261
+       §13.2.2.4). Without the fix this never arrives. -->
+  <recv request="ACK" timeout="5000" />
+
+  <!-- Carol hangs up; siphon tears down the surviving far leg (bob). -->
+  <send retrans="500">
+    <![CDATA[
+BYE [$remote_contact] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:carol@[local_ip]>;tag=[pid]SIPpTag02[call_number]
+To: <[$remote_from_uri]>;tag=[$remote_tag]
+Call-ID: [$dialog_callid]
+CSeq: 1 BYE
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-referrer-bye-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+</scenario>

--- a/sipp/b2bua_refer_referrer_bye_uac.xml
+++ b/sipp/b2bua_refer_referrer_bye_uac.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated, referrer leaves mid-transfer — Alice:
+  INVITE → 200 → ACK
+  → REFER (X-Refer-Mode: terminate, Refer-To: carol) → 202
+  → NOTIFY (sipfrag 100 Trying) → 200
+  → BYE (Alice hangs up IMMEDIATELY, while carol is still ringing) → 200
+  → nothing further
+
+  RFC 5589 §7 lets the transferor end its dialog as soon as the REFER is
+  accepted, and real transferors do: a Teams blind transfer BYEs within a few
+  hundred ms of the 202, roughly a second before the target answers. The
+  transfer must still complete — bob stays up and is bridged to carol.
+
+  Two properties are asserted here, and the rest on the bob/carol UAS sides:
+    * the BYE is answered 200 (the referrer leaves cleanly), and
+    * NOTHING further is sent to this dialog. The closing pause outlives
+      carol's answer, so a terminating sipfrag NOTIFY or a referrer BYE
+      emitted after the referrer already left lands inside the call and SIPp
+      fails it as an unexpected message (RFC 3515 §2.4.4 — the implicit
+      subscription died with the dialog, so a late NOTIFY would draw a 481).
+-->
+<scenario name="B2BUA REFER terminate, referrer BYEs mid-transfer">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-referrer-bye-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+REFER sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 REFER
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Refer-To: <sip:carol@172.20.0.54:5060>
+X-Refer-Mode: terminate
+User-Agent: SIPp/b2bua-refer-referrer-bye-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="202" crlf="true" />
+
+  <!-- sipfrag NOTIFY 100 Trying opens the implicit subscription. -->
+  <recv request="NOTIFY" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!--
+    Hang up NOW — carol has not answered yet (she holds 180 for 1.5 s). This is
+    the exact ordering a Teams transfer produces and the one that used to take
+    the surviving leg down with it.
+  -->
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+Max-Forwards: 70
+Reason: Q.850;cause=16;text="Referrer left after the REFER was accepted"
+User-Agent: SIPp/b2bua-refer-referrer-bye-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+  <!--
+    Outlives carol's answer + the bridge. Any NOTIFY or BYE siphon sends to the
+    departed referrer arrives here and fails the call.
+  -->
+  <pause milliseconds="3000" />
+
+</scenario>

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -1543,6 +1543,8 @@ services:
     profiles:
       - b2bua-refer-reject
       - b2bua-refer-terminate
+      - b2bua-refer-referrer-bye
+      - b2bua-refer-attended
       - b2bua-refer-outbound
 
   sipp-b2bua-refer-modes-register:
@@ -1573,6 +1575,8 @@ services:
     profiles:
       - b2bua-refer-reject
       - b2bua-refer-terminate
+      - b2bua-refer-referrer-bye
+      - b2bua-refer-attended
       - b2bua-refer-outbound
 
   sipp-b2bua-refer-reject-uas:
@@ -1704,6 +1708,167 @@ services:
       - -trace_err
     profiles:
       - b2bua-refer-terminate
+
+  # --- REFER terminate, referrer hangs up mid-transfer (RFC 5589 §7) ---
+  # The Teams blind-transfer ordering: alice REFERs, then BYEs her own dialog
+  # while carol is still ringing. bob must survive and be bridged to carol.
+
+  sipp-b2bua-refer-referrer-bye-bob-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-refer-modes-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_referrer_bye_bob_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-referrer-bye
+
+  sipp-b2bua-refer-referrer-bye-carol-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.54
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_referrer_bye_carol_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-referrer-bye
+
+  sipp-b2bua-refer-referrer-bye-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+      sipp-b2bua-refer-referrer-bye-bob-uas:
+        condition: service_started
+      sipp-b2bua-refer-referrer-bye-carol-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.60:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_referrer_bye_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-referrer-bye
+
+  # --- REFER terminate, ATTENDED (Refer-To carries a Replaces) ---
+  # RFC 3891 §3: the dialog reference must reach the target's INVITE.
+
+  sipp-b2bua-refer-attended-bob-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-refer-modes-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_bob_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-attended
+
+  sipp-b2bua-refer-attended-carol-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.54
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_attended_carol_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-attended
+
+  sipp-b2bua-refer-attended-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+      sipp-b2bua-refer-attended-bob-uas:
+        condition: service_started
+      sipp-b2bua-refer-attended-carol-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.60:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_attended_uac.xml
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-attended
 
   # siphon-originated (outbound) REFER: siphon REFERs the caller after answer.
 

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -803,6 +803,33 @@ pub struct ReferSubscription {
     /// so an unrelated leg dialed while a transfer is pending can't be mistaken
     /// for the transfer target. `None` for the subscriber (outbound) role.
     pub target_leg_call_id: Option<String>,
+    /// True once the referrer's dialog ended while this transfer was still in
+    /// flight — the referrer sent a BYE after siphon accepted the REFER but
+    /// before the dialed target resolved.
+    ///
+    /// RFC 3515 §2.4.4: the implicit refer subscription lives in the dialog the
+    /// REFER arrived on, so once that dialog ends no further NOTIFY can be
+    /// delivered (a late one draws a 481) and the referrer needs no BYE at
+    /// completion — it already left. The transfer itself continues: RFC 5589 §7
+    /// has the transferor free to end its dialog as soon as the REFER is
+    /// accepted, and the surviving party ↔ target call is what the transfer
+    /// exists to create. Notifier (siphon-terminated) role only.
+    pub referrer_gone: bool,
+}
+
+/// One end of a dialog, in the shape `Replaces` (RFC 3891) names it.
+///
+/// Produced by [`CallActorStore::replaces_as_seen_by_peer`] when an attended
+/// transfer's `Replaces` has to be rewritten from the referrer's view of a
+/// dialog to the transfer target's.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplacesDialog {
+    /// Call-ID of the dialog, as the far party knows it.
+    pub call_id: String,
+    /// The `from-tag` parameter — siphon's local tag on the leg facing that party.
+    pub from_tag: String,
+    /// The `to-tag` parameter — that party's own tag.
+    pub to_tag: String,
 }
 
 /// Per-call supervisor managing A-leg + B-leg(s).
@@ -1708,6 +1735,56 @@ impl CallActorStore {
         None
     }
 
+    /// Resolve the `Replaces` triple a referrer supplied (its own view of the
+    /// dialog to be replaced) into the triple the *far* party of that dialog
+    /// would recognise, together with the internal call id the dialog belongs to.
+    ///
+    /// On a B2BUA the two ends of a call never share dialog identifiers: the
+    /// referrer names its held call by the Call-ID and tag pair of the leg
+    /// facing *it*, while the transfer target only knows the leg facing itself.
+    /// A `Replaces` forwarded verbatim therefore names a dialog the target has
+    /// never seen, and RFC 3891 §3 requires it to answer `481`. This returns the
+    /// far leg's identifiers *as the far party sees them* — its Call-ID,
+    /// siphon's local tag as the `from-tag`, and the far party's own tag as the
+    /// `to-tag` (RFC 3891 §3 matches those against the remote and local tag of
+    /// the dialog at the receiving UAS, respectively).
+    ///
+    /// `None` when the dialog is not one this node hosts (a referrer
+    /// transferring against a call that never traversed siphon), when the far
+    /// leg has no tag yet (nothing to replace), or when the far leg has not been
+    /// chosen — the caller passes the referrer's own triple through in that case.
+    pub fn replaces_as_seen_by_peer(
+        &self,
+        call_id: &str,
+        from_tag: &str,
+        to_tag: &str,
+    ) -> Option<(String, ReplacesDialog)> {
+        for entry in self.calls.iter() {
+            let call = entry.value();
+            let matches = |leg: &Leg| {
+                leg.dialog.call_id == call_id
+                    && leg.dialog.local_tag == to_tag
+                    && leg.dialog.remote_tag.as_deref() == Some(from_tag)
+            };
+            let peer = if matches(&call.a_leg) {
+                call.winner.and_then(|index| call.b_legs.get(index))
+            } else if call.b_legs.iter().any(matches) {
+                Some(&call.a_leg)
+            } else {
+                continue;
+            }?;
+            return Some((
+                entry.key().clone(),
+                ReplacesDialog {
+                    call_id: peer.dialog.call_id.clone(),
+                    from_tag: peer.dialog.local_tag.clone(),
+                    to_tag: peer.dialog.remote_tag.clone()?,
+                },
+            ));
+        }
+        None
+    }
+
     /// Atomically increment the local CSeq counter on the A-leg or the
     /// winning B-leg and return the new value. Used when the B2BUA needs
     /// to originate an in-dialog request (PRACK, BYE, re-INVITE) and must
@@ -2108,6 +2185,60 @@ impl CallActorStore {
             .unwrap_or(false)
     }
 
+    /// Record that the referrer of an in-flight siphon-terminated transfer has
+    /// ended its dialog (sent BYE) before the dialed target resolved, and report
+    /// whether that was the case.
+    ///
+    /// `true` means the BYE closed the *referrer's* leg of a transfer that is
+    /// still running, so the call must NOT be torn down: the surviving party is
+    /// waiting to be bridged to the transfer target (RFC 5589 §7 — the
+    /// transferor is free to leave as soon as the REFER is accepted). Every
+    /// matching notifier subscription is flagged so the completion path skips
+    /// the terminating NOTIFY and the referrer BYE it can no longer deliver
+    /// (RFC 3515 §2.4.4 — the implicit subscription died with the dialog).
+    ///
+    /// `false` for every other BYE — a plain hangup, the surviving party's own
+    /// BYE, a transparent-mode transfer (siphon owns no subscription there), or
+    /// a transfer whose target already resolved — and those take the normal
+    /// teardown path unchanged.
+    ///
+    /// Idempotent: a retransmitted BYE re-flags an already-flagged subscription
+    /// and still reports `true`, so the retransmission is answered the same way
+    /// rather than falling through to a teardown.
+    pub fn mark_transfer_referrer_gone(&self, call_id: &str, on_a_leg: bool) -> bool {
+        let Some(mut call) = self.calls.get_mut(call_id) else {
+            return false;
+        };
+        let mut matched = false;
+        for subscription in call.refer_subscriptions.iter_mut() {
+            if subscription.siphon_notifies
+                && subscription.on_a_leg == on_a_leg
+                && subscription.target_leg_call_id.is_some()
+            {
+                subscription.referrer_gone = true;
+                matched = true;
+            }
+        }
+        matched
+    }
+
+    /// True when the referrer of the in-flight siphon-terminated transfer on
+    /// this leg has already left (see [`mark_transfer_referrer_gone`]).
+    ///
+    /// [`mark_transfer_referrer_gone`]: Self::mark_transfer_referrer_gone
+    pub fn transfer_referrer_gone(&self, call_id: &str, on_a_leg: bool) -> bool {
+        self.calls
+            .get(call_id)
+            .map(|call| {
+                call.refer_subscriptions.iter().any(|subscription| {
+                    subscription.siphon_notifies
+                        && subscription.on_a_leg == on_a_leg
+                        && subscription.referrer_gone
+                })
+            })
+            .unwrap_or(false)
+    }
+
     /// Drop any REFER subscriptions recorded on the given leg (e.g. on the
     /// terminating NOTIFY of a siphon-owned subscription).
     pub fn clear_refer_subscriptions_on_leg(&self, call_id: &str, on_a_leg: bool) {
@@ -2239,13 +2370,34 @@ impl CallActorStore {
                 _ => {}
             }
             let old_referrer = std::mem::replace(&mut call.a_leg, target);
+            drop(call);
+            self.retire_promoted_referrer(&old_referrer);
             Some(old_referrer)
         } else {
             let old_winner_idx = call.winner?;
             let old_referrer = call.b_legs.get(old_winner_idx).cloned()?;
             call.winner = Some(target_idx);
+            drop(call);
+            self.retire_promoted_referrer(&old_referrer);
             Some(old_referrer)
         }
+    }
+
+    /// Retire the dialog the transfer promoted away from.
+    ///
+    /// The referrer's leg leaves the call at promotion, so `remove_call` will
+    /// never see it at teardown — it only walks the legs still attached. Without
+    /// this its `Call-ID → call` registry entry outlives the call forever, and
+    /// the next INVITE that reuses that Call-ID matches the dispatcher's
+    /// "call already exists" guard and is silently absorbed as a retransmission:
+    /// the caller gets no response at all, not even a 100. Retiring it here also
+    /// makes a late in-dialog request on the retired dialog answer 481 rather
+    /// than resolving to a call that has moved on (RFC 3261 §12.2.2), which is
+    /// the same treatment every other torn-down leg gets.
+    fn retire_promoted_referrer(&self, referrer: &Leg) {
+        self.registry.remove_call_id(&referrer.dialog.call_id);
+        self.registry.remove_branch(&referrer.branch);
+        self.remember_terminated(&referrer.dialog.call_id);
     }
 
     /// Remove a call and clean up all registry entries.

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17056,6 +17056,40 @@ fn handle_b2bua_bye(
         }
     };
 
+    // The referrer of an in-flight siphon-terminated transfer hanging up is NOT
+    // the end of this call (RFC 5589 §7: the transferor is free to end its
+    // dialog as soon as the REFER is accepted — Microsoft Teams BYEs within a
+    // few hundred ms of the 202, long before the target answers). The surviving
+    // party is still up and is waiting to be bridged to the transfer target, so
+    // everything below — @b2bua.on_bye, the ACR-STOP/CDR close, the BYE
+    // generated at the far leg, the rtpengine teardown and `remove_call` —
+    // would destroy exactly the state the transfer needs to finish. Answer the
+    // BYE and keep the call.
+    //
+    // Left in place deliberately: the referrer's `Leg` stays on the actor until
+    // the target resolves, because `promote_transfer_target` swaps the target
+    // into its slot and the old anchor keyed on the A-leg Call-ID is what the
+    // media re-anchor reads. Only the subscription is flagged, which is what
+    // suppresses the NOTIFY + BYE aimed at a dialog that no longer exists.
+    if state.call_actors.mark_transfer_referrer_gone(&call_id, from_a_leg) {
+        let bye_response =
+            build_response(&message, 200, "OK", state.server_header.as_deref(), &[]);
+        send_message_from(
+            bye_response,
+            inbound.transport,
+            inbound.remote_addr,
+            inbound.connection_id,
+            Some(inbound.local_addr),
+            state,
+        );
+        info!(
+            call_id = %call_id,
+            referrer_on_a_leg = from_a_leg,
+            "B2BUA REFER (terminate): referrer hung up mid-transfer — call kept for the pending target"
+        );
+        return;
+    }
+
     // Extract the rest from the DashMap ref and drop it before entering Python
     let (a_leg_invite, a_leg_source_ip, a_leg_transport, a_leg_call_id, a_leg_flow) =
         match state.call_actors.get_call(&call_id) {
@@ -17718,6 +17752,65 @@ fn b2bua_terminate_call_inner(
     true
 }
 
+/// Tear down a call whose transfer collapsed after the referrer had already
+/// left, WITHOUT generating any further BYE.
+///
+/// The BYE-sending half of [`b2bua_terminate_call_inner`] is deliberately not
+/// reused here: that helper BYEs the A-leg and the winning B-leg unconditionally,
+/// and on this path one of those two is the referrer whose dialog is already
+/// terminated — an in-dialog BYE addressed to it would be answered 481 (RFC 3261
+/// §12.2.2). The caller has already released the one leg that is still up, so
+/// this is the cleanup tail only: accounting, media, recording, actor removal.
+fn b2bua_release_transferred_call(internal_call_id: &str, state: &DispatcherState) {
+    let Some(sip_call_id) = state
+        .call_actors
+        .get_call(internal_call_id)
+        .map(|call| call.a_leg.dialog.call_id.clone())
+    else {
+        return;
+    };
+
+    // Rf/Ro ACR-STOP (TS 32.299 §6.2.2) — framework-initiated teardown, so the
+    // Diameter "normal" cause, same as the session-timer path.
+    spawn_rf_b2bua_stop(state, internal_call_id, None);
+    spawn_ro_b2bua_stop(state, internal_call_id, None);
+
+    if crate::cdr::auto_emit_enabled() {
+        cdr_finalize(state, internal_call_id, "b2bua", None, None);
+    }
+
+    // Safety-net RTPEngine cleanup. Keyed on the A-leg Call-ID (the store key);
+    // a transfer that never completed leaves the pre-transfer anchor in place,
+    // and the fresh survivor↔target anchor offered in phase 1 is dropped by the
+    // engine's own timeout since the target never answered.
+    if let (Some(rtpengine_set), Some(media_sessions)) =
+        (&state.rtpengine_set, &state.rtpengine_sessions)
+    {
+        if let Some(session) = media_sessions.remove(&sip_call_id) {
+            let set = Arc::clone(rtpengine_set);
+            tokio::spawn(async move {
+                if let Err(error) = set.delete(session.rtpengine_id(), &session.from_tag).await {
+                    if error.is_call_not_found() {
+                        debug!(call_id = %session.call_id, "safety-net RTPEngine delete: call already gone ({error})");
+                    } else {
+                        warn!(call_id = %session.call_id, "safety-net RTPEngine delete failed: {error}");
+                    }
+                }
+            });
+        }
+    }
+
+    b2bua_stop_siprec(internal_call_id, state);
+    control_notify_terminated(&sip_call_id, "transfer_failed");
+
+    state
+        .call_actors
+        .set_state(internal_call_id, CallState::Terminated);
+    state.call_actors.remove_call(internal_call_id);
+    state.call_event_receivers.remove(internal_call_id);
+    schedule_zombie_reinvite_cleanup(&state.call_actors);
+}
+
 /// Emit a control-plane `StasisEnd` for a controlled call at teardown (no-op
 /// when the control plane isn't configured or the call isn't controlled).
 fn control_notify_terminated(sip_call_id: &str, reason: &str) {
@@ -18248,6 +18341,9 @@ fn b2bua_send_outbound_refer(
             notify_cseq: cseq,
             state: crate::b2bua::transfer::TransferState::Trying,
             target_leg_call_id: None,
+            // Subscriber role: siphon is the referrer here, so there is no
+            // remote referrer whose departure this could track.
+            referrer_gone: false,
         },
     );
     info!(
@@ -21422,6 +21518,55 @@ fn b2bua_refer_accept(
                 "B2BUA REFER: accepting (siphon-terminated) — 202 + NOTIFY 100 Trying"
             );
 
+            // Attended transfer (RFC 5589 §7): the INVITE siphon triggers towards
+            // the target MUST carry the `Replaces` naming the dialog it is to
+            // replace (RFC 3891 §3), otherwise the target treats it as an
+            // ordinary new call and the held call it was supposed to take over is
+            // left up — the referrer's second leg strands.
+            //
+            // The referrer named that dialog with the identifiers it can see. On
+            // a B2BUA those belong to the leg facing the referrer, and the target
+            // knows only the leg facing itself, so the triple is rewritten to the
+            // target's own view; a dialog siphon does not host is passed through
+            // untouched (best effort — it is not ours to translate).
+            let replaces_header = replaces.as_ref().map(|replaces| {
+                let translated = state
+                    .call_actors
+                    .replaces_as_seen_by_peer(
+                        &replaces.call_id,
+                        &replaces.from_tag,
+                        &replaces.to_tag,
+                    )
+                    // A `Replaces` pointing back at the very call carrying the
+                    // REFER would name the surviving party's own dialog: that is
+                    // not an attended transfer, and rewriting it would aim the
+                    // target at the leg it is meant to join. Leave it verbatim
+                    // and let the target reject it.
+                    .filter(|(replaced_call_id, _)| replaced_call_id != call_id);
+                match translated {
+                    Some((replaced_call_id, peer)) => {
+                        debug!(
+                            call_id = %call_id,
+                            replaced_call = %replaced_call_id,
+                            "B2BUA REFER (terminate): translated attended Replaces to the target's dialog view"
+                        );
+                        crate::sip::headers::refer::Replaces {
+                            call_id: peer.call_id,
+                            from_tag: peer.from_tag,
+                            to_tag: peer.to_tag,
+                            early_only: replaces.early_only,
+                        }
+                    }
+                    None => {
+                        debug!(
+                            call_id = %call_id,
+                            "B2BUA REFER (terminate): attended Replaces names a dialog this node does not host — forwarding verbatim"
+                        );
+                        replaces.clone()
+                    }
+                }
+            });
+
             // 202 Accepted to the referrer, on the flow the REFER arrived on,
             // followed by the first NOTIFY (sipfrag 100 Trying) opening the
             // implicit subscription.
@@ -21570,6 +21715,13 @@ fn b2bua_refer_accept(
                     None
                 }
             };
+            // Injected verbatim onto the triggered INVITE. `Replaces` is not a
+            // dialog-defining header for the dialog this INVITE creates — it
+            // references a *different* dialog — so it is safe in this slot.
+            let replaces_extra_headers: Vec<(String, String)> = replaces_header
+                .map(|replaces| vec![("Replaces".to_string(), replaces.to_string())])
+                .unwrap_or_default();
+
             let dialed = if let Some(template) = dial_template {
                 b2bua_send_b_leg_invite(
                     call_id,
@@ -21584,7 +21736,7 @@ fn b2bua_refer_accept(
                     None,
                     None,
                     None,
-                    &[],
+                    replaces_extra_headers.as_slice(),
                     state,
                 );
                 true
@@ -21611,6 +21763,7 @@ fn b2bua_refer_accept(
                     notify_cseq: refer_cseq,
                     state: crate::b2bua::transfer::TransferState::Trying,
                     target_leg_call_id,
+                    referrer_gone: false,
                 },
             );
         }
@@ -21633,17 +21786,23 @@ fn b2bua_complete_terminated_transfer(
     state: &DispatcherState,
 ) {
     // Snapshot the referrer side + the target (Z) leg before mutating.
-    let (referrer_on_a_leg, target_leg) = match state.call_actors.get_call(call_id) {
+    // `referrer_gone` is set when the referrer already BYE'd this call while the
+    // target was still ringing (see `mark_transfer_referrer_gone`): the transfer
+    // still completes, but there is no dialog left to NOTIFY or BYE.
+    let (referrer_on_a_leg, referrer_gone, target_leg) = match state.call_actors.get_call(call_id) {
         Some(call) => {
-            let Some(on_a_leg) = call
+            let Some(subscription) = call
                 .refer_subscriptions
                 .iter()
                 .find(|subscription| subscription.siphon_notifies)
-                .map(|subscription| subscription.on_a_leg)
             else {
                 return;
             };
-            (on_a_leg, call.b_legs.get(target_idx).cloned())
+            (
+                subscription.on_a_leg,
+                subscription.referrer_gone,
+                call.b_legs.get(target_idx).cloned(),
+            )
         }
         None => return,
     };
@@ -21752,11 +21911,20 @@ fn b2bua_complete_terminated_transfer(
     // Two separate sends do NOT order on UDP — the workers share the outbound
     // channel and each owns its own socket — so when both target the same flow
     // they travel as one unit (see `OutboundMessage::followups`).
+    //
+    // Both are skipped entirely when the referrer already left: its dialog is
+    // gone, so the NOTIFY would draw a 481 and the BYE would be addressed to a
+    // dialog that no longer exists (RFC 3515 §2.4.4).
     let mut referrer_messages: Vec<SipMessage> = Vec::new();
     let mut referrer_route: Option<(Transport, SocketAddr, ConnectionId, Option<SocketAddr>)> =
         None;
 
-    if let Some(cseq) = state.call_actors.reserve_leg_cseq(call_id, referrer_on_a_leg) {
+    let notify_cseq = if referrer_gone {
+        None
+    } else {
+        state.call_actors.reserve_leg_cseq(call_id, referrer_on_a_leg)
+    };
+    if let Some(cseq) = notify_cseq {
         if let Some(referrer_leg) = state.call_actors.clone_leg(call_id, referrer_on_a_leg) {
             let extra_headers = [
                 ("Event", "refer".to_string()),
@@ -21797,11 +21965,14 @@ fn b2bua_complete_terminated_transfer(
     }
 
     // Promote the target into the surviving pair, then BYE the referrer leg.
-    if let Some(referrer_leg) =
+    // The promotion runs either way — it is what makes the target the surviving
+    // party's peer, and is the whole point of the transfer. Only the BYE is
+    // conditional on there still being a referrer to receive it.
+    let promoted_referrer =
         state
             .call_actors
-            .promote_transfer_target(call_id, target_idx, referrer_on_a_leg)
-    {
+            .promote_transfer_target(call_id, target_idx, referrer_on_a_leg);
+    if let Some(referrer_leg) = promoted_referrer.filter(|_| !referrer_gone) {
         if let Some(bye) = build_b2bua_bye(&referrer_leg, state) {
             let (dest, transport) = resolve_in_dialog_destination(
                 &referrer_leg.dialog.route_set,
@@ -21927,7 +22098,8 @@ fn b2bua_complete_terminated_transfer(
     info!(
         call_id = %call_id,
         referrer_on_a_leg,
-        "B2BUA REFER (terminate): transfer completed — target active, referrer BYE'd"
+        referrer_gone,
+        "B2BUA REFER (terminate): transfer completed — target active, referrer released"
     );
 }
 
@@ -21941,14 +22113,50 @@ fn b2bua_fail_terminated_transfer(
     status_code: u16,
     state: &DispatcherState,
 ) {
-    let Some(referrer_on_a_leg) = state.call_actors.get_call(call_id).and_then(|call| {
-        call.refer_subscriptions
-            .iter()
-            .find(|subscription| subscription.siphon_notifies)
-            .map(|subscription| subscription.on_a_leg)
-    }) else {
+    let Some((referrer_on_a_leg, referrer_gone)) =
+        state.call_actors.get_call(call_id).and_then(|call| {
+            call.refer_subscriptions
+                .iter()
+                .find(|subscription| subscription.siphon_notifies)
+                .map(|subscription| (subscription.on_a_leg, subscription.referrer_gone))
+        })
+    else {
         return;
     };
+
+    // The referrer already hung up and the target it asked for is now refusing:
+    // nobody is left for the surviving party to talk to. Keeping the call would
+    // strand it on a dialog whose peer has gone and whose replacement never
+    // arrived, so release it and tear the call down. (When the referrer is still
+    // there the original call is intact and simply continues — the arm below.)
+    if referrer_gone {
+        let survivor_on_a_leg = !referrer_on_a_leg;
+        if let Some(survivor_leg) = state.call_actors.clone_leg(call_id, survivor_on_a_leg) {
+            if let Some(bye) = build_b2bua_bye(&survivor_leg, state) {
+                let (dest, transport) = resolve_in_dialog_destination(
+                    &survivor_leg.dialog.route_set,
+                    state,
+                    survivor_leg.transport.remote_addr,
+                    survivor_leg.transport.transport,
+                );
+                send_message_from(
+                    bye,
+                    transport,
+                    dest,
+                    survivor_leg.transport.connection_id,
+                    survivor_leg.transport.local_addr,
+                    state,
+                );
+            }
+        }
+        warn!(
+            call_id = %call_id,
+            status = status_code,
+            "B2BUA REFER (terminate): transfer target failed after the referrer left — releasing the orphaned surviving leg"
+        );
+        b2bua_release_transferred_call(call_id, state);
+        return;
+    }
 
     let failure = crate::b2bua::transfer::transfer_result_from_response(status_code);
     let (code, reason) = match &failure {

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -2181,6 +2181,7 @@ fn refer_subscription_push_query_clear() {
             notify_cseq: 4,
             state: TransferState::Trying,
             target_leg_call_id: None,
+            referrer_gone: false,
         },
     );
     assert!(store.has_subscriber_refer_subscription(&call_id, true));
@@ -2189,6 +2190,257 @@ fn refer_subscription_push_query_clear() {
 
     store.clear_refer_subscriptions_on_leg(&call_id, true);
     assert!(!store.has_subscriber_refer_subscription(&call_id, true));
+}
+
+#[test]
+fn promoting_the_transfer_target_retires_the_referrers_call_id() {
+    // The referrer's leg leaves the call at promotion, so the teardown never
+    // walks it. If its Call-ID stays in the registry, a later INVITE reusing
+    // that Call-ID matches the dispatcher's "call already exists" guard and is
+    // absorbed as a retransmission — the caller gets no response at all.
+    let store = CallActorStore::new();
+    let referrer_call_id = "referrer-dialog@test";
+    let call_id = store.create_call(make_a_leg(referrer_call_id));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.3:5060"));
+
+    assert_eq!(
+        store.find_by_sip_call_id(referrer_call_id).as_deref(),
+        Some(call_id.as_str()),
+        "the referrer's dialog resolves while the call is up"
+    );
+
+    // Target is at index 1; the referrer is the A-leg (the Teams shape).
+    let promoted = store.promote_transfer_target(&call_id, 1, true);
+    assert!(promoted.is_some(), "the target must be promoted");
+
+    assert!(
+        store.find_by_sip_call_id(referrer_call_id).is_none(),
+        "the promoted-away referrer's Call-ID must not resolve to the call any more"
+    );
+
+    // The call itself carries on, now fronted by the transfer target.
+    assert!(store.get_call(&call_id).is_some());
+}
+
+#[test]
+fn transfer_referrer_bye_is_recognised_and_flags_the_subscription() {
+    // The Teams blind-transfer shape: A REFERs, siphon dials the target, and A
+    // BYEs its own dialog ~300 ms later, long before the target answers. That
+    // BYE must be recognised as the referrer leaving a transfer that is still
+    // running (RFC 5589 §7) and NOT as the end of the call — the surviving
+    // party is still up, waiting to be bridged to the target.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("teams-refer@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+
+    let target = make_b_leg("10.0.0.3:5060");
+    let target_call_id = target.dialog.call_id.clone();
+    store.add_b_leg(&call_id, target);
+    store.push_refer_subscription(
+        &call_id,
+        ReferSubscription {
+            on_a_leg: true,
+            siphon_notifies: true,
+            event_id: 2,
+            notify_cseq: 2,
+            state: TransferState::Trying,
+            target_leg_call_id: Some(target_call_id),
+            referrer_gone: false,
+        },
+    );
+
+    assert!(!store.transfer_referrer_gone(&call_id, true));
+    assert!(store.mark_transfer_referrer_gone(&call_id, true));
+    assert!(store.transfer_referrer_gone(&call_id, true));
+
+    // The call itself survives — that is the whole point.
+    assert!(store.get_call(&call_id).is_some());
+}
+
+#[test]
+fn transfer_referrer_bye_is_idempotent_for_retransmissions() {
+    // A BYE is retransmitted to Timer F over UDP. The second one must be
+    // recognised the same way, or it would fall through to the normal teardown
+    // and kill the call the first one deliberately kept.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("retx@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+    let target = make_b_leg("10.0.0.3:5060");
+    let target_call_id = target.dialog.call_id.clone();
+    store.add_b_leg(&call_id, target);
+    store.push_refer_subscription(
+        &call_id,
+        ReferSubscription {
+            on_a_leg: true,
+            siphon_notifies: true,
+            event_id: 2,
+            notify_cseq: 2,
+            state: TransferState::Trying,
+            target_leg_call_id: Some(target_call_id),
+            referrer_gone: false,
+        },
+    );
+
+    assert!(store.mark_transfer_referrer_gone(&call_id, true));
+    assert!(store.mark_transfer_referrer_gone(&call_id, true));
+}
+
+#[test]
+fn plain_bye_is_not_mistaken_for_a_transfer_referrer_bye() {
+    // No transfer in flight: an ordinary hangup must take the normal teardown
+    // path, or every BYE would leak a call.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("plain@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+
+    assert!(!store.mark_transfer_referrer_gone(&call_id, true));
+    assert!(!store.mark_transfer_referrer_gone(&call_id, false));
+}
+
+#[test]
+fn surviving_party_bye_during_transfer_still_tears_the_call_down() {
+    // Only the REFERRER's departure is survivable. When the party that is being
+    // transferred hangs up instead, there is nothing left to hand to the target,
+    // so that BYE must take the ordinary teardown path.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("survivor-bye@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+    let target = make_b_leg("10.0.0.3:5060");
+    let target_call_id = target.dialog.call_id.clone();
+    store.add_b_leg(&call_id, target);
+    store.push_refer_subscription(
+        &call_id,
+        ReferSubscription {
+            on_a_leg: true,
+            siphon_notifies: true,
+            event_id: 2,
+            notify_cseq: 2,
+            state: TransferState::Trying,
+            target_leg_call_id: Some(target_call_id),
+            referrer_gone: false,
+        },
+    );
+
+    // Referrer is the A-leg, so a B-leg BYE is the survivor's.
+    assert!(!store.mark_transfer_referrer_gone(&call_id, false));
+}
+
+#[test]
+fn transparent_transfer_referrer_bye_is_a_normal_teardown() {
+    // Transparent mode owns no siphon subscription — the far leg runs the
+    // transfer itself — so the referrer hanging up genuinely ends this bridge.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("transparent@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+
+    assert!(!store.mark_transfer_referrer_gone(&call_id, true));
+}
+
+#[test]
+fn originated_refer_subscription_never_flags_referrer_gone() {
+    // The subscriber role is siphon's own outbound REFER: siphon IS the
+    // referrer, so there is no remote referrer to leave, and a BYE on that leg
+    // is a real hangup.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("originated@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+    store.push_refer_subscription(
+        &call_id,
+        ReferSubscription {
+            on_a_leg: true,
+            siphon_notifies: false,
+            event_id: 3,
+            notify_cseq: 3,
+            state: TransferState::Trying,
+            target_leg_call_id: None,
+            referrer_gone: false,
+        },
+    );
+
+    assert!(!store.mark_transfer_referrer_gone(&call_id, true));
+}
+
+#[test]
+fn attended_replaces_is_translated_to_the_targets_dialog_view() {
+    // RFC 3891 §3: the triggered INVITE names the dialog to replace with the
+    // identifiers the RECEIVING UAS knows. On a B2BUA the referrer names the
+    // leg facing itself, so the triple has to be rewritten to the far leg —
+    // forwarded verbatim it names a dialog the target has never seen and draws
+    // a 481.
+    let store = CallActorStore::new();
+
+    // The referrer's held call: A-leg faces the referrer, B-leg faces the target.
+    let mut held_a = make_a_leg("held-call@test");
+    held_a.dialog.local_tag = "siphon-to-referrer".to_string();
+    held_a.dialog.remote_tag = Some("referrer-tag".to_string());
+    let held_call = store.create_call(held_a);
+
+    let mut held_b = make_b_leg("10.0.0.9:5060");
+    held_b.dialog.call_id = "held-b-leg@test".to_string();
+    held_b.dialog.local_tag = "siphon-to-target".to_string();
+    held_b.dialog.remote_tag = Some("target-tag".to_string());
+    store.add_b_leg(&held_call, held_b);
+    store.set_winner(&held_call, 0);
+
+    // The referrer's view of that dialog: its own Call-ID, its tag as from-tag,
+    // siphon's tag as to-tag.
+    let (found_call, peer) = store
+        .replaces_as_seen_by_peer("held-call@test", "referrer-tag", "siphon-to-referrer")
+        .expect("dialog is hosted here, so it must resolve");
+
+    assert_eq!(found_call, held_call);
+    assert_eq!(peer.call_id, "held-b-leg@test");
+    // from-tag is siphon's tag on the leg facing the target...
+    assert_eq!(peer.from_tag, "siphon-to-target");
+    // ...and to-tag is the target's own.
+    assert_eq!(peer.to_tag, "target-tag");
+}
+
+#[test]
+fn attended_replaces_for_an_unknown_dialog_is_left_alone() {
+    // A referrer transferring against a call that never traversed this node:
+    // nothing to translate, so the caller forwards the triple verbatim.
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("unrelated@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+
+    assert!(store
+        .replaces_as_seen_by_peer("not-ours@elsewhere", "x", "y")
+        .is_none());
+}
+
+#[test]
+fn attended_replaces_resolves_from_the_b_leg_side_too() {
+    // The referrer may be the callee: then the leg facing it is a B-leg and the
+    // peer to name is the A-leg.
+    let store = CallActorStore::new();
+    let mut held_a = make_a_leg("held-from-b@test");
+    held_a.dialog.local_tag = "siphon-to-caller".to_string();
+    held_a.dialog.remote_tag = Some("caller-tag".to_string());
+    let held_call = store.create_call(held_a);
+
+    let mut held_b = make_b_leg("10.0.0.9:5060");
+    held_b.dialog.call_id = "b-side@test".to_string();
+    held_b.dialog.local_tag = "siphon-to-referrer".to_string();
+    held_b.dialog.remote_tag = Some("referrer-tag".to_string());
+    store.add_b_leg(&held_call, held_b);
+    store.set_winner(&held_call, 0);
+
+    let (_, peer) = store
+        .replaces_as_seen_by_peer("b-side@test", "referrer-tag", "siphon-to-referrer")
+        .expect("B-leg-facing referrer must resolve to the A-leg");
+    assert_eq!(peer.call_id, "held-from-b@test");
+    assert_eq!(peer.from_tag, "siphon-to-caller");
+    assert_eq!(peer.to_tag, "caller-tag");
 }
 
 #[test]
@@ -2207,6 +2459,7 @@ fn refer_notifier_subscription_is_not_a_subscriber_one() {
             notify_cseq: 2,
             state: TransferState::Trying,
             target_leg_call_id: None,
+            referrer_gone: false,
         },
     );
     assert!(!store.has_subscriber_refer_subscription(&call_id, true));


### PR DESCRIPTION
## The bug

In a siphon-terminated `REFER`, the transferor is entitled to end its own dialog
the moment the transfer is accepted (RFC 5589 §7), and real ones do — a Microsoft
Teams blind transfer BYEs a few hundred milliseconds after the `202`, roughly a
second before the transfer target answers.

That BYE was taken for an ordinary bridge hangup. `handle_b2bua_bye` had no
awareness of an in-flight transfer at all, so it ran the full teardown: a fresh
BYE generated at the far leg — the one party the transfer exists to keep — then
the rtpengine delete and `remove_call`. With the actor gone the target's `200 OK`
matched nothing and was never ACKed, so it retransmitted to Timer B.

Observed end to end: both parties dropped, and the transfer destination rang into
a call nobody was on.

```
REFER  / 202 + NOTIFY 100      →  transfer accepted, target INVITE sent
BYE    (referrer, +280 ms)     →  forwarded across the bridge, survivor killed
200 OK (target,   +1.2 s)      →  matches nothing, never ACKed, retransmits ×9
```

## What changed

**The referrer leaving mid-transfer is no longer the end of the call.** The BYE is
answered `200`, the surviving leg is kept, and the target is dialled through and
bridged as normal. The terminating sipfrag `NOTIFY` and the referrer `BYE` are
skipped, because the implicit subscription died with the dialog (RFC 3515 §2.4.4)
and a late NOTIFY would only draw a `481`.

`@b2bua.on_bye` deliberately does **not** fire for that BYE — the call is not
ending, so a handler that calls `call.terminate()` on every BYE can no longer undo
the transfer. If the target subsequently fails, the now-orphaned surviving leg is
released rather than stranded.

**Attended transfer emits the `Replaces` it was given.** It was parsed, used for a
log field, and then dropped, so every attended transfer silently degraded into a
blind one and the held call was never taken over (RFC 3891 §3). It is now carried
onto the triggered INVITE, and rewritten to the dialog *as the target sees it*
when siphon hosts the replaced call — the referrer names the leg facing itself,
whose identifiers mean nothing at the far end. A dialog siphon does not host
crosses unchanged.

**A completed transfer no longer strands the referrer's Call-ID.** Pre-existing,
and found while testing the above. `promote_transfer_target` drops the referrer's
leg without clearing its registry entry, and teardown only walks the legs still
attached — so the `Call-ID → call` mapping outlived the call permanently. A later
INVITE reusing that Call-ID matched the "call already exists" guard and was
absorbed as a retransmission: **no response at all, not even a `100`.** It never
bit before because the one promoting scenario was last on its container; it
surfaced immediately once two of them ran back to back.

## Proof

New SIPp profile `b2bua-refer-referrer-bye` — Alice REFERs then BYEs while Carol
holds `180` for 1.5 s, which is the production ordering. Verified in both
directions by disabling the guard:

| | with fix | fix disabled |
|---|---|---|
| Bob (survivor) | `INVITE → 200 → ACK → re-INVITE → BYE`, 1 successful | `Aborting call on an unexpected BYE` |
| Carol (target) | `200` ACKed, 0 retransmits | `200` ×3 retransmits, ACK never arrives |
| Alice (referrer) | 1 successful, 0 unexpected | — |

That is the reported failure reproduced exactly.

Also `b2bua-refer-attended`, where Carol asserts the `Replaces` on her INVITE with
`check_it`. Confirmed the assertion fails when pointed at a value that is not
there, so it is not a no-op.

Note the CI step for the referrer-BYE case grades **all three** legs rather than
using `--exit-code-from` on the UAC: the referrer completes its own scenario
cleanly even when the transfer is broken, so gating on it alone reports green over
both failures.

## Testing

- 3728 lib + 326 integration tests green; `clippy --all-targets --all-features -D warnings` clean
- All four pre-existing REFER scenarios (transparent, reject, terminate, outbound) still pass
- All four now run back-to-back against a single siphon, which they could not before the third fix
- SDK unaffected — no scripting-API surface change (642 SDK tests green)
