### PR TITLE
ci: build the SIPp image once per run instead of twenty times

### DIFF
--- a/.github/actions/load-siphon-image/action.yaml
+++ b/.github/actions/load-siphon-image/action.yaml
@@ -1,0 +1,25 @@
+# Pull in the siphon image that the `build-image` job produced once for this run
+# and load it under the `sipp-siphon` tag that every siphon service in
+# sipp/docker-compose.yaml declares.
+#
+# With the tag present, `docker compose up` reuses it and never builds, which is
+# the whole point: a cold build of that image is ~10 minutes and it used to run
+# once per SIPp job. Any job using this action must declare `needs: build-image`.
+name: Load the siphon test image
+description: Download and load the sipp-siphon image built once per run by build-image.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v7
+      with:
+        name: sipp-siphon-image
+        path: /tmp
+
+    - name: docker load
+      shell: bash
+      run: |
+        docker load -i /tmp/sipp-siphon.tar.gz
+        # Fail loudly here rather than 10 minutes later inside an implicit
+        # `compose up` rebuild that would silently mask a broken artifact.
+        docker image inspect sipp-siphon:latest > /dev/null

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -320,15 +320,68 @@ jobs:
             sbom.spdx.json
             sbom.cdx.json
 
-  # ── SIPp functional tests (basic) ───────────────────────────────────────
-  sipp-functional:
+  # ── The one siphon image every SIPp job runs against ───────────────────────
+  # Every service in sipp/docker-compose.yaml that runs siphon builds `context: ..`
+  # against the root Dockerfile with no build-args and no target override, so they
+  # are all the same image. They share the `sipp-siphon` tag; this job produces it
+  # once and hands it to the SIPp jobs as an artifact, which they `docker load`.
+  # `docker compose up` only builds when the tag is absent, so a loaded image makes
+  # every one of them skip the build.
+  #
+  # Built here rather than per job because a cold `docker compose build` is ~10
+  # minutes (apt, uv, CPython 3.14t, rustup, cargo-chef, then the whole release
+  # dependency graph) against 10-40 s of actual SIPp testing — it used to be ~96 %
+  # of the SIPp fleet's runner time, repeated 20 times per run.
+  build-image:
     runs-on: ubuntu-latest
-    needs: rust-tests
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon image
-        run: docker compose -f sipp/docker-compose.yaml build siphon
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build the siphon test image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          tags: sipp-siphon:latest
+          # Same scope as release.yaml's amd64 leg: identical context, Dockerfile
+          # and build-args, so the two share one cache entry rather than competing
+          # for the repo's cache budget, and each warms the other.
+          cache-from: type=gha,scope=linux/amd64
+          # Only trunk pushes write it. A cache written from a PR branch is scoped
+          # to that branch — invisible to every other PR and to main — so writing
+          # from a PR would evict entries that Swatinem/rust-cache also needs
+          # without ever being read back.
+          #
+          # mode=max is load-bearing: everything expensive lives in the chef/planner/
+          # builder stages, and mode=min exports only the final stage (debian plus
+          # the copied binary), which would cache nothing that costs anything.
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=linux/amd64' || '' }}
+          outputs: type=docker,dest=/tmp/sipp-siphon.tar
+
+      # ~100 MB compressed vs ~300 MB raw, and `docker load` reads gzip directly.
+      # gzip -1 plus compression-level 0 beats letting upload-artifact deflate the
+      # whole uncompressed tar.
+      - name: Compress
+        run: gzip -1 /tmp/sipp-siphon.tar
+
+      - name: Upload the siphon image
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipp-siphon-image
+          path: /tmp/sipp-siphon.tar.gz
+          retention-days: 1
+          compression-level: 0
+
+  # ── SIPp functional tests (basic) ───────────────────────────────────────
+  sipp-functional:
+    runs-on: ubuntu-latest
+    needs: build-image
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start siphon
         run: docker compose -f sipp/docker-compose.yaml up -d --wait siphon
@@ -371,9 +424,12 @@ jobs:
   # the stack down on exit.
   sipp-mtu:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: MTU §18.1.1 fallback tests (IPv4)
         run: scripts/mtu_test.sh v4
@@ -390,9 +446,12 @@ jobs:
   # consumed and the request relayed.
   sipp-route-selfid:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Route self-identity (in-dialog BYE must be relayed, not 404'd)
         run: scripts/route_selfid_test.sh
@@ -406,9 +465,12 @@ jobs:
   # caller demands the 500 within 20 s.
   sipp-transport-error:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Transport error on forwarding must be answered, not dropped
         run: scripts/transport_error_test.sh
@@ -425,9 +487,12 @@ jobs:
   # which downstream actually received each INVITE.
   sipp-failover:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Terminating failover (per-binding Path + on_failure retarget)
         run: scripts/failover_test.sh
@@ -445,9 +510,12 @@ jobs:
   # NOT.
   sipp-b2bua-path:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: B2BUA B-leg follows the binding's Path (fork, dial, over-MTU)
         run: scripts/b2bua_path_test.sh
@@ -460,9 +528,12 @@ jobs:
   sipp-mtu-ipv6:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Enable docker IPv6 (merge into the runner's daemon.json)
         run: |
@@ -480,12 +551,12 @@ jobs:
   # ── B2BUA functional tests ─────────────────────────────────────────────
   sipp-b2bua:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-b2bua image
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua build siphon-b2bua
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start siphon-b2bua
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua up -d --wait siphon-b2bua
@@ -547,12 +618,12 @@ jobs:
   # media session + delete of the old anchor).
   sipp-b2bua-refer:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build B2BUA / refer-modes / anchored siphon images
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer-terminate --profile b2bua-replaces --profile b2bua-rtpengine-refer build siphon-b2bua siphon-b2bua-refer-modes siphon-b2bua-replaces siphon-b2bua-rtpengine-refer
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start siphon-b2bua
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua up -d --wait siphon-b2bua
@@ -674,12 +745,12 @@ jobs:
   # exits 0, which it does not — but the grep is the belt to that braces).
   sipp-originate:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-originate image
-        run: docker compose -f sipp/docker-compose.yaml --profile originate build siphon-originate
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start siphon (control listener) + the UAS
         run: docker compose -f sipp/docker-compose.yaml --profile originate up -d --wait siphon-originate
@@ -728,12 +799,12 @@ jobs:
   # fails on the extra INVITE.
   sipp-b2bua-invite-auth:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-b2bua-invite-auth image
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-invite-auth build siphon-b2bua-invite-auth
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start siphon-b2bua-invite-auth
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-invite-auth up -d --wait siphon-b2bua-invite-auth
@@ -764,12 +835,12 @@ jobs:
   # text-protocol client + siphon-side SDP rewrite work end-to-end.
   sipp-rtpproxy:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-rtpproxy image
-        run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy build siphon-rtpproxy
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start mock rtpproxy + siphon-rtpproxy
         run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy up -d --wait mock-rtpproxy siphon-rtpproxy
@@ -807,12 +878,12 @@ jobs:
   # ── Voice-AI B2BUA (single-leg answer + WebSocket bridge) ──────────────
   sipp-voice-ai:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-voice-ai image
-        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai build siphon-voice-ai
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start mock siphon-rtp + siphon-voice-ai
         run: docker compose -f sipp/docker-compose.yaml --profile voice-ai up -d --wait mock-siphon-rtp siphon-voice-ai
@@ -847,12 +918,12 @@ jobs:
   # ── Re-INVITE renegotiation on the siphon-rtp backend ──────────────────
   sipp-reoffer:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-reoffer image
-        run: docker compose -f sipp/docker-compose.yaml --profile reoffer build siphon-reoffer
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start mock siphon-rtp + siphon
         run: docker compose -f sipp/docker-compose.yaml --profile reoffer up -d --wait mock-siphon-rtp-reoffer siphon-reoffer
@@ -900,12 +971,12 @@ jobs:
   # ── Cold transfer off a single-leg answered call ───────────────────────
   sipp-refer-single-leg:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-refer image
-        run: docker compose -f sipp/docker-compose.yaml --profile refer-single-leg build siphon-refer
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start mock siphon-rtp + siphon-refer
         run: docker compose -f sipp/docker-compose.yaml --profile refer-single-leg up -d --wait mock-siphon-rtp-refer siphon-refer
@@ -987,12 +1058,12 @@ jobs:
   # complementary half, that a real engine accepts it.
   sipp-siphon-rtp-native:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-rtp-native image
-        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native build siphon-rtp-native
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start the real engine + siphon
         run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-native up -d --wait siphon-rtp-engine siphon-rtp-native
@@ -1043,12 +1114,12 @@ jobs:
   # straight from an existing rtpengine deployment.
   sipp-siphon-rtp-ng:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-rtp-ng image
-        run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-ng build siphon-rtp-ng
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start the real engine + siphon
         run: docker compose -f sipp/docker-compose.yaml --profile siphon-rtp-ng up -d --wait siphon-rtp-engine siphon-rtp-ng
@@ -1097,12 +1168,12 @@ jobs:
   # one until you measure the samples, which is what mock_ai_ws.py does.
   sipp-voice-ai-real:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-voice-ai-real image
-        run: docker compose -f sipp/docker-compose.yaml --profile voice-ai-real build siphon-voice-ai-real
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start the real engine + AI server + siphon
         run: docker compose -f sipp/docker-compose.yaml --profile voice-ai-real up -d --wait siphon-rtp-engine mock-ai-ws siphon-voice-ai-real
@@ -1158,12 +1229,12 @@ jobs:
   # below in the same way sipp-rtpproxy is of sipp-rtpproxy-real.
   sipp-rtpengine:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-rtpengine image
-        run: docker compose -f sipp/docker-compose.yaml --profile rtpengine build siphon-rtpengine
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start mock rtpengine + siphon
         run: docker compose -f sipp/docker-compose.yaml --profile rtpengine up -d --wait mock-rtpengine siphon-rtpengine
@@ -1200,12 +1271,12 @@ jobs:
   # behavioural difference between the jobs is attributable to the engine.
   sipp-rtpengine-real:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-rtpengine-real image
-        run: docker compose -f sipp/docker-compose.yaml --profile rtpengine-real build siphon-rtpengine-real
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start real rtpengine + siphon
         run: docker compose -f sipp/docker-compose.yaml --profile rtpengine-real up -d --wait rtpengine-real siphon-rtpengine-real
@@ -1247,12 +1318,12 @@ jobs:
   # it did the work, active sessions back at 0 proves siphon sent the delete.
   sipp-rtpproxy-real:
     runs-on: ubuntu-latest
-    needs: rust-tests
+    needs: build-image
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build siphon-rtpproxy-real image
-        run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy-real build siphon-rtpproxy-real
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
 
       - name: Start real rtpproxy + siphon
         run: docker compose -f sipp/docker-compose.yaml --profile rtpproxy-real up -d --wait rtpproxy-real siphon-rtpproxy-real

--- a/scripts/b2bua_path_test.sh
+++ b/scripts/b2bua_path_test.sh
@@ -67,8 +67,15 @@ wait_edge_received_invite() {
 }
 
 echo "=== B2BUA: routing a binding through its RFC 3327 Path ==="
-echo "[*] Building siphon image..."
-"${COMPOSE[@]}" build siphon-b2bua-path
+# CI loads sipp-siphon from the build-image job, and every siphon service in the
+# compose files shares that tag, so building here would redo a ~10 minute image
+# that is already present. Build only when it is absent, which is the local case.
+if docker image inspect sipp-siphon:latest >/dev/null 2>&1; then
+  echo "[*] Reusing the existing sipp-siphon image."
+else
+  echo "[*] Building siphon image..."
+  "${COMPOSE[@]}" build siphon-b2bua-path
+fi
 
 echo "[*] Starting siphon..."
 "${COMPOSE[@]}" up -d --wait siphon-b2bua-path || fail "siphon did not become healthy"

--- a/scripts/failover_test.sh
+++ b/scripts/failover_test.sh
@@ -33,8 +33,15 @@ fail() {
 }
 
 echo "=== Terminating failover across an AoR's bindings ==="
-echo "[*] Building siphon image..."
-"${COMPOSE[@]}" build siphon-failover
+# CI loads sipp-siphon from the build-image job, and every siphon service in the
+# compose files shares that tag, so building here would redo a ~10 minute image
+# that is already present. Build only when it is absent, which is the local case.
+if docker image inspect sipp-siphon:latest >/dev/null 2>&1; then
+  echo "[*] Reusing the existing sipp-siphon image."
+else
+  echo "[*] Building siphon image..."
+  "${COMPOSE[@]}" build siphon-failover
+fi
 
 echo "[*] Starting siphon..."
 "${COMPOSE[@]}" up -d --wait siphon-failover || fail "siphon did not become healthy"

--- a/scripts/mtu_test.sh
+++ b/scripts/mtu_test.sh
@@ -43,8 +43,15 @@ run_case() {
   echo "PASS (${name})"
 }
 
-echo "Building siphon image (sipp-siphon)..."
-"${COMPOSE[@]}" build siphon-mtu4
+# CI loads sipp-siphon from the build-image job, and every siphon service in the
+# compose files shares that tag, so building here would redo a ~10 minute image
+# that is already present. Build only when it is absent, which is the local case.
+if docker image inspect sipp-siphon:latest >/dev/null 2>&1; then
+  echo "[*] Reusing the existing sipp-siphon image."
+else
+  echo "Building siphon image (sipp-siphon)..."
+  "${COMPOSE[@]}" build siphon-mtu4
+fi
 
 for fam in ${FAMILIES}; do
   case "${fam}" in

--- a/scripts/route_selfid_test.sh
+++ b/scripts/route_selfid_test.sh
@@ -42,8 +42,15 @@ fail() {
 }
 
 echo "=== Route self-identity (RFC 3261 §16.4) ==="
-echo "[*] Building siphon image..."
-"${COMPOSE[@]}" build siphon-routing
+# CI loads sipp-siphon from the build-image job, and every siphon service in the
+# compose files shares that tag, so building here would redo a ~10 minute image
+# that is already present. Build only when it is absent, which is the local case.
+if docker image inspect sipp-siphon:latest >/dev/null 2>&1; then
+  echo "[*] Reusing the existing sipp-siphon image."
+else
+  echo "[*] Building siphon image..."
+  "${COMPOSE[@]}" build siphon-routing
+fi
 
 echo "[*] Starting siphon (two udp listeners, domain.local without the address)..."
 "${COMPOSE[@]}" up -d --wait siphon-routing \

--- a/scripts/transport_error_test.sh
+++ b/scripts/transport_error_test.sh
@@ -41,8 +41,15 @@ wait_for_log() {
 }
 
 echo "=== Transport error on forwarding must be answered (RFC 3261 §16.9 / §16.7) ==="
-echo "[*] Building siphon image..."
-"${COMPOSE[@]}" build siphon-transport-error
+# CI loads sipp-siphon from the build-image job, and every siphon service in the
+# compose files shares that tag, so building here would redo a ~10 minute image
+# that is already present. Build only when it is absent, which is the local case.
+if docker image inspect sipp-siphon:latest >/dev/null 2>&1; then
+  echo "[*] Reusing the existing sipp-siphon image."
+else
+  echo "[*] Building siphon image..."
+  "${COMPOSE[@]}" build siphon-transport-error
+fi
 
 echo "[*] Starting siphon and the blackhole (up, listening on nothing)..."
 "${COMPOSE[@]}" up -d transport-error-blackhole

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -521,6 +521,7 @@ services:
 
   # SIPhon proxy with RTPEngine config
   siphon-rtpengine:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-rtpengine-test
@@ -660,6 +661,7 @@ services:
 
   # SIPhon proxy with rtpproxy config (media.backend: rtpproxy)
   siphon-rtpproxy:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-rtpproxy-test
@@ -838,6 +840,7 @@ services:
   #   172.20.0.57 — A-leg UAC (cancel)
 
   siphon-b2bua:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-test
@@ -974,6 +977,7 @@ services:
   # for the auth_passthrough fix. Uses the b2bua_auth_passthrough.py script.
 
   siphon-b2bua-auth:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-auth-test
@@ -1059,6 +1063,7 @@ services:
   #   172.20.0.102 — SIPp UAC (A-leg caller)
 
   siphon-b2bua-invite-auth:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-invite-auth-test
@@ -1204,6 +1209,7 @@ services:
   #   172.20.0.53 — A-leg UAC (non-100rel trunk)
 
   siphon-b2bua-trunk-edge:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-trunk-edge-test
@@ -1525,6 +1531,7 @@ services:
   # picks the mode from the X-Refer-Mode header.
 
   siphon-b2bua-refer-modes:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-refer-modes-test
@@ -1795,6 +1802,7 @@ services:
   # quote dialog identifiers that only exist once the first call is up.
 
   siphon-b2bua-replaces:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-replaces-test
@@ -2521,6 +2529,7 @@ services:
   #   172.20.0.62 — SIPp UAC (caller)
 
   siphon-gateway:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-gateway-test
@@ -2600,6 +2609,7 @@ services:
   #   172.20.0.67 — SIPp UAC (A-leg caller)
 
   siphon-b2bua-gateway:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-gateway-test
@@ -2688,6 +2698,7 @@ services:
   #     up --abort-on-container-exit sipp-ims-uac
 
   siphon-ims:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-ims-test
@@ -2877,6 +2888,7 @@ services:
   # stop-the-world). On a many-core host the stall is only transient, so the
   # bug does NOT reproduce without this limit.
   siphon-http-auth:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-http-auth-test
@@ -2939,6 +2951,7 @@ services:
   # the registrar-side, Python-level analogue of the blocking-while-attached
   # hazard (static auth, so the on_change notify is the only blocking call).
   siphon-onchange:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-onchange-test
@@ -2999,6 +3012,7 @@ services:
   # Real sip.js WS user agents register and call each other through siphon's
   # flow-based MT routing. profile: webrtc
   siphon-webrtc:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-webrtc-test
@@ -3044,6 +3058,7 @@ services:
   # Same two-UA WS call test, but siphon runs as a B2BUA (bridges onto a fresh
   # B-leg INVITE over the callee's captured WS flow). profile: webrtc
   siphon-webrtc-b2bua:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-webrtc-b2bua-test
@@ -3200,6 +3215,7 @@ services:
       - rtpengine-real
 
   siphon-b2bua-rtpengine-refer:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-b2bua-rtpengine-refer-test
@@ -4375,6 +4391,7 @@ services:
 
   # SIPhon B2BUA running examples/voice_ai_b2bua.py
   siphon-voice-ai:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-voice-ai-test
@@ -4460,6 +4477,7 @@ services:
       - refer-single-leg
 
   siphon-refer:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-refer-test
@@ -4574,6 +4592,7 @@ services:
       - reoffer
 
   siphon-reoffer:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-reoffer-test
@@ -4760,6 +4779,7 @@ services:
 
   # ── Native JSON control plane (media.backend: siphon-rtp) ─────────────────
   siphon-rtp-native:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-rtp-native-test
@@ -4864,6 +4884,7 @@ services:
   # Identical to the native stack above except for the media backend, and it
   # runs the same scenarios the rtpengine profile uses, unmodified.
   siphon-rtp-ng:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-rtp-ng-test
@@ -4992,6 +5013,7 @@ services:
       - voice-ai-real
 
   siphon-voice-ai-real:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-voice-ai-real-test
@@ -5055,6 +5077,7 @@ services:
   # run in CI; it asserts what siphon *sent*, this asserts a real engine
   # accepted it.
   siphon-rtpengine-real:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-rtpengine-real-test
@@ -5183,6 +5206,7 @@ services:
       - rtpproxy-real
 
   siphon-rtpproxy-real:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-rtpproxy-real-test
@@ -5302,6 +5326,7 @@ services:
   #     siphon-originate sipp-originate-uas originate-app
 
   siphon-originate:
+    image: sipp-siphon   # reuse the siphon image (built by the `siphon` service)
     build:
       context: ..
     container_name: siphon-originate-test


### PR DESCRIPTION
Every SIPp job rebuilds a byte-identical siphon image from scratch. Measured on run `33378093884` (main, 2026-08-31):

| | |
|---|---|
| SIPp jobs on a PR | 20 |
| Total runner time | 205 min |
| Of that, `docker compose build` | ~198 min (96%) |
| Actual SIPp testing | ~6.6 min |
| Run wall clock | 24 min |

Step-level, `sipp-functional` spent **593 s building for 12 s of testing**; `sipp-b2bua` 598 s for 35 s. All twenty are that shape.

The rebuilds are redundant: all 29 siphon services in `sipp/docker-compose.yaml` build `context: ..` against the root `Dockerfile` with **zero** `args:` and **zero** `target:` overrides, so they are the same image. And nothing cached — no `buildx`, no `cache-from`, no `type=gha` anywhere in `ci.yaml`, only `Swatinem/rust-cache` on the native-cargo jobs, which the Docker builds never touch. So each cold runner redid apt, uv, CPython 3.14t, rustup, `cargo install cargo-chef` from source, `cargo chef cook --release` over the whole release graph, then the real build.

## Changes

**`sipp/docker-compose.yaml`** — 24 services gain `image: sipp-siphon`, so all 29 share one tag. This extends a convention already in the file: `siphon-scscf` and `siphon-ipsec` carry exactly that line today. The `build:` stanzas stay, so a local `compose up` from a clean tree still builds implicitly and the script-driven tests (`failover_test.sh`, `b2bua_path_test.sh`, …) are unaffected.

**`.github/actions/load-siphon-image/`** (new) — composite action doing download + `docker load`, rather than repeating it across 21 jobs. It asserts the tag exists afterwards, so a broken artifact fails there instead of silently falling through to a 10-minute implicit rebuild.

**`.github/workflows/ci.yaml`** — new `build-image` job producing the image once and uploading it; 21 SIPp jobs moved to `needs: build-image` plus the load step, with 15 explicit build steps removed.

`needs: build-image` replaces `needs: rust-tests` because `build-image` compiles siphon and so already gates on a compile error, which is what that gate bought. Keeping `rust-tests` would put it on the critical path in the warm-cache case for no added signal.

Cache scope is deliberately `linux/amd64`, the same one `release.yaml` uses: identical context, Dockerfile and build-args, so the two share one entry instead of competing, and each warms the other. `cache-to` fires only on trunk pushes, since a cache written from a PR branch is scoped to that branch, unreadable by other PRs and by main, and would only evict entries `rust-cache` needs. `mode=max` is load-bearing: everything expensive is in the chef/planner/builder stages, and `mode=min` exports only the final stage.

## Verified locally

The core assumption, against the real compose file:

- **Image present** → `up` goes straight to `Creating`/`Starting`, no build.
- **Image absent** → `Building`, so local dev is not regressed.
- **Artifact round-trip** on a real image: `docker save` 2.0 s → 258 MB raw, **104 MB gzipped** → `docker load -i *.tar.gz` 0.7 s, image ID unchanged.

Both YAML files parse, all 21 jobs have checkout before the load step, and the only remaining `docker compose build` is `sipp-ipsec` (self-hosted runner with a persistent docker cache, push-only trigger, deliberately untouched, as is `nftables-firewall`).

## Expected

| | before | after (cold) | after (warm) |
|---|---|---|---|
| SIPp runner-min | 205 | ~30 | ~28 |
| Run wall clock | 24 min | ~11 min | ~6 min |
| Per SIPp job | ~600 s | ~90 s | ~90 s |

This PR's own run is the real test.

No CHANGELOG entry: CI/test-harness only, exempt as internal churn.

`sipp-b2bua-refer` is a known flake at step #10; a failure there is not this change.