### PR TITLE
feat(transport): size the UDP listener receive buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`listen.udp_recv_buffer_bytes` — the UDP listener receive buffer is now
+  sized by siphon instead of inherited from the kernel.** Listener sockets set
+  `SO_REUSEPORT` and otherwise took whatever `net.core.rmem_default` gave them,
+  typically ~212 KB, which is only a few hundred milliseconds of headroom at
+  IMS registration rates. A scheduler stall on a busy box then overflows the
+  socket queue and the kernel drops the datagrams silently — which a UAC sees
+  as a retransmission rather than an error, so it shows up as a sharp cliff in
+  the retransmit rate rather than gradual degradation, and looks like a peer
+  problem rather than a local one. Defaults to 1 MiB per socket. Because
+  `SO_REUSEPORT` gives one socket per worker the real cost is this value times
+  the worker count, and socket buffers are charged to the cgroup, so it is
+  deliberately modest; set `0` to leave the kernel default alone. siphon now
+  reads the granted size back and warns when `net.core.rmem_max` clamped the
+  request, which is otherwise invisible.
 - **`originate` — a call siphon places itself.** Both the control-plane verb
   (`module: "sip"`, `verb: "originate"`) and the in-process
   `b2bua.originate(...)`. Until now a call could only ever be a *reaction*:

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -26,6 +26,19 @@ listen:
   # Set to 0 or "BE" (Best Effort) to disable marking.
   # Per-listener overrides are possible in the extended form (see below).
   dscp: CS3
+  # Receive buffer (SO_RCVBUF) in bytes for every UDP listener socket.
+  # Default: 1048576 (1 MiB).  The kernel default (net.core.rmem_default,
+  # typically ~212 KB) is only a few hundred milliseconds of headroom at IMS
+  # registration rates: a scheduler stall on a busy box overflows the socket
+  # queue and the kernel drops the datagrams silently.  A UAC sees that as a
+  # retransmission rather than an error, so it presents as a sharp cliff in the
+  # retransmit rate rather than gradual degradation.
+  # SO_REUSEPORT gives one socket per worker, so the real cost is this value
+  # times the worker count, and socket buffers are charged to the process's
+  # cgroup — raise it deliberately on a memory-capped deployment.
+  # net.core.rmem_max caps what the kernel will actually grant; siphon reads the
+  # value back and warns when it was clamped.  Set 0 to leave the kernel default.
+  udp_recv_buffer_bytes: 1048576
   # Path MTU (bytes) for the outbound UDP request path (RFC 3261 §18.1.1).
   # When set, an outbound SIP request built for UDP whose serialised length
   # exceeds mtu-200 is relayed over TCP instead (if the next hop has a reachable

--- a/src/config.rs
+++ b/src/config.rs
@@ -337,6 +337,16 @@ pub fn parse_dscp(value: &str) -> std::result::Result<u8, String> {
 }
 
 /// Convert a 6-bit DSCP value to the 8-bit TOS byte (RFC 2474 §3).
+/// Default UDP receive-buffer size: 1 MiB per listener socket.
+///
+/// Roughly 5x the usual kernel default, which is enough to ride out a
+/// scheduler stall at the throughput siphon targets, while staying small
+/// enough that `worker_count` sockets do not meaningfully dent a
+/// memory-capped container's cgroup budget.
+fn default_udp_recv_buffer_bytes() -> usize {
+    1024 * 1024
+}
+
 pub fn dscp_to_tos(dscp: u8) -> u32 {
     (dscp as u32) << 2
 }
@@ -447,6 +457,23 @@ pub struct ListenConfig {
     /// the inbound side is unaffected.
     #[serde(default)]
     pub mtu: Option<u16>,
+    /// Receive-buffer size in bytes (`SO_RCVBUF`) for every UDP listener
+    /// socket. Default 1 MiB.
+    ///
+    /// The kernel default (`net.core.rmem_default`, typically ~212 KB) is a
+    /// few hundred milliseconds of headroom at IMS registration rates, so a
+    /// scheduler stall on a busy box overflows the socket queue and the kernel
+    /// drops datagrams silently — which a UAC sees as a retransmit, not an
+    /// error, and which shows up as a sharp cliff rather than gradual
+    /// degradation. `SO_REUSEPORT` gives one socket per worker, so the real
+    /// cost is this value times the worker count.
+    ///
+    /// Socket buffers are charged to the process's cgroup, so raise this
+    /// deliberately on a memory-capped deployment. `net.core.rmem_max` caps
+    /// what the kernel will actually grant; siphon reads the value back and
+    /// warns when it was clamped. `0` leaves the kernel default in place.
+    #[serde(default = "default_udp_recv_buffer_bytes")]
+    pub udp_recv_buffer_bytes: usize,
     #[serde(default)]
     pub udp: Vec<ListenEntry>,
     #[serde(default)]
@@ -469,6 +496,7 @@ impl Default for ListenConfig {
         Self {
             dscp: default_dscp(),
             mtu: None,
+            udp_recv_buffer_bytes: default_udp_recv_buffer_bytes(),
             udp: Vec::new(),
             tcp: Vec::new(),
             tls: Vec::new(),
@@ -6840,6 +6868,43 @@ registrar:
         assert!(parse_dscp("INVALID").is_err());
         assert!(parse_dscp("CS8").is_err());
         assert!(parse_dscp("").is_err());
+    }
+
+    #[test]
+    fn udp_recv_buffer_defaults_and_overrides() {
+        // Absent → the 1 MiB default.
+        let config = Config::from_str(minimal_yaml()).unwrap();
+        assert_eq!(config.listen.udp_recv_buffer_bytes, 1024 * 1024);
+
+        // Explicit value wins.
+        let yaml = r#"
+listen:
+  udp_recv_buffer_bytes: 4194304
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert_eq!(config.listen.udp_recv_buffer_bytes, 4 * 1024 * 1024);
+
+        // 0 is the documented "leave the kernel default alone" escape hatch.
+        let yaml = r#"
+listen:
+  udp_recv_buffer_bytes: 0
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert_eq!(config.listen.udp_recv_buffer_bytes, 0);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1291,6 +1291,7 @@ impl SiphonServer {
         // DSCP → TOS byte resolution helper.
         // Per-entry overrides the global listen.dscp (default CS3 = 24 → TOS 96).
         let global_dscp = config.listen.dscp;
+        let udp_recv_buffer_bytes = config.listen.udp_recv_buffer_bytes;
         let resolve_tos = |entry: &config::ListenEntry| -> Option<u32> {
             let dscp = entry.dscp().or(global_dscp)?;
             if dscp == 0 { None } else { Some(config::dscp_to_tos(dscp)) }
@@ -1328,7 +1329,7 @@ impl SiphonServer {
                 .get(&addr)
                 .map(|(_, rx)| rx.clone())
                 .unwrap_or_else(|| flume::unbounded().1);
-            transport::udp::listen(addr, inbound_tx.clone(), listener_rx, Arc::clone(&transport_acl), tos).await;
+            transport::udp::listen(addr, inbound_tx.clone(), listener_rx, Arc::clone(&transport_acl), tos, udp_recv_buffer_bytes).await;
         }
 
         // RFC 5626 §4.4.1 pong tracker — created up front so it can be

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use bytes::BytesMut;
 use socket2::SockAddr;
 use tokio::net::UdpSocket;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::transport::{ConnectionId, InboundMessage, OutboundMessage, Transport};
 use crate::transport::acl::TransportAcl;
@@ -30,6 +30,7 @@ pub async fn listen(
     outbound_rx: flume::Receiver<OutboundMessage>,
     acl: Arc<TransportAcl>,
     tos: Option<u32>,
+    recv_buffer_bytes: usize,
 ) {
     let worker_count = num_cpus::get();
     info!("Starting {} UDP workers on {}", worker_count, local_addr);
@@ -40,7 +41,7 @@ pub async fn listen(
         let acl = Arc::clone(&acl);
 
         tokio::spawn(async move {
-            let socket = match create_reusable_udp_socket(local_addr, tos) {
+            let socket = match create_reusable_udp_socket(local_addr, tos, recv_buffer_bytes) {
                 Ok(socket) => Arc::new(socket),
                 Err(error) => {
                     error!("[udp-worker-{}] failed to create socket: {}", worker_index, error);
@@ -126,7 +127,11 @@ fn udp_connection_id(local: SocketAddr, remote: SocketAddr) -> ConnectionId {
     ConnectionId(hasher.finish())
 }
 
-fn create_reusable_udp_socket(local_addr: SocketAddr, tos: Option<u32>) -> std::io::Result<UdpSocket> {
+fn create_reusable_udp_socket(
+    local_addr: SocketAddr,
+    tos: Option<u32>,
+    recv_buffer_bytes: usize,
+) -> std::io::Result<UdpSocket> {
     let socket = match local_addr {
         SocketAddr::V4(_) => socket2::Socket::new(
             socket2::Domain::IPV4,
@@ -151,14 +156,96 @@ fn create_reusable_udp_socket(local_addr: SocketAddr, tos: Option<u32>) -> std::
         super::apply_tos(&socket2::SockRef::from(&socket), tos);
     }
 
+    apply_recv_buffer(&socket, local_addr, recv_buffer_bytes);
+
     socket.bind(&SockAddr::from(local_addr))?;
 
     UdpSocket::from_std(socket.into())
 }
 
+/// Request `SO_RCVBUF` and report what the kernel actually granted.
+///
+/// Best-effort: a listener that cannot get the buffer it asked for is still a
+/// working listener, so a failure here warns rather than aborting the bind.
+///
+/// Linux returns roughly double the requested size from `getsockopt` (the extra
+/// is bookkeeping overhead), so "at least what we asked for" is the honest
+/// check — anything less means `net.core.rmem_max` clamped us, which is the
+/// case worth telling an operator about, because the symptom otherwise is
+/// silent datagram drops that look like peer retransmissions.
+fn apply_recv_buffer(socket: &socket2::Socket, local_addr: SocketAddr, requested: usize) {
+    if requested == 0 {
+        return;
+    }
+    if let Err(error) = socket.set_recv_buffer_size(requested) {
+        warn!(
+            "[udp {}] could not set SO_RCVBUF to {} bytes: {} — continuing with the kernel default",
+            local_addr, requested, error
+        );
+        return;
+    }
+    match socket.recv_buffer_size() {
+        Ok(granted) if granted < requested => warn!(
+            "[udp {}] SO_RCVBUF clamped to {} bytes (asked for {}) — raise net.core.rmem_max, \
+             or inbound bursts will be dropped by the kernel and look like peer retransmissions",
+            local_addr, granted, requested
+        ),
+        Ok(granted) => debug!("[udp {}] SO_RCVBUF granted {} bytes", local_addr, granted),
+        Err(error) => debug!("[udp {}] could not read back SO_RCVBUF: {}", local_addr, error),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    /// A listener asks the kernel for the configured `SO_RCVBUF` and gets at
+    /// least that much. Linux reports back roughly double the request, so the
+    /// assertion is "no less than asked", which is exactly the condition
+    /// `apply_recv_buffer` warns about when `net.core.rmem_max` clamps it.
+    ///
+    /// Uses a modest size so the test passes under a conservative `rmem_max`.
+    #[tokio::test]
+    async fn listener_socket_honours_the_configured_recv_buffer() {
+        const REQUESTED: usize = 256 * 1024;
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr parses");
+        let socket = create_reusable_udp_socket(addr, None, REQUESTED)
+            .expect("listener socket binds");
+
+        let granted = socket2::SockRef::from(&socket)
+            .recv_buffer_size()
+            .expect("SO_RCVBUF reads back");
+        assert!(
+            granted >= REQUESTED,
+            "kernel granted {granted} B for a {REQUESTED} B request — if this fails on a \
+             developer box, net.core.rmem_max is set below the request"
+        );
+    }
+
+    /// `0` is the documented "leave the kernel default alone" escape hatch, so
+    /// it must not fail the bind and must not raise the buffer.
+    #[tokio::test]
+    async fn zero_recv_buffer_leaves_the_kernel_default() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr parses");
+
+        let defaulted = create_reusable_udp_socket(addr, None, 0).expect("binds with 0");
+        let default_size = socket2::SockRef::from(&defaulted)
+            .recv_buffer_size()
+            .expect("SO_RCVBUF reads back");
+
+        let raised = create_reusable_udp_socket(addr, None, 4 * 1024 * 1024)
+            .expect("binds with an explicit size");
+        let raised_size = socket2::SockRef::from(&raised)
+            .recv_buffer_size()
+            .expect("SO_RCVBUF reads back");
+
+        assert!(
+            raised_size > default_size,
+            "an explicit request ({raised_size} B) should exceed the untouched default \
+             ({default_size} B)"
+        );
+    }
+
     use bytes::Bytes;
 
     #[test]
@@ -251,6 +338,7 @@ mod tests {
             outbound_rx,
             Arc::new(TransportAcl::new(vec![], vec![])),
             None,
+            0,
         )
         .await;
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/tests/integration/transport_tests.rs
+++ b/tests/integration/transport_tests.rs
@@ -74,7 +74,7 @@ async fn udp_roundtrip() {
     let (inbound_tx, inbound_rx) = flume::unbounded();
     let (outbound_tx, outbound_rx) = flume::unbounded::<OutboundMessage>();
 
-    udp::listen(addr, inbound_tx, outbound_rx, test_acl(), None).await;
+    udp::listen(addr, inbound_tx, outbound_rx, test_acl(), None, 0).await;
     tokio::time::sleep(SETTLE).await;
 
     // Client: send OPTIONS
@@ -637,7 +637,7 @@ async fn multi_transport_shared_inbound_channel() {
         Arc::new(DashMap::new());
 
     // Start all three transports with the same inbound_tx
-    udp::listen(udp_addr, inbound_tx.clone(), udp_outbound_rx, test_acl(), None).await;
+    udp::listen(udp_addr, inbound_tx.clone(), udp_outbound_rx, test_acl(), None, 0).await;
     tcp::listen(tcp_addr, inbound_tx.clone(), tcp_outbound_rx, Arc::clone(&tcp_connection_map), test_acl(), None, None, None, None).await;
     ws::listen(ws_addr, inbound_tx.clone(), ws_outbound_rx, Arc::clone(&ws_connection_map), test_acl(), StreamConnections::new(), None, None).await;
     drop(inbound_tx); // Only transport workers hold clones now


### PR DESCRIPTION
## The gap

UDP listener sockets set `SO_REUSEPORT` and then took whatever the kernel gave
them for `SO_RCVBUF` — `net.core.rmem_default`, typically ~212 KB.

At IMS registration rates that is a few hundred milliseconds of headroom. A
scheduler stall on a busy box overflows the socket queue and the kernel drops
the datagrams silently. The UAC sees no error, only a missing response, so it
retransmits — which means the symptom is a **sharp cliff in the retransmit
rate** rather than gradual degradation, and it reads as a peer problem rather
than a local one. `netstat -su | grep RcvbufErrors` is the tell, and nothing in
siphon pointed at it.

## The change

`listen.udp_recv_buffer_bytes`, defaulting to **1 MiB** per listener socket.

The default is deliberately modest rather than generous: `SO_REUSEPORT` gives
one socket per worker, so the real cost is this value times the worker count,
and socket buffers are charged to the process's cgroup. On a memory-capped NF a
large default would be a regression, not a fix. `0` leaves the kernel default
alone.

siphon now also reads the granted size back and warns when `net.core.rmem_max`
clamped the request. `setsockopt` succeeds and silently gives you less, so
without the read-back an operator who sets 4 MiB has no way to learn they got
212 KB.

## Tests

- `listener_socket_honours_the_configured_recv_buffer` — a bound listener really
  gets at least what was asked for (Linux reports back roughly double the
  request; "no less than asked" is the honest assertion and is exactly the
  condition the clamp warning fires on)
- `zero_recv_buffer_leaves_the_kernel_default` — the escape hatch binds fine and
  an explicit request measurably exceeds the untouched default
- `udp_recv_buffer_defaults_and_overrides` — default, explicit value, and `0`

`cargo test` 4,123 pass / 0 fail. `cargo clippy --all-targets --all-features -- -D warnings` clean.
