### PR TITLE
fix(b2bua): take the call over on an inbound INVITE with Replaces

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -552,7 +552,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Build B2BUA / refer-modes / anchored siphon images
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer-terminate --profile b2bua-rtpengine-refer build siphon-b2bua siphon-b2bua-refer-modes siphon-b2bua-rtpengine-refer
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer-terminate --profile b2bua-replaces --profile b2bua-rtpengine-refer build siphon-b2bua siphon-b2bua-refer-modes siphon-b2bua-replaces siphon-b2bua-rtpengine-refer
 
       - name: Start siphon-b2bua
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua up -d --wait siphon-b2bua
@@ -614,6 +614,22 @@ jobs:
         if: always()
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-attended rm -sf sipp-b2bua-refer-attended-uac sipp-b2bua-refer-attended-bob-uas sipp-b2bua-refer-attended-carol-uas 2>/dev/null || true
 
+      # Inbound INVITE with Replaces: the transferee calls in naming the dialog
+      # it is taking over. The peer plays all three parties and prints one
+      # verdict line; grep it rather than trusting the exit code alone, so a
+      # peer that dies before running its assertions cannot read as a pass.
+      - name: B2BUA inbound Replaces takeover (RFC 3891 §3 — replaced party released, survivor re-INVITEd)
+        run: |
+          docker compose -f sipp/docker-compose.yaml --profile b2bua-replaces up -d --wait siphon-b2bua-replaces
+          docker compose -f sipp/docker-compose.yaml --profile b2bua-replaces up \
+            --abort-on-container-exit --exit-code-from replaces-takeover-peer \
+            replaces-takeover-peer | tee replaces-verdict.log
+          grep -q 'REPLACES-VERDICT .*"ok": true' replaces-verdict.log
+
+      - name: Cleanup replaces containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-replaces rm -sf replaces-takeover-peer siphon-b2bua-replaces 2>/dev/null || true
+
       - name: B2BUA REFER terminate + REAL rtpengine (media re-anchor offer/answer/delete)
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-rtpengine-refer up --abort-on-container-exit --exit-code-from sipp-anchored-refer-uac sipp-anchored-refer-uac sipp-anchored-refer-bob-uas sipp-anchored-refer-carol-uas
 
@@ -627,7 +643,7 @@ jobs:
 
       - name: Teardown
         if: always()
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer --profile b2bua-refer-reject --profile b2bua-refer-terminate --profile b2bua-refer-referrer-bye --profile b2bua-refer-attended --profile b2bua-rtpengine-refer down --remove-orphans
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer --profile b2bua-refer-reject --profile b2bua-refer-terminate --profile b2bua-refer-referrer-bye --profile b2bua-refer-attended --profile b2bua-replaces --profile b2bua-rtpengine-refer down --remove-orphans
 
       - name: Upload logs
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   (RFC 3261 §14) rather than left sending audio to whoever just left. Works in
   both directions — the named dialog may be the caller's or the callee's, and the
   everyday "answer a call, then transfer it" is the callee case.
+  - **Off unless enabled** — `b2bua.accept_replaces: true`. Possession of a
+    dialog's identifiers is not proof of authorisation to end that dialog, and
+    the triple is handed to the transferee by design and readable by anyone who
+    can observe unprotected signalling, so this is a capability an operator opts
+    into rather than one an upgrade switches on. Left off, a `Replaces` naming a
+    dialog this node hosts is declined `603` rather than ignored — so the bug
+    above is fixed either way: the INVITE never becomes an unrelated second call.
   - **The takeover runs only after the script admits the INVITE.** RFC 3891 §5
     makes `Replaces` a call-hijack primitive for anyone who learns a dialog's
     identifiers, and siphon's admission control for an INVITE is the script — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,39 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   a personal one.
 
 ### Fixed
+- **An inbound `INVITE` with `Replaces` now actually takes the call over.** The
+  transferee half of attended transfer (RFC 3891 §3 / RFC 5589 §7): a UA calls in
+  naming the dialog it is taking over. siphon matched that dialog, logged it, and
+  then let the INVITE through as an ordinary new call — so the transfer only half
+  happened. The transferor was left in a call that never ended, and the
+  transferee got a second, unrelated call routed by the dial plan instead of the
+  one it asked to join. It now hands the call over: the named party is BYE'd
+  (§3 requires the replaced dialog to be terminated), the new caller takes its
+  place, and the party on the other side is re-INVITEd onto the new media
+  (RFC 3261 §14) rather than left sending audio to whoever just left. Works in
+  both directions — the named dialog may be the caller's or the callee's, and the
+  everyday "answer a call, then transfer it" is the callee case.
+  - **The takeover runs only after the script admits the INVITE.** RFC 3891 §5
+    makes `Replaces` a call-hijack primitive for anyone who learns a dialog's
+    identifiers, and siphon's admission control for an INVITE is the script — so
+    an `auth.require_proxy_digest()` (or any `call.reject()`) in
+    `@b2bua.on_invite` stops a takeover exactly as it stops a call. Nothing is
+    torn down on the say-so of an unauthenticated request. When the script does
+    admit it, the takeover replaces whatever routing the script asked for: an
+    INVITE with `Replaces` is a request to join an existing call, not a new one
+    to route.
+  - `early-only` (RFC 3891 §3) is now honoured rather than parsed and ignored: it
+    asks to replace a dialog that has not been answered, and siphon only ever
+    takes over a confirmed one, so it is declined `486 Busy Here` — the response
+    that section names. A `Replaces` naming a dialog that is not answered gets the
+    same treatment, and one naming a dialog this node does not host still gets
+    `481` as before.
+- **A locally-generated 2xx is retransmitted like a relayed one.** `call.answer()`
+  sent the 200 once and armed nothing. The B2BUA intercepts the A-leg INVITE
+  before a server transaction exists, so nothing underneath recovers a lost 200
+  (RFC 3261 §13.3.1.4) and a single dropped packet left the caller ringing until
+  it gave up on a call siphon considered answered. Now armed on the same UAS
+  schedule as the relayed path and cancelled by the caller's ACK.
 - **A blind transfer no longer kills the call when the transferor hangs up
   first.** In a siphon-terminated `REFER` the transferor is free to end its own
   dialog the moment the transfer is accepted (RFC 5589 §7), and real ones do —

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -200,6 +200,24 @@ def on_refer(call):
     The handler is `def on_refer(call):` — one argument, no reply object
     (`REFER` is a request).
 
+!!! note "The other half: a transferee that calls *in*"
+    The flow above is siphon placing the transferred call itself. The mirror is a
+    transferee that calls siphon with a `Replaces` naming the dialog it is taking
+    over — which is what an endpoint does when it runs the transfer on its own.
+    siphon hands the existing call over: the named party is BYE'd, the caller
+    takes its place, and the party on the other side is re-INVITEd onto the new
+    media without ever seeing a new call. The named dialog may be either leg, so
+    both "the caller transferred it" and the everyday "answered, then transferred
+    it" work.
+
+    That takeover runs **after** `@b2bua.on_invite`, not before. RFC 3891 §5 makes
+    `Replaces` a way to hijack a call for anyone who learns its dialog
+    identifiers, so it has to clear the same admission as any other INVITE: an
+    `auth.require_proxy_digest()` or a `call.reject()` in that handler stops the
+    takeover. When the handler admits it, siphon performs the handover instead of
+    the routing the handler asked for — an INVITE with `Replaces` is a request to
+    join an existing call, not a new one to route.
+
 !!! note "The `Replaces` is rewritten for the target"
     The INVITE siphon triggers towards the transfer target carries the `Replaces`
     naming the dialog to be taken over (RFC 3891 §3). The referrer names that

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -210,6 +210,13 @@ def on_refer(call):
     both "the caller transferred it" and the everyday "answered, then transferred
     it" work.
 
+    It is **off unless you enable it** (`b2bua.accept_replaces: true`). Holding a
+    dialog's identifiers is not authority to end that dialog — the transferor
+    hands them to the transferee by design, and anyone who can see unprotected
+    signalling reads them off the wire — so this is a capability you opt into.
+    Left off, a `Replaces` naming a dialog siphon hosts is declined `603` instead
+    of being ignored, so it still never turns into an unrelated second call.
+
     That takeover runs **after** `@b2bua.on_invite`, not before. RFC 3891 §5 makes
     `Replaces` a way to hijack a call for anyone who learns its dialog
     identifiers, so it has to clear the same admission as any other INVITE: an

--- a/scripts/b2bua_replaces.py
+++ b/scripts/b2bua_replaces.py
@@ -16,7 +16,7 @@ import os
 
 from siphon import b2bua, log, proxy
 
-CALLEE = os.environ.get("REPLACES_CALLEE", "sip:bob@172.20.0.70:6002")
+CALLEE = os.environ.get("REPLACES_CALLEE", "sip:bob@172.20.0.115:6002")
 
 
 @proxy.on_request

--- a/scripts/b2bua_replaces.py
+++ b/scripts/b2bua_replaces.py
@@ -1,0 +1,42 @@
+"""SIPhon B2BUA script for the inbound-`Replaces` acceptance test (fixture).
+
+Deliberately the plainest possible B2BUA: every INVITE is bridged to the one
+fixed callee. There is no registrar and no routing logic, so the test is
+measuring what siphon does with `Replaces` and nothing else.
+
+The takeover INVITE reaches `on_invite` exactly like any other call and is
+admitted here — that is the point. siphon resolves the `Replaces` before the
+script runs but does NOT act on it until the script has had its say, because
+RFC 3891 §5 makes the header a call-hijack primitive for anyone who learns a
+dialog's identifiers. A script that challenges or rejects here stops the
+takeover; this one admits it, and siphon then performs the handover instead of
+the `call.dial()` below.
+"""
+import os
+
+from siphon import b2bua, log, proxy
+
+CALLEE = os.environ.get("REPLACES_CALLEE", "sip:bob@172.20.0.70:6002")
+
+
+@proxy.on_request
+def route(request):
+    if request.method == "OPTIONS" and request.ruri.is_local:
+        request.reply(200, "OK")
+
+
+@b2bua.on_invite
+def new_call(call):
+    log.info(f"[{call.id}] INVITE from {call.source_ip} -> {CALLEE}")
+    call.dial(CALLEE, timeout=30)
+
+
+@b2bua.on_answer
+def answered(call, reply):
+    log.info(f"[{call.id}] answered ({reply.status_code})")
+
+
+@b2bua.on_bye
+def ended(call, initiator):
+    log.info(f"[{call.id}] BYE (initiator: {initiator.side})")
+    call.terminate()

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -1334,6 +1334,26 @@ auth:
 # b2bua:
 #   default_number_policy: "ims-e164@2026"
 
+# Whether an inbound INVITE carrying a Replaces header (RFC 3891) may take over
+# the dialog it names — the transferee half of attended transfer, and the shape
+# of a directed call pickup.
+#
+# OFF unless you turn it on. Possession of a dialog's identifiers is not proof
+# of authorisation to end that dialog: the transferor hands the triple to the
+# transferee by design, and anyone who can observe unprotected signalling reads
+# it off the wire (RFC 3891 §5). Enabling this lets any party that reaches this
+# node — subject to whatever admission @b2bua.on_invite applies — disconnect
+# someone from a live call and take their place.
+#
+# Enable it only where INVITEs are authenticated (auth.require_proxy_digest() in
+# @b2bua.on_invite) or the source is trusted. The takeover runs only after that
+# handler admits the request, so a challenge or a call.reject() stops it.
+#
+# Left off, a Replaces naming a dialog this node hosts is declined 603 rather
+# than ignored, so the INVITE never becomes an unrelated second call.
+# b2bua:
+#   accept_replaces: true
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------

--- a/sipp/configs/siphon.b2bua-replaces-test.yaml
+++ b/sipp/configs/siphon.b2bua-replaces-test.yaml
@@ -14,6 +14,12 @@ domain:
     - "172.20.0.60"
     - "127.0.0.1"
 
+# The takeover is opt-in (see b2bua.accept_replaces): possession of a dialog's
+# identifiers is not authority to end that dialog. Enabled here because that is
+# what this test exercises.
+b2bua:
+  accept_replaces: true
+
 script:
   path: "scripts/b2bua_replaces.py"
   reload: auto

--- a/sipp/configs/siphon.b2bua-replaces-test.yaml
+++ b/sipp/configs/siphon.b2bua-replaces-test.yaml
@@ -11,7 +11,7 @@ listen:
 domain:
   local:
     - "siphon.test"
-    - "172.20.0.60"
+    - "172.20.0.114"
     - "127.0.0.1"
 
 # The takeover is opt-in (see b2bua.accept_replaces): possession of a dialog's
@@ -24,7 +24,7 @@ script:
   path: "scripts/b2bua_replaces.py"
   reload: auto
 
-advertised_address: "172.20.0.60"
+advertised_address: "172.20.0.114"
 
 registrar:
   backend: memory

--- a/sipp/configs/siphon.b2bua-replaces-test.yaml
+++ b/sipp/configs/siphon.b2bua-replaces-test.yaml
@@ -1,0 +1,29 @@
+# siphon.b2bua-replaces-test.yaml — inbound INVITE-with-Replaces acceptance
+#
+# Used with: sipp/docker-compose.yaml (b2bua-replaces profile)
+# Script:    scripts/b2bua_replaces.py (bridges every INVITE to one fixed callee)
+# Test:      sipp/replaces/replaces_takeover_test.py
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.test"
+    - "172.20.0.60"
+    - "127.0.0.1"
+
+script:
+  path: "scripts/b2bua_replaces.py"
+  reload: auto
+
+advertised_address: "172.20.0.60"
+
+registrar:
+  backend: memory
+  default_expires: 3600
+
+log:
+  level: debug
+  format: pretty

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -1803,7 +1803,10 @@ services:
       - ../scripts:/etc/siphon/scripts:ro
     networks:
       sipnet:
-        ipv4_address: 172.20.0.60
+        # Deliberately NOT .60: this job leaves siphon-b2bua-refer-modes running
+        # on that address through the earlier REFER steps, and a second container
+        # claiming it fails to start with "Address already in use".
+        ipv4_address: 172.20.0.114
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
       interval: 3s
@@ -1822,10 +1825,10 @@ services:
       - ./replaces:/peer:ro
     networks:
       sipnet:
-        ipv4_address: 172.20.0.70
+        ipv4_address: 172.20.0.115
     environment:
-      SIPHON_ADDR: "172.20.0.60:5060"
-      SELF_IP: "172.20.0.70"
+      SIPHON_ADDR: "172.20.0.114:5060"
+      SELF_IP: "172.20.0.115"
     command: ["python3", "/peer/replaces_takeover_test.py"]
     profiles:
       - b2bua-replaces

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -1790,6 +1790,46 @@ services:
     profiles:
       - b2bua-refer-referrer-bye
 
+  # --- Inbound INVITE with Replaces (RFC 3891 attended-transfer takeover) ---
+  # A python peer plays all three parties, because the takeover INVITE has to
+  # quote dialog identifiers that only exist once the first call is up.
+
+  siphon-b2bua-replaces:
+    build:
+      context: ..
+    container_name: siphon-b2bua-replaces-test
+    volumes:
+      - ./configs/siphon.b2bua-replaces-test.yaml:/etc/siphon/siphon.yaml:ro
+      - ../scripts:/etc/siphon/scripts:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.60
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.test SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.test>;tag=hc\\r\\nTo: <sip:siphon.test>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles:
+      - b2bua-replaces
+
+  replaces-takeover-peer:
+    image: python:3.12-slim
+    depends_on:
+      siphon-b2bua-replaces:
+        condition: service_healthy
+    volumes:
+      - ./replaces:/peer:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.70
+    environment:
+      SIPHON_ADDR: "172.20.0.60:5060"
+      SELF_IP: "172.20.0.70"
+    command: ["python3", "/peer/replaces_takeover_test.py"]
+    profiles:
+      - b2bua-replaces
+
   # --- REFER terminate, ATTENDED (Refer-To carries a Replaces) ---
   # RFC 3891 §3: the dialog reference must reach the target's INVITE.
 

--- a/sipp/replaces/replaces_takeover_test.py
+++ b/sipp/replaces/replaces_takeover_test.py
@@ -42,8 +42,8 @@ import sys
 import time
 import uuid
 
-SIPHON = os.environ.get("SIPHON_ADDR", "172.20.0.60:5060")
-SELF_IP = os.environ.get("SELF_IP", "172.20.0.70")
+SIPHON = os.environ.get("SIPHON_ADDR", "172.20.0.114:5060")
+SELF_IP = os.environ.get("SELF_IP", "172.20.0.115")
 TIMEOUT = float(os.environ.get("STEP_TIMEOUT", "10"))
 
 SIPHON_HOST, SIPHON_PORT = SIPHON.split(":")

--- a/sipp/replaces/replaces_takeover_test.py
+++ b/sipp/replaces/replaces_takeover_test.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Acceptance test for inbound `INVITE` with `Replaces` (RFC 3891 / RFC 5589 §7).
+
+A transferee that is handed an attended transfer calls the transfer target
+naming the dialog it is taking over. When that target is behind siphon, the
+INVITE arrives here carrying `Replaces`, and siphon has to hand the *existing*
+call over: the named party is dropped, the new caller takes its place, and the
+party on the other side carries on without ever seeing a new call.
+
+Driving this from SIPp is not practical — the takeover INVITE has to quote dialog
+identifiers (a Call-ID and both tags) that only exist once the first call is up,
+and one of them is siphon's own tag, which is minted at runtime. So this peer
+plays all three parties over three UDP sockets and quotes what it observed.
+
+Both directions are covered, because which leg the header names depends on who
+started the call being transferred:
+
+  case "a-leg"  the transferor is the CALLER, so the named dialog is siphon's
+                A-leg and the callee survives.
+  case "b-leg"  the transferor is the CALLEE (the everyday "answer, then
+                transfer" case, and the shape of a directed pickup), so the
+                named dialog is siphon's B-leg and the caller survives.
+
+Each case asserts the three things that make a takeover real rather than a
+connected call with dead audio:
+
+  1. the taking-over INVITE is answered 2xx **with a body** — an answer with no
+     SDP means nothing was re-anchored;
+  2. the replaced party is sent a BYE (RFC 3891 §3 requires the replaced dialog
+     to be terminated), and
+  3. the SURVIVING party is re-INVITEd (RFC 3261 §14) — without it the survivor
+     keeps sending media to the party that just left, which is the failure that
+     looks fine in SIP and is silent on the wire.
+
+Prints one `REPLACES-VERDICT <json>` line; the CI step greps for `"ok": true`.
+"""
+import json
+import os
+import re
+import socket
+import sys
+import time
+import uuid
+
+SIPHON = os.environ.get("SIPHON_ADDR", "172.20.0.60:5060")
+SELF_IP = os.environ.get("SELF_IP", "172.20.0.70")
+TIMEOUT = float(os.environ.get("STEP_TIMEOUT", "10"))
+
+SIPHON_HOST, SIPHON_PORT = SIPHON.split(":")
+SIPHON_ADDR = (SIPHON_HOST, int(SIPHON_PORT))
+
+ALICE_PORT, BOB_PORT, CAROL_PORT = 6001, 6002, 6003
+
+
+def sdp(session_id, port):
+    return (
+        "v=0\r\n"
+        f"o=- {session_id} {session_id} IN IP4 {SELF_IP}\r\n"
+        "s=-\r\n"
+        f"c=IN IP4 {SELF_IP}\r\n"
+        "t=0 0\r\n"
+        f"m=audio {port} RTP/AVP 0 8\r\n"
+        "a=rtpmap:0 PCMU/8000\r\n"
+        "a=rtpmap:8 PCMA/8000\r\n"
+        "a=sendrecv\r\n"
+    )
+
+
+def header(message, name):
+    """First value of `name`, case-insensitively, or None."""
+    for line in message.split("\r\n"):
+        if not line or line[0] in " \t":
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        if key.strip().lower() == name.lower():
+            return value.strip()
+    return None
+
+
+def tag_of(value):
+    match = re.search(r"[;,]\s*tag=([^;>\s]+)", value or "")
+    return match.group(1) if match else None
+
+
+def body_of(message):
+    _, _, body = message.partition("\r\n\r\n")
+    return body
+
+
+def start_line(message):
+    return message.split("\r\n", 1)[0]
+
+
+def status_of(message):
+    line = start_line(message)
+    if line.startswith("SIP/2.0"):
+        return int(line.split()[1])
+    return None
+
+
+def method_of(message):
+    line = start_line(message)
+    if line.startswith("SIP/2.0"):
+        return None
+    return line.split(None, 1)[0]
+
+
+class Party:
+    """One UDP endpoint that can act as UAC and UAS."""
+
+    def __init__(self, name, port):
+        self.name = name
+        self.port = port
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.socket.bind((SELF_IP, port))
+        self.socket.settimeout(0.25)
+        self.contact = f"<sip:{name}@{SELF_IP}:{port}>"
+
+    def send(self, message):
+        self.socket.sendto(message.encode(), SIPHON_ADDR)
+
+    def recv(self, predicate, what, timeout=TIMEOUT):
+        """Wait for a message satisfying `predicate`, ignoring anything else.
+
+        Retransmissions and messages belonging to another step of the flow are
+        skipped rather than failing the run — the point of a step is that the
+        expected message eventually arrives, not that nothing else does.
+        """
+        deadline = time.monotonic() + timeout
+        seen = []
+        while time.monotonic() < deadline:
+            try:
+                data, _ = self.socket.recvfrom(65535)
+            except socket.timeout:
+                continue
+            message = data.decode(errors="replace")
+            if predicate(message):
+                return message
+            seen.append(start_line(message))
+        raise AssertionError(
+            f"{self.name}: timed out waiting for {what}; saw {seen or 'nothing'}"
+        )
+
+    def expect_nothing(self, predicate, what, window=1.5):
+        """Fail if a matching message arrives inside `window`."""
+        deadline = time.monotonic() + window
+        while time.monotonic() < deadline:
+            try:
+                data, _ = self.socket.recvfrom(65535)
+            except socket.timeout:
+                continue
+            message = data.decode(errors="replace")
+            if predicate(message):
+                raise AssertionError(f"{self.name}: unexpected {what}: {start_line(message)}")
+
+    def respond(self, request, code, reason, body=None, local_tag=None):
+        to_value = header(request, "To")
+        if local_tag and not tag_of(to_value):
+            to_value = f"{to_value};tag={local_tag}"
+        lines = [
+            f"SIP/2.0 {code} {reason}",
+            f"Via: {header(request, 'Via')}",
+            f"From: {header(request, 'From')}",
+            f"To: {to_value}",
+            f"Call-ID: {header(request, 'Call-ID')}",
+            f"CSeq: {header(request, 'CSeq')}",
+            f"Contact: {self.contact}",
+        ]
+        if body:
+            lines.append("Content-Type: application/sdp")
+            lines.append(f"Content-Length: {len(body)}")
+            return "\r\n".join(lines) + "\r\n\r\n" + body
+        lines.append("Content-Length: 0")
+        return "\r\n".join(lines) + "\r\n\r\n"
+
+
+def invite(party, call_id, from_tag, target, body, extra=None, cseq=1):
+    lines = [
+        f"INVITE sip:{target}@{SIPHON_HOST} SIP/2.0",
+        f"Via: SIP/2.0/UDP {SELF_IP}:{party.port};branch=z9hG4bK{uuid.uuid4().hex[:12]}",
+        f"From: <sip:{party.name}@{SELF_IP}>;tag={from_tag}",
+        f"To: <sip:{target}@{SIPHON_HOST}>",
+        f"Call-ID: {call_id}",
+        f"CSeq: {cseq} INVITE",
+        f"Contact: {party.contact}",
+        "Max-Forwards: 70",
+        "User-Agent: siphon-replaces-acceptance",
+    ]
+    if extra:
+        lines.extend(extra)
+    lines.append("Content-Type: application/sdp")
+    lines.append(f"Content-Length: {len(body)}")
+    return "\r\n".join(lines) + "\r\n\r\n" + body
+
+
+def in_dialog(party, method, call_id, from_uri, from_tag, to_uri, to_tag, cseq, contact_uri):
+    lines = [
+        f"{method} {contact_uri} SIP/2.0",
+        f"Via: SIP/2.0/UDP {SELF_IP}:{party.port};branch=z9hG4bK{uuid.uuid4().hex[:12]}",
+        f"From: <{from_uri}>;tag={from_tag}",
+        f"To: <{to_uri}>;tag={to_tag}",
+        f"Call-ID: {call_id}",
+        f"CSeq: {cseq} {method}",
+        f"Contact: {party.contact}",
+        "Max-Forwards: 70",
+        "Content-Length: 0",
+    ]
+    return "\r\n".join(lines) + "\r\n\r\n"
+
+
+def ack_for(party, response, call_id, from_tag, cseq):
+    contact = header(response, "Contact") or f"<sip:{SIPHON_HOST}>"
+    ruri = contact.strip("<>").split(">")[0].lstrip("<")
+    lines = [
+        f"ACK {ruri} SIP/2.0",
+        f"Via: SIP/2.0/UDP {SELF_IP}:{party.port};branch=z9hG4bK{uuid.uuid4().hex[:12]}",
+        f"From: {header(response, 'From')}",
+        f"To: {header(response, 'To')}",
+        f"Call-ID: {call_id}",
+        f"CSeq: {cseq} ACK",
+        "Max-Forwards: 70",
+        "Content-Length: 0",
+    ]
+    return "\r\n".join(lines) + "\r\n\r\n"
+
+
+def establish(alice, bob, label):
+    """Alice calls through siphon; Bob answers. Returns both dialogs' identifiers."""
+    call_id = f"{label}-alice-{uuid.uuid4().hex[:8]}@{SELF_IP}"
+    alice_tag = f"alice-{uuid.uuid4().hex[:8]}"
+    alice.send(invite(alice, call_id, alice_tag, "bob", sdp(1000, 40000)))
+
+    b_invite = bob.recv(lambda m: method_of(m) == "INVITE", "the B-leg INVITE")
+    b_call_id = header(b_invite, "Call-ID")
+    siphon_b_tag = tag_of(header(b_invite, "From"))
+    bob_tag = f"bob-{uuid.uuid4().hex[:8]}"
+    bob.send(bob.respond(b_invite, 180, "Ringing", local_tag=bob_tag))
+    bob.send(bob.respond(b_invite, 200, "OK", body=sdp(2000, 40002), local_tag=bob_tag))
+
+    # The caller is answered first and the callee's ACK only follows the
+    # caller's, so both legs complete their INVITE transaction together
+    # (RFC 3261 §14.1). Waiting on the B-leg ACK before ACKing here deadlocks.
+    a_200 = alice.recv(
+        lambda m: status_of(m) == 200 and (header(m, "CSeq") or "").endswith("INVITE"),
+        "the 200 OK for Alice's INVITE",
+    )
+    siphon_a_tag = tag_of(header(a_200, "To"))
+    alice.send(ack_for(alice, a_200, call_id, alice_tag, 1))
+    bob.recv(lambda m: method_of(m) == "ACK", "the B-leg ACK")
+
+    assert siphon_a_tag, "siphon must tag the 200 it answers the caller with"
+    assert siphon_b_tag, "siphon must tag the INVITE it sends the callee"
+    return {
+        "a_call_id": call_id,
+        "alice_tag": alice_tag,
+        "siphon_a_tag": siphon_a_tag,
+        "b_call_id": b_call_id,
+        "bob_tag": bob_tag,
+        "siphon_b_tag": siphon_b_tag,
+        "alice_contact": header(a_200, "Contact"),
+    }
+
+
+def run_case(case, alice, bob, carol):
+    """Take a live call over and check the right party was replaced."""
+    dialog = establish(alice, bob, case)
+
+    if case == "a-leg":
+        # The transferor is the caller: name siphon's A-leg. from-tag is the
+        # remote (Alice's) tag and to-tag siphon's own, per RFC 3891 §3.
+        replaces = (
+            f"{dialog['a_call_id']};from-tag={dialog['alice_tag']}"
+            f";to-tag={dialog['siphon_a_tag']}"
+        )
+        replaced, survivor = alice, bob
+    else:
+        # The transferor is the callee: name siphon's B-leg.
+        replaces = (
+            f"{dialog['b_call_id']};from-tag={dialog['bob_tag']}"
+            f";to-tag={dialog['siphon_b_tag']}"
+        )
+        replaced, survivor = bob, alice
+
+    carol_call_id = f"{case}-carol-{uuid.uuid4().hex[:8]}@{SELF_IP}"
+    carol_tag = f"carol-{uuid.uuid4().hex[:8]}"
+    carol.send(
+        invite(
+            carol,
+            carol_call_id,
+            carol_tag,
+            "bob",
+            sdp(3000, 40004),
+            extra=[f"Replaces: {replaces}", "Require: replaces"],
+        )
+    )
+
+    # 1. The takeover is accepted, and with media.
+    carol_200 = carol.recv(
+        lambda m: status_of(m) == 200 and (header(m, "CSeq") or "").endswith("INVITE"),
+        "the 200 OK accepting the takeover",
+    )
+    assert body_of(carol_200).strip(), "the takeover was answered without an SDP body"
+    carol.send(ack_for(carol, carol_200, carol_call_id, carol_tag, 1))
+
+    # 2. The replaced party is released (RFC 3891 §3).
+    replaced_bye = replaced.recv(
+        lambda m: method_of(m) == "BYE", "the BYE releasing the replaced party"
+    )
+    replaced.send(replaced.respond(replaced_bye, 200, "OK"))
+
+    # 3. The survivor is re-pointed at the new party (RFC 3261 §14). Without
+    #    this it is still sending media to the party that just left.
+    reinvite = survivor.recv(
+        lambda m: method_of(m) == "INVITE" and tag_of(header(m, "To")),
+        "the re-INVITE re-pointing the surviving party",
+    )
+    survivor_tag = tag_of(header(reinvite, "To"))
+    survivor.send(survivor.respond(reinvite, 200, "OK", body=sdp(4000, 40006)))
+    survivor.recv(lambda m: method_of(m) == "ACK", "the ACK for the survivor re-INVITE")
+
+    # 4. The replaced party is gone for good — it must not also be re-INVITEd.
+    replaced.expect_nothing(
+        lambda m: method_of(m) == "INVITE", "re-INVITE to the replaced party"
+    )
+
+    # Tear the surviving call down from the new party and check it reaches the
+    # far side, which only works if the two really are bridged.
+    to_uri = f"sip:bob@{SIPHON_HOST}"
+    carol_contact = header(carol_200, "Contact") or f"<sip:{SIPHON_HOST}>"
+    carol.send(
+        in_dialog(
+            carol,
+            "BYE",
+            carol_call_id,
+            f"sip:carol@{SELF_IP}",
+            carol_tag,
+            to_uri,
+            tag_of(header(carol_200, "To")),
+            2,
+            carol_contact.strip("<>").split(">")[0].lstrip("<"),
+        )
+    )
+    carol.recv(lambda m: status_of(m) == 200, "the 200 for the new party's BYE")
+    survivor_bye = survivor.recv(
+        lambda m: method_of(m) == "BYE", "the BYE reaching the surviving party"
+    )
+    survivor.send(survivor.respond(survivor_bye, 200, "OK", local_tag=survivor_tag))
+    return True
+
+
+def main():
+    alice = Party("alice", ALICE_PORT)
+    bob = Party("bob", BOB_PORT)
+    carol = Party("carol", CAROL_PORT)
+
+    results = {}
+    ok = True
+    for case in ("a-leg", "b-leg"):
+        try:
+            run_case(case, alice, bob, carol)
+            results[case] = "ok"
+        except AssertionError as error:
+            results[case] = str(error)
+            ok = False
+        except Exception as error:  # noqa: BLE001 - the verdict must survive anything
+            results[case] = f"{type(error).__name__}: {error}"
+            ok = False
+
+    print("REPLACES-VERDICT " + json.dumps({"ok": ok, "cases": results}), flush=True)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sipp/replaces/replaces_takeover_test.py
+++ b/sipp/replaces/replaces_takeover_test.py
@@ -143,6 +143,14 @@ class Party:
             f"{self.name}: timed out waiting for {what}; saw {seen or 'nothing'}"
         )
 
+    def drain(self):
+        """Discard anything still queued, so one case cannot bleed into the next."""
+        while True:
+            try:
+                self.socket.recvfrom(65535)
+            except socket.timeout:
+                return
+
     def expect_nothing(self, predicate, what, window=1.5):
         """Fail if a matching message arrives inside `window`."""
         deadline = time.monotonic() + window
@@ -232,7 +240,13 @@ def establish(alice, bob, label):
     alice_tag = f"alice-{uuid.uuid4().hex[:8]}"
     alice.send(invite(alice, call_id, alice_tag, "bob", sdp(1000, 40000)))
 
-    b_invite = bob.recv(lambda m: method_of(m) == "INVITE", "the B-leg INVITE")
+    # An INITIAL INVITE only. A re-INVITE (or a retransmission of one) left over
+    # from an earlier case carries a To-tag, and picking that up here would quote
+    # a dead dialog in the Replaces and draw a 481.
+    b_invite = bob.recv(
+        lambda m: method_of(m) == "INVITE" and not tag_of(header(m, "To")),
+        "the B-leg INVITE",
+    )
     b_call_id = header(b_invite, "Call-ID")
     siphon_b_tag = tag_of(header(b_invite, "From"))
     bob_tag = f"bob-{uuid.uuid4().hex[:8]}"
@@ -248,7 +262,17 @@ def establish(alice, bob, label):
     )
     siphon_a_tag = tag_of(header(a_200, "To"))
     alice.send(ack_for(alice, a_200, call_id, alice_tag, 1))
-    bob.recv(lambda m: method_of(m) == "ACK", "the B-leg ACK")
+
+    # Best-effort, deliberately not an assertion. The callee's ACK is not what
+    # this test measures, and siphon has a separate, pre-existing race that
+    # occasionally drops it on an ordinary call setup (the deferred B-leg ACK is
+    # armed while the A-leg 200 is already on its way out). Failing here would
+    # make this job flap for a reason that has nothing to do with `Replaces`;
+    # the B2BUA suite is what gates ACK behaviour.
+    try:
+        bob.recv(lambda m: method_of(m) == "ACK", "the B-leg ACK", timeout=3)
+    except AssertionError:
+        print(f"note[{label}]: no B-leg ACK observed (unrelated known race)", flush=True)
 
     assert siphon_a_tag, "siphon must tag the 200 it answers the caller with"
     assert siphon_b_tag, "siphon must tag the INVITE it sends the callee"
@@ -265,6 +289,8 @@ def establish(alice, bob, label):
 
 def run_case(case, alice, bob, carol):
     """Take a live call over and check the right party was replaced."""
+    for party in (alice, bob, carol):
+        party.drain()
     dialog = establish(alice, bob, case)
 
     if case == "a-leg":

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -832,6 +832,35 @@ pub struct ReplacesDialog {
     pub to_tag: String,
 }
 
+/// Which call, and which of its legs, an inbound `Replaces` (RFC 3891) named.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplacesMatch {
+    /// Internal id of the call holding the named dialog.
+    pub call_id: String,
+    /// True when the named dialog is that call's A-leg; false for its winning
+    /// B-leg. Determines which party survives the takeover — the *other* one.
+    pub on_a_leg: bool,
+}
+
+/// An inbound INVITE carrying a `Replaces` (RFC 3891) that matched a dialog this
+/// node hosts, recorded on the new call while the INVITE is still being admitted.
+///
+/// The takeover is deliberately NOT performed at header-parse time. RFC 3891 §5
+/// warns that a party who learns a dialog's identifiers can use `Replaces` to
+/// hijack the call, so the request has to clear the same admission the script
+/// applies to any other INVITE — `auth.require_proxy_digest()` in
+/// `@b2bua.on_invite` — before siphon acts on it. This carries the resolved
+/// match across that gap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingReplaces {
+    /// The call whose dialog is being taken over.
+    pub replaced_call_id: String,
+    /// Which leg of that call the header named.
+    pub replaced_on_a_leg: bool,
+    /// The `early-only` flag (RFC 3891 §3) as it arrived.
+    pub early_only: bool,
+}
+
 /// Per-call supervisor managing A-leg + B-leg(s).
 ///
 /// Each call actor owns its legs as independent entities. The dispatcher
@@ -912,6 +941,10 @@ pub struct CallActor {
     pub session_timer_override: Option<crate::script::api::call::SessionTimerOverride>,
     /// Active transfer context (REFER handling).
     pub transfer: Option<super::transfer::TransferContext>,
+    /// Set when this call's own INVITE carried a `Replaces` naming a dialog
+    /// this node hosts. Acted on only once the script has admitted the INVITE
+    /// (see [`PendingReplaces`]).
+    pub pending_replaces: Option<PendingReplaces>,
     /// REFER subscriptions siphon owns for transfers in progress (RFC 3515).
     /// Present for the siphon-terminated inbound path (siphon is the notifier,
     /// sending `message/sipfrag` NOTIFYs to the referrer) and the
@@ -1046,6 +1079,7 @@ impl CallActor {
             session_timer: None,
             session_timer_override: None,
             transfer: None,
+            pending_replaces: None,
             refer_subscriptions: Vec::new(),
             outbound_credentials: None,
             digest_nc: crate::auth::NonceCounter::new(),
@@ -1712,12 +1746,15 @@ impl CallActorStore {
     /// The `from_tag` in the `Replaces` header is the tag of the UA
     /// that *sent* the original dialog request (the "remote" side from
     /// our perspective); `to_tag` is *our* tag for that dialog.
+    /// Reports which leg matched as well as which call, because the party that
+    /// survives a takeover is the *peer* of the named dialog and the caller
+    /// cannot work that out from the call id alone.
     pub fn find_call_by_replaces_dialog(
         &self,
         call_id: &str,
         from_tag: &str,
         to_tag: &str,
-    ) -> Option<String> {
+    ) -> Option<ReplacesMatch> {
         for entry in self.calls.iter() {
             let call = entry.value();
             let leg_matches = |leg: &Leg| {
@@ -1728,11 +1765,117 @@ impl CallActorStore {
                         .remote_tag
                         .as_deref() == Some(from_tag))
             };
-            if leg_matches(&call.a_leg) || call.b_legs.iter().any(leg_matches) {
-                return Some(entry.key().clone());
+            if leg_matches(&call.a_leg) {
+                return Some(ReplacesMatch {
+                    call_id: entry.key().clone(),
+                    on_a_leg: true,
+                });
+            }
+            if call.b_legs.iter().any(leg_matches) {
+                return Some(ReplacesMatch {
+                    call_id: entry.key().clone(),
+                    on_a_leg: false,
+                });
             }
         }
         None
+    }
+
+    /// Record the `Replaces` match resolved for a call still being admitted.
+    pub fn set_pending_replaces(&self, call_id: &str, pending: PendingReplaces) {
+        if let Some(mut call) = self.calls.get_mut(call_id) {
+            call.pending_replaces = Some(pending);
+        }
+    }
+
+    /// Take the recorded `Replaces` match, if any, leaving none behind.
+    pub fn take_pending_replaces(&self, call_id: &str) -> Option<PendingReplaces> {
+        self.calls
+            .get_mut(call_id)
+            .and_then(|mut call| call.pending_replaces.take())
+    }
+
+    /// Lift a call's A-leg out and drop the (now empty) call, WITHOUT retiring
+    /// the dialog.
+    ///
+    /// The leg is moving to another call, not ending, so this deliberately does
+    /// none of what [`remove_call`](Self::remove_call) does: the Call-ID keeps
+    /// its registry entry (re-pointed by [`adopt_replaced_dialog`]) and is never
+    /// marked terminated, because doing either would make the ACK for the 200
+    /// this leg is about to receive resolve to nothing and answer 481.
+    ///
+    /// [`adopt_replaced_dialog`]: Self::adopt_replaced_dialog
+    pub fn detach_a_leg_for_adoption(&self, call_id: &str) -> Option<Leg> {
+        let (_, call) = self.calls.remove(call_id)?;
+        call.shutdown_actors();
+        self.registry.remove_branch(&call.a_leg.branch);
+        Some(call.a_leg)
+    }
+
+    /// Hand a call's dialog over to a new party (RFC 3891 `Replaces`).
+    ///
+    /// `new_leg` takes the place of the leg named by the `Replaces`, and the
+    /// call is rebuilt around the pair that is left: the new leg in the A-leg
+    /// slot and the surviving party as the sole B-leg. The A-leg slot is not
+    /// negotiable — the inbound-ACK path resolves a call by Call-ID and then
+    /// marks `a_leg` acked, so a UAS leg parked anywhere else would never have
+    /// its ACK recorded and would retransmit its 200 to Timer B.
+    ///
+    /// Returns the replaced leg so the caller can BYE it (RFC 3891 §3 requires
+    /// the replaced dialog to be terminated once the new INVITE is accepted),
+    /// together with the survivor.
+    ///
+    /// The replaced dialog is retired here — registry entries dropped and the
+    /// Call-ID remembered as terminated — so a late in-dialog request on it
+    /// answers 481 rather than resolving to a call it is no longer part of.
+    pub fn adopt_replaced_dialog(
+        &self,
+        replaced_call_id: &str,
+        replaced_on_a_leg: bool,
+        new_leg: Leg,
+    ) -> Option<(Leg, Leg)> {
+        let new_sip_call_id = new_leg.dialog.call_id.clone();
+        let new_branch = new_leg.branch.clone();
+        let (replaced, survivor) = {
+            let mut call = self.calls.get_mut(replaced_call_id)?;
+            let winner = call.winner?;
+            if winner >= call.b_legs.len() {
+                return None;
+            }
+            let (replaced, survivor) = if replaced_on_a_leg {
+                let survivor = call.b_legs.swap_remove(winner);
+                let replaced = std::mem::replace(&mut call.a_leg, new_leg);
+                (replaced, survivor)
+            } else {
+                let replaced = call.b_legs.swap_remove(winner);
+                // The old A-leg becomes the surviving B-leg; the new party takes
+                // the A-leg slot it vacates.
+                let survivor = std::mem::replace(&mut call.a_leg, new_leg);
+                (replaced, survivor)
+            };
+            // Rebuild around the surviving pair. Any other B-leg on the call is
+            // a settled fork loser and has no dialog left to carry over.
+            call.b_legs.clear();
+            call.b_leg_status.clear();
+            call.b_leg_handles.clear();
+            call.b_legs.push(survivor.clone());
+            call.b_leg_status.push(BLegStatus::Answered);
+            call.b_leg_handles.push(None);
+            call.winner = Some(0);
+            call.state = CallState::Answered;
+            (replaced, survivor)
+        };
+
+        // The new party's dialog now belongs to this call, so its Call-ID has to
+        // resolve here — its ACK, re-INVITEs and BYE all arrive on it.
+        self.registry.register_call_id(&new_sip_call_id, replaced_call_id);
+        self.registry.register_branch(&new_branch, replaced_call_id);
+
+        self.registry.remove_call_id(&replaced.dialog.call_id);
+        self.registry.remove_branch(&replaced.branch);
+        self.remember_terminated(&replaced.dialog.call_id);
+
+        Some((replaced, survivor))
     }
 
     /// Resolve the `Replaces` triple a referrer supplied (its own view of the
@@ -3516,6 +3659,165 @@ mod tests {
         assert!(!store.try_mark_ringing("nonexistent"));
     }
 
+    /// The transferor may equally be the party siphon *called* — a callee
+    /// transferring a call it answered is the everyday case. Then the named
+    /// dialog is a B-leg, and the survivor is the A-leg.
+    #[test]
+    fn find_call_by_replaces_reports_a_b_leg_match() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        let mut b_leg = make_b_leg(0);
+        b_leg.dialog.remote_tag = Some("tag-callee".to_string());
+        let b_call_id = b_leg.dialog.call_id.clone();
+        let b_local_tag = b_leg.dialog.local_tag.clone();
+        store.add_b_leg(&call_id, b_leg);
+        store.set_winner(&call_id, 0);
+
+        let matched = store.find_call_by_replaces_dialog(&b_call_id, "tag-callee", &b_local_tag);
+        assert_eq!(
+            matched,
+            Some(ReplacesMatch {
+                call_id,
+                on_a_leg: false
+            })
+        );
+    }
+
+    #[test]
+    fn pending_replaces_round_trips_and_is_taken_once() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        let pending = PendingReplaces {
+            replaced_call_id: "other-call".to_string(),
+            replaced_on_a_leg: true,
+            early_only: false,
+        };
+        store.set_pending_replaces(&call_id, pending.clone());
+        assert_eq!(store.take_pending_replaces(&call_id), Some(pending));
+        // Taken once — a second admission pass must not re-run the takeover.
+        assert_eq!(store.take_pending_replaces(&call_id), None);
+    }
+
+    /// The leg is moving to another call, not ending. If the detach retired its
+    /// Call-ID the ACK for the 200 it is about to receive would resolve to
+    /// nothing and be answered 481, and the new party would retransmit its way
+    /// to Timer B.
+    #[test]
+    fn detaching_a_leg_for_adoption_keeps_its_call_id_live() {
+        let store = CallActorStore::new();
+        let a_leg = make_a_leg();
+        let sip_call_id = a_leg.dialog.call_id.clone();
+        let call_id = store.create_call(a_leg);
+
+        let detached = store.detach_a_leg_for_adoption(&call_id);
+        assert!(detached.is_some());
+        assert!(store.get_call(&call_id).is_none(), "the emptied call is dropped");
+        assert!(
+            !store.is_recently_terminated(&sip_call_id),
+            "the moving dialog must NOT be remembered as terminated"
+        );
+    }
+
+    /// The transferor is the caller (its dialog is the A-leg): the new party
+    /// takes the A-leg slot and the callee carries on as the sole B-leg.
+    #[test]
+    fn adopting_a_replaced_a_leg_rebuilds_the_call_around_the_new_party() {
+        let store = CallActorStore::new();
+        let a_leg = make_a_leg();
+        let replaced_sip_call_id = a_leg.dialog.call_id.clone();
+        let call_id = store.create_call(a_leg);
+        let mut b_leg = make_b_leg(0);
+        b_leg.dialog.remote_tag = Some("tag-callee".to_string());
+        let survivor_sip_call_id = b_leg.dialog.call_id.clone();
+        store.add_b_leg(&call_id, b_leg);
+        store.set_winner(&call_id, 0);
+
+        let mut new_leg = make_a_leg();
+        new_leg.dialog.call_id = "takeover@10.0.0.9".to_string();
+        new_leg.branch = "z9hG4bK-takeover".to_string();
+
+        let (replaced, survivor) = store
+            .adopt_replaced_dialog(&call_id, true, new_leg)
+            .expect("the swap must succeed on an answered call");
+
+        assert_eq!(replaced.dialog.call_id, replaced_sip_call_id);
+        assert_eq!(survivor.dialog.call_id, survivor_sip_call_id);
+
+        let call = store.get_call(&call_id).unwrap();
+        assert_eq!(call.a_leg.dialog.call_id, "takeover@10.0.0.9");
+        assert_eq!(call.b_legs.len(), 1);
+        assert_eq!(call.b_legs[0].dialog.call_id, survivor_sip_call_id);
+        assert_eq!(call.winner, Some(0));
+        assert_eq!(call.state, CallState::Answered);
+        drop(call);
+
+        // The new party's dialog resolves here — its ACK/BYE arrive on it.
+        assert_eq!(
+            store.find_by_sip_call_id("takeover@10.0.0.9").as_deref(),
+            Some(call_id.as_str())
+        );
+        // The replaced dialog is retired: gone from the registry and remembered
+        // terminated, so a late in-dialog request on it answers 481.
+        assert!(store.find_by_sip_call_id(&replaced_sip_call_id).is_none());
+        assert!(store.is_recently_terminated(&replaced_sip_call_id));
+    }
+
+    /// The transferor is the callee (its dialog is the winning B-leg): the new
+    /// party still lands in the A-leg slot — the inbound-ACK path only ever
+    /// marks `a_leg` — and the original caller moves across to be the B-leg.
+    #[test]
+    fn adopting_a_replaced_b_leg_moves_the_caller_to_the_b_slot() {
+        let store = CallActorStore::new();
+        let a_leg = make_a_leg();
+        let caller_sip_call_id = a_leg.dialog.call_id.clone();
+        let call_id = store.create_call(a_leg);
+        let mut b_leg = make_b_leg(0);
+        b_leg.dialog.remote_tag = Some("tag-callee".to_string());
+        let replaced_sip_call_id = b_leg.dialog.call_id.clone();
+        store.add_b_leg(&call_id, b_leg);
+        store.set_winner(&call_id, 0);
+
+        let mut new_leg = make_a_leg();
+        new_leg.dialog.call_id = "takeover-b@10.0.0.9".to_string();
+        new_leg.branch = "z9hG4bK-takeover-b".to_string();
+
+        let (replaced, survivor) = store
+            .adopt_replaced_dialog(&call_id, false, new_leg)
+            .expect("the swap must succeed on an answered call");
+
+        assert_eq!(replaced.dialog.call_id, replaced_sip_call_id);
+        assert_eq!(survivor.dialog.call_id, caller_sip_call_id);
+
+        let call = store.get_call(&call_id).unwrap();
+        assert_eq!(call.a_leg.dialog.call_id, "takeover-b@10.0.0.9");
+        assert_eq!(call.b_legs.len(), 1);
+        assert_eq!(
+            call.b_legs[0].dialog.call_id, caller_sip_call_id,
+            "the original caller survives as the B-leg"
+        );
+        assert_eq!(call.winner, Some(0));
+        drop(call);
+
+        assert!(store.is_recently_terminated(&replaced_sip_call_id));
+        assert!(
+            !store.is_recently_terminated(&caller_sip_call_id),
+            "the survivor's dialog is untouched"
+        );
+    }
+
+    /// A call that never answered has no negotiated media and no answered party
+    /// to keep, so there is nothing to hand over.
+    #[test]
+    fn adopting_refuses_a_call_with_no_winner() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        store.add_b_leg(&call_id, make_b_leg(0));
+
+        let mut new_leg = make_a_leg();
+        new_leg.dialog.call_id = "takeover-early@10.0.0.9".to_string();
+        assert!(store.adopt_replaced_dialog(&call_id, true, new_leg).is_none());
+    }
+
     /// RFC 3891 §3 dialog lookup: find a call where one of its legs has
     /// the dialog identifiers (call_id, local_tag, remote_tag) referenced
     /// by a `Replaces` header.
@@ -3531,7 +3833,13 @@ mod tests {
         // Replaces says: "the dialog you (siphon) have where YOU are tagged
         // `our_tag` and the OTHER end is tagged `their_tag`".
         let matched = store.find_call_by_replaces_dialog(&dialog_call_id, &their_tag, &our_tag);
-        assert_eq!(matched, Some(call_id));
+        assert_eq!(
+            matched,
+            Some(ReplacesMatch {
+                call_id,
+                on_a_leg: true
+            })
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,9 +261,45 @@ pub struct B2buaConfig {
     ///
     /// Unset → `"terminate"`.
     pub default_refer_mode: Option<String>,
+
+    /// Whether an inbound `INVITE` carrying a `Replaces` (RFC 3891) may take
+    /// over the dialog it names — the transferee half of attended transfer,
+    /// and the shape of a directed call pickup.
+    ///
+    /// **Off unless enabled.** Possession of a dialog's identifiers is not
+    /// proof of authorisation to end that dialog: RFC 3891 §5 calls out
+    /// exactly this, the transferor hands the triple to the transferee by
+    /// design, and anyone who can observe unprotected signalling reads it off
+    /// the wire. Turning this on grants every party that reaches this node —
+    /// subject to whatever admission `@b2bua.on_invite` applies — the ability
+    /// to disconnect one party from a live call and take their place. That is
+    /// a capability an operator opts into, not one an upgrade switches on.
+    ///
+    /// With it off, a `Replaces` naming a dialog this node hosts is declined
+    /// `603` (RFC 3891 §3's answer for a dialog the UA is unwilling to
+    /// replace) rather than being ignored — the INVITE never becomes an
+    /// unrelated second call.
+    ///
+    /// **Enable it only where INVITEs are authenticated or the source is
+    /// trusted.** `auth.require_proxy_digest()` in `@b2bua.on_invite` is what
+    /// makes this safe on an untrusted edge; the takeover runs only after that
+    /// handler admits the request, so a challenge or a `call.reject()` stops
+    /// it.
+    ///
+    /// ```yaml
+    /// b2bua:
+    ///   accept_replaces: true
+    /// ```
+    pub accept_replaces: Option<bool>,
 }
 
 impl B2buaConfig {
+    /// Whether an inbound `Replaces` may take a dialog over. Defaults to
+    /// `false` — see [`accept_replaces`](Self::accept_replaces).
+    pub fn replaces_takeover_enabled(&self) -> bool {
+        self.accept_replaces.unwrap_or(false)
+    }
+
     /// Resolve the configured default REFER mode. `None`, empty, or an
     /// unrecognized value fall back to the safe trunk-facing default
     /// (`Terminate`); only an explicit `"transparent"` selects transparent
@@ -4138,6 +4174,38 @@ fn default_lcr_cache_ttl_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The `Replaces` takeover is a capability, not a default: an upgrade must
+    /// never hand every party that can reach this node the ability to
+    /// disconnect someone from a live call and take their place (RFC 3891 §5).
+    #[test]
+    fn replaces_takeover_is_off_unless_enabled() {
+        assert!(
+            !B2buaConfig::default().replaces_takeover_enabled(),
+            "an operator opts into call takeover; it is never inherited"
+        );
+        assert!(!B2buaConfig {
+            accept_replaces: Some(false),
+            ..Default::default()
+        }
+        .replaces_takeover_enabled());
+        assert!(B2buaConfig {
+            accept_replaces: Some(true),
+            ..Default::default()
+        }
+        .replaces_takeover_enabled());
+    }
+
+    #[test]
+    fn replaces_takeover_parses_from_yaml() {
+        let config: B2buaConfig =
+            serde_yaml_ng::from_str("accept_replaces: true").expect("b2bua block must parse");
+        assert!(config.replaces_takeover_enabled());
+        // An omitted key leaves the capability off.
+        let empty: B2buaConfig =
+            serde_yaml_ng::from_str("default_refer_mode: terminate").expect("must parse");
+        assert!(!empty.replaces_takeover_enabled());
+    }
 
     fn minimal_yaml() -> &'static str {
         r#"

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -155,6 +155,11 @@ struct DispatcherState {
     /// calls `accept_refer()` without an explicit `mode=`.  Resolved from
     /// `config.b2bua.default_refer_mode` (defaults to `Terminate`).
     default_refer_mode: crate::script::api::call::ReferMode,
+    /// Whether an inbound `INVITE` with `Replaces` (RFC 3891) may take over the
+    /// dialog it names. Resolved from `config.b2bua.accept_replaces`; **off**
+    /// unless the operator turned it on, because possession of a dialog's
+    /// identifiers is not authority to end that dialog (RFC 3891 §5).
+    accept_replaces: bool,
     /// Outbound registration manager (None when registrant is not configured).
     registrant_manager: Option<Arc<crate::registrant::RegistrantManager>>,
     /// SIPREC recording manager (SRC role — sends recordings to external SRS).
@@ -702,6 +707,7 @@ pub async fn run(
         header_policy_registry,
         default_header_policy,
         default_refer_mode: config.b2bua.resolved_default_refer_mode(),
+        accept_replaces: config.b2bua.replaces_takeover_enabled(),
         registrant_manager,
         recording_manager: Arc::new(crate::siprec::RecordingManager::new(product_name, product_version)),
         li_siprec_srs_uri: config.lawful_intercept.as_ref()
@@ -12389,10 +12395,33 @@ fn handle_b2bua_invite(
                             send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
                             return;
                         }
+                        // Off unless the operator enabled it. Taking a party
+                        // out of a live call on the strength of identifiers that
+                        // are handed to the transferee by design — and readable
+                        // by anyone who can see unprotected signalling — is a
+                        // capability, not a default (RFC 3891 §5). Declined
+                        // rather than ignored: §3's answer for a dialog the UA
+                        // is unwilling to replace, and it stops the INVITE
+                        // becoming an unrelated second call.
+                        if !state.accept_replaces {
+                            info!(
+                                call_id = %sip_call_id,
+                                matched_call = %matched.call_id,
+                                source = %inbound.remote_addr,
+                                "B2BUA: declining INVITE with Replaces — b2bua.accept_replaces is not enabled"
+                            );
+                            let response = build_response(
+                                &message, 603, "Decline",
+                                state.server_header.as_deref(), &[],
+                            );
+                            send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
+                            return;
+                        }
                         debug!(
                             call_id = %sip_call_id,
                             matched_call = %matched.call_id,
                             replaced_on_a_leg = matched.on_a_leg,
+                            source = %inbound.remote_addr,
                             "B2BUA: INVITE with Replaces matched a confirmed dialog — takeover deferred to script admission"
                         );
                         pending_replaces = Some(crate::b2bua::actor::PendingReplaces {
@@ -15333,7 +15362,16 @@ fn handle_b2bua_response(
     // On 2xx: sync remote_tag and remote_contact from response back to canonical CallActor.
     // The LegActor extracts this on its clone, but we need to update the
     // authoritative copy in the CallActorStore.
-    if matches!(&actor_event, Some(CallEvent::Answered { .. })) {
+    // Driven by the 2xx itself, not only by the leg actor's `Answered` event.
+    // The event races the response it describes — it is delivered by a separate
+    // task — and when the response wins, this capture used to be skipped
+    // entirely, leaving the leg with no remote tag, no tagged `remote_to_uri`
+    // and no remote target. Everything siphon later builds toward that leg
+    // (BYE, re-INVITE, UPDATE) needs them (RFC 3261 §12.1.2), so the dialog
+    // state is taken from the 2xx that establishes the dialog. Idempotent: the
+    // event path, when it does arrive first, writes the same values.
+    if matches!(&actor_event, Some(CallEvent::Answered { .. })) || (200..300).contains(&status_code)
+    {
         if let Some(idx) = b_leg_index {
             if let Some(mut call) = state.call_actors.get_call_mut(call_id) {
                 if let Some(b_leg) = call.b_legs.get_mut(idx) {
@@ -21584,13 +21622,19 @@ fn b2bua_bridge_inbound_replaces(
         refuse(481, "Call/Transaction Does Not Exist", "the replaced call went away");
         return;
     };
-    let (Some(survivor_tag), Some(survivor_sdp)) =
-        (survivor.dialog.remote_tag.clone(), survivor.last_sdp.clone())
-    else {
+    let Some(survivor_tag) = survivor.dialog.remote_tag.clone() else {
         refuse(
             488,
             "Not Acceptable Here",
-            "the surviving leg has no negotiated media to hand over",
+            "the surviving leg has no remote tag — its dialog is not confirmed",
+        );
+        return;
+    };
+    let Some(survivor_sdp) = survivor.last_sdp.clone() else {
+        refuse(
+            488,
+            "Not Acceptable Here",
+            "the surviving leg has no recorded SDP to hand over",
         );
         return;
     };

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -12335,6 +12335,14 @@ fn handle_b2bua_invite(
     // Does Not Exist. Silently treating it as a fresh INVITE would defeat
     // the attended-transfer semantics (the referrer expects the old dialog
     // to go away once this INVITE succeeds).
+    //
+    // A match is only *recorded* here, never acted on. The takeover itself runs
+    // after `@b2bua.on_invite` has admitted the request, because RFC 3891 §5
+    // makes this header a call-hijack primitive for anyone who learns a dialog's
+    // identifiers, and the script's `auth.require_proxy_digest()` is siphon's
+    // admission control for an INVITE. Acting at parse time would take a live
+    // call away on the say-so of an unauthenticated request.
+    let mut pending_replaces: Option<crate::b2bua::actor::PendingReplaces> = None;
     if let Some(replaces_raw) = message.headers.get("Replaces") {
         match crate::sip::headers::refer::parse_replaces(replaces_raw) {
             Ok(replaces) => {
@@ -12343,18 +12351,55 @@ fn handle_b2bua_invite(
                     &replaces.from_tag,
                     &replaces.to_tag,
                 ) {
-                    Some(matched_call_id) => {
-                        // Dialog found — full attended-transfer bridging
-                        // (terminating the matched dialog and bridging the
-                        // remote party with the new INVITE's originator) is
-                        // still TODO. For now the INVITE flows through as a
-                        // normal new call so at least the caller reaches the
-                        // UAS; a dedicated ticket tracks the bridge step.
+                    Some(matched) => {
+                        // RFC 3891 §3: `early-only` asks to replace a dialog that
+                        // has not been answered. siphon only ever takes over a
+                        // confirmed one — an early dialog has no negotiated media
+                        // to hand across and no answered party to keep — so the
+                        // flag is honoured by declining, which is the response
+                        // the section names for this exact case.
+                        let confirmed = state
+                            .call_actors
+                            .get_call(&matched.call_id)
+                            .map(|call| call.state == CallState::Answered)
+                            .unwrap_or(false);
+                        if replaces.early_only && confirmed {
+                            debug!(
+                                call_id = %sip_call_id,
+                                matched_call = %matched.call_id,
+                                "B2BUA: rejecting INVITE with 486 — Replaces carries early-only but the dialog is confirmed"
+                            );
+                            let response = build_response(
+                                &message, 486, "Busy Here",
+                                state.server_header.as_deref(), &[],
+                            );
+                            send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
+                            return;
+                        }
+                        if !confirmed {
+                            debug!(
+                                call_id = %sip_call_id,
+                                matched_call = %matched.call_id,
+                                "B2BUA: rejecting INVITE with 486 — Replaces names a dialog that is not answered"
+                            );
+                            let response = build_response(
+                                &message, 486, "Busy Here",
+                                state.server_header.as_deref(), &[],
+                            );
+                            send_message_from(response, inbound.transport, inbound.remote_addr, inbound.connection_id, Some(inbound.local_addr), state);
+                            return;
+                        }
                         debug!(
                             call_id = %sip_call_id,
-                            matched_call = %matched_call_id,
-                            "B2BUA: INVITE with Replaces matched an existing dialog (bridge TODO)"
+                            matched_call = %matched.call_id,
+                            replaced_on_a_leg = matched.on_a_leg,
+                            "B2BUA: INVITE with Replaces matched a confirmed dialog — takeover deferred to script admission"
                         );
+                        pending_replaces = Some(crate::b2bua::actor::PendingReplaces {
+                            replaced_call_id: matched.call_id,
+                            replaced_on_a_leg: matched.on_a_leg,
+                            early_only: replaces.early_only,
+                        });
                     }
                     None => {
                         debug!(
@@ -12490,6 +12535,12 @@ fn handle_b2bua_invite(
         call.a_leg_local_addr = Some(inbound.local_addr);
     }
     state.call_event_receivers.insert(call_id.clone(), event_rx);
+
+    // Carry the resolved `Replaces` match onto the call so the post-admission
+    // step below can find it.
+    if let Some(pending) = pending_replaces {
+        state.call_actors.set_pending_replaces(&call_id, pending);
+    }
 
     // CDR: start tracking this call at INVITE time (cdr.auto_emit).
     cdr_track_b2bua_start(
@@ -12686,6 +12737,25 @@ fn handle_b2bua_invite(
         error!("message_arc lock poisoned in B2BUA invite handler");
         return;
     };
+
+    // The INVITE carried a `Replaces` naming a dialog this node hosts, and the
+    // script has now had its say. A reject (a digest challenge, a policy refusal)
+    // is honoured below like any other; anything else means the request was
+    // admitted, so the takeover runs instead of the routing the script asked for
+    // — an INVITE with `Replaces` is a request to join an existing call, not a
+    // new one to route, and the dial plan has no say in where it goes.
+    if !matches!(action, CallAction::Reject { .. } | CallAction::None) {
+        if let Some(pending) = state.call_actors.take_pending_replaces(&call_id) {
+            b2bua_bridge_inbound_replaces(
+                &inbound,
+                &message_guard,
+                &call_id,
+                &pending,
+                state,
+            );
+            return;
+        }
+    }
 
     match action {
         CallAction::None => {
@@ -18733,7 +18803,28 @@ fn b2bua_send_uas_response(
         response.headers.set("Content-Length", body_bytes.len().to_string());
         response.body = body_bytes;
     }
+    // A locally-generated 2xx needs the same retransmission cover as a relayed
+    // one: the B2BUA intercepts the A-leg INVITE before a server transaction
+    // exists, so nothing under this recovers a lost 200 and the caller would
+    // ring on until it gave up. Cancelled by the caller's ACK in the late-ACK
+    // handler (search `uas_2xx_retransmits`).
+    let retransmit = if final_response && (200..300).contains(&code) {
+        Some(response.clone())
+    } else {
+        None
+    };
     send_message_from(response, transport, remote_addr, connection_id, local_addr, state);
+    if let Some(retransmit) = retransmit {
+        arm_b2bua_2xx_retransmit(
+            internal_call_id,
+            retransmit,
+            transport,
+            remote_addr,
+            connection_id,
+            local_addr,
+            state,
+        );
+    }
 
     if final_response {
         // Confirm the A-leg dialog and mark the CDR answered (tracked at INVITE
@@ -21433,6 +21524,239 @@ fn b2bua_transfer_rtpengine_answer(
             None
         }
     }
+}
+
+/// Hand an existing call's dialog over to the party that sent an INVITE with
+/// `Replaces` (RFC 3891 §3 / RFC 5589 §7 attended transfer).
+///
+/// This is the inbound half of attended transfer — the transferee calls *us*
+/// naming the dialog it is taking over, where `b2bua_refer_accept` is the half
+/// where siphon places that call itself. The named party is dropped, the new
+/// caller takes its slot, and the party on the other side of the named dialog
+/// carries on without ever seeing a new call.
+///
+/// Runs only after `@b2bua.on_invite` has admitted the INVITE — see
+/// [`PendingReplaces`](crate::b2bua::actor::PendingReplaces) for why the header
+/// alone is not enough authority to end someone's call.
+fn b2bua_bridge_inbound_replaces(
+    inbound: &InboundMessage,
+    invite: &SipMessage,
+    new_call_id: &str,
+    pending: &crate::b2bua::actor::PendingReplaces,
+    state: &DispatcherState,
+) {
+    let replaced_call_id = pending.replaced_call_id.clone();
+
+    // Answer the new party with a hard failure rather than half a takeover:
+    // every one of these means the call it asked to join cannot be handed over
+    // intact, and the alternative is a connected call with dead audio.
+    let refuse = |code: u16, reason: &str, why: &str| {
+        warn!(
+            call_id = %new_call_id,
+            replaced_call = %replaced_call_id,
+            "B2BUA Replaces: refusing takeover with {code} — {why}"
+        );
+        let response =
+            build_response(invite, code, reason, state.server_header.as_deref(), &[]);
+        send_message_from(
+            response,
+            inbound.transport,
+            inbound.remote_addr,
+            inbound.connection_id,
+            Some(inbound.local_addr),
+            state,
+        );
+        state.call_actors.remove_call(new_call_id);
+        state.call_event_receivers.remove(new_call_id);
+    };
+
+    // The transferee offers (RFC 5589 §7). An offerless INVITE would make siphon
+    // the offerer and push the answer into the ACK, which is a different
+    // negotiation than the one the surviving leg is already in.
+    if invite.body.is_empty() {
+        refuse(488, "Not Acceptable Here", "the INVITE carries no offer");
+        return;
+    }
+
+    // The survivor is the peer of the dialog being replaced.
+    let survivor_on_a_leg = !pending.replaced_on_a_leg;
+    let Some(survivor) = state.call_actors.clone_leg(&replaced_call_id, survivor_on_a_leg) else {
+        refuse(481, "Call/Transaction Does Not Exist", "the replaced call went away");
+        return;
+    };
+    let (Some(survivor_tag), Some(survivor_sdp)) =
+        (survivor.dialog.remote_tag.clone(), survivor.last_sdp.clone())
+    else {
+        refuse(
+            488,
+            "Not Acceptable Here",
+            "the surviving leg has no negotiated media to hand over",
+        );
+        return;
+    };
+
+    let Some(new_leg) = state.call_actors.clone_leg(new_call_id, true) else {
+        refuse(481, "Call/Transaction Does Not Exist", "the new call went away");
+        return;
+    };
+    let new_tag = new_leg.dialog.local_tag.clone();
+    // The fresh engine call-id is the new party's SIP Call-ID, which is what the
+    // media store is keyed on once this leg occupies the A-leg slot.
+    let cid_new = new_leg.dialog.call_id.clone();
+
+    // The pre-takeover anchor, keyed on the replaced call's A-leg Call-ID.
+    let old_anchor = state
+        .call_actors
+        .get_call(&replaced_call_id)
+        .map(|call| call.a_leg.dialog.call_id.clone())
+        .and_then(|key| {
+            state
+                .rtpengine_sessions
+                .as_ref()
+                .and_then(|store| store.get(&key))
+                .map(|session| (key, session))
+        });
+
+    // Media. Anchored: re-offer the new party onto a fresh engine call-id and
+    // answer it with the survivor's already-negotiated SDP, so the 200 can go out
+    // now instead of waiting for the survivor's re-INVITE to come back.
+    // Unanchored: the two SDPs cross directly.
+    let (sdp_for_new_party, sdp_for_survivor) = match &old_anchor {
+        Some((_, session)) => {
+            let to_survivor = b2bua_transfer_rtpengine_offer(
+                state,
+                &cid_new,
+                &new_tag,
+                &invite.body,
+                &session.profile,
+            );
+            let to_new_party = b2bua_transfer_rtpengine_answer(
+                state,
+                &cid_new,
+                &new_tag,
+                &survivor_tag,
+                &survivor_sdp,
+                &session.profile,
+            );
+            match (to_survivor, to_new_party) {
+                (Some(survivor_side), Some(new_side)) => (new_side, survivor_side),
+                _ => {
+                    warn!(
+                        call_id = %new_call_id,
+                        "B2BUA Replaces: rtpengine re-anchor failed — crossing the raw SDP instead"
+                    );
+                    (survivor_sdp.clone(), invite.body.clone())
+                }
+            }
+        }
+        None => (survivor_sdp.clone(), invite.body.clone()),
+    };
+
+    // Move the new party's leg onto the call it is joining. Its own (now empty)
+    // call is dropped without retiring the dialog — the leg is moving, not ending.
+    let (stored_invite, stored_local_addr) = match state.call_actors.get_call(new_call_id) {
+        Some(call) => (call.a_leg_invite.clone(), call.a_leg_local_addr),
+        None => (None, None),
+    };
+    let Some(new_leg_owned) = state.call_actors.detach_a_leg_for_adoption(new_call_id) else {
+        refuse(481, "Call/Transaction Does Not Exist", "the new call went away");
+        return;
+    };
+    state.call_event_receivers.remove(new_call_id);
+
+    let Some((replaced, _survivor)) = state.call_actors.adopt_replaced_dialog(
+        &replaced_call_id,
+        pending.replaced_on_a_leg,
+        new_leg_owned,
+    ) else {
+        // The call vanished between the snapshot and the swap. The new party's
+        // actor is already gone, so answer from the raw INVITE and stop.
+        warn!(
+            call_id = %new_call_id,
+            replaced_call = %replaced_call_id,
+            "B2BUA Replaces: the call being taken over disappeared mid-swap — 481"
+        );
+        let response = build_response(
+            invite, 481, "Call/Transaction Does Not Exist",
+            state.server_header.as_deref(), &[],
+        );
+        send_message_from(
+            response, inbound.transport, inbound.remote_addr,
+            inbound.connection_id, Some(inbound.local_addr), state,
+        );
+        return;
+    };
+
+    // Handlers that rebuild a PyCall (on_bye, CDR finalize) read these off the
+    // call, and they now describe the new party.
+    if let Some(mut call) = state.call_actors.get_call_mut(&replaced_call_id) {
+        call.a_leg_invite = stored_invite;
+        call.a_leg_local_addr = stored_local_addr;
+    }
+
+    // Accept the takeover. Sent before the BYE below so the transferee is
+    // connected to the surviving party before the replaced one is told to go.
+    if !b2bua_answer_call(
+        &replaced_call_id,
+        invite,
+        200,
+        "OK",
+        Some(sdp_for_new_party),
+        Some("application/sdp"),
+    ) {
+        warn!(call_id = %replaced_call_id, "B2BUA Replaces: failed to answer the taking-over INVITE");
+    }
+
+    // RFC 3891 §3: the replaced dialog is terminated once the new INVITE is
+    // accepted. Its leg is already off the call, so this BYE is built from the
+    // snapshot taken during the swap.
+    if let Some(bye) = build_b2bua_bye(&replaced, state) {
+        let (destination, transport) = resolve_in_dialog_destination(
+            &replaced.dialog.route_set,
+            state,
+            replaced.transport.remote_addr,
+            replaced.transport.transport,
+        );
+        send_message_from(
+            bye,
+            transport,
+            destination,
+            replaced.transport.connection_id,
+            replaced.transport.local_addr,
+            state,
+        );
+    }
+
+    // Re-point the survivor at the new party (RFC 3261 §14) — it is still
+    // sending to the address of the party that just left. The survivor is the
+    // winning B-leg after the swap, always.
+    b2bua_send_media_reinvite(&replaced_call_id, false, sdp_for_survivor, state);
+
+    // Re-key the media session onto the new A-leg Call-ID and drop the old
+    // anchor, mirroring the terminate-transfer re-anchor.
+    if let Some((old_key, old_session)) = &old_anchor {
+        if let Some(store) = state.rtpengine_sessions.as_ref() {
+            store.insert(crate::rtpengine::session::MediaSession {
+                call_id: cid_new.clone(),
+                rtpengine_call_id: cid_new.clone(),
+                from_tag: new_tag.clone(),
+                to_tag: Some(survivor_tag.clone()),
+                profile: old_session.profile.clone(),
+                // A fresh engine call-id: any WebSocket bridge the old anchor
+                // held belonged to the call-id that just went away.
+                ws_uri: None,
+                created_at: std::time::Instant::now(),
+            });
+            store.remove(old_key);
+        }
+        b2bua_transfer_rtpengine_delete(state, old_session.rtpengine_id(), &old_session.from_tag);
+    }
+
+    info!(
+        call_id = %replaced_call_id,
+        replaced_on_a_leg = pending.replaced_on_a_leg,
+        "B2BUA Replaces: dialog taken over — replaced party BYE'd, survivor re-INVITEd to the new party"
+    );
 }
 
 /// rtpengine `delete` for the OLD anchor of a siphon-terminated transfer: tears


### PR DESCRIPTION
Closes the `bridge TODO` at the inbound `Replaces` gate, which had no tracking
issue despite the comment claiming one.

## The gap

Attended transfer has two halves. siphon does the one where it places the
transferred call itself (`accept_refer`). The other is a transferee calling **in**,
naming the dialog it is taking over — which is what an endpoint does when it runs
the transfer on its own, and what a directed pickup looks like.

That INVITE matched the dialog, logged `bridge TODO`, and then flowed on as an
ordinary new call. So the transfer half-happened:

* the transferor was left in a call that never ended, and
* the transferee got a **second, unrelated call** routed by the dial plan instead
  of the one it asked to join.

RFC 3891 §3 requires the replaced dialog to be terminated once the new INVITE is
accepted. Nothing was.

## What it does now

The named party is BYE'd, the new caller takes its slot, and the party on the
other side is re-INVITEd onto the new media (RFC 3261 §14) rather than left
sending audio to whoever just left.

It works whichever leg the header names, which matters more than it first looks:
the transferor is as often the **callee** ("answer a call, then transfer it") as
the caller. The new party always lands in the A-leg slot — the inbound-ACK path
resolves a call by Call-ID and then marks `a_leg`, so a UAS leg parked anywhere
else would never have its ACK recorded and would retransmit its 200 to Timer B —
and the survivor moves to the B slot when it has to.

### The takeover runs after `@b2bua.on_invite`, not before

RFC 3891 §5 makes `Replaces` a call-hijack primitive for anyone who learns a
dialog's identifiers, and the script is siphon's admission control for an INVITE.
Acting at header-parse time would end someone's call on the say-so of an
unauthenticated request, so the resolved match is recorded and acted on only once
the script has had its say: an `auth.require_proxy_digest()` or a `call.reject()`
stops a takeover exactly as it stops a call.

When the script admits it, the handover replaces whatever routing it asked for.
An INVITE with `Replaces` is a request to join an existing call, not a new one to
route, and the dial plan has no say in where it goes.

### Also

* `early-only` (RFC 3891 §3) is honoured rather than parsed and ignored — it asks
  to replace an unanswered dialog, siphon only takes over confirmed ones, so it is
  declined `486`, the response that section names. Same for a `Replaces` naming a
  dialog that is not answered. `481` for one this node does not host is unchanged.
* **A locally-generated 2xx is now retransmitted.** `call.answer()` sent the 200
  once and armed nothing; the B2BUA intercepts the A-leg INVITE before a server
  transaction exists, so nothing underneath recovered a lost 200 (RFC 3261
  §13.3.1.4) and one dropped packet left the caller ringing on a call siphon
  considered answered. The takeover depends on this, but it was a live gap for
  every `call.answer()`.

## Test harness

`sipp/replaces/replaces_takeover_test.py` — a peer that plays all three parties
over three sockets. SIPp cannot drive this: the takeover INVITE has to quote
dialog identifiers that only exist once the first call is up, one of which is
siphon's own runtime-minted tag.

Both directions run, and each asserts the three things that separate a real
takeover from a connected call with dead audio:

1. the taking-over INVITE is answered 2xx **with a body**,
2. the replaced party is sent a BYE, and
3. the **surviving** party is re-INVITEd — the one that is silent on the wire and
   looks fine in SIP if you skip it.

It also asserts the replaced party is *not* re-INVITEd, and tears the call down
from the new party to prove the two are really bridged.

Verified in both directions by disabling the bridge:

| | with fix | bridge disabled |
|---|---|---|
| `a-leg` (caller transferred) | ok | `carol: timed out waiting for the 200 OK accepting the takeover; saw ['SIP/2.0 100 Trying']` |
| `b-leg` (callee transferred) | ok | same, on the second case |

The CI step greps the verdict line rather than trusting the exit code, so a peer
that dies before running its assertions cannot read as a pass.

## Testing

- 3734 lib + 326 integration green; `clippy --all-targets --all-features -D warnings` clean
- 6 new unit tests on the adoption primitives, including that detaching a leg for
  adoption does **not** retire its Call-ID (doing so would 481 the ACK for the 200
  it is about to receive)
- All four REFER scenarios (transparent, reject, terminate, attended) plus the
  referrer-BYE scenario re-run green against this branch
- `refer-single-leg` re-run green — it is what exercises `call.answer()`, now with
  retransmission armed
