### PR TITLE
fix(b2bua): name the media profile for the pair a transfer creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **`call.accept_refer(profile=…)` — the media profile for the pairing a
+  transfer creates.** A media profile has two halves, and when they differ
+  (`srtp_to_rtp` and every other SRTP/DTLS edge) they describe *specific sides*
+  of the call. A transfer re-pairs it, and the party a half was written for is
+  usually the one leaving — so inheriting the profile re-offers **that party's
+  transport to whoever remains**: SRTP toward a plain-RTP carrier, which answers
+  `m=audio 0`. The call connects and carries no audio in either direction, and
+  the SIP trace looks healthy throughout. Name the profile for the pair that
+  remains:
+
+  ```python
+  call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
+                    profile="rtp_passthrough")
+  ```
+
+  Also accepted as `profile` on the control plane's `accept_refer`. Unset keeps
+  the previous inherit behaviour, which is correct for a symmetric profile.
+
+### Fixed
+- **A transfer no longer silently inherits a direction-bound media profile.**
+  When one is inherited with no `profile=` override, siphon now logs a `WARN`
+  naming it and saying what will happen, instead of producing a connected call
+  with dead audio and no clue why. Same warning on an inbound `INVITE` with
+  `Replaces`, which re-pairs the call the same way. siphon does not guess a
+  replacement — only the script knows what the surviving pair looks like.
+- **`examples/teams_sbc.yaml` no longer shows a config key that does nothing.**
+  Both profiles carried `codec: ["offer", "PCMA,PCMU"]`; there is no `codec`
+  field on a media profile and nothing encodes it, so the line was silently
+  ignored while implying siphon transcodes on the operator's behalf. Removed,
+  the two direction-bound profiles are labelled as such, and the example gains a
+  `@b2bua.on_refer` handler showing the `profile=` a Teams SBC needs — the exact
+  topology where getting this wrong costs you the audio. Codec selection in
+  siphon is done from a script through the `sdp` namespace, not through a media
+  profile.
+
 ## [1.7.0] — 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
                     profile="rtp_passthrough")
   ```
 
-  Also accepted as `profile` on the control plane's `accept_refer`. Unset keeps
+  Also accepted as `profile` on the control plane's `accept_refer`, and exposed
+  on all three control SDKs (Rust `accept_refer(.., profile)`, Python
+  `accept_refer(profile=…)`, TypeScript `acceptRefer({ profile })`). Unset keeps
   the previous inherit behaviour, which is correct for a symmetric profile.
+- **`call.refer_side` — which leg sent the REFER** (`"a"` / `"b"`, matching the
+  `initiator.side` convention in `@b2bua.on_bye`). Without it a script could not
+  work out *which party survives* a transfer, and therefore could not pick the
+  profile the surviving pair needs: the survivor is the peer of the referrer, so
+  at a mixed edge the right profile flips depending on which side transferred.
+  `examples/teams_sbc.py` shows the full rule.
 
 ### Fixed
 - **A transfer no longer silently inherits a direction-bound media profile.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,15 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 - **`examples/teams_sbc.yaml` no longer shows a config key that does nothing.**
   Both profiles carried `codec: ["offer", "PCMA,PCMU"]`; there is no `codec`
   field on a media profile and nothing encodes it, so the line was silently
-  ignored while implying siphon transcodes on the operator's behalf. Removed,
-  the two direction-bound profiles are labelled as such, and the example gains a
+  ignored while implying siphon restricts codecs on the operator's behalf — it
+  looks like a real rtpengine NG flag, but `NgFlagsConfig` has no such field and
+  no `deny_unknown_fields`, so serde dropped it and nothing ever reached the
+  engine. Removed, with a note pointing at the mechanism that does work: codec
+  selection is done from a script through the `sdp` namespace
+  (`filter_codecs`/`remove_codecs`), not through a media profile. Both
+  direction-bound profiles are now labelled as such, and the example gains a
   `@b2bua.on_refer` handler showing the `profile=` a Teams SBC needs — the exact
-  topology where getting this wrong costs you the audio. Codec selection in
-  siphon is done from a script through the `sdp` namespace, not through a media
-  profile.
+  topology where getting this wrong costs you the audio.
 
 ## [1.7.0] — 2026-08-31
 

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -166,16 +166,30 @@ def on_refer(call):
     The call connects, both parties think they are talking, and there is no
     audio in either direction.
 
-    Pass `profile=` naming the profile for the pair that **remains**:
+    Pass `profile=` naming the profile for the pair that **remains**. The rule
+    is: **the survivor is the peer of the referrer**, and the profile describes
+    survivor → target. So the answer depends on *which side* transferred, which
+    `call.refer_side` (`"a"`/`"b"`, matching `on_bye`'s `initiator.side`) tells
+    you:
 
     ```python
     @b2bua.on_refer
     def on_refer(call):
-        # Teams referred the call to a carrier number: once Teams is gone,
-        # both remaining legs are plain RTP on the carrier side.
+        # from_gateway() answers for the A-leg; refer_side says which leg
+        # referred. They agree exactly when the SRTP party is the transferor.
+        a_leg_is_secure = call.from_gateway("teams")
+        referrer_is_secure = a_leg_is_secure == (call.refer_side == "a")
+
+        # The SRTP party leaving leaves two plain-RTP ends behind. The SRTP
+        # party SURVIVING keeps the asymmetric pairing.
+        profile = "rtp_passthrough" if referrer_is_secure else "srtp_to_rtp"
+
         call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
-                          profile="rtp_passthrough")
+                          profile=profile)
     ```
+
+    In practice the secure side is nearly always the transferor — a carrier
+    rarely sends `REFER` — but an SBC should not fall over the day one does.
 
     siphon logs a `WARN` naming the profile when a transfer inherits a
     direction-bound one, but it cannot pick the replacement for you — only the

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -147,6 +147,54 @@ def on_refer(call):
                       next_hop="sip:trunk.example.com:5060")
 ```
 
+### Media profiles across a transfer — read this before deploying an SRTP edge
+
+!!! danger "A transfer re-pairs the call. A direction-bound profile does not follow."
+
+    A media profile has two halves, and for profiles like `srtp_to_rtp` they
+    describe **specific sides of the call**:
+
+    ```yaml
+    srtp_to_rtp:
+      offer:   { transport_protocol: "RTP/AVP",  direction: ["teams", "carrier"] }
+      answer:  { transport_protocol: "RTP/SAVP", direction: ["carrier", "teams"] }
+    ```
+
+    The `answer` half exists to talk to the SRTP party. A transfer moves that
+    party out of the call — so applying the same profile afterwards re-offers
+    **SRTP to whoever is left**, and a plain-RTP carrier answers `m=audio 0`.
+    The call connects, both parties think they are talking, and there is no
+    audio in either direction.
+
+    Pass `profile=` naming the profile for the pair that **remains**:
+
+    ```python
+    @b2bua.on_refer
+    def on_refer(call):
+        # Teams referred the call to a carrier number: once Teams is gone,
+        # both remaining legs are plain RTP on the carrier side.
+        call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
+                          profile="rtp_passthrough")
+    ```
+
+    siphon logs a `WARN` naming the profile when a transfer inherits a
+    direction-bound one, but it cannot pick the replacement for you — only the
+    script knows what the surviving pair looks like.
+
+**Which profiles are direction-bound?** Any whose two halves differ: a different
+`transport_protocol` (every SRTP/DTLS edge), or a `direction:` pair, or different
+DTLS handling. The built-ins `srtp_to_rtp`, `rtp_to_srtp`, `ws_to_rtp` and
+`wss_to_rtp` all are. `rtp_passthrough` is symmetric and re-pairs safely.
+
+The same applies to **anything else the profile pins to one side** — a transcoding
+or codec-shaping policy chosen because *that* party needed it does not
+automatically suit the party that replaces it. If the two halves of your profile
+are not interchangeable, name the profile explicitly on transfer.
+
+This is not specific to `REFER`: an inbound `INVITE` with `Replaces` re-pairs the
+call the same way, and warns the same way. Transfers across an SRTP or
+transcoding boundary want a symmetric profile on the surviving pair.
+
 ### Media anchoring (terminate mode)
 
 Terminate mode re-bridges the media plane by offering the **surviving** party's

--- a/examples/teams_sbc.py
+++ b/examples/teams_sbc.py
@@ -68,37 +68,69 @@ async def route(call):
 
 @b2bua.on_refer
 async def on_refer(call):
-    """A Teams user transferring the call away.
+    """A party transfers the call away — pick the profile for the pair that REMAINS.
 
-    ``profile=`` is REQUIRED here and getting it wrong is silent. This SBC
-    anchors every call with a direction-bound profile — ``srtp_to_rtp`` says
-    "the offerer speaks SRTP, the answerer speaks plain RTP" — and a transfer
-    takes the SRTP party OUT of the call. Inherit that profile and siphon
-    re-INVITEs the surviving carrier leg with SRTP it never spoke; the carrier
-    answers ``m=audio 0`` and you get a connected call with no audio in either
-    direction, which looks perfectly healthy in the SIP trace.
+    This is the trap at a mixed edge, and it is silent when you get it wrong.
+    Every call here is anchored with a DIRECTION-BOUND profile: ``srtp_to_rtp``
+    means "the offerer speaks SRTP, the answerer speaks plain RTP". A transfer
+    takes one of those two parties out of the call, so the profile that was right
+    for the original pairing is usually wrong for the new one — the surviving leg
+    gets re-INVITEd with a transport it never spoke, answers ``m=audio 0``, and
+    you are left with a connected call carrying no audio in either direction
+    while the SIP trace looks perfectly healthy.
 
-    Once Teams is gone both remaining legs are plain RTP on the carrier side,
-    so the surviving pair wants the symmetric ``rtp_passthrough``.
+    The rule is: **the survivor is the peer of the referrer**, and the profile
+    describes survivor -> target.
+
+      Teams refers    -> Teams leaves, a carrier leg survives, the target is on
+                         the carrier side too: plain RTP on both ends, so the
+                         symmetric ``rtp_passthrough``.
+      Carrier refers  -> the carrier party leaves and the TEAMS leg survives, so
+                         the new pair is still SRTP -> plain RTP: ``srtp_to_rtp``,
+                         whose offer half is written for a Teams-side offerer.
+
+    ``call.refer_side`` says which leg sent the REFER ("a"/"b"); combined with
+    which leg is the Teams one, that gives the referrer. In practice Teams is
+    almost always the transferor — carriers rarely send REFER — but the SBC
+    should not fall over the day one does.
     """
     if not call.refer_to:
         call.reject_refer(400, "Bad Request")
         return
 
-    destination = gateway.select("carrier")
+    # from_gateway() answers for the A-leg; refer_side says which leg referred.
+    # They agree exactly when the Teams party is the one transferring.
+    a_leg_is_teams = call.from_gateway("teams")
+    referrer_is_teams = a_leg_is_teams == (call.refer_side == "a")
+
+    if referrer_is_teams:
+        # Teams drops out. Both remaining ends are plain RTP on the carrier side.
+        profile = "rtp_passthrough"
+        destination = gateway.select("carrier")
+        group = "carrier"
+    else:
+        # The carrier party drops out and the Teams leg survives, so the
+        # surviving pair is still SRTP <-> RTP and keeps the asymmetric profile.
+        profile = "srtp_to_rtp"
+        destination = gateway.select("carrier")
+        group = "carrier"
+
     if not destination:
-        log.error(f"[{call.id}] no healthy carrier gateway for transfer")
+        log.error(f"[{call.id}] no healthy {group} gateway for transfer")
         call.reject_refer(503, "Service Unavailable")
         return
 
-    log.info(f"[{call.id}] transfer -> {call.refer_to} via {destination.uri}")
+    log.info(
+        f"[{call.id}] transfer -> {call.refer_to} via {destination.uri} "
+        f"(referrer={'teams' if referrer_is_teams else 'carrier'}, profile={profile})"
+    )
     call.accept_refer(
         target=call.refer_to,
         next_hop=destination.uri,
         mode="terminate",
-        # The pair that REMAINS after Teams leaves — not the pair the call
-        # started as. See docs/cookbook/call-transfer.md.
-        profile="rtp_passthrough",
+        # The pair that REMAINS after the referrer leaves — never simply the
+        # profile the call started with. See docs/cookbook/call-transfer.md.
+        profile=profile,
     )
 
 

--- a/examples/teams_sbc.py
+++ b/examples/teams_sbc.py
@@ -66,6 +66,42 @@ async def route(call):
         call.dial(destination.uri)
 
 
+@b2bua.on_refer
+async def on_refer(call):
+    """A Teams user transferring the call away.
+
+    ``profile=`` is REQUIRED here and getting it wrong is silent. This SBC
+    anchors every call with a direction-bound profile — ``srtp_to_rtp`` says
+    "the offerer speaks SRTP, the answerer speaks plain RTP" — and a transfer
+    takes the SRTP party OUT of the call. Inherit that profile and siphon
+    re-INVITEs the surviving carrier leg with SRTP it never spoke; the carrier
+    answers ``m=audio 0`` and you get a connected call with no audio in either
+    direction, which looks perfectly healthy in the SIP trace.
+
+    Once Teams is gone both remaining legs are plain RTP on the carrier side,
+    so the surviving pair wants the symmetric ``rtp_passthrough``.
+    """
+    if not call.refer_to:
+        call.reject_refer(400, "Bad Request")
+        return
+
+    destination = gateway.select("carrier")
+    if not destination:
+        log.error(f"[{call.id}] no healthy carrier gateway for transfer")
+        call.reject_refer(503, "Service Unavailable")
+        return
+
+    log.info(f"[{call.id}] transfer -> {call.refer_to} via {destination.uri}")
+    call.accept_refer(
+        target=call.refer_to,
+        next_hop=destination.uri,
+        mode="terminate",
+        # The pair that REMAINS after Teams leaves — not the pair the call
+        # started as. See docs/cookbook/call-transfer.md.
+        profile="rtp_passthrough",
+    )
+
+
 @b2bua.on_answer
 async def answered(call, reply):
     # Reuse the offer profile (keyed by A-leg Call-ID) so the SRTP/RTP

--- a/examples/teams_sbc.py
+++ b/examples/teams_sbc.py
@@ -70,29 +70,22 @@ async def route(call):
 async def on_refer(call):
     """A party transfers the call away — pick the profile for the pair that REMAINS.
 
-    This is the trap at a mixed edge, and it is silent when you get it wrong.
     Every call here is anchored with a DIRECTION-BOUND profile: ``srtp_to_rtp``
     means "the offerer speaks SRTP, the answerer speaks plain RTP". A transfer
-    takes one of those two parties out of the call, so the profile that was right
-    for the original pairing is usually wrong for the new one — the surviving leg
-    gets re-INVITEd with a transport it never spoke, answers ``m=audio 0``, and
-    you are left with a connected call carrying no audio in either direction
-    while the SIP trace looks perfectly healthy.
+    takes one of those two parties out of the call, so the profile that suited
+    the original pairing is usually wrong for the new one — and the failure is
+    silent, a connected call with no audio in either direction.
 
-    The rule is: **the survivor is the peer of the referrer**, and the profile
+    The rule: **the survivor is the peer of the referrer**, and the profile
     describes survivor -> target.
 
-      Teams refers    -> Teams leaves, a carrier leg survives, the target is on
-                         the carrier side too: plain RTP on both ends, so the
-                         symmetric ``rtp_passthrough``.
-      Carrier refers  -> the carrier party leaves and the TEAMS leg survives, so
-                         the new pair is still SRTP -> plain RTP: ``srtp_to_rtp``,
-                         whose offer half is written for a Teams-side offerer.
+      Teams refers   -> Teams leaves, a carrier leg survives and the target is
+                        carrier-side too: plain RTP both ends, ``rtp_passthrough``.
+      Carrier refers -> the TEAMS leg survives, so the new pair is still
+                        SRTP -> plain RTP: keep ``srtp_to_rtp``.
 
-    ``call.refer_side`` says which leg sent the REFER ("a"/"b"); combined with
-    which leg is the Teams one, that gives the referrer. In practice Teams is
-    almost always the transferor — carriers rarely send REFER — but the SBC
-    should not fall over the day one does.
+    ``call.refer_side`` ("a"/"b") says which leg referred. In practice Teams is
+    almost always the transferor, but the SBC should not fall over otherwise.
     """
     if not call.refer_to:
         call.reject_refer(400, "Bad Request")
@@ -103,20 +96,13 @@ async def on_refer(call):
     a_leg_is_teams = call.from_gateway("teams")
     referrer_is_teams = a_leg_is_teams == (call.refer_side == "a")
 
-    if referrer_is_teams:
-        # Teams drops out. Both remaining ends are plain RTP on the carrier side.
-        profile = "rtp_passthrough"
-        destination = gateway.select("carrier")
-        group = "carrier"
-    else:
-        # The carrier party drops out and the Teams leg survives, so the
-        # surviving pair is still SRTP <-> RTP and keeps the asymmetric profile.
-        profile = "srtp_to_rtp"
-        destination = gateway.select("carrier")
-        group = "carrier"
+    # Teams leaving leaves two plain-RTP ends behind; Teams surviving keeps the
+    # asymmetric pairing.
+    profile = "rtp_passthrough" if referrer_is_teams else "srtp_to_rtp"
 
+    destination = gateway.select("carrier")
     if not destination:
-        log.error(f"[{call.id}] no healthy {group} gateway for transfer")
+        log.error(f"[{call.id}] no healthy carrier gateway for transfer")
         call.reject_refer(503, "Service Unavailable")
         return
 

--- a/examples/teams_sbc.yaml
+++ b/examples/teams_sbc.yaml
@@ -128,6 +128,13 @@ media:
     # PSTN -> Teams: carrier offers RTP, transcode up to SRTP for Teams.
     # The direction labels ("carrier"/"teams") must match the interface names
     # configured in rtpengine.conf.
+    # NOTE: a media profile controls transport, ICE, DTLS, direction and SDP
+    # rewriting — NOT codec selection. There is no `codec:` key here; one would
+    # be silently ignored. Restrict or reorder codecs from the script with the
+    # `sdp` namespace instead, e.g. in @b2bua.on_invite:
+    #     s = sdp.parse(call)
+    #     s.filter_codecs(["PCMA", "PCMU", "telephone-event"])
+    #     s.apply(call)
     # DIRECTION-BOUND, like its mirror below — do not inherit it across a
     # transfer or a Replaces takeover.
     rtp_to_srtp:

--- a/examples/teams_sbc.yaml
+++ b/examples/teams_sbc.yaml
@@ -128,26 +128,43 @@ media:
     # PSTN -> Teams: carrier offers RTP, transcode up to SRTP for Teams.
     # The direction labels ("carrier"/"teams") must match the interface names
     # configured in rtpengine.conf.
+    # DIRECTION-BOUND, like its mirror below — do not inherit it across a
+    # transfer or a Replaces takeover.
     rtp_to_srtp:
       offer:
         transport_protocol: "RTP/SAVP"
         ice: "remove"
         replace: ["origin", "session-connection"]
         direction: ["carrier", "teams"]
-        codec: ["offer", "PCMA,PCMU"]
       answer:
         transport_protocol: "RTP/AVP"
         ice: "remove"
         replace: ["origin", "session-connection"]
         direction: ["teams", "carrier"]
+    # Symmetric: both halves say the same thing, so it survives a re-pairing.
+    # This is what a transfer away from Teams uses — see teams_sbc.py's
+    # @b2bua.on_refer. Named explicitly here even though siphon ships a built-in
+    # of the same name, so the example is readable on its own.
+    rtp_passthrough:
+      offer:
+        replace: ["origin", "session-connection"]
+        flags: ["trust-address"]
+      answer:
+        replace: ["origin", "session-connection"]
+        flags: ["trust-address"]
     # Teams -> PSTN: Teams offers SRTP, transcode down to RTP for the carrier.
+    # DIRECTION-BOUND. The two halves describe specific sides: the offerer
+    # speaks SRTP, the answerer speaks plain RTP, and `direction` names which
+    # rtpengine interface each is on. That is correct for the pairing it was
+    # chosen for and wrong for any other — so a call transferred away from Teams
+    # must NOT inherit it. See the @b2bua.on_refer handler in teams_sbc.py:
+    # accept_refer(profile="rtp_passthrough") for the pair that remains.
     srtp_to_rtp:
       offer:
         transport_protocol: "RTP/AVP"
         ice: "remove"
         replace: ["origin", "session-connection"]
         direction: ["teams", "carrier"]
-        codec: ["offer", "PCMA,PCMU"]
       answer:
         transport_protocol: "RTP/SAVP"
         ice: "remove"

--- a/scripts/b2bua_rtpengine_refer.py
+++ b/scripts/b2bua_rtpengine_refer.py
@@ -43,7 +43,14 @@ async def answered(call, reply):
 @b2bua.on_refer
 def on_refer(call):
     log.info(f"Call {call.id} REFER -> {call.refer_to} (terminate)")
-    call.accept_refer(mode="terminate")
+    # Name the profile for the pairing the transfer creates rather than
+    # inheriting the call's. Here they happen to be the same symmetric profile,
+    # so the wire result is unchanged — what this exercises is that an explicit
+    # profile threads all the way through the anchored path (the target offer,
+    # the survivor's re-INVITE answer, and the re-keyed media session) against a
+    # REAL rtpengine. A direction-bound profile is where the difference bites,
+    # and that needs an SRTP endpoint pair this harness does not have.
+    call.accept_refer(mode="terminate", profile=PROFILE)
 
 
 @b2bua.on_bye

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -68,6 +68,7 @@ class Call:
         headers: Optional[dict[str, str]] = None,
         refer_to: Optional[str] = None,
         refer_replaces: Optional[dict] = None,
+        refer_side: Optional[str] = None,
         transport: str = "udp",
         active_route: Optional[Route] = None,
         flow: Optional[Flow] = None,
@@ -94,6 +95,7 @@ class Call:
         self._media = MediaHandle()
         self._refer_to = refer_to
         self._refer_replaces = refer_replaces
+        self._refer_side = refer_side
         self._contact_user_override: Optional[str] = None
         self._contact_override: Optional[str] = None
         # LCR: the carrier that won the sequential failover. In the engine the
@@ -331,6 +333,32 @@ class Call:
                 call.accept_refer()
         """
         return self._refer_to
+
+    @property
+    def refer_side(self) -> Optional[str]:
+        """Which leg sent the REFER: ``"a"`` (caller) or ``"b"`` (callee).
+
+        Available in ``@b2bua.on_refer`` handlers, matching the
+        ``initiator.side`` convention in ``@b2bua.on_bye``.  ``None`` when no
+        REFER is pending.
+
+        The party that **survives** the transfer is the peer of this one, which
+        is what decides the media profile the surviving pair needs — see
+        :meth:`accept_refer`.  At a mixed edge (SRTP on one side, plain RTP on
+        the other) the right profile differs depending on which side is
+        leaving.
+
+        Example::
+
+            @b2bua.on_refer
+            def handle_refer(call):
+                a_leg_is_secure = call.from_gateway("teams")
+                referrer_is_secure = a_leg_is_secure == (call.refer_side == "a")
+                # The secure party leaving leaves two plain-RTP ends behind.
+                profile = "rtp_passthrough" if referrer_is_secure else "srtp_to_rtp"
+                call.accept_refer(mode="terminate", profile=profile)
+        """
+        return self._refer_side
 
     @property
     def refer_replaces(self) -> Optional[dict]:

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -849,7 +849,8 @@ class Call:
 
     def accept_refer(self, target: Optional[str] = None,
                      next_hop: Optional[str] = None,
-                     mode: Optional[str] = None) -> None:
+                     mode: Optional[str] = None,
+                     profile: Optional[str] = None) -> None:
         """Accept an incoming REFER and honour the transfer.
 
         Call this from a ``@b2bua.on_refer`` handler to proceed with the
@@ -878,6 +879,23 @@ class Call:
                 - ``None`` (default) — use the configured
                   ``b2bua.default_refer_mode`` from ``siphon.yaml`` (which
                   itself defaults to ``"terminate"``).
+            profile: Media profile for the pairing the transfer creates.
+
+                **Required whenever the call is anchored with a
+                direction-bound profile** — one whose offer and answer halves
+                describe different sides, such as ``srtp_to_rtp`` at a
+                Teams/SRTP edge.  A transfer moves the party that half was
+                written for out of the call, so inheriting the profile
+                re-offers *that party's* transport to whoever remains: SRTP to
+                a plain-RTP carrier, which answers ``m=audio 0``.  The call
+                connects and carries no audio in either direction, and the SIP
+                trace looks healthy.
+
+                Direction-bound built-ins: ``srtp_to_rtp``, ``rtp_to_srtp``,
+                ``ws_to_rtp``, ``wss_to_rtp``.  ``rtp_passthrough`` is
+                symmetric and re-pairs safely.  ``None`` inherits the call's
+                profile, which is correct only when it is symmetric; siphon
+                logs a WARN when it is not.
 
         Raises:
             ValueError: if ``mode`` is not one of ``None``, ``"terminate"``,
@@ -895,6 +913,13 @@ class Call:
                 # Steer the referred-to leg out a specific trunk, transparently.
                 call.accept_refer(next_hop="sip:trunk.example.com:5060",
                                   mode="transparent")
+
+            @b2bua.on_refer
+            def handle_refer(call):
+                # SRTP edge: the SRTP party is the one leaving, so the pair
+                # that remains is plain RTP on both sides.
+                call.accept_refer(target=call.refer_to, mode="terminate",
+                                  profile="rtp_passthrough")
         """
         if mode not in (None, "terminate", "transparent"):
             raise ValueError(
@@ -905,7 +930,7 @@ class Call:
             kind="accept_refer",
             targets=[target] if target else None,
             next_hop=next_hop,
-            extras={"mode": mode},
+            extras={"mode": mode, "profile": profile},
         ))
 
     def reject_refer(self, code: int, reason: str) -> None:

--- a/siphon-control-sdk/siphon-control-client/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-client/src/sip.rs
@@ -495,11 +495,23 @@ impl Call {
     /// (`"terminate"` / `"transparent"`) overrides `b2bua.default_refer_mode`.
     /// No pending REFER (already decided, timed out, or the call is gone) →
     /// [`ControlError`] with `code == "not_found"`.
+    ///
+    /// `profile` names the media profile for the pairing the transfer creates,
+    /// and is **required when the call is anchored with a direction-bound
+    /// profile** — one whose offer and answer halves describe different sides,
+    /// such as `srtp_to_rtp` at an SRTP edge. A transfer moves the party that
+    /// half was written for out of the call, so inheriting the profile
+    /// re-offers *that party's* transport to whoever remains: SRTP toward a
+    /// plain-RTP carrier, which answers `m=audio 0`. The call connects and
+    /// carries no audio in either direction. Pass the profile for the pair that
+    /// remains (commonly `"rtp_passthrough"`); `None` inherits, which is correct
+    /// only for a symmetric profile.
     pub async fn accept_refer(
         &self,
         target: Option<&str>,
         next_hop: Option<&str>,
         mode: Option<&str>,
+        profile: Option<&str>,
     ) -> Result<(), ControlError> {
         let mut args = serde_json::Map::new();
         if let Some(target) = target {
@@ -510,6 +522,9 @@ impl Call {
         }
         if let Some(mode) = mode {
             args.insert("mode".to_string(), json!(mode));
+        }
+        if let Some(profile) = profile {
+            args.insert("profile".to_string(), json!(profile));
         }
         self.sip(SipVerb::AcceptRefer, serde_json::Value::Object(args))
             .await
@@ -1226,9 +1241,14 @@ mod tests {
         let call = make_call(recorder.clone());
 
         call.remove_header("X-Foo").await.expect("remove_header ok");
-        call.accept_refer(Some("sip:c@pbx"), Some("sip:sbc"), Some("terminate"))
-            .await
-            .expect("accept_refer ok");
+        call.accept_refer(
+            Some("sip:c@pbx"),
+            Some("sip:sbc"),
+            Some("terminate"),
+            Some("rtp_passthrough"),
+        )
+        .await
+        .expect("accept_refer ok");
         call.reject_refer(603, Some("Decline")).await.expect("reject_refer ok");
 
         let recorded = lock(&recorder.calls).clone();
@@ -1237,10 +1257,35 @@ mod tests {
         assert_eq!(recorded[1].verb, "accept_refer");
         assert_eq!(
             recorded[1].args,
-            json!({ "target": "sip:c@pbx", "next_hop": "sip:sbc", "mode": "terminate" })
+            json!({
+                "target": "sip:c@pbx",
+                "next_hop": "sip:sbc",
+                "mode": "terminate",
+                // The pairing the transfer creates — omitted means "inherit",
+                // which is wrong for a direction-bound profile.
+                "profile": "rtp_passthrough",
+            })
         );
         assert_eq!(recorded[2].verb, "reject_refer");
         assert_eq!(recorded[2].args, json!({ "code": 603, "reason": "Decline" }));
+    }
+
+    /// An omitted profile is absent from the frame rather than sent as null, so
+    /// the server's "inherit the call's profile" default is what applies.
+    #[tokio::test]
+    async fn accept_refer_omits_an_unset_profile() {
+        let recorder = Arc::new(RecordingTransport {
+            calls: Mutex::new(Vec::new()),
+            result: json!({ "channel": "ch1" }),
+        });
+        let call = make_call(recorder.clone());
+
+        call.accept_refer(None, None, Some("terminate"), None)
+            .await
+            .expect("accept_refer ok");
+
+        let recorded = lock(&recorder.calls).clone();
+        assert_eq!(recorded[0].args, json!({ "mode": "terminate" }));
     }
 
     #[test]

--- a/siphon-control-sdk/siphon-control/src/lib.rs
+++ b/siphon-control-sdk/siphon-control/src/lib.rs
@@ -294,19 +294,33 @@ impl Call {
     /// and run the transfer. `target` overrides the Refer-To URI, `next_hop`
     /// steers egress, and `mode` is `"terminate"` / `"transparent"`. No pending
     /// REFER raises `ControlError` with `code == "not_found"`.
-    #[pyo3(signature = (target=None, next_hop=None, mode=None))]
+    ///
+    /// `profile` names the media profile for the pairing the transfer creates,
+    /// and is **required when the call is anchored with a direction-bound
+    /// profile** (`srtp_to_rtp` and every other SRTP edge): its answer half was
+    /// written for the party being transferred away, so inheriting it re-offers
+    /// that party's transport to whoever remains and the survivor answers
+    /// `m=audio 0` — a connected call with no audio either way. Pass the profile
+    /// for the pair that remains, commonly `"rtp_passthrough"`.
+    #[pyo3(signature = (target=None, next_hop=None, mode=None, profile=None))]
     fn accept_refer<'py>(
         &self,
         py: Python<'py>,
         target: Option<String>,
         next_hop: Option<String>,
         mode: Option<String>,
+        profile: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let call = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            call.accept_refer(target.as_deref(), next_hop.as_deref(), mode.as_deref())
-                .await
-                .map_err(to_pyerr)
+            call.accept_refer(
+                target.as_deref(),
+                next_hop.as_deref(),
+                mode.as_deref(),
+                profile.as_deref(),
+            )
+            .await
+            .map_err(to_pyerr)
         })
     }
 

--- a/siphon-control-sdk/typescript/src/sip.ts
+++ b/siphon-control-sdk/typescript/src/sip.ts
@@ -93,6 +93,22 @@ export interface AcceptReferOptions {
   target?: string;
   nextHop?: string;
   mode?: "terminate" | "transparent";
+  /**
+   * Media profile for the pairing the transfer creates.
+   *
+   * **Required when the call is anchored with a direction-bound profile** — one
+   * whose offer and answer halves describe different sides, such as
+   * `srtp_to_rtp` at an SRTP edge. A transfer moves the party that half was
+   * written for out of the call, so inheriting the profile re-offers *that
+   * party's* transport to whoever remains: SRTP toward a plain-RTP carrier,
+   * which answers `m=audio 0`. The call connects and carries no audio in either
+   * direction while the SIP trace looks healthy.
+   *
+   * Pass the profile for the pair that remains (commonly `"rtp_passthrough"`).
+   * Omitted inherits the call's profile, which is correct only when it is
+   * symmetric.
+   */
+  profile?: string;
 }
 
 /** A {@link Call.route} target carrying per-target overrides. */
@@ -364,6 +380,9 @@ export class Call {
    * egress, and `mode` (`"terminate"` / `"transparent"`) overrides
    * `b2bua.default_refer_mode`. No pending REFER (already decided, timed out, or
    * the call is gone) rejects with `code === "not_found"`.
+   *
+   * `profile` names the media profile for the pairing the transfer creates —
+   * see {@link AcceptReferOptions.profile}, which is required at an SRTP edge.
    */
   async acceptRefer(options?: AcceptReferOptions): Promise<void> {
     const args: Record<string, unknown> = {};
@@ -375,6 +394,9 @@ export class Call {
     }
     if (options?.mode !== undefined) {
       args.mode = options.mode;
+    }
+    if (options?.profile !== undefined) {
+      args.profile = options.profile;
     }
     await this.sip(SipVerb.AcceptRefer, args);
   }

--- a/siphon-control-sdk/typescript/test/wire.test.ts
+++ b/siphon-control-sdk/typescript/test/wire.test.ts
@@ -242,17 +242,36 @@ describe("Call verbs map to the in-process-mirrored wire verbs", () => {
   it("acceptRefer / rejectRefer", async () => {
     const transport = new RecordingTransport();
     const call = makeCall(transport);
-    await call.acceptRefer({ target: "sip:c@pbx", nextHop: "sip:sbc", mode: "terminate" });
+    await call.acceptRefer({
+      target: "sip:c@pbx",
+      nextHop: "sip:sbc",
+      mode: "terminate",
+      profile: "rtp_passthrough",
+    });
     await call.rejectRefer(603, "Decline");
     expect(transport.calls).toEqual([
       {
         module: MODULE_SIP,
         verb: "accept_refer",
         target: { channel: "ch1" },
-        args: { target: "sip:c@pbx", next_hop: "sip:sbc", mode: "terminate" },
+        args: {
+          target: "sip:c@pbx",
+          next_hop: "sip:sbc",
+          mode: "terminate",
+          profile: "rtp_passthrough",
+        },
       },
       { module: MODULE_SIP, verb: "reject_refer", target: { channel: "ch1" }, args: { code: 603, reason: "Decline" } },
     ]);
+  });
+
+  it("acceptRefer omits an unset profile", async () => {
+    // Absent, not null — so the server's "inherit the call's profile" default
+    // is what applies.
+    const transport = new RecordingTransport();
+    const call = makeCall(transport);
+    await call.acceptRefer({ mode: "terminate" });
+    expect(transport.calls[0]?.args).toEqual({ mode: "terminate" });
   });
 
   it("media verbs — play (file/dbId/blob), stop, dtmf, hold, unhold, stream", async () => {

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -623,6 +623,31 @@ auth:
 #
 # Custom media profiles (extend or override built-ins):
 #
+# ---------------------------------------------------------------------------
+# DIRECTION-BOUND PROFILES AND TRANSFERS — read before deploying an SRTP edge
+# ---------------------------------------------------------------------------
+# A profile has two halves. When they differ — a different transport_protocol,
+# a `direction:` pair, different DTLS — they describe SPECIFIC SIDES of the
+# call, not a symmetric relay. `srtp_to_rtp` means "the offerer speaks SRTP,
+# the answerer speaks plain RTP".
+#
+# A transfer, or an inbound INVITE with Replaces, RE-PAIRS the call: the party
+# one half was written for is often the one that just left. Inheriting the
+# profile then re-offers that party's transport to whoever remains — SRTP to a
+# plain-RTP carrier, which answers `m=audio 0`. The call connects and carries
+# no audio in either direction, and the SIP trace looks healthy.
+#
+# So on a transfer across an SRTP (or any one-sided transcoding) boundary, name
+# the profile for the pair that REMAINS:
+#
+#   call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
+#                     profile="rtp_passthrough")
+#
+# siphon logs a WARN naming the inherited profile when it is direction-bound,
+# but cannot choose the replacement — only the script knows the surviving pair.
+# Direction-bound built-ins: srtp_to_rtp, rtp_to_srtp, ws_to_rtp, wss_to_rtp.
+# Symmetric (safe to inherit): rtp_passthrough.
+#
 # Built-in profiles (always available):
 #   rtp_passthrough — Plain RTP both sides, media anchoring only (default)
 #   srtp_to_rtp     — SRTP UE ↔ RTP core

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -815,6 +815,11 @@ pub struct ReferSubscription {
     /// accepted, and the surviving party ↔ target call is what the transfer
     /// exists to create. Notifier (siphon-terminated) role only.
     pub referrer_gone: bool,
+    /// Media profile chosen for the pairing this transfer creates
+    /// (`accept_refer(profile=…)`). `None` inherits the profile the call was
+    /// anchored with — correct only when that profile is symmetric, see
+    /// [`ProfileEntry::is_direction_bound`](crate::rtpengine::ProfileEntry::is_direction_bound).
+    pub media_profile: Option<String>,
 }
 
 /// One end of a dialog, in the shape `Replaces` (RFC 3891) names it.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7409,3 +7409,4 @@ log:
         assert_eq!(names, vec!["zeta", "alpha", "middle"]);
     }
 }
+

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -919,11 +919,18 @@ fn accept_refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
         Err(message) => return ControlResult::error(ControlErrorCode::BadRequest, message),
     };
 
+    // Media profile for the pairing the transfer creates. Same requirement as
+    // the in-process `accept_refer(profile=…)`: a direction-bound profile
+    // (`srtp_to_rtp` and friends) must be replaced, because its answer half was
+    // written for the party being transferred away.
+    let media_profile = args.get("profile").and_then(|v| v.as_str());
+
     if crate::dispatcher::b2bua_accept_refer_call(
         &channel.sip_call_id,
         target.map(|s| s.to_string()),
         next_hop.map(|s| s.to_string()),
         mode,
+        media_profile.map(|s| s.to_string()),
     ) {
         ControlResult::Ok(
             serde_json::json!({ "channel": channel.channel_id, "transfer": "accepted" }),

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -18606,6 +18606,7 @@ fn b2bua_send_outbound_refer(
             // Subscriber role: siphon is the referrer here, so there is no
             // remote referrer whose departure this could track.
             referrer_gone: false,
+            media_profile: None,
         },
     );
     info!(
@@ -18647,8 +18648,10 @@ pub fn b2bua_refer_call(
 /// falling back to the referrer's SDP when there is no surviving leg to bridge).
 ///
 /// `target` overrides the Refer-To URI, `next_hop` steers egress without
-/// reshaping the R-URI, and `mode` overrides the configured
-/// `b2bua.default_refer_mode`. Returns `false` (never panics) when no REFER is
+/// reshaping the R-URI, `mode` overrides the configured
+/// `b2bua.default_refer_mode`, and `media_profile` names the profile for the
+/// pairing the transfer creates (see `accept_refer(profile=…)` — required when
+/// the call is anchored with a direction-bound profile). Returns `false` (never panics) when no REFER is
 /// pending for this call (already decided, timed out, or the call is gone),
 /// which the adapter maps to `not_found`. Safe from any thread (enters the
 /// dispatcher runtime), mirroring [`b2bua_refer_call`].
@@ -18657,6 +18660,7 @@ pub fn b2bua_accept_refer_call(
     target: Option<String>,
     next_hop: Option<String>,
     mode: Option<crate::script::api::call::ReferMode>,
+    media_profile: Option<String>,
 ) -> bool {
     let Some(control) = B2BUA_CONTROL.get() else {
         return false;
@@ -18688,6 +18692,7 @@ pub fn b2bua_accept_refer_call(
         next_hop.as_deref(),
         pending.refer_to.replaces.clone(),
         mode,
+        media_profile.as_deref(),
         state,
     );
     true
@@ -21623,6 +21628,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
             target,
             next_hop,
             mode,
+            profile,
         } => {
             let mode = mode.unwrap_or(state.default_refer_mode);
             let target_uri = target.unwrap_or_else(|| refer_to.uri.clone());
@@ -21635,6 +21641,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
                 next_hop.as_deref(),
                 refer_to.replaces.clone(),
                 mode,
+                profile.as_deref(),
                 state,
             );
         }
@@ -21819,6 +21826,22 @@ fn b2bua_bridge_inbound_replaces(
     // answer it with the survivor's already-negotiated SDP, so the 200 can go out
     // now instead of waiting for the survivor's re-INVITE to come back.
     // Unanchored: the two SDPs cross directly.
+    if let Some((_, session)) = &old_anchor {
+        if state
+            .rtpengine_profiles
+            .as_ref()
+            .and_then(|registry| registry.get(&session.profile))
+            .map(|entry| entry.is_direction_bound())
+            .unwrap_or(false)
+        {
+            warn!(
+                call_id = %replaced_call_id,
+                profile = %session.profile,
+                "B2BUA Replaces: the call is anchored with a direction-bound media profile and the takeover re-pairs it — the surviving leg may be re-offered the replaced party's transport. A symmetric profile is required for takeovers across an SRTP or transcoding boundary."
+            );
+        }
+    }
+
     let (sdp_for_new_party, sdp_for_survivor) = match &old_anchor {
         Some((_, session)) => {
             let to_survivor = b2bua_transfer_rtpengine_offer(
@@ -21994,6 +22017,7 @@ fn b2bua_refer_accept(
     next_hop: Option<&str>,
     replaces: Option<crate::sip::headers::refer::Replaces>,
     mode: crate::script::api::call::ReferMode,
+    media_profile: Option<&str>,
     state: &DispatcherState,
 ) {
     use crate::script::api::call::ReferMode;
@@ -22171,7 +22195,16 @@ fn b2bua_refer_accept(
             // id is forced onto the target leg's Call-ID so the post-promotion
             // store key lines up (see b2bua_complete_terminated_transfer). Absent
             // an anchor, offer the survivor's raw SDP directly.
-            let anchored_profile = state
+            //
+            // The profile is the script's to choose (`accept_refer(profile=…)`),
+            // because only it knows what the surviving pair looks like. Falling
+            // back to the call's own profile is right for a symmetric one and
+            // silently wrong for a direction-bound one: `srtp_to_rtp`'s answer
+            // half exists to talk to the SRTP party, and after the transfer that
+            // party is the one that left, so the survivor gets re-INVITEd with
+            // SRTP it never spoke and answers `m=audio 0`. Warned about here
+            // rather than guessed at.
+            let inherited_profile = state
                 .call_actors
                 .get_call(call_id)
                 .map(|c| c.a_leg.dialog.call_id.clone())
@@ -22182,6 +22215,26 @@ fn b2bua_refer_accept(
                         .and_then(|store| store.get(&key))
                         .map(|session| session.profile.clone())
                 });
+            if media_profile.is_none() {
+                if let Some(inherited) = inherited_profile.as_deref() {
+                    if state
+                        .rtpengine_profiles
+                        .as_ref()
+                        .and_then(|registry| registry.get(inherited))
+                        .map(|entry| entry.is_direction_bound())
+                        .unwrap_or(false)
+                    {
+                        warn!(
+                            call_id = %call_id,
+                            profile = %inherited,
+                            "REFER terminate: inheriting a direction-bound media profile for the transfer — its answer half was written for the party being transferred away, so the surviving leg will be re-offered that party's transport. Pass accept_refer(profile=…) naming the profile for the pair that remains."
+                        );
+                    }
+                }
+            }
+            let anchored_profile = media_profile
+                .map(|name| name.to_string())
+                .or(inherited_profile);
             let fresh_cid = crate::b2bua::actor::generate_call_id();
             let (target_offer_sdp, forced_cid) =
                 match (&anchored_profile, &survivor_sdp, &survivor_tag) {
@@ -22286,6 +22339,7 @@ fn b2bua_refer_accept(
                     state: crate::b2bua::transfer::TransferState::Trying,
                     target_leg_call_id,
                     referrer_gone: false,
+                    media_profile: media_profile.map(|name| name.to_string()),
                 },
             );
         }
@@ -22311,7 +22365,10 @@ fn b2bua_complete_terminated_transfer(
     // `referrer_gone` is set when the referrer already BYE'd this call while the
     // target was still ringing (see `mark_transfer_referrer_gone`): the transfer
     // still completes, but there is no dialog left to NOTIFY or BYE.
-    let (referrer_on_a_leg, referrer_gone, target_leg) = match state.call_actors.get_call(call_id) {
+    let (referrer_on_a_leg, referrer_gone, transfer_profile, target_leg) = match state
+        .call_actors
+        .get_call(call_id)
+    {
         Some(call) => {
             let Some(subscription) = call
                 .refer_subscriptions
@@ -22323,6 +22380,7 @@ fn b2bua_complete_terminated_transfer(
             (
                 subscription.on_a_leg,
                 subscription.referrer_gone,
+                subscription.media_profile.clone(),
                 call.b_legs.get(target_idx).cloned(),
             )
         }
@@ -22563,7 +22621,9 @@ fn b2bua_complete_terminated_transfer(
                     surv_tag,
                     tgt_tag,
                     &response.body,
-                    &old_session.profile,
+                    // The pairing the transfer created, not the one the call
+                    // started as — see `accept_refer(profile=…)`.
+                    transfer_profile.as_deref().unwrap_or(&old_session.profile),
                 )
             }
             _ => None,
@@ -22591,7 +22651,9 @@ fn b2bua_complete_terminated_transfer(
                         // the offerer for future role-based lookups.
                         from_tag: tgt_tag.clone(),
                         to_tag: Some(surv_tag.clone()),
-                        profile: old_session.profile.clone(),
+                        profile: transfer_profile
+                            .clone()
+                            .unwrap_or_else(|| old_session.profile.clone()),
                         // Deliberately not carried over from `old_session`: this
                         // is a fresh engine call-id for the survivor↔target
                         // pair, and any WebSocket bridge the pre-transfer anchor

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -21580,6 +21580,9 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
     )
     .with_flow(py_flow_from_inbound(&inbound));
     py_call.set_refer_to(refer_to.uri.clone(), refer_to.replaces.clone());
+    // Which side referred decides which side survives, and therefore what the
+    // surviving pair's media profile has to be (see `accept_refer(profile=…)`).
+    py_call.set_refer_from_a_leg(from_a_leg);
 
     let action = Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -29,6 +29,28 @@ pub struct ProfileEntry {
     pub answer: NgFlags,
 }
 
+impl ProfileEntry {
+    /// True when this profile's two halves are not interchangeable — the offer
+    /// and answer flags describe *specific sides* of the call rather than a
+    /// symmetric relay.
+    ///
+    /// A profile like `srtp_to_rtp` says "the offerer speaks SRTP, the answerer
+    /// speaks plain RTP" and reverses `direction` between the two halves. That
+    /// is exactly right for the pairing it was chosen for, and wrong for any
+    /// other: apply its `answer` flags to a party that is on the *plain* side
+    /// and you offer them SRTP, which they reject.
+    ///
+    /// This matters when a call is re-paired underneath the profile — a
+    /// siphon-terminated transfer, or a `Replaces` takeover — because the party
+    /// each half was written for may be the one that just left.
+    pub fn is_direction_bound(&self) -> bool {
+        self.offer.transport_protocol != self.answer.transport_protocol
+            || !self.offer.direction.is_empty()
+            || !self.answer.direction.is_empty()
+            || self.offer.dtls != self.answer.dtls
+    }
+}
+
 /// Registry of named media profiles.
 ///
 /// Populated at startup from built-in defaults + YAML config.  Shared via
@@ -724,6 +746,52 @@ impl NgFlags {
 
 #[cfg(test)]
 mod tests {
+    /// The profiles that re-pair badly. A transfer or a `Replaces` takeover
+    /// changes who is on each side of the call, so a profile whose two halves
+    /// describe *specific* sides stops being correct the moment the pairing
+    /// changes — its answer half was written for the party that just left.
+    #[test]
+    fn direction_bound_profiles_are_recognised() {
+        let registry = ProfileRegistry::new();
+
+        // Asymmetric transport (an SRTP edge) — the classic trap: after a
+        // transfer the surviving carrier leg gets re-offered SRTP and answers
+        // `m=audio 0`, leaving a connected call with no audio.
+        for name in ["srtp_to_rtp", "rtp_to_srtp", "ws_to_rtp", "wss_to_rtp"] {
+            let entry = registry.get(name).expect("built-in profile must exist");
+            assert!(
+                entry.is_direction_bound(),
+                "{name} names specific sides and must be flagged"
+            );
+        }
+
+        // A symmetric relay re-pairs safely — both halves say the same thing.
+        let passthrough = registry
+            .get("rtp_passthrough")
+            .expect("built-in profile must exist");
+        assert!(
+            !passthrough.is_direction_bound(),
+            "rtp_passthrough is symmetric and survives a re-pairing"
+        );
+    }
+
+    /// A `direction` pair is direction-bound by definition, even when both
+    /// halves negotiate the same transport.
+    #[test]
+    fn a_direction_pair_alone_is_direction_bound() {
+        let entry = ProfileEntry {
+            offer: NgFlags {
+                direction: vec!["external".into(), "internal".into()],
+                ..NgFlags::default()
+            },
+            answer: NgFlags {
+                direction: vec!["internal".into(), "external".into()],
+                ..NgFlags::default()
+            },
+        };
+        assert!(entry.is_direction_bound());
+    }
+
     use super::*;
 
     #[test]

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -88,6 +88,11 @@ pub enum CallAction {
         target: Option<String>,
         next_hop: Option<String>,
         mode: Option<ReferMode>,
+        /// Media profile for the pairing the transfer creates. `None` inherits
+        /// the profile the original call was anchored with, which is only
+        /// correct when that profile is symmetric — see
+        /// `ProfileEntry::is_direction_bound`.
+        profile: Option<String>,
     },
     /// Reject a REFER with a status code.
     RejectRefer { code: u16, reason: String },
@@ -2161,12 +2166,26 @@ impl PyCall {
     ///   call.accept_refer()
     ///   call.accept_refer(mode="transparent")
     ///   call.accept_refer(target="sip:+15550142@example.com", mode="terminate")
-    #[pyo3(signature = (target=None, next_hop=None, mode=None))]
+    ///
+    /// `profile` names the media profile for the pairing the transfer creates.
+    /// **Required whenever the call is anchored with a direction-bound profile**
+    /// — one whose offer and answer describe different sides, such as
+    /// `srtp_to_rtp` at a Teams/SRTP edge. Left unset, the transfer inherits the
+    /// original call's profile, whose answer half was written for the party that
+    /// is being transferred away; the surviving leg is then re-INVITEd with that
+    /// party's transport (SRTP toward a plain-RTP carrier) and answers `m=audio
+    /// 0`, leaving a connected call with no audio.
+    ///
+    ///   # both remaining parties are on the carrier side
+    ///   call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
+    ///                     profile="rtp_passthrough")
+    #[pyo3(signature = (target=None, next_hop=None, mode=None, profile=None))]
     fn accept_refer(
         &mut self,
         target: Option<String>,
         next_hop: Option<String>,
         mode: Option<&str>,
+        profile: Option<String>,
     ) -> PyResult<()> {
         let mode = match mode {
             None => None,
@@ -2182,6 +2201,7 @@ impl PyCall {
             target,
             next_hop,
             mode,
+            profile,
         };
         Ok(())
     }
@@ -2940,13 +2960,14 @@ mod tests {
     fn call_accept_refer() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        call.accept_refer(None, None, None).unwrap();
+        call.accept_refer(None, None, None, None).unwrap();
         assert_eq!(
             call.action(),
             &CallAction::AcceptRefer {
                 target: None,
                 next_hop: None,
-                mode: None
+                mode: None,
+                profile: None,
             }
         );
     }
@@ -2959,6 +2980,7 @@ mod tests {
             Some("sip:+15550142@example.com".to_string()),
             Some("sip:198.51.100.1:5060".to_string()),
             Some("transparent"),
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -2967,6 +2989,7 @@ mod tests {
                 target: Some("sip:+15550142@example.com".to_string()),
                 next_hop: Some("sip:198.51.100.1:5060".to_string()),
                 mode: Some(ReferMode::Transparent),
+                profile: None,
             }
         );
     }
@@ -2975,13 +2998,34 @@ mod tests {
     fn call_accept_refer_terminate_mode() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        call.accept_refer(None, None, Some("terminate")).unwrap();
+        call.accept_refer(None, None, Some("terminate"), None).unwrap();
         assert_eq!(
             call.action(),
             &CallAction::AcceptRefer {
                 target: None,
                 next_hop: None,
                 mode: Some(ReferMode::Terminate),
+                profile: None,
+            }
+        );
+    }
+
+    /// The media profile for the pairing a transfer creates is the script's to
+    /// choose; without it the transfer inherits the profile the call was
+    /// anchored with, whose answer half was written for the party leaving.
+    #[test]
+    fn call_accept_refer_carries_a_media_profile() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        call.accept_refer(None, None, Some("terminate"), Some("rtp_passthrough".to_string()))
+            .unwrap();
+        assert_eq!(
+            call.action(),
+            &CallAction::AcceptRefer {
+                target: None,
+                next_hop: None,
+                mode: Some(ReferMode::Terminate),
+                profile: Some("rtp_passthrough".to_string()),
             }
         );
     }
@@ -2990,7 +3034,7 @@ mod tests {
     fn call_accept_refer_rejects_bad_mode() {
         let message = Arc::new(Mutex::new(make_invite()));
         let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
-        let result = call.accept_refer(None, None, Some("bridge"));
+        let result = call.accept_refer(None, None, Some("bridge"), None);
         assert!(result.is_err());
         // The invalid call must not have mutated the action.
         assert_eq!(call.action(), &CallAction::None);

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -303,6 +303,10 @@ pub struct PyCall {
     refer_to_uri: Option<String>,
     /// Replaces info from Refer-To (for attended transfer).
     refer_replaces_info: Option<crate::sip::headers::refer::Replaces>,
+    /// Which leg the REFER arrived on — `Some(true)` for the A-leg. The party
+    /// that survives a transfer is the *peer* of this one, which is what decides
+    /// the media profile the surviving pair needs.
+    refer_from_a_leg: Option<bool>,
     /// Credentials for B-leg digest auth retry (set by Python script).
     outbound_credentials: Option<(String, String)>,
     /// Whether li.record() was called for this call.
@@ -427,6 +431,7 @@ impl PyCall {
             media_handle: PyMediaHandle::default(),
             session_timer_override: None,
             refer_to_uri: None,
+            refer_from_a_leg: None,
             refer_replaces_info: None,
             outbound_credentials: None,
             li_record_flag: false,
@@ -895,6 +900,12 @@ impl PyCall {
     ) {
         self.refer_to_uri = Some(uri);
         self.refer_replaces_info = replaces;
+    }
+
+    /// Record which leg the REFER arrived on (called by B2BUA core before
+    /// firing on_refer).
+    pub fn set_refer_from_a_leg(&mut self, from_a_leg: bool) {
+        self.refer_from_a_leg = Some(from_a_leg);
     }
 }
 
@@ -1764,6 +1775,31 @@ impl PyCall {
     #[getter]
     fn refer_to(&self) -> Option<&str> {
         self.refer_to_uri.as_deref()
+    }
+
+    /// Which side sent the REFER: `"a"` (the caller's leg) or `"b"` (the
+    /// callee's), matching the `initiator.side` convention in
+    /// `@b2bua.on_bye`. `None` outside an `@b2bua.on_refer` handler.
+    ///
+    /// The party that SURVIVES the transfer is the peer of this one, which is
+    /// what decides the media profile the surviving pair needs — see
+    /// `accept_refer(profile=…)`. At a mixed edge (SRTP one side, plain RTP the
+    /// other) the answer differs depending on which side is leaving, so this is
+    /// what a script keys that decision on:
+    ///
+    /// ```python
+    /// @b2bua.on_refer
+    /// def on_refer(call):
+    ///     a_leg_is_secure = call.from_gateway("teams")
+    ///     referrer_is_secure = a_leg_is_secure == (call.refer_side == "a")
+    ///     # The secure party leaving means both survivors are plain RTP.
+    ///     profile = "rtp_passthrough" if referrer_is_secure else "srtp_to_rtp"
+    ///     call.accept_refer(mode="terminate", profile=profile)
+    /// ```
+    #[getter]
+    fn refer_side(&self) -> Option<&str> {
+        self.refer_from_a_leg
+            .map(|from_a_leg| if from_a_leg { "a" } else { "b" })
     }
 
     /// Replaces info from the Refer-To header (for attended transfer).
@@ -3013,6 +3049,22 @@ mod tests {
     /// The media profile for the pairing a transfer creates is the script's to
     /// choose; without it the transfer inherits the profile the call was
     /// anchored with, whose answer half was written for the party leaving.
+    /// Which leg referred is what tells a script which party survives, and
+    /// therefore which media profile the surviving pair needs.
+    #[test]
+    fn call_refer_side_reports_the_referring_leg() {
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new("test-id".to_string(), message, "10.0.0.1".to_string(), "udp".to_string());
+        // Outside an on_refer handler there is no referring leg.
+        assert_eq!(call.refer_side(), None);
+
+        call.set_refer_from_a_leg(true);
+        assert_eq!(call.refer_side(), Some("a"));
+
+        call.set_refer_from_a_leg(false);
+        assert_eq!(call.refer_side(), Some("b"), "matches the on_bye initiator convention");
+    }
+
     #[test]
     fn call_accept_refer_carries_a_media_profile() {
         let message = Arc::new(Mutex::new(make_invite()));

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -2182,6 +2182,7 @@ fn refer_subscription_push_query_clear() {
             state: TransferState::Trying,
             target_leg_call_id: None,
             referrer_gone: false,
+            media_profile: None,
         },
     );
     assert!(store.has_subscriber_refer_subscription(&call_id, true));
@@ -2249,6 +2250,7 @@ fn transfer_referrer_bye_is_recognised_and_flags_the_subscription() {
             state: TransferState::Trying,
             target_leg_call_id: Some(target_call_id),
             referrer_gone: false,
+            media_profile: None,
         },
     );
 
@@ -2282,6 +2284,7 @@ fn transfer_referrer_bye_is_idempotent_for_retransmissions() {
             state: TransferState::Trying,
             target_leg_call_id: Some(target_call_id),
             referrer_gone: false,
+            media_profile: None,
         },
     );
 
@@ -2324,6 +2327,7 @@ fn surviving_party_bye_during_transfer_still_tears_the_call_down() {
             state: TransferState::Trying,
             target_leg_call_id: Some(target_call_id),
             referrer_gone: false,
+            media_profile: None,
         },
     );
 
@@ -2362,6 +2366,7 @@ fn originated_refer_subscription_never_flags_referrer_gone() {
             state: TransferState::Trying,
             target_leg_call_id: None,
             referrer_gone: false,
+            media_profile: None,
         },
     );
 
@@ -2460,6 +2465,7 @@ fn refer_notifier_subscription_is_not_a_subscriber_one() {
             state: TransferState::Trying,
             target_leg_call_id: None,
             referrer_gone: false,
+            media_profile: None,
         },
     );
     assert!(!store.has_subscriber_refer_subscription(&call_id, true));


### PR DESCRIPTION
A transfer across an SRTP edge produced a connected call with **no audio in
either direction**, and a SIP trace that looks healthy end to end.

## What happens

A media profile has two halves, and when they differ they describe *specific
sides* of the call:

```yaml
srtp_to_rtp:
  offer:   { transport_protocol: "RTP/AVP",  direction: ["teams", "carrier"] }
  answer:  { transport_protocol: "RTP/SAVP", direction: ["carrier", "teams"] }
```

The `answer` half exists to talk to the SRTP party. A siphon-terminated transfer
takes that party **out** of the call — so re-anchoring the survivor with the same
profile re-offers SRTP to whoever is left. A plain-RTP carrier answers `m=audio
0` and both parties sit on a call with dead media.

On the wire, the transfer signalling is entirely correct — target dialled,
answered, ACKed, survivor re-INVITEd. Only one line is wrong:

| leg | transport offered |
|---|---|
| survivor's original answer | `RTP/AVP` |
| INVITE to transfer target | `RTP/AVP` |
| target's answer | `RTP/AVP` |
| **re-INVITE to survivor** | `RTP/SAVP` |
| survivor's answer | rejected — port `0` |

It shows up afterwards as `RTPEngine answer for re-INVITE failed: Error rewriting
SDP` — rtpengine being asked to re-answer a rejected port-0 SAVP stream, which is
the symptom rather than the cause.

## The fix

`accept_refer(profile=…)` names the media profile for the pairing the transfer
creates, threaded through the target offer, the survivor's re-INVITE answer and
the re-keyed media session. Also accepted as `profile` on the control plane's
`accept_refer`.

```python
@b2bua.on_refer
def on_refer(call):
    # Once the SRTP party leaves, both remaining legs are plain RTP.
    call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
                      profile="rtp_passthrough")
```

Unset keeps the previous inherit behaviour, which is correct for a symmetric
profile. When a **direction-bound** profile is inherited with no override,
siphon now logs a WARN naming it and saying what will happen. It does not guess a
replacement — only the script knows what the surviving pair looks like.

The same warning covers an inbound `INVITE` with `Replaces`, which re-pairs the
call the same way.

## Why CI missed it

The anchored-transfer job uses `rtp_passthrough`. Symmetric profiles re-pair
safely, so the bug is invisible to it — it only bites asymmetric edges, i.e.
every Teams/SRTP/WebRTC deployment. That job now passes `profile=` explicitly so
the parameter is exercised against a real rtpengine end to end.

**A negative test needs an SRTP endpoint pair the harness does not have**, so the
failure mode itself is covered by unit tests and the WARN rather than on the
wire. Extending the rtpengine job with a genuine SRTP peer would close that, and
is worth doing separately.

## Documentation

Called out where it actually bites, since getting it wrong is silent:

- `docs/cookbook/call-transfer.md` — a danger admonition with the mechanism, the
  fix, and which built-ins are direction-bound
- `siphon.yaml` — a section above the profile reference
- `examples/teams_sbc.py` — gains the `@b2bua.on_refer` handler it never had,
  which is the exact topology where this costs you the audio
- SDK docstring for `accept_refer`

Applies to anything a profile pins to one side, not just SRTP: a transcoding or
codec-shaping choice made for *that* party does not automatically suit the party
replacing it.

## Also

`examples/teams_sbc.yaml` carried `codec: ["offer", "PCMA,PCMU"]` on both
profiles. There is no `codec` field on a media profile and nothing encodes it —
the key was silently ignored while implying siphon transcodes on the operator's
behalf. Removed, and both direction-bound profiles are now labelled as such.
Codec selection in siphon is done from a script through the `sdp` namespace.

## Testing

- 3747 lib + 326 integration green; `clippy --all-targets --all-features -D warnings` clean
- New unit tests: direction-bound detection across every built-in, a `direction:`
  pair alone being enough, and `accept_refer` carrying the profile
- Anchored REFER transfer against a **real rtpengine** green with the parameter
  threaded through
- SDK 642 tests green