### PR TITLE
fix(b2bua): ACK the callee on every answered call

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -626,6 +626,23 @@ jobs:
             replaces-takeover-peer | tee replaces-verdict.log
           grep -q 'REPLACES-VERDICT .*"ok": true' replaces-verdict.log
 
+      # The callee's ACK. Its own gate because nothing else catches it: the
+      # failure is invisible on the caller's side, and it only appears when a
+      # call's 18x and its 200 are handled concurrently, which the scenario
+      # files never produce. Greps the verdict so a peer that dies before
+      # asserting cannot read as a pass.
+      - name: B2BUA callee is ACKed on every answered call (RFC 3261 §14.1)
+        run: |
+          docker compose -f sipp/docker-compose.yaml --profile b2bua-bleg-ack up -d --wait siphon-b2bua-replaces
+          docker compose -f sipp/docker-compose.yaml --profile b2bua-bleg-ack up \
+            --abort-on-container-exit --exit-code-from bleg-ack-peer \
+            bleg-ack-peer | tee bleg-ack.log
+          grep -q 'ACK-REPRO .*"failures": 0' bleg-ack.log
+
+      - name: Cleanup bleg-ack containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-bleg-ack rm -sf bleg-ack-peer 2>/dev/null || true
+
       - name: Cleanup replaces containers
         if: always()
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-replaces rm -sf replaces-takeover-peer siphon-b2bua-replaces 2>/dev/null || true
@@ -643,7 +660,7 @@ jobs:
 
       - name: Teardown
         if: always()
-        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer --profile b2bua-refer-reject --profile b2bua-refer-terminate --profile b2bua-refer-referrer-bye --profile b2bua-refer-attended --profile b2bua-replaces --profile b2bua-rtpengine-refer down --remove-orphans
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua --profile b2bua-refer --profile b2bua-refer-reject --profile b2bua-refer-terminate --profile b2bua-refer-referrer-bye --profile b2bua-refer-attended --profile b2bua-replaces --profile b2bua-bleg-ack --profile b2bua-rtpengine-refer down --remove-orphans
 
       - name: Upload logs
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,24 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   a personal one.
 
 ### Fixed
+- **The callee is ACKed on every answered call again.** A B-leg response was
+  classified from the leg actor's `CallEvent` rather than from its own status
+  line, and that event arrives on a per-call channel every leg pushes to, with no
+  guarantee it describes the response in hand. The receiver is taken out of the
+  map to be waited on, so when a call's `18x` and its `200` are processed at once
+  — the normal shape of an answered call — the second handler finds the receiver
+  gone and falls back to the status code while the event its own send produced
+  stays queued, leaving the stream off by one. The next response then reads its
+  predecessor's event, and a `200 OK` read as a `Provisional` skips `set_winner`
+  and the deferred B-leg ACK (RFC 3261 §14.1): the callee's `200` is never ACKed,
+  it retransmits to Timer B, and the dialog collapses seconds after everyone
+  believes the call is up — with nothing wrong on the caller's side. Filtering
+  stray `Terminated` events had removed one source of the skew; the
+  classification no longer depends on the event at all, which removes the rest.
+  Measured at **8-15% of plain B2BUA calls** on a loopback bridge before the fix
+  and **0 of 180** after, with a new acceptance gate that drives calls in a tight
+  loop — the existing SIPp scenarios never produced the concurrency and so never
+  caught it.
 - **An inbound `INVITE` with `Replaces` now actually takes the call over.** The
   transferee half of attended transfer (RFC 3891 §3 / RFC 5589 §7): a UA calls in
   naming the dialog it is taking over. siphon matched that dialog, logged it, and

--- a/sipp/ack/bleg_ack_test.py
+++ b/sipp/ack/bleg_ack_test.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Acceptance test: the callee is ACKed on every answered B2BUA call.
+
+siphon uses the late-ACK pattern (RFC 3261 §14.1) — it does not ACK the callee's
+200 immediately, it holds the ACK until the caller ACKs and then sends it. If
+that deferred ACK is never armed, the callee's INVITE transaction never
+completes: it retransmits its 200 to Timer B and tears the call down, seconds
+after everyone thinks the call is up. Nothing on the caller's side looks wrong,
+which is exactly why this needs its own gate.
+
+The existing SIPp suites did not catch it. It only appears when a call's 18x and
+its 200 are processed concurrently, which needs back-to-back calls with no pause
+between the ringing and the answer — a shape the scenario files do not produce.
+This peer drives plain calls in a tight loop and fails if ANY of them leaves the
+callee unacknowledged.
+
+Prints one `ACK-REPRO <json>` line; the CI step greps for `"failures": 0`.
+"""
+
+import json, os, socket, sys, time, uuid
+
+SIPHON = os.environ.get("SIPHON_ADDR", "172.20.0.114:5060")
+SELF_IP = os.environ.get("SELF_IP", "172.20.0.115")
+CALLS = int(os.environ.get("CALLS", "40"))
+HOST, PORT = SIPHON.split(":")
+ADDR = (HOST, int(PORT))
+
+
+def sdp(port):
+    return ("v=0\r\no=- 1 1 IN IP4 %s\r\ns=-\r\nc=IN IP4 %s\r\nt=0 0\r\n"
+            "m=audio %d RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n" % (SELF_IP, SELF_IP, port))
+
+
+def header(m, name):
+    for line in m.split("\r\n"):
+        if ":" in line and line[:1] not in (" ", "\t"):
+            k, _, v = line.partition(":")
+            if k.strip().lower() == name.lower():
+                return v.strip()
+    return None
+
+
+def start(m):
+    return m.split("\r\n", 1)[0]
+
+
+def method(m):
+    l = start(m)
+    return None if l.startswith("SIP/2.0") else l.split(None, 1)[0]
+
+
+def status(m):
+    l = start(m)
+    return int(l.split()[1]) if l.startswith("SIP/2.0") else None
+
+
+class P:
+    def __init__(self, name, port):
+        self.name, self.port = name, port
+        self.s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.s.bind((SELF_IP, port))
+        self.s.settimeout(0.2)
+        self.contact = "<sip:%s@%s:%d>" % (name, SELF_IP, port)
+
+    def send(self, m):
+        self.s.sendto(m.encode(), ADDR)
+
+    def recv(self, pred, timeout=5):
+        end = time.monotonic() + timeout
+        while time.monotonic() < end:
+            try:
+                d, _ = self.s.recvfrom(65535)
+            except socket.timeout:
+                continue
+            m = d.decode(errors="replace")
+            if pred(m):
+                return m
+        return None
+
+    def drain(self):
+        while True:
+            try:
+                self.s.recvfrom(65535)
+            except socket.timeout:
+                return
+
+    def respond(self, req, code, reason, body=None, tag=None):
+        to = header(req, "To")
+        if tag and ";tag=" not in (to or ""):
+            to = "%s;tag=%s" % (to, tag)
+        head = ["SIP/2.0 %d %s" % (code, reason), "Via: %s" % header(req, "Via"),
+                "From: %s" % header(req, "From"), "To: %s" % to,
+                "Call-ID: %s" % header(req, "Call-ID"), "CSeq: %s" % header(req, "CSeq"),
+                "Contact: %s" % self.contact]
+        if body:
+            head += ["Content-Type: application/sdp", "Content-Length: %d" % len(body)]
+            return "\r\n".join(head) + "\r\n\r\n" + body
+        head.append("Content-Length: 0")
+        return "\r\n".join(head) + "\r\n\r\n"
+
+
+def one_call(alice, bob, n):
+    alice.drain(); bob.drain()
+    cid = "ack-%d-%s@%s" % (n, uuid.uuid4().hex[:6], SELF_IP)
+    ftag = "a%s" % uuid.uuid4().hex[:8]
+    alice.send("\r\n".join([
+        "INVITE sip:bob@%s SIP/2.0" % HOST,
+        "Via: SIP/2.0/UDP %s:%d;branch=z9hG4bK%s" % (SELF_IP, alice.port, uuid.uuid4().hex[:12]),
+        "From: <sip:alice@%s>;tag=%s" % (SELF_IP, ftag),
+        "To: <sip:bob@%s>" % HOST, "Call-ID: %s" % cid, "CSeq: 1 INVITE",
+        "Contact: %s" % alice.contact, "Max-Forwards: 70",
+        "Content-Type: application/sdp", "Content-Length: %d" % len(sdp(40000)),
+    ]) + "\r\n\r\n" + sdp(40000))
+
+    binv = bob.recv(lambda m: method(m) == "INVITE" and ";tag=" not in (header(m, "To") or ""))
+    if not binv:
+        return ("no-b-invite", cid, None)
+    bcid = header(binv, "Call-ID")
+    btag = "b%s" % uuid.uuid4().hex[:8]
+    bob.send(bob.respond(binv, 180, "Ringing", tag=btag))
+    bob.send(bob.respond(binv, 200, "OK", body=sdp(40002), tag=btag))
+
+    a200 = alice.recv(lambda m: status(m) == 200 and (header(m, "CSeq") or "").endswith("INVITE"))
+    if not a200:
+        return ("no-a-200", cid, bcid)
+    ct = header(a200, "Contact") or "<sip:%s>" % HOST
+    ruri = ct.strip("<>").split(">")[0].lstrip("<")
+    alice.send("\r\n".join([
+        "ACK %s SIP/2.0" % ruri,
+        "Via: SIP/2.0/UDP %s:%d;branch=z9hG4bK%s" % (SELF_IP, alice.port, uuid.uuid4().hex[:12]),
+        "From: %s" % header(a200, "From"), "To: %s" % header(a200, "To"),
+        "Call-ID: %s" % cid, "CSeq: 1 ACK", "Max-Forwards: 70", "Content-Length: 0",
+    ]) + "\r\n\r\n")
+
+    back = bob.recv(lambda m: method(m) == "ACK", timeout=4)
+    verdict = "ok" if back else "NO-B-LEG-ACK"
+
+    # Tear down from alice so the next call starts clean.
+    alice.send("\r\n".join([
+        "BYE %s SIP/2.0" % ruri,
+        "Via: SIP/2.0/UDP %s:%d;branch=z9hG4bK%s" % (SELF_IP, alice.port, uuid.uuid4().hex[:12]),
+        "From: %s" % header(a200, "From"), "To: %s" % header(a200, "To"),
+        "Call-ID: %s" % cid, "CSeq: 2 BYE", "Max-Forwards: 70", "Content-Length: 0",
+    ]) + "\r\n\r\n")
+    alice.recv(lambda m: status(m) == 200, timeout=3)
+    bbye = bob.recv(lambda m: method(m) == "BYE", timeout=3)
+    if bbye:
+        bob.send(bob.respond(bbye, 200, "OK", tag=btag))
+    return (verdict, cid, bcid)
+
+
+def main():
+    alice, bob = P("alice", 6001), P("bob", 6002)
+    bad = []
+    for n in range(CALLS):
+        v, cid, bcid = one_call(alice, bob, n)
+        if v != "ok":
+            bad.append({"call": n, "verdict": v, "a_call_id": cid, "b_call_id": bcid})
+        time.sleep(0.05)
+    print("ACK-REPRO " + json.dumps({"calls": CALLS, "failures": len(bad), "detail": bad[:8]}), flush=True)
+    return 0 if not bad else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -1815,6 +1815,7 @@ services:
       start_period: 10s
     profiles:
       - b2bua-replaces
+      - b2bua-bleg-ack
 
   replaces-takeover-peer:
     image: python:3.12-slim
@@ -1832,6 +1833,29 @@ services:
     command: ["python3", "/peer/replaces_takeover_test.py"]
     profiles:
       - b2bua-replaces
+
+  # --- The callee is ACKed on every answered call (RFC 3261 §14.1) ---
+  # Reuses the replaces siphon (a plain bridge to one fixed callee) and drives
+  # calls in a tight loop, which is what makes a 18x and its 200 land on
+  # different workers at once.
+
+  bleg-ack-peer:
+    image: python:3.12-slim
+    depends_on:
+      siphon-b2bua-replaces:
+        condition: service_healthy
+    volumes:
+      - ./ack:/peer:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.115
+    environment:
+      SIPHON_ADDR: "172.20.0.114:5060"
+      SELF_IP: "172.20.0.115"
+      CALLS: "60"
+    command: ["python3", "/peer/bleg_ack_test.py"]
+    profiles:
+      - b2bua-bleg-ack
 
   # --- REFER terminate, ATTENDED (Refer-To carries a Replaces) ---
   # RFC 3891 §3: the dialog reference must reach the target's INVITE.

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -14062,6 +14062,36 @@ fn spawn_b_leg_actor_at(call_id: &str, b_leg: &Leg, index: usize, state: &Dispat
 /// The caller block-recvs only after a successful `try_send` of the response to
 /// the live actor, so exactly one non-`Terminated` classification event is
 /// always forthcoming and this loop terminates.
+/// How a B-leg response drives the B2BUA: an answer, a ringing indication, or a
+/// failure.
+#[derive(Debug, PartialEq, Eq)]
+enum ResponseClass {
+    Answered,
+    Provisional,
+    Failed,
+}
+
+/// Classify a B-leg response from its status code. `None` means "absorb" — a
+/// `100 Trying` is hop-by-hop and drives nothing here.
+///
+/// Deliberately a pure function of the status line. This used to be decided by
+/// the leg actor's `CallEvent`, which is delivered on a per-call channel shared
+/// by every leg and is not guaranteed to describe the response being handled;
+/// a 2xx read as its predecessor's `Provisional` skips `set_winner` and the
+/// deferred B-leg ACK, so the callee's 200 is never ACKed and it retransmits
+/// until the dialog collapses.
+fn classify_b_leg_response(status_code: u16) -> Option<ResponseClass> {
+    if (200..300).contains(&status_code) {
+        Some(ResponseClass::Answered)
+    } else if (180..200).contains(&status_code) {
+        Some(ResponseClass::Provisional)
+    } else if status_code >= 300 {
+        Some(ResponseClass::Failed)
+    } else {
+        None
+    }
+}
+
 fn recv_b_leg_classification_event(
     rx: &mut tokio::sync::mpsc::Receiver<CallEvent>,
 ) -> Option<CallEvent> {
@@ -15319,7 +15349,11 @@ fn handle_b2bua_response(
     // use the event to drive response handling below.
     // Re-INVITE tracking legs and retry legs may not have actors — fall
     // back to raw status_code classification in that case.
-    let actor_event: Option<CallEvent> = if let Some(handle_tx) = &b_leg_handle_tx {
+    // Kept for its side effects, not its value: the response still has to reach
+    // the leg actor so its own state machine advances, and the event it emits
+    // still has to be consumed so the per-call channel drains. What comes back
+    // is deliberately unused — see the classification note below.
+    let _actor_event: Option<CallEvent> = if let Some(handle_tx) = &b_leg_handle_tx {
         let leg_transport = b_leg_dest.map(|(addr, transport)| LegTransport {
             remote_addr: addr,
             connection_id: ConnectionId::default(),
@@ -15362,16 +15396,12 @@ fn handle_b2bua_response(
     // On 2xx: sync remote_tag and remote_contact from response back to canonical CallActor.
     // The LegActor extracts this on its clone, but we need to update the
     // authoritative copy in the CallActorStore.
-    // Driven by the 2xx itself, not only by the leg actor's `Answered` event.
-    // The event races the response it describes — it is delivered by a separate
-    // task — and when the response wins, this capture used to be skipped
-    // entirely, leaving the leg with no remote tag, no tagged `remote_to_uri`
-    // and no remote target. Everything siphon later builds toward that leg
-    // (BYE, re-INVITE, UPDATE) needs them (RFC 3261 §12.1.2), so the dialog
-    // state is taken from the 2xx that establishes the dialog. Idempotent: the
-    // event path, when it does arrive first, writes the same values.
-    if matches!(&actor_event, Some(CallEvent::Answered { .. })) || (200..300).contains(&status_code)
-    {
+    // Driven by the 2xx itself. The dialog state a B-leg needs for every request
+    // siphon later builds toward it (BYE, re-INVITE, UPDATE) comes from the 2xx
+    // that establishes the dialog (RFC 3261 §12.1.2) — not from an actor event
+    // that may describe a different response entirely (see the classification
+    // note below).
+    if (200..300).contains(&status_code) {
         if let Some(idx) = b_leg_index {
             if let Some(mut call) = state.call_actors.get_call_mut(call_id) {
                 if let Some(b_leg) = call.b_legs.get_mut(idx) {
@@ -15403,23 +15433,31 @@ fn handle_b2bua_response(
     }
 
     // Event-driven response classification.
-    // Actor events are authoritative when available; fall back to status_code.
-    #[derive(Debug)]
-    enum ResponseClass { Answered, Provisional, Failed }
-
-    let class = match &actor_event {
-        Some(CallEvent::Answered { .. }) => ResponseClass::Answered,
-        Some(CallEvent::Provisional { status_code: code, .. }) if *code >= 180 => {
-            ResponseClass::Provisional
-        }
-        Some(CallEvent::Failed { .. }) => ResponseClass::Failed,
-        _ => {
-            // No actor, filtered provisional (<180), or unexpected event
-            if (200..300).contains(&status_code) { ResponseClass::Answered }
-            else if (180..200).contains(&status_code) { ResponseClass::Provisional }
-            else if status_code >= 300 { ResponseClass::Failed }
-            else { return; } // 100 Trying from B-leg — absorb
-        }
+    // Classified from the response's OWN status line, never from the actor
+    // event.
+    //
+    // The event is popped from a per-call channel that every leg actor pushes
+    // to, and there is no guarantee the one that comes back describes the
+    // response in hand. The receiver is taken out of the map to be waited on, so
+    // when two responses for a call are processed at once — a 180 and its 200 on
+    // different workers, which is the normal shape of an answered call — the
+    // second handler finds the receiver gone and classifies by status, while the
+    // event its own `try_send` produced stays queued. The stream is then off by
+    // one and the next response reads its predecessor's event.
+    //
+    // Filtering `Terminated` (see `recv_b_leg_classification_event`) fixed one
+    // source of that skew; this removes the dependency instead of chasing the
+    // rest. A 2xx read as its predecessor's `Provisional` skips `set_winner` and
+    // the deferred B-leg ACK, so the callee's 200 is never ACKed and it
+    // retransmits until the dialog collapses — measured at 8-15% of plain calls
+    // on a loopback B2BUA before this change.
+    //
+    // The response's status line is unambiguous, always present, and describes
+    // exactly the message being handled. The actor is still fed the response so
+    // its own state machine advances, and the event is still consumed so the
+    // channel drains; only the classification no longer depends on it.
+    let Some(class) = classify_b_leg_response(status_code) else {
+        return; // 100 Trying from B-leg — absorb
     };
 
     // siphon-terminated transfer: intercept EVERY response from a newly-dialed
@@ -23462,6 +23500,46 @@ mod tests {
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
     use crate::sip::builder::SipMessageBuilder;
+
+    /// A B-leg response is classified by its own status line and nothing else.
+    ///
+    /// This is the invariant behind the callee actually being ACKed. When the
+    /// leg actor's `CallEvent` decided this instead, a 2xx processed while its
+    /// own 18x's event was still queued read as `Provisional` — skipping
+    /// `set_winner` and the deferred B-leg ACK, so the callee's 200 was never
+    /// ACKed and it retransmitted until the dialog collapsed. Measured at
+    /// 8-15% of plain calls on a loopback B2BUA.
+    #[test]
+    fn b_leg_response_is_classified_by_its_own_status() {
+        // Every 2xx answers the call.
+        for code in [200, 202, 250, 299] {
+            assert_eq!(
+                classify_b_leg_response(code),
+                Some(ResponseClass::Answered),
+                "{code} must answer"
+            );
+        }
+        // 18x rings; 100 is absorbed rather than classified.
+        assert_eq!(
+            classify_b_leg_response(180),
+            Some(ResponseClass::Provisional)
+        );
+        assert_eq!(
+            classify_b_leg_response(183),
+            Some(ResponseClass::Provisional)
+        );
+        assert_eq!(classify_b_leg_response(199), Some(ResponseClass::Provisional));
+        assert_eq!(classify_b_leg_response(100), None, "100 Trying is absorbed");
+        assert_eq!(classify_b_leg_response(179), None, "a 1xx below 180 is absorbed");
+        // Everything final and non-2xx fails the leg.
+        for code in [300, 401, 404, 486, 500, 603] {
+            assert_eq!(
+                classify_b_leg_response(code),
+                Some(ResponseClass::Failed),
+                "{code} must fail the leg"
+            );
+        }
+    }
 
     // -----------------------------------------------------------------------
     // LCR per-route header injection must not forge dialog headers


### PR DESCRIPTION
The call-drop race flagged during #223, root-caused and fixed.

## The bug

siphon uses the late-ACK pattern (RFC 3261 §14.1): it does not ACK the callee's
`200` immediately, it arms a deferred ACK and sends it once the caller ACKs. On
**8-15% of plain B2BUA calls** that ACK was never armed. The callee's INVITE
transaction then never completes — it retransmits its `200` to Timer B and tears
the call down, seconds after everyone believes the call is up. Nothing looks
wrong on the caller's side, which is why this has been invisible.

## Root cause

A B-leg response was classified from the leg actor's `CallEvent` rather than from
its own status line. That event arrives on a **per-call channel every leg pushes
to**, and nothing ties the event you pop to the response you are holding.

The receiver is *lifted out of the map* to be waited on. So when a call's `18x`
and its `200` are processed concurrently — the normal shape of an answered call —
the second handler finds the receiver gone, correctly falls back to the status
code, and the event its own `try_send` produced stays queued. The stream is now
off by one, and the next response reads its predecessor's event.

A `200 OK` read as a `Provisional` takes the provisional path: no `set_winner`,
no route-set capture, no deferred B-leg ACK. The `200` is still forwarded to the
caller, so the call looks answered.

This exact consequence is already described in `recv_b_leg_classification_event`'s
own doc comment — someone hit it before and fixed **one** source of the skew
(stray `Terminated` events from a superseded leg after a 401/407 retry). My repro
has no auth and no retry, so there was at least one more. Rather than chase the
next one, this removes the dependency: the response's status line is unambiguous,
always present, and describes exactly the message being handled.

The actor is still fed the response so its own state machine advances, and the
event is still consumed so the channel drains. Only the classification changed.

## Evidence

Measured with a peer driving plain calls (no transfer, no Replaces):

| | before | after |
|---|---|---|
| calls with no callee ACK | 5/60, 9/60, 8/60, 7/60, 4/60 | **0 / 180** |
| deferred ACKs armed | 51 of 60 | **180 of 180** |
| `no pending B-leg ACK` | 9 | **0** |

Instrumented run before the fix, on the 200s:

```
18 class=Answered   event=None          (status fallback)
36 class=Answered   event=Answered
 6 class=Provisional event=Provisional  <-- a 200 read as its 18x's event
```

## Test harness

`sipp/ack/bleg_ack_test.py`, wired as its own CI step. It drives calls in a tight
loop, which is what makes a `18x` and its `200` land on different workers at
once — the scenario files pause between ringing and answer and so never produce
the concurrency. It fails if **any** call leaves the callee unacknowledged.

Proven to catch the bug: putting the old event-driven classification back gives
`"failures": 4` and exit 1.

Plus a unit test pinning the status-line rule (`classify_b_leg_response`), which
is now a pure function instead of an inline match.

## Testing

- 3741 lib + 326 integration green; `clippy --all-targets --all-features -D warnings` clean
- Regression across the whole B2BUA surface, since this is the core response
  path: base B2BUA, REFER transparent / terminate / attended / referrer-BYE, and
  the Replaces takeover — all green
- `transport_tests::multi_transport_shared_inbound_channel` flaked once; it is
  the known TOCTOU-flaky test from the 1.6.0 follow-ups and flakes identically
  with this change stashed

## Not done

The 16-row throughput baseline and the memory-leak pair have **not** been run —
they are your gate and your hardware. This change removes an enum match from the
per-response path rather than adding work, so I would not expect movement, but
that is an expectation, not a measurement.
