### PR TITLE
feat(media): codec manipulation on a media profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **Codec manipulation on a media profile (`codec:`), rtpengine only.** A profile
+  half can now restrict, reorder, drop or transcode codecs through rtpengine's
+  `codec` dictionary — `strip`, `offer`, `transcode`, `mask`, `consume`,
+  `accept`, `except`, `ignore` and `set`, each a list of RTP payload names:
+
+  ```yaml
+  offer:
+    transport_protocol: "RTP/AVP"
+    codec:
+      strip: ["SILK"]                             # the carrier cannot take it
+      offer: ["PCMA", "PCMU", "telephone-event"]  # and in this order
+  ```
+
+  Put it on the `offer:` half — rtpengine applies codec manipulation to the offer
+  and ignores most of it on an answer. It reaches the engine as its own nested
+  dict, not as tokens in `flags`, which the engine would drop.
+
+  **rtpengine only.** Neither the native `siphon-rtp` engine's `ProfileFlags` nor
+  rtpproxy can carry it, so a profile setting it on either is **refused at config
+  load** rather than reading as a codec restriction while every offered codec
+  crosses untouched. Codecs can still be shaped from a script with the `sdp`
+  namespace on any backend.
+
+  An asymmetric codec policy also makes a profile **direction-bound**: it was
+  chosen for the party on the far side of that half, so it is not inherited
+  across a transfer without an explicit `accept_refer(profile=…)`.
+
+  The `codec: ["offer", "PCMA,PCMU"]` line that `examples/teams_sbc.yaml` used to
+  carry was not this shape and never did anything. That form now **fails the
+  config load** instead of being silently ignored, and the example carries a real
+  codec block.
+
+### Added
 - **`call.accept_refer(profile=…)` — the media profile for the pairing a
   transfer creates.** A media profile has two halves, and when they differ
   (`srtp_to_rtp` and every other SRTP/DTLS edge) they describe *specific sides*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   and ignores most of it on an answer. It reaches the engine as its own nested
   dict, not as tokens in `flags`, which the engine would drop.
 
-  **rtpengine only.** Neither the native `siphon-rtp` engine's `ProfileFlags` nor
-  rtpproxy can carry it, so a profile setting it on either is **refused at config
-  load** rather than reading as a codec restriction while every offered codec
-  crosses untouched. Codecs can still be shaped from a script with the `sdp`
-  namespace on any backend.
+  **One block, both real engines.** rtpengine takes the NG `codec` dictionary;
+  the native `siphon-rtp` engine already implements the same model but reads it
+  off its flag list, so siphon flattens the block to `codec-<op>-<NAME>` for it
+  — the policy is written once. `ignore` and `set` have no native equivalent and
+  are refused on that backend; `rtpproxy` is a plain relay with no transcoder and
+  refuses the block outright. Refused at config load, never silently dropped.
+  Codecs can also still be shaped from a script with the `sdp` namespace.
 
   An asymmetric codec policy also makes a profile **direction-bound**: it was
   chosen for the party on the far side of that half, so it is not inherited

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
-- **Codec manipulation on a media profile (`codec:`), rtpengine only.** A profile
+- **Codec manipulation on a media profile (`codec:`).** A profile
   half can now restrict, reorder, drop or transcode codecs through rtpengine's
   `codec` dictionary — `strip`, `offer`, `transcode`, `mask`, `consume`,
   `accept`, `except`, `ignore` and `set`, each a list of RTP payload names:

--- a/examples/teams_sbc.yaml
+++ b/examples/teams_sbc.yaml
@@ -128,13 +128,6 @@ media:
     # PSTN -> Teams: carrier offers RTP, transcode up to SRTP for Teams.
     # The direction labels ("carrier"/"teams") must match the interface names
     # configured in rtpengine.conf.
-    # NOTE: a media profile controls transport, ICE, DTLS, direction and SDP
-    # rewriting — NOT codec selection. There is no `codec:` key here; one would
-    # be silently ignored. Restrict or reorder codecs from the script with the
-    # `sdp` namespace instead, e.g. in @b2bua.on_invite:
-    #     s = sdp.parse(call)
-    #     s.filter_codecs(["PCMA", "PCMU", "telephone-event"])
-    #     s.apply(call)
     # DIRECTION-BOUND, like its mirror below — do not inherit it across a
     # transfer or a Replaces takeover.
     rtp_to_srtp:
@@ -143,6 +136,10 @@ media:
         ice: "remove"
         replace: ["origin", "session-connection"]
         direction: ["carrier", "teams"]
+        # Offer Teams only what it should see, in this order. rtpengine honours
+        # codec manipulation on the OFFER; it is mostly ignored on an answer.
+        codec:
+          offer: ["PCMA", "PCMU", "telephone-event"]
       answer:
         transport_protocol: "RTP/AVP"
         ice: "remove"
@@ -172,6 +169,12 @@ media:
         ice: "remove"
         replace: ["origin", "session-connection"]
         direction: ["teams", "carrier"]
+        # Teams offers SILK, which most PSTN carriers cannot take. Drop it and
+        # hand the carrier a plain G.711 offer; `transcode` would additionally
+        # let rtpengine convert, at the cost of engaging the transcoder.
+        codec:
+          strip: ["SILK"]
+          offer: ["PCMA", "PCMU", "telephone-event"]
       answer:
         transport_protocol: "RTP/SAVP"
         ice: "remove"

--- a/scripts/b2bua_rtpengine_refer.py
+++ b/scripts/b2bua_rtpengine_refer.py
@@ -10,7 +10,7 @@ rtpengine so the offer/answer/delete command sequence is exercised end to end.
 from siphon import b2bua, proxy, registrar, rtpengine, auth, log
 
 DOMAIN = "siphon.test"
-PROFILE = "rtp_passthrough"
+PROFILE = "codec_restricted"
 
 
 @proxy.on_request("REGISTER")

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -649,15 +649,16 @@ auth:
 # Symmetric (safe to inherit): rtp_passthrough.
 #
 # ---------------------------------------------------------------------------
-# CODEC MANIPULATION (rtpengine only)
+# CODEC MANIPULATION
 # ---------------------------------------------------------------------------
-# A profile half can restrict, reorder, drop or transcode codecs through the
-# rtpengine `codec` dictionary. Every key is a list of RTP payload names:
+# A profile half can restrict, reorder, drop or transcode codecs. Every key is a
+# list of RTP payload names:
 #
 #   strip      remove these from the outgoing SDP (`all` / `full` wildcards)
 #   offer      the only codecs to offer, in this order (also fixes preference)
 #   transcode  add these even if the offerer did not list them (engages the
-#              transcoder — rtpengine must be built --with-transcoding)
+#              transcoder — on rtpengine that needs a --with-transcoding build;
+#              the native engine transcodes what its codec set supports)
 #   mask       hide from the far side but keep accepting from the offerer
 #   consume    like mask, but engages the transcoder on its own
 #   accept     like mask/consume but leaves the codec in the offered list
@@ -665,8 +666,8 @@ auth:
 #   ignore     treat as though the offer never contained them
 #   set        options for accepted transcoding codecs (bitrate/rate/channels)
 #
-# Put it on the OFFER half — rtpengine applies codec manipulation to the offer
-# and ignores most of it on an answer:
+# Put it on the OFFER half — both engines apply codec manipulation to the offer
+# and ignore most of it on an answer:
 #
 #   media:
 #     profiles:
@@ -677,10 +678,10 @@ auth:
 #             strip: ["SILK"]                             # carrier cannot take it
 #             offer: ["PCMA", "PCMU", "telephone-event"]  # and in this order
 #
-# Works on BOTH real engines from the same block. rtpengine takes it as its NG
-# `codec` dictionary; the native siphon-rtp engine implements the same model but
-# reads it off its flag list, so siphon flattens the block to `codec-<op>-<NAME>`
-# for it — you write the policy once.
+# BOTH real engines honour this from the same block — you write the policy once.
+# rtpengine takes it as its NG `codec` dictionary; the native siphon-rtp engine
+# implements the same model but reads it off its flag list, so siphon flattens
+# the block to `codec-<op>-<NAME>` for it.
 #
 # Two exceptions, refused at config load rather than left looking applied:
 #   * `ignore:` and `set:` have no native equivalent — rtpengine only.

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -677,9 +677,14 @@ auth:
 #             strip: ["SILK"]                             # carrier cannot take it
 #             offer: ["PCMA", "PCMU", "telephone-event"]  # and in this order
 #
-# rtpengine ONLY. The native siphon-rtp engine and rtpproxy cannot express it,
-# and a profile that sets it on either is REFUSED at config load rather than
-# reading as a codec restriction while every offered codec crosses untouched.
+# Works on BOTH real engines from the same block. rtpengine takes it as its NG
+# `codec` dictionary; the native siphon-rtp engine implements the same model but
+# reads it off its flag list, so siphon flattens the block to `codec-<op>-<NAME>`
+# for it — you write the policy once.
+#
+# Two exceptions, refused at config load rather than left looking applied:
+#   * `ignore:` and `set:` have no native equivalent — rtpengine only.
+#   * `rtpproxy` is a plain relay with no transcoder: any codec block is refused.
 #
 # An asymmetric codec policy makes a profile direction-bound (see above): it was
 # chosen for the party on the far side of that half, so do not inherit it across

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -648,6 +648,47 @@ auth:
 # Direction-bound built-ins: srtp_to_rtp, rtp_to_srtp, ws_to_rtp, wss_to_rtp.
 # Symmetric (safe to inherit): rtp_passthrough.
 #
+# ---------------------------------------------------------------------------
+# CODEC MANIPULATION (rtpengine only)
+# ---------------------------------------------------------------------------
+# A profile half can restrict, reorder, drop or transcode codecs through the
+# rtpengine `codec` dictionary. Every key is a list of RTP payload names:
+#
+#   strip      remove these from the outgoing SDP (`all` / `full` wildcards)
+#   offer      the only codecs to offer, in this order (also fixes preference)
+#   transcode  add these even if the offerer did not list them (engages the
+#              transcoder — rtpengine must be built --with-transcoding)
+#   mask       hide from the far side but keep accepting from the offerer
+#   consume    like mask, but engages the transcoder on its own
+#   accept     like mask/consume but leaves the codec in the offered list
+#   except     allow only these through
+#   ignore     treat as though the offer never contained them
+#   set        options for accepted transcoding codecs (bitrate/rate/channels)
+#
+# Put it on the OFFER half — rtpengine applies codec manipulation to the offer
+# and ignores most of it on an answer:
+#
+#   media:
+#     profiles:
+#       teams_to_carrier:
+#         offer:
+#           transport_protocol: "RTP/AVP"
+#           codec:
+#             strip: ["SILK"]                             # carrier cannot take it
+#             offer: ["PCMA", "PCMU", "telephone-event"]  # and in this order
+#
+# rtpengine ONLY. The native siphon-rtp engine and rtpproxy cannot express it,
+# and a profile that sets it on either is REFUSED at config load rather than
+# reading as a codec restriction while every offered codec crosses untouched.
+#
+# An asymmetric codec policy makes a profile direction-bound (see above): it was
+# chosen for the party on the far side of that half, so do not inherit it across
+# a transfer.
+#
+# Codecs can also be shaped from a script with the `sdp` namespace
+# (`filter_codecs` / `remove_codecs`), which works on every backend because it
+# rewrites the SDP directly rather than asking the engine to.
+#
 # Built-in profiles (always available):
 #   rtp_passthrough — Plain RTP both sides, media anchoring only (default)
 #   srtp_to_rtp     — SRTP UE ↔ RTP core

--- a/sipp/b2bua_refer_anchored_bob_uas.xml
+++ b/sipp/b2bua_refer_anchored_bob_uas.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Anchored variant of b2bua_refer_terminate_bob_uas.xml: identical flow, plus an
+  assertion that the media profile's `codec:` block was applied by the REAL
+  rtpengine.
+
+  The caller offers `0 8 101` (PCMU, PCMA, telephone-event). The profile strips
+  PCMA and restricts the offer, so what reaches this UAS must carry PCMU and
+  telephone-event and NOT PCMA. That is the whole point of gating it here: a
+  codec dict that is malformed, or encoded as tokens in `flags` instead of its
+  own NG dict, is silently ignored by the engine — every codec crosses untouched
+  and nothing else in the flow looks wrong.
+
+  B2BUA REFER siphon-terminated — Bob, the surviving far leg:
+  Receive INVITE → 180 → 200 → ACK
+  → receive the media re-INVITE (siphon re-points Bob's media at the transfer
+    target Carol, RFC 3261 §14) → 200 → ACK
+  → receive BYE (Carol hung up) → 200
+
+  After the transfer completes, siphon re-INVITEs the surviving party with the
+  transfer target's SDP so media flows Bob <-> Carol.
+-->
+<scenario name="B2BUA REFER anchored Bob UAS">
+
+  <recv request="INVITE" crlf="true">
+    <action>
+      <!-- check_it: the call fails unless the restricted offer arrived. -->
+      <ereg regexp="m=audio [0-9]+ RTP/AVP 0 101"
+            search_in="body"
+            check_it="true"
+            assign_to="restricted_m_line" />
+      <log message="codec restriction applied: [$restricted_m_line]" />
+      <!-- check_it_inverse: PCMA was stripped, so its rtpmap must be gone. -->
+      <ereg regexp="a=rtpmap:8 PCMA"
+            search_in="body"
+            check_it_inverse="true"
+            assign_to="pcma_absent" />
+      <log message="PCMA absent as expected [$pcma_absent]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <!-- siphon re-INVITEs Bob with the transfer target's SDP (media re-anchor). -->
+  <recv request="INVITE" crlf="true" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687638 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/configs/siphon.b2bua-rtpengine-refer.yaml
+++ b/sipp/configs/siphon.b2bua-rtpengine-refer.yaml
@@ -38,6 +38,23 @@ media:
   rtpengine:
     address: "172.20.0.44:22222"
     timeout_ms: 2000
+  profiles:
+    # Real-engine proof that codec manipulation reaches rtpengine as its own NG
+    # dict and is applied. The UAC offers `0 8 101` (PCMU, PCMA,
+    # telephone-event); this drops PCMA and restricts the offer, so the SDP the
+    # callee receives is observably narrower than what the caller sent. Encode
+    # it wrong — as tokens in `flags`, say — and the engine silently ignores it
+    # and all three codecs cross, which is exactly what the UAS asserts against.
+    codec_restricted:
+      offer:
+        replace: ["origin"]
+        flags: ["trust-address"]
+        codec:
+          strip: ["PCMA"]
+          offer: ["PCMU", "telephone-event"]
+      answer:
+        replace: ["origin"]
+        flags: ["trust-address"]
 
 log:
   level: debug

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -4886,6 +4886,8 @@ services:
     depends_on:
       siphon-rtp-engine-ready:
         condition: service_completed_successfully
+    environment:
+      MEDIA_PROFILE: "codec_restricted"
     volumes:
       - ./siphon-rtp/siphon-rtp-native.yaml:/etc/siphon/siphon.yaml:ro
       - ./siphon-rtp/proxy_rtp_passthrough.py:/etc/siphon/scripts/proxy_rtp_passthrough.py:ro
@@ -4941,7 +4943,7 @@ services:
     entrypoint:
       - sipp
       - -sf
-      - /sipp/scenarios/rtpengine_uas.xml
+      - /sipp/scenarios/media_codec_policy_uas.xml
       - -p
       - "5060"
       - -m
@@ -4991,6 +4993,8 @@ services:
     depends_on:
       siphon-rtp-engine-ready:
         condition: service_completed_successfully
+    environment:
+      MEDIA_PROFILE: "codec_restricted"
     volumes:
       - ./siphon-rtp/siphon-rtp-ng.yaml:/etc/siphon/siphon.yaml:ro
       - ./siphon-rtp/proxy_rtp_passthrough.py:/etc/siphon/scripts/proxy_rtp_passthrough.py:ro
@@ -5046,7 +5050,7 @@ services:
     entrypoint:
       - sipp
       - -sf
-      - /sipp/scenarios/rtpengine_uas.xml
+      - /sipp/scenarios/media_codec_policy_uas.xml
       - -p
       - "5060"
       - -m

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -3377,7 +3377,7 @@ services:
     entrypoint:
       - sipp
       - -sf
-      - /sipp/scenarios/b2bua_refer_terminate_bob_uas.xml
+      - /sipp/scenarios/b2bua_refer_anchored_bob_uas.xml
       - -p
       - "5060"
       - -m

--- a/sipp/media_codec_policy_uas.xml
+++ b/sipp/media_codec_policy_uas.xml
@@ -1,0 +1,96 @@
+<!--
+  UAS for the control-plane A/B (siphon-rtp-native / siphon-rtp-ng): identical to
+  rtpengine_uas.xml plus an assertion that the profile's `codec:` block was
+  applied by the engine.
+
+  The UAC offers `0 8 101` (PCMU, PCMA, telephone-event); the profile strips PCMA
+  and restricts the offer. rtpengine takes that as its NG `codec` dict and the
+  native engine reads it off the flag list siphon flattens it onto — both must
+  land here as the same restricted offer. A control plane that drops the policy
+  relays all three codecs and fails the run, which is the point: an unapplied
+  codec policy is otherwise invisible.
+-->
+<scenario name="Media codec-policy UAS">
+
+  <!-- Receive INVITE from proxy -->
+  <recv request="INVITE" crlf="true">
+    <action>
+      <ereg regexp="m=audio [0-9]+ RTP/AVP 0 101"
+            search_in="body"
+            check_it="true"
+            assign_to="restricted_m_line" />
+      <log message="codec policy applied: [$restricted_m_line]" />
+      <ereg regexp="a=rtpmap:8 PCMA"
+            search_in="body"
+            check_it_inverse="true"
+            assign_to="pcma_absent" />
+      <log message="PCMA stripped as expected [$pcma_absent]" />
+    </action>
+  </recv>
+
+  <!-- Send 180 Ringing -->
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_Record-Route:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!-- Send 200 OK with SDP -->
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_Record-Route:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <!-- Receive ACK -->
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <!-- Receive BYE -->
+  <recv request="BYE" />
+
+  <!-- Send 200 OK for BYE -->
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/media_codec_policy_uas.xml
+++ b/sipp/media_codec_policy_uas.xml
@@ -1,14 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  RTPEngine proxy UAS scenario:
+  Receive INVITE → 180 → 200 OK with SDP → ACK → BYE → 200
+
+  The INVITE SDP should have been rewritten by RTPEngine (offer direction).
+  We just answer normally — the proxy will rewrite our 200 OK SDP too (answer direction).
+-->
 <!--
   UAS for the control-plane A/B (siphon-rtp-native / siphon-rtp-ng): identical to
   rtpengine_uas.xml plus an assertion that the profile's `codec:` block was
   applied by the engine.
 
   The UAC offers `0 8 101` (PCMU, PCMA, telephone-event); the profile strips PCMA
-  and restricts the offer. rtpengine takes that as its NG `codec` dict and the
-  native engine reads it off the flag list siphon flattens it onto — both must
-  land here as the same restricted offer. A control plane that drops the policy
-  relays all three codecs and fails the run, which is the point: an unapplied
-  codec policy is otherwise invisible.
+  and restricts the offer. rtpengine takes that as its NG `codec` dict; the
+  native engine reads the same policy off the flag list siphon flattens it onto.
+  Both must land here as the same restricted offer — a control plane that drops
+  the policy relays all three codecs and fails the run, which is the point: an
+  unapplied codec policy is otherwise invisible.
 -->
 <scenario name="Media codec-policy UAS">
 

--- a/sipp/siphon-rtp/proxy_rtp_passthrough.py
+++ b/sipp/siphon-rtp/proxy_rtp_passthrough.py
@@ -21,10 +21,15 @@ perform, not to relax the engine. Both legs here are plain RTP, so
 Testing the real SRTP interworking path needs a UAS that answers SAVP with a
 crypto line; that is a separate scenario, not this one.
 """
+
+import os
 from siphon import proxy, registrar, auth, rtpengine, log
 
 DOMAIN = "siphon.test"
-PROFILE = "rtp_passthrough"
+# The two control-plane A/B jobs (siphon-rtp-native / siphon-rtp-ng) override
+# this to a codec-restricted profile so both planes are asserted to apply the
+# same codec policy. Everything else keeps the plain relay.
+PROFILE = os.environ.get("MEDIA_PROFILE", "rtp_passthrough")
 
 
 @proxy.on_request

--- a/sipp/siphon-rtp/siphon-rtp-native.yaml
+++ b/sipp/siphon-rtp/siphon-rtp-native.yaml
@@ -46,6 +46,21 @@ media:
   siphon_rtp:
     address: "172.20.0.130:8080"
     timeout_ms: 2000
+  profiles:
+    # Both control planes must apply the SAME codec policy from the SAME block:
+    # rtpengine takes it as its NG `codec` dict, the native engine reads it off
+    # the flag list siphon flattens it onto. The UAS asserts the result, so a
+    # plane that drops it fails the run rather than relaying every codec.
+    codec_restricted:
+      offer:
+        replace: ["origin"]
+        flags: ["trust-address"]
+        codec:
+          strip: ["PCMA"]
+          offer: ["PCMU", "telephone-event"]
+      answer:
+        replace: ["origin"]
+        flags: ["trust-address"]
 
 log:
   level: debug

--- a/sipp/siphon-rtp/siphon-rtp-ng.yaml
+++ b/sipp/siphon-rtp/siphon-rtp-ng.yaml
@@ -49,6 +49,21 @@ media:
     address: "172.20.0.130:22222"
     timeout_ms: 2000
 
+  profiles:
+    # Both control planes must apply the SAME codec policy from the SAME block:
+    # rtpengine takes it as its NG `codec` dict, the native engine reads it off
+    # the flag list siphon flattens it onto. The UAS asserts the result, so a
+    # plane that drops it fails the run rather than relaying every codec.
+    codec_restricted:
+      offer:
+        replace: ["origin"]
+        flags: ["trust-address"]
+        codec:
+          strip: ["PCMA"]
+          offer: ["PCMU", "telephone-event"]
+      answer:
+        replace: ["origin"]
+        flags: ["trust-address"]
 log:
   level: debug
   format: pretty

--- a/src/config.rs
+++ b/src/config.rs
@@ -2151,12 +2151,20 @@ impl MediaBackendKind {
             }
         }
 
-        // Codec manipulation is an rtpengine capability. Neither the native
-        // engine's `ProfileFlags` nor rtpproxy's control protocol can carry it,
-        // so a profile asking for it anywhere else is refused at load — the
-        // alternative is a config that reads as "this call is restricted to
-        // PCMA/PCMU" while every codec the endpoints offered crosses untouched.
-        if !matches!(self, Self::Rtpengine) && !flags.codec.is_empty() {
+        // Codec manipulation works on both real engines. rtpengine takes it as
+        // its NG `codec` dict; the native engine implements the same model but
+        // reads it off the flag list, so siphon flattens the block for it
+        // (`CodecFlags::to_native_flags`). Only the two ops with no native
+        // equivalent are refused there — the alternative is a config that reads
+        // as "restricted to PCMA/PCMU" while every offered codec crosses
+        // untouched, which is the failure this feature replaces.
+        if matches!(self, Self::SiphonRtp) {
+            for op in flags.codec.native_unsupported_ops() {
+                unsupported.push(op);
+            }
+        }
+        // rtpproxy is a plain relay with no transcoder and no codec control.
+        if matches!(self, Self::Rtpproxy) && !flags.codec.is_empty() {
             unsupported.push("codec");
         }
 
@@ -2579,10 +2587,15 @@ pub struct MediaProfileConfig {
 /// Every field is a list of RTP payload names (`PCMA`, `opus`, `AMR-WB`), and
 /// an empty one is omitted from the wire entirely.
 ///
-/// **rtpengine only.** The native `siphon-rtp` engine and `rtpproxy` have no way
-/// to express this, so a profile that sets any of it on those backends is
-/// refused at config load rather than quietly relaying whatever the endpoints
-/// happened to offer.
+/// Works on both real engines from one block: rtpengine takes it as its NG
+/// `codec` dictionary, and the native `siphon-rtp` engine implements the same
+/// model but reads it off its flag list, so siphon flattens the block to
+/// `codec-<op>-<NAME>` for it.
+///
+/// `ignore` and `set` have no native equivalent and are refused on that backend;
+/// `rtpproxy` is a plain relay with no transcoder and refuses the block outright.
+/// Refused at config load, never silently dropped — a codec policy that reads as
+/// applied but is not is the failure this exists to remove.
 ///
 /// **Honoured on `offer:`.** rtpengine applies codec manipulation to the offer;
 /// most of it is ignored on an answer, so put it under the `offer:` half.
@@ -2630,6 +2643,20 @@ pub struct CodecFlagsConfig {
 }
 
 impl CodecFlagsConfig {
+    /// The ops the native `siphon-rtp` engine has no equivalent for. It
+    /// implements the rest of the rtpengine codec model, so only these are
+    /// refused on that backend.
+    pub fn native_unsupported_ops(&self) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if !self.ignore.is_empty() {
+            out.push("codec.ignore");
+        }
+        if !self.set.is_empty() {
+            out.push("codec.set");
+        }
+        out
+    }
+
     /// True when nothing is set, so nothing is emitted on the wire.
     pub fn is_empty(&self) -> bool {
         self.strip.is_empty()
@@ -4306,13 +4333,41 @@ mod tests {
                 .is_empty(),
             "rtpengine speaks the codec dict"
         );
-        for backend in [MediaBackendKind::SiphonRtp, MediaBackendKind::Rtpproxy] {
-            assert!(
-                backend.unsupported_profile_fields(&flags).contains(&"codec"),
-                "{} cannot express codec manipulation and must refuse it",
-                backend.as_str()
-            );
-        }
+        // The native engine implements the same codec model, reading it off the
+        // flag list — so an `offer` list is honoured there, not refused.
+        assert!(
+            MediaBackendKind::SiphonRtp
+                .unsupported_profile_fields(&flags)
+                .is_empty(),
+            "siphon-rtp implements codec manipulation and must accept it"
+        );
+        // rtpproxy is a plain relay: no transcoder, no codec control.
+        assert!(
+            MediaBackendKind::Rtpproxy
+                .unsupported_profile_fields(&flags)
+                .contains(&"codec"),
+            "rtpproxy cannot express codec manipulation and must refuse it"
+        );
+
+        // The two ops with no native equivalent ARE refused on siphon-rtp,
+        // rather than silently dropped when the block is flattened to flags.
+        let unmappable = NgFlagsConfig {
+            codec: CodecFlagsConfig {
+                ignore: vec!["G729".to_string()],
+                set: vec!["opus/48000/2".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let native = MediaBackendKind::SiphonRtp.unsupported_profile_fields(&unmappable);
+        assert!(native.contains(&"codec.ignore"), "got {native:?}");
+        assert!(native.contains(&"codec.set"), "got {native:?}");
+        assert!(
+            MediaBackendKind::Rtpengine
+                .unsupported_profile_fields(&unmappable)
+                .is_empty(),
+            "rtpengine takes every op"
+        );
 
         // An unset codec block is inert on every backend.
         let bare = NgFlagsConfig::default();

--- a/src/config.rs
+++ b/src/config.rs
@@ -2582,7 +2582,8 @@ pub struct MediaProfileConfig {
 }
 
 /// rtpengine `codec` dictionary — which codecs cross, in what order, and what
-/// gets transcoded (rtpengine NG `codec` sub-dict).
+/// gets transcoded. Modelled on the rtpengine NG `codec` sub-dict, which the
+/// native engine implements too.
 ///
 /// Every field is a list of RTP payload names (`PCMA`, `opus`, `AMR-WB`), and
 /// an empty one is omitted from the wire entirely.
@@ -2597,8 +2598,8 @@ pub struct MediaProfileConfig {
 /// Refused at config load, never silently dropped — a codec policy that reads as
 /// applied but is not is the failure this exists to remove.
 ///
-/// **Honoured on `offer:`.** rtpengine applies codec manipulation to the offer;
-/// most of it is ignored on an answer, so put it under the `offer:` half.
+/// **Honoured on `offer:`.** Both engines apply codec manipulation to the offer
+/// and ignore most of it on an answer, so put it under the `offer:` half.
 ///
 /// ```yaml
 /// offer:
@@ -2676,7 +2677,8 @@ impl CodecFlagsConfig {
 pub struct NgFlagsConfig {
     /// Transport protocol override (e.g. "RTP/AVP", "RTP/SAVPF").
     pub transport_protocol: Option<String>,
-    /// Codec manipulation (rtpengine only) — see [`CodecFlagsConfig`].
+    /// Codec manipulation — see [`CodecFlagsConfig`]. Honoured by rtpengine and
+    /// the native `siphon-rtp` engine; refused on `rtpproxy`.
     #[serde(default)]
     pub codec: CodecFlagsConfig,
     /// ICE handling: "remove", "force", or "force-relay".

--- a/src/config.rs
+++ b/src/config.rs
@@ -2151,6 +2151,15 @@ impl MediaBackendKind {
             }
         }
 
+        // Codec manipulation is an rtpengine capability. Neither the native
+        // engine's `ProfileFlags` nor rtpproxy's control protocol can carry it,
+        // so a profile asking for it anywhere else is refused at load — the
+        // alternative is a config that reads as "this call is restricted to
+        // PCMA/PCMU" while every codec the endpoints offered crosses untouched.
+        if !matches!(self, Self::Rtpengine) && !flags.codec.is_empty() {
+            unsupported.push("codec");
+        }
+
         unsupported
     }
 }
@@ -2564,11 +2573,85 @@ pub struct MediaProfileConfig {
     pub answer: NgFlagsConfig,
 }
 
+/// rtpengine `codec` dictionary — which codecs cross, in what order, and what
+/// gets transcoded (rtpengine NG `codec` sub-dict).
+///
+/// Every field is a list of RTP payload names (`PCMA`, `opus`, `AMR-WB`), and
+/// an empty one is omitted from the wire entirely.
+///
+/// **rtpengine only.** The native `siphon-rtp` engine and `rtpproxy` have no way
+/// to express this, so a profile that sets any of it on those backends is
+/// refused at config load rather than quietly relaying whatever the endpoints
+/// happened to offer.
+///
+/// **Honoured on `offer:`.** rtpengine applies codec manipulation to the offer;
+/// most of it is ignored on an answer, so put it under the `offer:` half.
+///
+/// ```yaml
+/// offer:
+///   codec:
+///     strip: ["SILK", "G722"]
+///     offer: ["PCMA", "PCMU", "telephone-event"]
+/// ```
+#[derive(Debug, Deserialize, Clone, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CodecFlagsConfig {
+    /// Remove these from the outgoing SDP. Accepts the wildcards `all` / `full`.
+    #[serde(default)]
+    pub strip: Vec<String>,
+    /// The only codecs to offer, in this order (rtpengine `offer`) — like
+    /// `except` but also fixes preference order.
+    #[serde(default)]
+    pub offer: Vec<String>,
+    /// Add these to the offer even when the offerer did not list them, engaging
+    /// the transcoder.
+    #[serde(default)]
+    pub transcode: Vec<String>,
+    /// Hide these from the far side but keep accepting them from the offerer,
+    /// transcoding on its behalf.
+    #[serde(default)]
+    pub mask: Vec<String>,
+    /// Like `mask`, but engages the transcoder even with no other codec option set.
+    #[serde(default)]
+    pub consume: Vec<String>,
+    /// Like `mask`/`consume` but leaves the codec in the offered list.
+    #[serde(default)]
+    pub accept: Vec<String>,
+    /// Allow only these through, blocking every other offered codec.
+    #[serde(default)]
+    pub except: Vec<String>,
+    /// Treat these as though the offer never contained them.
+    #[serde(default)]
+    pub ignore: Vec<String>,
+    /// Options for implicitly accepted transcoding codecs — bitrate, clock rate,
+    /// channels (e.g. `opus/48000/2/16000`).
+    #[serde(default)]
+    pub set: Vec<String>,
+}
+
+impl CodecFlagsConfig {
+    /// True when nothing is set, so nothing is emitted on the wire.
+    pub fn is_empty(&self) -> bool {
+        self.strip.is_empty()
+            && self.offer.is_empty()
+            && self.transcode.is_empty()
+            && self.mask.is_empty()
+            && self.consume.is_empty()
+            && self.accept.is_empty()
+            && self.except.is_empty()
+            && self.ignore.is_empty()
+            && self.set.is_empty()
+    }
+}
+
 /// NG protocol flags for one direction (offer or answer).
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct NgFlagsConfig {
     /// Transport protocol override (e.g. "RTP/AVP", "RTP/SAVPF").
     pub transport_protocol: Option<String>,
+    /// Codec manipulation (rtpengine only) — see [`CodecFlagsConfig`].
+    #[serde(default)]
+    pub codec: CodecFlagsConfig,
     /// ICE handling: "remove", "force", or "force-relay".
     pub ice: Option<String>,
     /// DTLS mode: "passive", "active", or "off".
@@ -4202,6 +4285,74 @@ fn default_lcr_cache_ttl_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Codec manipulation is an rtpengine NG capability. The native engine's
+    /// `ProfileFlags` has no codec fields and rtpproxy is a plain relay, so a
+    /// profile asking for it there is refused at load rather than reading as
+    /// "restricted to PCMA/PCMU" while every offered codec crosses untouched.
+    #[test]
+    fn codec_flags_are_rtpengine_only() {
+        let flags = NgFlagsConfig {
+            codec: CodecFlagsConfig {
+                offer: vec!["PCMA".to_string(), "PCMU".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(
+            MediaBackendKind::Rtpengine
+                .unsupported_profile_fields(&flags)
+                .is_empty(),
+            "rtpengine speaks the codec dict"
+        );
+        for backend in [MediaBackendKind::SiphonRtp, MediaBackendKind::Rtpproxy] {
+            assert!(
+                backend.unsupported_profile_fields(&flags).contains(&"codec"),
+                "{} cannot express codec manipulation and must refuse it",
+                backend.as_str()
+            );
+        }
+
+        // An unset codec block is inert on every backend.
+        let bare = NgFlagsConfig::default();
+        for backend in [
+            MediaBackendKind::Rtpengine,
+            MediaBackendKind::SiphonRtp,
+            MediaBackendKind::Rtpproxy,
+        ] {
+            assert!(!backend.unsupported_profile_fields(&bare).contains(&"codec"));
+        }
+    }
+
+    /// The codec block is a DICT of named lists. The shape that shipped in the
+    /// Teams example (`codec: ["offer", "PCMA,PCMU"]`) is not it, and now fails
+    /// the config load instead of being silently dropped — which is how it went
+    /// unnoticed while implying siphon was restricting codecs.
+    #[test]
+    fn codec_block_parses_as_a_dict_and_rejects_the_old_list_form() {
+        let good: NgFlagsConfig = serde_yaml_ng::from_str(
+            r#"
+transport_protocol: "RTP/AVP"
+codec:
+  strip: ["SILK", "G722"]
+  offer: ["PCMA", "PCMU", "telephone-event"]
+"#,
+        )
+        .expect("the dict form must parse");
+        assert_eq!(good.codec.strip, vec!["SILK", "G722"]);
+        assert_eq!(good.codec.offer, vec!["PCMA", "PCMU", "telephone-event"]);
+        assert!(good.codec.transcode.is_empty());
+
+        assert!(
+            serde_yaml_ng::from_str::<NgFlagsConfig>("codec: [\"offer\", \"PCMA,PCMU\"]").is_err(),
+            "the old list form must be rejected, not ignored"
+        );
+        assert!(
+            serde_yaml_ng::from_str::<NgFlagsConfig>("codec:\n  bogus: [\"PCMA\"]").is_err(),
+            "an unknown codec key must be rejected, not ignored"
+        );
+    }
 
     /// The `Replaces` takeover is a capability, not a default: an upgrade must
     /// never hand every party that can reach this node the ability to

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -73,6 +73,44 @@ impl CodecFlags {
         }
     }
 
+    /// The ops the native `siphon-rtp` engine understands, flattened to the
+    /// `codec-<op>-<NAME>` flag strings its `ProfileFlags.flags` carries.
+    ///
+    /// The engine implements the same rtpengine codec model but reads it off the
+    /// flag list rather than a nested dict, so one profile drives both engines.
+    /// `ignore` and `set` have no native equivalent and are deliberately not
+    /// emitted here — the config gate refuses them on that backend rather than
+    /// letting them look applied.
+    pub fn to_native_flags(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        for (op, list) in [
+            ("strip", &self.strip),
+            ("mask", &self.mask),
+            ("consume", &self.consume),
+            ("except", &self.except),
+            ("accept", &self.accept),
+            ("offer", &self.offer),
+            ("transcode", &self.transcode),
+        ] {
+            for name in list {
+                out.push(format!("codec-{op}-{name}"));
+            }
+        }
+        out
+    }
+
+    /// The ops with no native equivalent, for the backend capability gate.
+    pub fn native_unsupported_ops(&self) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if !self.ignore.is_empty() {
+            out.push("codec.ignore");
+        }
+        if !self.set.is_empty() {
+            out.push("codec.set");
+        }
+        out
+    }
+
     /// The `codec` sub-dict, or `None` when nothing is set. Keys are emitted in
     /// a fixed order so a command is byte-stable for a given profile.
     fn to_bencode(&self) -> Option<super::bencode::BencodeValue> {
@@ -900,6 +938,55 @@ mod tests {
         assert!(
             flags_pair.is_none(),
             "codec manipulation must not be smuggled into the flags list"
+        );
+    }
+
+    /// The native engine takes the same codec model off its flag list, so the
+    /// block is flattened to `codec-<op>-<NAME>` for it. One profile, two
+    /// engines — an operator does not write the policy twice.
+    #[test]
+    fn codec_flags_flatten_for_the_native_engine() {
+        let codec = CodecFlags {
+            strip: vec!["SILK".into()],
+            offer: vec!["PCMA".into(), "PCMU".into()],
+            transcode: vec!["PCMA".into()],
+            except: vec!["telephone-event".into()],
+            ..CodecFlags::default()
+        };
+        let flat = codec.to_native_flags();
+
+        assert!(flat.contains(&"codec-strip-SILK".to_string()), "{flat:?}");
+        assert!(flat.contains(&"codec-offer-PCMA".to_string()), "{flat:?}");
+        assert!(flat.contains(&"codec-offer-PCMU".to_string()), "{flat:?}");
+        assert!(flat.contains(&"codec-transcode-PCMA".to_string()), "{flat:?}");
+        assert!(
+            flat.contains(&"codec-except-telephone-event".to_string()),
+            "{flat:?}"
+        );
+        // Order within `offer` is the operator's stated preference and must survive.
+        let offer_positions: Vec<usize> = ["codec-offer-PCMA", "codec-offer-PCMU"]
+            .iter()
+            .map(|needle| flat.iter().position(|f| f == needle).expect("present"))
+            .collect();
+        assert!(
+            offer_positions[0] < offer_positions[1],
+            "codec-offer order is the preference order: {flat:?}"
+        );
+
+        // The two ops the engine has no equivalent for are never emitted...
+        let unmappable = CodecFlags {
+            ignore: vec!["G729".into()],
+            set: vec!["opus/48000/2".into()],
+            ..CodecFlags::default()
+        };
+        assert!(
+            unmappable.to_native_flags().is_empty(),
+            "unmappable ops must not be flattened into something meaningless"
+        );
+        // ...and are reported so the config gate can refuse them.
+        assert_eq!(
+            unmappable.native_unsupported_ops(),
+            vec!["codec.ignore", "codec.set"]
         );
     }
 

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -534,7 +534,8 @@ pub fn validate_ws_sample_rate(rate: u32) -> Result<(), String> {
 pub struct NgFlags {
     /// Transport protocol override (e.g. "RTP/AVP", "RTP/SAVPF").
     pub transport_protocol: Option<String>,
-    /// Codec manipulation (rtpengine only) — see [`CodecFlags`].
+    /// Codec manipulation — see [`CodecFlags`]. Honoured by rtpengine (as its NG
+    /// `codec` dict) and by the native engine (flattened onto its flag list).
     pub codec: CodecFlags,
     /// ICE handling: "remove", "force", or "force-relay".
     pub ice: Option<String>,

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -29,6 +29,78 @@ pub struct ProfileEntry {
     pub answer: NgFlags,
 }
 
+/// Runtime form of [`CodecFlagsConfig`](crate::config::CodecFlagsConfig) — the
+/// rtpengine `codec` sub-dict.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CodecFlags {
+    pub strip: Vec<String>,
+    pub offer: Vec<String>,
+    pub transcode: Vec<String>,
+    pub mask: Vec<String>,
+    pub consume: Vec<String>,
+    pub accept: Vec<String>,
+    pub except: Vec<String>,
+    pub ignore: Vec<String>,
+    pub set: Vec<String>,
+}
+
+impl CodecFlags {
+    /// True when nothing is set — the `codec` key is then omitted entirely
+    /// rather than sent as an empty dict.
+    pub fn is_empty(&self) -> bool {
+        self.strip.is_empty()
+            && self.offer.is_empty()
+            && self.transcode.is_empty()
+            && self.mask.is_empty()
+            && self.consume.is_empty()
+            && self.accept.is_empty()
+            && self.except.is_empty()
+            && self.ignore.is_empty()
+            && self.set.is_empty()
+    }
+
+    fn from_config(config: &crate::config::CodecFlagsConfig) -> Self {
+        Self {
+            strip: config.strip.clone(),
+            offer: config.offer.clone(),
+            transcode: config.transcode.clone(),
+            mask: config.mask.clone(),
+            consume: config.consume.clone(),
+            accept: config.accept.clone(),
+            except: config.except.clone(),
+            ignore: config.ignore.clone(),
+            set: config.set.clone(),
+        }
+    }
+
+    /// The `codec` sub-dict, or `None` when nothing is set. Keys are emitted in
+    /// a fixed order so a command is byte-stable for a given profile.
+    fn to_bencode(&self) -> Option<super::bencode::BencodeValue> {
+        use super::bencode::BencodeValue;
+        if self.is_empty() {
+            return None;
+        }
+        let mut pairs: Vec<(&str, BencodeValue)> = Vec::new();
+        for (key, list) in [
+            ("strip", &self.strip),
+            ("offer", &self.offer),
+            ("transcode", &self.transcode),
+            ("mask", &self.mask),
+            ("consume", &self.consume),
+            ("accept", &self.accept),
+            ("except", &self.except),
+            ("ignore", &self.ignore),
+            ("set", &self.set),
+        ] {
+            if !list.is_empty() {
+                let items: Vec<&str> = list.iter().map(|s| s.as_str()).collect();
+                pairs.push((key, BencodeValue::string_list(&items)));
+            }
+        }
+        Some(BencodeValue::dict(pairs))
+    }
+}
+
 impl ProfileEntry {
     /// True when this profile's two halves are not interchangeable — the offer
     /// and answer flags describe *specific sides* of the call rather than a
@@ -48,6 +120,10 @@ impl ProfileEntry {
             || !self.offer.direction.is_empty()
             || !self.answer.direction.is_empty()
             || self.offer.dtls != self.answer.dtls
+            // Codec manipulation is chosen for the party on the far side of
+            // this half — strip SILK because *that* carrier cannot take it —
+            // so it is as side-specific as the transport is.
+            || self.offer.codec != self.answer.codec
     }
 }
 
@@ -420,6 +496,8 @@ pub fn validate_ws_sample_rate(rate: u32) -> Result<(), String> {
 pub struct NgFlags {
     /// Transport protocol override (e.g. "RTP/AVP", "RTP/SAVPF").
     pub transport_protocol: Option<String>,
+    /// Codec manipulation (rtpengine only) — see [`CodecFlags`].
+    pub codec: CodecFlags,
     /// ICE handling: "remove", "force", or "force-relay".
     pub ice: Option<String>,
     /// DTLS mode: "passive", "active", or "off".
@@ -633,6 +711,7 @@ impl NgFlags {
     pub fn from_config(config: &NgFlagsConfig) -> Self {
         Self {
             transport_protocol: config.transport_protocol.clone(),
+            codec: CodecFlags::from_config(&config.codec),
             ice: config.ice.clone(),
             dtls: config.dtls.clone(),
             replace: config.replace.clone(),
@@ -675,6 +754,11 @@ impl NgFlags {
                 "transport-protocol",
                 BencodeValue::string(transport_protocol),
             ));
+        }
+        // rtpengine takes codec manipulation as a nested dict under `codec`,
+        // not as tokens in `flags`.
+        if let Some(codec) = self.codec.to_bencode() {
+            pairs.push(("codec", codec));
         }
         if let Some(ice) = &self.ice {
             pairs.push(("ICE", BencodeValue::string(ice)));
@@ -773,6 +857,105 @@ mod tests {
             !passthrough.is_direction_bound(),
             "rtp_passthrough is symmetric and survives a re-pairing"
         );
+    }
+
+    /// The `codec` dict must reach rtpengine as a NESTED DICT under `codec`,
+    /// not as tokens in `flags` — a codec list smuggled into `flags` is
+    /// silently dropped by the engine, which is the failure mode this whole
+    /// feature exists to remove.
+    #[test]
+    fn codec_flags_encode_as_a_nested_dict() {
+        let flags = NgFlags {
+            transport_protocol: Some("RTP/AVP".into()),
+            codec: CodecFlags {
+                strip: vec!["SILK".into(), "G722".into()],
+                offer: vec!["PCMA".into(), "PCMU".into()],
+                transcode: vec!["PCMA".into()],
+                ..CodecFlags::default()
+            },
+            ..NgFlags::default()
+        };
+
+        let pairs = flags.to_bencode_pairs();
+        let (_, codec) = pairs
+            .iter()
+            .find(|(key, _)| *key == "codec")
+            .expect("codec must be its own dict key");
+
+        let encoded =
+            String::from_utf8_lossy(&crate::rtpengine::bencode::encode(codec)).to_string();
+        // Bencode dict of three string lists, keys in the order emitted.
+        assert!(encoded.contains("strip"), "strip missing: {encoded}");
+        assert!(encoded.contains("SILK"), "SILK missing: {encoded}");
+        assert!(encoded.contains("offer"), "offer missing: {encoded}");
+        assert!(encoded.contains("PCMA"), "PCMA missing: {encoded}");
+        assert!(encoded.contains("transcode"), "transcode missing: {encoded}");
+
+        // Empty lists never reach the wire.
+        assert!(!encoded.contains("mask"), "an unset key leaked: {encoded}");
+        assert!(!encoded.contains("ignore"), "an unset key leaked: {encoded}");
+
+        // And it is NOT folded into `flags`.
+        let flags_pair = pairs.iter().find(|(key, _)| *key == "flags");
+        assert!(
+            flags_pair.is_none(),
+            "codec manipulation must not be smuggled into the flags list"
+        );
+    }
+
+    /// Nothing set means no `codec` key at all, rather than an empty dict the
+    /// engine would have to interpret.
+    #[test]
+    fn absent_codec_flags_emit_no_key() {
+        let flags = NgFlags {
+            transport_protocol: Some("RTP/AVP".into()),
+            ..NgFlags::default()
+        };
+        assert!(
+            !flags
+                .to_bencode_pairs()
+                .iter()
+                .any(|(key, _)| *key == "codec"),
+            "an empty codec dict must not be sent"
+        );
+        assert!(CodecFlags::default().is_empty());
+    }
+
+    /// Codec policy is chosen for the party on the far side of that half, so a
+    /// profile that strips one way and not the other is as side-specific as an
+    /// SRTP edge — and equally wrong to inherit across a transfer.
+    #[test]
+    fn asymmetric_codec_policy_is_direction_bound() {
+        let entry = ProfileEntry {
+            offer: NgFlags {
+                codec: CodecFlags {
+                    offer: vec!["PCMA".into(), "PCMU".into()],
+                    ..CodecFlags::default()
+                },
+                ..NgFlags::default()
+            },
+            answer: NgFlags::default(),
+        };
+        assert!(entry.is_direction_bound());
+
+        // The same policy on both halves re-pairs safely.
+        let symmetric = ProfileEntry {
+            offer: NgFlags {
+                codec: CodecFlags {
+                    strip: vec!["SILK".into()],
+                    ..CodecFlags::default()
+                },
+                ..NgFlags::default()
+            },
+            answer: NgFlags {
+                codec: CodecFlags {
+                    strip: vec!["SILK".into()],
+                    ..CodecFlags::default()
+                },
+                ..NgFlags::default()
+            },
+        };
+        assert!(!symmetric.is_direction_bound());
     }
 
     /// A `direction` pair is direction-bound by definition, even when both

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -75,7 +75,15 @@ pub(crate) fn profile_flags_from_ng(flags: &NgFlags) -> ProfileFlags {
         dtls: flags.dtls.clone(),
         replace: flags.replace.clone(),
         address_family: flags.address_family.clone(),
-        flags: flags.flags.clone(),
+        // The native engine implements the same rtpengine codec model but reads
+        // it from the flag list (`codec-<op>-<NAME>`) rather than a nested dict,
+        // so the profile's `codec:` block is flattened onto the flags here and
+        // one profile drives both engines.
+        flags: {
+            let mut merged = flags.flags.clone();
+            merged.extend(flags.codec.to_native_flags());
+            merged
+        },
         direction: flags.direction.clone(),
         record_call: flags.record_call,
         record_path: flags.record_path.clone(),

--- a/src/rtpengine/siphon_rtp.rs
+++ b/src/rtpengine/siphon_rtp.rs
@@ -2295,6 +2295,7 @@ mod tests {
     fn profile_flags_from_ng_maps_every_field() {
         let ng = NgFlags {
             transport_protocol: Some("RTP/SAVPF".into()),
+            codec: Default::default(),
             ice: Some("force".into()),
             dtls: Some("passive".into()),
             replace: vec!["origin".into()],


### PR DESCRIPTION
You were right that rtpengine supports this — siphon just had no way to reach it.

## What was missing

`examples/teams_sbc.yaml` carried `codec: ["offer", "PCMA,PCMU"]` on both
profiles, implying the SBC restricted what it offered the carrier. It didn't:
`NgFlagsConfig` had no `codec` field and no `deny_unknown_fields`, so serde
dropped it. The intent was sound — the shape and the plumbing were not.

rtpengine takes a `codec` **dictionary** on the offer with nine keys. A profile
half now maps all of them:

| key | effect |
|---|---|
| `strip` | remove from the outgoing SDP (`all` / `full` wildcards) |
| `offer` | the only codecs to offer, in this order |
| `transcode` | add even if not offered — engages the transcoder |
| `mask` | hide from the far side, keep accepting from the offerer |
| `consume` | like `mask`, engages the transcoder on its own |
| `accept` | like `mask`/`consume` but leaves it in the offered list |
| `except` | allow only these through |
| `ignore` | treat as though never offered |
| `set` | options for accepted transcoding codecs (bitrate/rate/channels) |

```yaml
offer:
  transport_protocol: "RTP/AVP"
  codec:
    strip: ["SILK"]                             # the carrier cannot take it
    offer: ["PCMA", "PCMU", "telephone-event"]  # and in this order
```

Put it on the `offer:` half — rtpengine applies codec manipulation to the offer
and ignores most of it on an answer.

## Three things that make it hard to get silently wrong

**It reaches the engine as its own nested dict**, not as tokens in `flags`. A
codec list smuggled into `flags` is silently ignored by rtpengine — the same
class of failure as the config key that started this.

**One block, both real engines — and no proto change.** siphon-rtp already
implements the whole model: `engine.rs`'s `offer()` runs
`parse_codec_flags(&profile.flags)` into a `CodecPolicy` covering
strip/mask/consume/except/accept/offer/transcode plus the `all`/`full` wildcards,
reading them as `codec-<op>-<NAME>` strings off `ProfileFlags.flags` — which has
shipped in every released proto tag back to `v0.2.0`. So siphon flattens the
block onto the flag list for that backend rather than refusing it, and an
operator writes the policy once.

Only `ignore` and `set` are refused there (no native equivalent — flattening them
into something meaningless is the failure this replaces). `rtpproxy` refuses the
block outright: plain relay, no transcoder.

**The old list form now fails the load** instead of being dropped, as does an
unknown key inside the block (`deny_unknown_fields`).

An asymmetric codec policy also counts as **direction-bound**, so a transfer will
not inherit it without an explicit `accept_refer(profile=…)` — codec choice is
made for the party on the far side of that half, exactly like transport.

## Proven against a real rtpengine

Not a round-trip — the engine is the independent decoder. The anchored REFER job
now runs a `codec_restricted` profile: the caller offers `0 8 101`
(PCMU/PCMA/telephone-event), the profile strips PCMA, and a dedicated UAS
scenario fails the run unless what arrives is restricted.

Measured on the way in, comparing the rewritten offer:

| profile | rewritten offer |
|---|---|
| `rtp_passthrough` (no codec dict) | 240 bytes |
| `codec_restricted` | **216 bytes** |

24 bytes — the `8` in the `m=` line plus its `a=rtpmap:8 PCMA/8000`. The engine
parsed and applied it.

Verified the gate bites: with the codec dict removed the UAS exits **255**; with
it, **0**.

The native/NG control-plane A/B pair now shares a UAS that asserts the same
restricted offer, so a plane that drops the policy fails the run. That job could
not be reproduced locally at the end of this work — `siphon-rtp-native` fails the
same way on unmodified `main` here, so the local harness is the problem, not the
change; CI is the arbiter for that leg.

## Testing

- 3753 lib + 326 integration green; `clippy --all-targets --all-features -D warnings` clean; SDK 642
- Unit tests on the wire shape (nested dict, unset keys omitted, never folded
  into `flags`), the backend gate across all three engines, the dict-vs-list
  parsing, and codec asymmetry counting as direction-bound
- Anchored REFER against a real rtpengine, green, with the effect asserted