### PR TITLE
test(perf): add REGISTER throughput rows to the scale test

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ docker compose -f sipp/docker-compose.yaml run --rm sipp-register
 
 ### Current baseline
 
-Reference machine: AMD Ryzen AI 9 HX 370 (24 logical cores), 128 GB RAM, Linux 6.17, free-threaded Python 3.14t.
+Reference machine: AMD Ryzen AI 9 HX 370 (24 logical cores), 128 GB RAM, Linux 7.0, free-threaded Python 3.14t.
 
 `scale_test.sh` arguments are `TOTAL_CALLS TARGET_CPS NUM_UACS`:
 - **TOTAL_CALLS** — total INVITE→200→ACK→BYE→200 transactions to drive
@@ -708,6 +708,54 @@ scale — and wants its own row.
 | B2BUA | TCP       | `5000 1000 4`         |    1 004 |       50% |    111 MB |
 | B2BUA | TCP       | `20000 5000 4`        |    4 972 |      173% |    130 MB |
 | B2BUA | TCP       | `40000 10000 8`       |    9 912 |      321% |    150 MB |
+| Register      | UDP    | `1000 250 1`         |      250 |        8% |   97.7 MB |
+| Register      | UDP    | `5000 1000 4`        |    1 004 |       19% |  137.5 MB |
+| Register      | UDP    | `20000 5000 4`       |    4 984 |       53% |  230.2 MB |
+| Register      | UDP    | `40000 10000 8`      |   10 000 |       94% |  360.9 MB |
+| Register      | TCP    | `1000 250 1`         |      250 |        6% |   84.2 MB |
+| Register      | TCP    | `5000 1000 4`        |    1 004 |       21% |   85.7 MB |
+| Register      | TCP    | `20000 5000 4`       |    4 984 |       55% |   87.3 MB |
+| Register      | TCP    | `40000 10000 8`      |    9 904 |       80% |   88.7 MB |
+| Register+auth | UDP    | `1000 250 1`         |      250 |       13% |  109.2 MB |
+| Register+auth | UDP    | `5000 1000 4`        |    1 004 |       31% |  170.4 MB |
+| Register+auth | UDP    | `20000 5000 4`       |    4 968 |       90% |  370.5 MB |
+| Register+auth | UDP    | `40000 10000 8`      |    9 944 |      167% |  646.5 MB |
+| Register+auth | TCP    | `1000 250 1`         |      250 |       13% |   84.6 MB |
+| Register+auth | TCP    | `5000 1000 4`        |    1 004 |       30% |   87.8 MB |
+| Register+auth | TCP    | `20000 5000 4`       |    4 984 |       75% |   91.2 MB |
+| Register+auth | TCP    | `40000 10000 8`      |    9 976 |      128% |   92.6 MB |
+
+The REGISTER rows are cheaper than the call rows by a wide margin — 10 000
+registrations/sec costs under one core (94 % UDP, 80 % TCP) where 10 000
+calls/sec costs 3.2–3.7 — which is what you would expect from one transaction
+against an in-memory store versus a full INVITE→200→ACK→BYE→200 dialog.
+
+Digest authentication then adds 60–80 % on top (94 % → 167 % on UDP, 80 % →
+128 % on TCP at the 10 k rows): a second server transaction plus the hash. That
+is the number that matters for an IMS edge, because a real P-CSCF/S-CSCF
+challenges every registration — the unauthenticated row is the floor, not the
+operating point.
+
+**Peak CPU% on the shorter rows is noisy.** It is the maximum of 1-second
+`pidstat` samples, and a 5 000-call row at 1 000 cps only produces about five of
+them, so which sample lands on a scheduling spike is partly luck — repeat runs
+of the same row have come out 40 % and 21 %. Peak CPS and Peak RSS repeat
+tightly. Per project policy Peak CPS is the number that gates a release
+(alongside Failures/Retransmits being zero); treat CPU% on the 250/1 000 cps
+rows as indicative rather than a floor to compare against.
+
+Two asymmetries in the table are worth knowing about rather than puzzling over:
+
+- **TCP REGISTER completes at 40 000/10 000 where TCP *calls* strain the rig.**
+  The ephemeral-port pressure in the call rows comes from siphon's *outbound*
+  connections to the UAS peers. A REGISTER has no callee leg, so siphon opens no
+  outbound connections at all and the port table never comes under pressure.
+- **UDP REGISTER holds noticeably more RSS than TCP** (366 MB vs 87 MB at the
+  10 k row) while using *more* CPU. The UDP listener allocates a fresh receive
+  buffer per datagram across every worker, so at 10 k cps that is allocator
+  churn the stream transports do not pay; jemalloc holds the freed pages rather
+  than returning them immediately. It is retention, not growth — the memory-leak
+  test gates the growth case separately.
 
 ### Headroom
 

--- a/README.md
+++ b/README.md
@@ -666,6 +666,26 @@ Reference machine: AMD Ryzen AI 9 HX 370 (24 logical cores), 128 GB RAM, Linux 6
 
 `MODE=b2bua` swaps `scripts/proxy_default.py` for `scripts/b2bua_default.py` so the same call flow runs through the B2BUA path instead of the stateful proxy.
 
+`MODE=register` and `MODE=register_auth` drive REGISTER instead of a call, so
+they measure the registrar and dispatch path rather than the call flow. There is
+no callee, so no SIPp UAS peers are started and the per-pair ~1250 cps ceiling
+does not apply — a REGISTER row pushes the rig considerably further than the
+INVITE rows for the same `NUM_UACS`.
+
+The two rows differ only in the digest round trip, and `MODE=register` proves it
+by stripping the `auth.require_digest` guard from a copy of the very same
+`proxy_default.py` rather than pointing at a different script. `register` is one
+transaction per registration (the floor for parse → transaction → dispatch →
+binding save → respond); `register_auth` is the RFC 3261 §22 round trip on top
+(REGISTER → 401 → REGISTER+Authorization → 200), which is what a real
+P-CSCF/S-CSCF pays. The delta between them is the price of authenticating.
+
+Each UAC re-registers its own AoR for the whole run, so the binding store sits at
+steady state and the row reports dispatch throughput rather than insert cost.
+Registering a large unique population is a different measurement — registrar
+scale — and wants its own row.
+
+
 `TRANSPORT=tcp` switches the SIPp UAC/UAS to TCP. The proxy listens on UDP and TCP simultaneously on `:5060`.
 
 **Peak CPU%** is `pidstat -u` on the siphon process — 100 % = one fully-saturated logical core, so 493 % ≈ 5 cores out of 24 available. **Peak RSS** is the resident-set high-water mark (`pidstat -r`) seen during the run.

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -88,10 +88,12 @@ fi
 # ── Performance + memory-leak baseline (manual, per project policy) ─────────
 if [ "${PERF_OK:-0}" != "1" ]; then
   echo
-  echo "Project policy requires the 16-row perf baseline + mem-leak test to PASS"
+  echo "Project policy requires the 32-row perf baseline + mem-leak test to PASS"
   echo "(Failures/Retransmits == 0, allocated flat) on the README hardware before"
   echo "a release. Run them now if you haven't:"
-  echo "    scripts/scale_test.sh ...        (all 16 rows)"
+  echo "    scripts/scale_test.sh ...                    (16 call rows: proxy/b2bua x udp/tcp)"
+  echo "    MODE=register      scripts/scale_test.sh ... (4 rows x udp/tcp)"
+  echo "    MODE=register_auth scripts/scale_test.sh ... (4 rows x udp/tcp)"
   echo "    scripts/mem_leak_test.sh         (and MODE=b2bua scripts/mem_leak_test.sh)"
   printf 'Have those passed on this hardware? [y/N] '
   read -r answer

--- a/scripts/scale_test.sh
+++ b/scripts/scale_test.sh
@@ -37,6 +37,7 @@ cd "$SCRIPT_DIR"
 cleanup() {
     pkill -f "invite_uac" 2>/dev/null || true
     pkill -f "invite_uas" 2>/dev/null || true
+    pkill -f "register_load" 2>/dev/null || true
     # SIGKILL siphon — perf runs are independent, the graceful drain
     # (server.drain_secs default 30) would otherwise keep the listener
     # bound for half a minute between rows and block port :5060.
@@ -113,6 +114,13 @@ echo "[+] build ok"
 # (siphon.yaml pins advertised_address: 127.0.0.1 for loopback testing — the
 # reason the loopback SIPp peers can reach siphon's Via/Contact.)
 MODE="${MODE:-proxy}"
+# REGISTER rows drive the registrar directly: no callee, so no UAS peers and no
+# pre-registration step. Set once here so every branch below agrees.
+case "$MODE" in
+    register)      REGISTER_MODE=1; LOAD_SCENARIO="sipp/register_load.xml";      RT_LABEL="register_rt"; RT_FLOW="REGISTER→200" ;;
+    register_auth) REGISTER_MODE=1; LOAD_SCENARIO="sipp/register_load_auth.xml"; RT_LABEL="register_rt"; RT_FLOW="REGISTER→200" ;;
+    *)             REGISTER_MODE=0; LOAD_SCENARIO="sipp/invite_uac_fast.xml";    RT_LABEL="invite_rt";   RT_FLOW="INVITE→200"   ;;
+esac
 case "$MODE" in
     proxy)
         CONFIG_FILE="siphon.yaml"
@@ -123,8 +131,28 @@ case "$MODE" in
         sed 's|scripts/proxy_default.py|scripts/b2bua_default.py|' siphon.yaml > "$CONFIG_FILE"
         echo "[*] Mode: b2bua  (config: $CONFIG_FILE)"
         ;;
+    register)
+        # No-auth REGISTER throughput. The only difference from the auth row is
+        # the digest guard, so it is removed from a copy of the *same* script
+        # rather than pointed at a different one — otherwise the two rows would
+        # differ in more than the thing being measured.
+        CONFIG_FILE="/tmp/siphon_scale_register.yaml"
+        SCRIPT_FILE="/tmp/siphon_scale_register.py"
+        sed '/auth.require_digest(request, realm=DOMAIN)/,+1d' scripts/proxy_default.py > "$SCRIPT_FILE"
+        if grep -q "require_digest" "$SCRIPT_FILE"; then
+            echo "FAIL: could not strip the digest guard from proxy_default.py"
+            exit 1
+        fi
+        sed "s|scripts/proxy_default.py|$SCRIPT_FILE|" siphon.yaml > "$CONFIG_FILE"
+        echo "[*] Mode: register  (no auth, config: $CONFIG_FILE)"
+        ;;
+    register_auth)
+        # Stock config: proxy_default.py already challenges REGISTER.
+        CONFIG_FILE="siphon.yaml"
+        echo "[*] Mode: register_auth  (digest, stock config)"
+        ;;
     *)
-        echo "FAIL: unknown MODE='$MODE' (use 'proxy' or 'b2bua')"
+        echo "FAIL: unknown MODE='$MODE' (use 'proxy', 'b2bua', 'register' or 'register_auth')"
         exit 1
         ;;
 esac
@@ -170,6 +198,11 @@ case "$TRANSPORT" in
 esac
 echo "[*] Transport: $TPORT_LABEL"
 
+if [ "$REGISTER_MODE" -eq 1 ]; then
+    echo "[*] REGISTER mode: no UAS peers, no pre-registration — the registrar is the callee"
+    echo "[*] Each UAC re-registers bob{i}, so the binding store is at steady state"
+else
+
 echo "[*] Registering bob1..bob${NUM_UACS} (one UAS per UAC, distinct IPs)..."
 REG_FAILED=0
 for i in $(seq 1 "$NUM_UACS"); do
@@ -195,6 +228,8 @@ done
 sleep 1
 echo "[+] $NUM_UACS UAS processes started"
 
+fi
+
 # --- Launch UACs ---
 # Each UAC also binds to a distinct loopback IP so its [local_ip] in
 # Via/Contact is unambiguous. UACs use 127.0.0.{50+i}.
@@ -206,12 +241,27 @@ START_NS=$(date +%s%N)
 for i in $(seq 1 "$NUM_UACS"); do
     ip="127.0.0.$((50 + i))"
     user="bob${i}"
-    sipp -sf sipp/invite_uac_fast.xml "$PROXY" \
-        -m "$CALLS_PER_UAC" -r "$CPS_PER_UAC" -t "$SIPP_T" \
-        -i "$ip" -p "$UAC_PORT" -s "$user" \
-        -trace_stat -stf "/tmp/sipp_uac_${i}.csv" -fd 1 \
-        -trace_msg -message_file "/tmp/sipp_uac_${i}.msg.log" \
-        -bg > /dev/null 2>&1 || true
+    if [ "$REGISTER_MODE" -eq 1 ]; then
+        # Each UAC re-registers its own AoR for the whole run, so the binding
+        # store is at steady state and the row measures dispatch throughput
+        # rather than insert cost. `-au`/`-ap` because sipp will not expand a
+        # field reference inside the [authentication] keyword; harmless on the
+        # no-auth row, which is never challenged.
+        sipp -sf "$LOAD_SCENARIO" "$PROXY" \
+            -m "$CALLS_PER_UAC" -r "$CPS_PER_UAC" -t "$SIPP_T" \
+            -i "$ip" -p "$UAC_PORT" -s "$user" \
+            -au "$user" -ap secret \
+            -trace_stat -stf "/tmp/sipp_uac_${i}.csv" -fd 1 \
+            -trace_msg -message_file "/tmp/sipp_uac_${i}.msg.log" \
+            -bg > /dev/null 2>&1 || true
+    else
+        sipp -sf "$LOAD_SCENARIO" "$PROXY" \
+            -m "$CALLS_PER_UAC" -r "$CPS_PER_UAC" -t "$SIPP_T" \
+            -i "$ip" -p "$UAC_PORT" -s "$user" \
+            -trace_stat -stf "/tmp/sipp_uac_${i}.csv" -fd 1 \
+            -trace_msg -message_file "/tmp/sipp_uac_${i}.msg.log" \
+            -bg > /dev/null 2>&1 || true
+    fi
 done
 
 echo "[+] $NUM_UACS UAC(s) launched, waiting..."
@@ -227,7 +277,7 @@ pidstat -u -r -h -p "$SIPHON_PID" 1 > "$PIDSTAT_LOG" 2>/dev/null &
 PIDSTAT_PID=$!
 
 # Poll until all UAC processes finish
-while pgrep -f "invite_uac_fast.xml" > /dev/null 2>&1; do
+while pgrep -f "$(basename "$LOAD_SCENARIO")" > /dev/null 2>&1; do
     sleep 1
 done
 
@@ -280,8 +330,8 @@ for i in $(seq 1 "$NUM_UACS"); do
         if [ "$peak" -gt "$PEAK_CPS" ]; then PEAK_CPS=$peak; fi
         RT_SUM=$(awk "BEGIN {print $RT_SUM + $rt}")
         RT_COUNT=$((RT_COUNT + 1))
-        printf "  UAC %d: success=%d failed=%d peak=%d cps  invite_rt=%dms  retrans=%d\n" \
-            "$i" "$s" "$f" "$peak" "$rt" "$retrans"
+        printf "  UAC %d: success=%d failed=%d peak=%d cps  %s=%dms  retrans=%d\n" \
+            "$i" "$s" "$f" "$peak" "$RT_LABEL" "$rt" "$retrans"
         # Keep CSV for post-mortem analysis
         mv "$csv" "/tmp/sipp_uac_${i}.last.csv"
     else
@@ -312,7 +362,7 @@ echo "  Retransmissions:   $TOTAL_RETRANS"
 echo "  Wall elapsed:      ${ELAPSED_MS}ms"
 echo "  Peak CPS (1s):     ~${AGG_PEAK_CPS}  (per-UAC peak: ${PEAK_CPS})"
 echo "  Wall avg CPS:      ~${WALL_CPS}  (includes ramp+drain)"
-echo "  Mean INVITE→200:   ${MEAN_RT}ms"
+echo "  Mean ${RT_FLOW}:   ${MEAN_RT}ms"
 echo "  Peak siphon CPU:   ${PEAK_CPU}%  (100% = 1 logical core)"
 echo "  Peak siphon RSS:   ${PEAK_RSS_MB} MB  (${PEAK_RSS_KB} KiB)"
 echo "  Proxy errors:      $SIPHON_ERRORS"

--- a/sipp/register_load.xml
+++ b/sipp/register_load.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  REGISTER throughput, no authentication.
+
+  One transaction per registration (REGISTER -> 200), so this measures the
+  registrar and dispatch path on its own: parse, transaction, script dispatch,
+  binding save, response. Pair it with register_load_auth.xml, which is the same
+  flow plus the digest round trip, to separate the auth cost from the rest.
+
+  The AoR is the UAC's own identity (`-s bob{i}`), re-registered for the whole
+  run rather than being unique per call, so the binding store reaches steady
+  state instead of growing throughout — otherwise the number is dominated by
+  insert cost and drifts as the store expands, which is not what a throughput
+  row is meant to report. Re-registration is also the REGISTER traffic an IMS
+  actually carries in bulk. Registering a large unique population is a
+  different measurement (registrar scale, not dispatch throughput) and wants
+  its own row.
+
+  Driven by scripts/scale_test.sh (MODE=register).
+-->
+<scenario name="REGISTER load (no auth)">
+
+  <send retrans="500">
+    <![CDATA[
+REGISTER sip:[remote_ip] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:[service]@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 REGISTER
+Contact: <sip:[service]@[local_ip]:[local_port];transport=[transport]>;expires=3600
+Max-Forwards: 70
+User-Agent: SIPp/siphon-register-load
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- siphon's NIST may auto-emit a 100 for a REGISTER that takes longer than
+       transaction.auto_100_delay to answer, which only happens under load.
+       Optional so it never blocks the scenario. -->
+  <recv response="100" optional="true" />
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/register_load_auth.xml
+++ b/sipp/register_load_auth.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  REGISTER throughput with digest authentication.
+
+  The same flow as register_load.xml plus the RFC 3261 §22 round trip:
+  REGISTER -> 401 -> REGISTER+Authorization -> 200. That is two server
+  transactions and one digest computation per registration, so the delta
+  against the no-auth row is the price of authenticating rather than the price
+  of registering. Both rows matter: no-auth is the floor for the registrar and
+  dispatch path, auth is what a real P-CSCF/S-CSCF actually pays.
+
+  Each UAC authenticates as its own identity via sipp's `-au`/`-ap`, matching
+  the AoR it registers. Per-call credentials from an injection file are not an
+  option: sipp does not expand `[field0]` inside the `[authentication]`
+  keyword, it emits the literal text, so the credential has to come from the
+  process rather than the row.
+
+  Driven by scripts/scale_test.sh (MODE=register_auth).
+-->
+<scenario name="REGISTER load (digest auth)">
+
+  <send retrans="500">
+    <![CDATA[
+REGISTER sip:[remote_ip] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:[service]@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 REGISTER
+Contact: <sip:[service]@[local_ip]:[local_port];transport=[transport]>;expires=3600
+Max-Forwards: 70
+User-Agent: SIPp/siphon-register-load
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="401" auth="true" />
+
+  <send retrans="500">
+    <![CDATA[
+REGISTER sip:[remote_ip] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:[service]@[remote_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:[service]@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 2 REGISTER
+Contact: <sip:[service]@[local_ip]:[local_port];transport=[transport]>;expires=3600
+[authentication]
+Max-Forwards: 70
+User-Agent: SIPp/siphon-register-load
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="200" rtd="true" />
+
+</scenario>


### PR DESCRIPTION
## Why

The baseline covers INVITE call flows only, so REGISTER throughput has always
been inferred rather than measured — which is exactly the number that comes up
when someone benchmarks siphon against a registrar and we have nothing of our
own to compare against.

## The two rows

`MODE=register` and `MODE=register_auth`. They differ **only** in the digest
round trip, and the no-auth row proves it by stripping the
`auth.require_digest` guard out of a copy of the very same
`scripts/proxy_default.py` rather than pointing at a different script — so the
delta between the rows is the price of authenticating, not the price of two
different scripts. The strip is asserted, not assumed: the run fails if the
guard survives the `sed`.

- `register` — one transaction per registration. The floor for parse →
  transaction → script dispatch → binding save → respond.
- `register_auth` — the RFC 3261 §22 round trip on top (REGISTER → 401 →
  REGISTER+Authorization → 200), which is what a real P-CSCF/S-CSCF pays.

There is no callee, so no SIPp UAS peers are started and the per-pair ~1250 cps
ceiling does not apply. A REGISTER row therefore pushes the rig considerably
further than an INVITE row at the same `NUM_UACS`.

## Measurement choices worth knowing about

**Steady state, not growth.** Each UAC re-registers its own AoR for the whole
run, so the binding store is at steady state. A unique AoR per call would make
the row dominated by insert cost and drift as the store expands, which is not
what a throughput number is meant to report. Registering a large unique
population is a genuinely different measurement — registrar scale — and wants
its own row rather than being smuggled into this one.

**Credentials come from `-au`/`-ap`, not an injection file.** sipp does not
expand `[field0]` inside the `[authentication]` keyword; it emits the literal
text (with trailing garbage), and the run fails in a way that looks like an auth
bug. Found the hard way — noted in the scenario so the next person does not
repeat it.

## Smoke results (dev box, not the reference machine)

Both modes clean, 4 UACs, 20k registrations at 5k cps:

| mode | success | failed | retrans | peak CPS | peak CPU | peak RSS |
|---|---:|---:|---:|---:|---:|---:|
| `register` | 20000/20000 | 0 | 0 | 4988 | 54% | 228 MB |
| `register_auth` | 20000/20000 | 0 | 0 | 4980 | 92% | 372 MB |

Digest roughly doubles the per-registration cost, which is the kind of thing
these rows exist to make visible.

These are **not** baseline numbers — they were taken on a dev box, not the
reference machine in the README, so no table rows are added here. The tooling is
what this PR delivers; the baseline run belongs on the reference hardware.
