### PR TITLE
fix(test): remove two load-sensitive flakes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,19 @@ jobs:
       - name: Run tests
         run: PYO3_PYTHON=python3.14 cargo test ${{ matrix.flags }}
 
+      # Runs alone because it measures a process-global counter: glibc in-use
+      # bytes. Inside the parallel binary the other tests allocate on the same
+      # order as the signal, so it is `#[ignore]`d there and gated here, where
+      # nothing else is running and the numbers are exact. Skipping it would
+      # let the reaped-thread PyThreadState leak back in — it orphans CPython
+      # thread states on the glibc heap, invisible to jemalloc and to
+      # `siphon_memory_*`.
+      - name: Python thread-state leak guard (needs the process to itself)
+        run: |
+          PYO3_PYTHON=python3.14 cargo test --lib ${{ matrix.flags }} -- --ignored --exact \
+            server::tests::reaped_thread_releases_its_python_thread_state \
+            --test-threads=1 --nocapture
+
   # ── Clippy lint gate ────────────────────────────────────────────────────
   # Mirrors the rust-tests build env (free-threaded Python 3.14 + libsctp-dev
   # are needed for the crate to compile at all). `-D warnings` turns any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Fixed
+- **Two tests that failed at random, both for reasons unrelated to what they
+  assert.** `free_port()` bound port 0, read the address and dropped the socket:
+  the kernel auto-assigns from the ephemeral range, so between the probe closing
+  and the real bind any outbound socket in the process could take that port. And
+  `listen()` binds on a spawned task and only *logs* a bind failure, so the test
+  never learned — it waited on a listener that was never created and failed as a
+  connect timeout, pointing at the wrong thing. Ports now come from a counter
+  below the ephemeral range, where nothing is auto-assigned, and are probed on
+  both TCP and UDP (separate namespaces; these tests bind either). The three
+  copies of the helper are down to two — one shared inside the crate, one for
+  `tests/`, which is a separate crate. Measured 4 failures in 20 runs before, 0
+  in 25 after.
+- **The Python thread-state leak guard now owns the process.** It compares glibc
+  in-use bytes across thread-churn batches, but that counter is process-global
+  and the parallel test binary allocates on the same order as the signal — it
+  failed about one run in four, including a release cut. It gains a control arm
+  (spawn/join without touching Python) so the ambient cost is measured and
+  subtracted rather than guessed at, and is `#[ignore]`d with a CI step that runs
+  it alone, as the CAP_NET_ADMIN tests already are. Alone it is exact: ambient
+  0 B, 241664 B leaked, 0 B retained, every run. The guard is unchanged in what
+  it proves.
+
 ## [1.7.1] — 2026-09-01
 
 ### Added

--- a/src/server.rs
+++ b/src/server.rs
@@ -3460,15 +3460,40 @@ mod tests {
     ///
     /// Two arms so the test cannot pass vacuously: the unpaired pin (the old
     /// behaviour) must visibly grow the C-side pool, and the paired
-    /// pin/unpin must not. Comparing the two also makes the assertion immune to
-    /// whatever unrelated allocation noise the harness contributes.
+    /// pin/unpin must not.
+    ///
+    /// `read_stats` reports the whole **process**, and the harness runs other
+    /// tests on other threads throughout, so every window also measures
+    /// whatever they allocated while it was open. That is not an occasional
+    /// outlier a median would absorb — it is a steady background of roughly
+    /// 50-140 KB per window, comparable to the ~240 KB signal, and it made the
+    /// bare `retained * 4 < leaked` comparison fail by fractions of a percent.
+    ///
+    /// So a third arm measures it. The **control** spawns and joins the same
+    /// threads without touching Python at all, which is exactly the ambient
+    /// cost of the window plus the neighbours' noise and none of the leak.
+    /// Subtracting it from both real arms leaves the thread-state allocation on
+    /// its own. The three arms are interleaved and taken on the median, so a
+    /// slow stretch of the suite biases all three alike rather than one.
     ///
     /// glibc-only: `malloc_info` is what `read_stats` reads.
+    ///
+    /// `#[ignore]`d because it must own the process, not because it is
+    /// optional. `read_stats` reports the whole process, and inside the parallel
+    /// test binary the neighbours allocate on the same order as the signal — the
+    /// control arm below subtracts the average of that, but not its variance,
+    /// and the test failed roughly one run in four. Alone it is exact: ambient
+    /// 0 B, 241664 B leaked, 0 B retained, every time. CI runs it on its own
+    /// (see the "Python thread-state leak guard" step), the same way the
+    /// CAP_NET_ADMIN tests are run.
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     #[test]
+    #[ignore = "process-global glibc measurement — run alone: cargo test --lib -- --ignored --exact server::tests::reaped_thread_releases_its_python_thread_state --test-threads=1"]
     fn reaped_thread_releases_its_python_thread_state() {
         const WARM: usize = 32;
         const BATCH: usize = 256;
+        // Odd, so the median is a real sample rather than an average of two.
+        const ROUNDS: usize = 3;
 
         pyo3::Python::initialize();
 
@@ -3478,12 +3503,25 @@ mod tests {
             return;
         };
 
-        // `paired` mirrors the runtime hooks; `!paired` reproduces the leak.
-        let churn = |count: usize, paired: bool| {
+        /// Which of the three arms a batch runs.
+        #[derive(Clone, Copy, PartialEq)]
+        enum Arm {
+            /// Spawn + join only — the ambient cost of the window.
+            Control,
+            /// Pin without unpinning: the old behaviour, which leaks.
+            Leaky,
+            /// Pin and unpin, as the runtime hooks do.
+            Paired,
+        }
+
+        let churn = |count: usize, arm: Arm| {
             for _ in 0..count {
                 std::thread::spawn(move || {
+                    if arm == Arm::Control {
+                        return;
+                    }
                     pin_python_thread_state();
-                    if paired {
+                    if arm == Arm::Paired {
                         unpin_python_thread_state();
                     }
                 })
@@ -3492,22 +3530,40 @@ mod tests {
             }
         };
 
-        // Warm up both paths so first-touch arena growth lands outside the
+        // Warm up every path so first-touch arena growth lands outside the
         // measured batches.
-        churn(WARM, true);
-        churn(WARM, false);
+        churn(WARM, Arm::Control);
+        churn(WARM, Arm::Paired);
+        churn(WARM, Arm::Leaky);
 
-        let before_leaky = in_use().unwrap_or(0);
-        churn(BATCH, false);
-        let leaked = in_use().unwrap_or(0).saturating_sub(before_leaky);
+        let measure = |arm: Arm| {
+            let before = in_use().unwrap_or(0);
+            churn(BATCH, arm);
+            in_use().unwrap_or(0).saturating_sub(before)
+        };
 
-        let before_fixed = in_use().unwrap_or(0);
-        churn(BATCH, true);
-        let retained = in_use().unwrap_or(0).saturating_sub(before_fixed);
+        let mut control_samples = Vec::with_capacity(ROUNDS);
+        let mut leaky_samples = Vec::with_capacity(ROUNDS);
+        let mut paired_samples = Vec::with_capacity(ROUNDS);
+        for _ in 0..ROUNDS {
+            control_samples.push(measure(Arm::Control));
+            leaky_samples.push(measure(Arm::Leaky));
+            paired_samples.push(measure(Arm::Paired));
+        }
+        let median = |samples: &[u64]| {
+            let mut sorted = samples.to_vec();
+            sorted.sort_unstable();
+            sorted[sorted.len() / 2]
+        };
+        let ambient = median(&control_samples);
+        // What the pin cost beyond simply running the window.
+        let leaked = median(&leaky_samples).saturating_sub(ambient);
+        let retained = median(&paired_samples).saturating_sub(ambient);
 
         eprintln!(
-            "unpaired pin: {leaked} B over {BATCH} threads ({:.1} B/thread); \
-             paired pin/unpin: {retained} B ({:.1} B/thread)",
+            "ambient {ambient} B {control_samples:?}; \
+             unpaired pin: {leaked} B net over {BATCH} threads ({:.1} B/thread) {leaky_samples:?}; \
+             paired pin/unpin: {retained} B net ({:.1} B/thread) {paired_samples:?}",
             leaked as f64 / BATCH as f64,
             retained as f64 / BATCH as f64,
         );
@@ -3515,14 +3571,15 @@ mod tests {
         // The leak must be visible, else the test proves nothing.
         assert!(
             leaked > BATCH as u64 * 64,
-            "unpaired pin did not reproduce the leak ({leaked} B over {BATCH} threads) — \
-             the guard cannot prove the fix"
+            "unpaired pin did not reproduce the leak ({leaked} B net over {BATCH} threads, \
+             ambient {ambient} B) — the guard cannot prove the fix"
         );
         // ...and pairing must remove essentially all of it.
         assert!(
             retained * 4 < leaked,
             "pairing pin with unpin did not release the thread state: \
-             {retained} B retained vs {leaked} B leaked over {BATCH} threads"
+             {retained} B retained vs {leaked} B leaked over {BATCH} threads \
+             (ambient {ambient} B subtracted from both)"
         );
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -15,6 +15,54 @@ pub mod acl;
 pub mod flow;
 pub mod crlf_keepalive;
 
+/// Test-only helpers shared by this module's unit tests.
+#[cfg(test)]
+pub(crate) mod testutil {
+    use std::net::SocketAddr;
+
+    /// A loopback address reserved for this test, on a port the kernel will not
+    /// hand to anything else.
+    ///
+    /// The obvious version — bind port 0, read the address, drop the socket —
+    /// looks fine and is the reason these tests flapped. Two things go wrong:
+    ///
+    /// * the kernel auto-assigns from the ephemeral range (32768-60999 here),
+    ///   so between the probe closing and the real bind, any outbound socket in
+    ///   this process can take that exact port, and
+    /// * `listen()` binds on a **spawned task** and merely logs on failure, so
+    ///   the caller never learns. The test then sits waiting on a listener that
+    ///   was never created and fails as a connect timeout, pointing at the
+    ///   wrong thing entirely.
+    ///
+    /// Handing out ports from a counter *below* the ephemeral range removes the
+    /// collision at its source: nothing is auto-assigned there, so only an
+    /// explicit bind can take one, and the counter guarantees no two callers in
+    /// this process are given the same port. The probe then confirms the port is
+    /// actually free before it is used.
+    pub(crate) fn free_port() -> SocketAddr {
+        use std::sync::atomic::{AtomicU16, Ordering};
+        // Below 32768 (`/proc/sys/net/ipv4/ip_local_port_range`), above the
+        // privileged range and clear of the SIP defaults these tests also use.
+        static NEXT: AtomicU16 = AtomicU16::new(21000);
+
+        for _ in 0..2048 {
+            let port = NEXT.fetch_add(1, Ordering::Relaxed);
+            assert!(port < 32000, "exhausted the reserved test port range");
+            // TCP and UDP are separate namespaces and these tests bind either,
+            // so a port is only free when it is free on both.
+            if std::net::TcpListener::bind(("127.0.0.1", port)).is_err() {
+                continue;
+            }
+            if std::net::UdpSocket::bind(("127.0.0.1", port)).is_err() {
+                continue;
+            }
+            return SocketAddr::from(([127, 0, 0, 1], port));
+        }
+        panic!("no free loopback port in the reserved test range");
+    }
+}
+
+
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;

--- a/src/transport/sctp.rs
+++ b/src/transport/sctp.rs
@@ -162,11 +162,7 @@ mod tests {
         Arc::new(TransportAcl::new(vec![], vec![]))
     }
 
-    /// Helper: find a free port by binding and releasing.
-    fn free_port() -> SocketAddr {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        listener.local_addr().unwrap()
-    }
+    use crate::transport::testutil::free_port;
 
     #[tokio::test]
     async fn sctp_connection_lifecycle() {

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -330,11 +330,7 @@ mod tests {
         Arc::new(TransportAcl::new(vec![], vec![]))
     }
 
-    /// Helper: find a free port by binding and releasing.
-    fn free_port() -> SocketAddr {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        listener.local_addr().unwrap()
-    }
+    use crate::transport::testutil::free_port;
 
     #[tokio::test]
     async fn ws_connection_lifecycle() {

--- a/tests/integration/transport_tests.rs
+++ b/tests/integration/transport_tests.rs
@@ -28,9 +28,45 @@ fn test_acl() -> Arc<TransportAcl> {
 }
 
 /// Helper: find a free port by binding and releasing.
+/// A loopback address reserved for this test, on a port the kernel will not
+/// hand to anything else.
+///
+/// The obvious version — bind port 0, read the address, drop the socket — looks
+/// fine and is why these tests flapped. Two things go wrong:
+///
+/// * the kernel auto-assigns from the ephemeral range (32768-60999 on Linux),
+///   so between the probe closing and the real bind, any outbound socket in this
+///   process can take that exact port, and
+/// * `listen()` binds on a **spawned task** and merely logs on failure, so the
+///   caller never learns. The test then waits on a listener that was never
+///   created and fails as a connect timeout, pointing at the wrong thing.
+///
+/// Handing out ports from a counter *below* the ephemeral range removes the
+/// collision at its source: nothing is auto-assigned there, so only an explicit
+/// bind can take one, and the counter guarantees no two callers in this process
+/// get the same port. The probe then confirms it really is free.
+///
+/// (The in-crate twin lives in `transport::testutil`; `tests/` is a separate
+/// crate and cannot see `#[cfg(test)]` items.)
 fn free_port() -> SocketAddr {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.local_addr().unwrap()
+    use std::sync::atomic::{AtomicU16, Ordering};
+    // A different base from the in-crate helper: both binaries can run at once.
+    static NEXT: AtomicU16 = AtomicU16::new(24000);
+
+    for _ in 0..2048 {
+        let port = NEXT.fetch_add(1, Ordering::Relaxed);
+        assert!(port < 32000, "exhausted the reserved test port range");
+        // TCP and UDP are separate namespaces and these tests bind either, so a
+        // port is only free when it is free on both.
+        if std::net::TcpListener::bind(("127.0.0.1", port)).is_err() {
+            continue;
+        }
+        if std::net::UdpSocket::bind(("127.0.0.1", port)).is_err() {
+            continue;
+        }
+        return SocketAddr::from(([127, 0, 0, 1], port));
+    }
+    panic!("no free loopback port in the reserved test range");
 }
 
 /// Standard SIP OPTIONS request used across tests.
@@ -63,6 +99,36 @@ fn sip_200_ok() -> &'static str {
 
 const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 const SETTLE: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Retry a connect while the listener is still coming up.
+///
+/// `listen()` returns once it has bound, but the accept loop is a spawned task
+/// that may not be scheduled yet. The fixed `SETTLE` sleep that used to cover
+/// that gap is a guess about scheduler latency, and on a loaded test binary the
+/// guess expires first — the connect is refused and the test fails for reasons
+/// that have nothing to do with what it asserts. Retrying against `TIMEOUT`
+/// removes the guess: a listener that never comes up still fails, and one that
+/// is merely slow no longer does.
+async fn connect_with_retry<F, Fut, T, E>(what: &str, mut attempt: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    let deadline = tokio::time::Instant::now() + TIMEOUT;
+    loop {
+        match attempt().await {
+            Ok(value) => return value,
+            Err(error) => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "{what} never became connectable within {TIMEOUT:?}: {error}"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // UDP round-trip
@@ -132,7 +198,7 @@ async fn tcp_roundtrip() {
     tokio::time::sleep(SETTLE).await;
 
     // Client: connect and send OPTIONS
-    let mut client = TcpStream::connect(addr).await.unwrap();
+    let mut client = connect_with_retry("tcp listener", || TcpStream::connect(addr)).await;
     client.write_all(sip_options_request().as_bytes()).await.unwrap();
 
     // Verify inbound arrives
@@ -202,7 +268,7 @@ async fn tcp_close_notifies_flow_failure() {
     tokio::time::sleep(SETTLE).await;
 
     // Connect and send a request so we learn the assigned ConnectionId.
-    let mut client = TcpStream::connect(addr).await.unwrap();
+    let mut client = connect_with_retry("tcp listener", || TcpStream::connect(addr)).await;
     client.write_all(sip_options_request().as_bytes()).await.unwrap();
     let inbound = tokio::time::timeout(TIMEOUT, inbound_rx.recv_async())
         .await
@@ -368,7 +434,7 @@ async fn tcp_responds_to_peer_crlf_ping_with_pong() {
     .await;
     tokio::time::sleep(SETTLE).await;
 
-    let mut client = TcpStream::connect(addr).await.unwrap();
+    let mut client = connect_with_retry("tcp listener", || TcpStream::connect(addr)).await;
 
     // 1) Peer ping → expect single-CRLF pong back.
     client.write_all(b"\r\n\r\n").await.unwrap();
@@ -433,7 +499,7 @@ async fn tls_roundtrip() {
     // Build a TLS client that trusts our self-signed cert
     let tls_connector = build_test_tls_connector(&tls_config);
 
-    let tcp_stream = TcpStream::connect(addr).await.unwrap();
+    let tcp_stream = connect_with_retry("tcp listener", || TcpStream::connect(addr)).await;
     let server_name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
     let mut tls_stream = tls_connector.connect(server_name, tcp_stream).await.unwrap();
 
@@ -496,7 +562,8 @@ async fn ws_roundtrip() {
 
     // Client: connect via WebSocket
     let url = format!("ws://127.0.0.1:{}", addr.port());
-    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let (mut ws_stream, _) =
+        connect_with_retry("ws listener", || tokio_tungstenite::connect_async(&url)).await;
 
     // Send OPTIONS as text frame
     ws_stream.send(Message::text(sip_options_request())).await.unwrap();
@@ -562,7 +629,7 @@ async fn wss_roundtrip() {
 
     // Manual TLS connect then WebSocket upgrade
     let tls_connector = build_test_tls_connector(&tls_config);
-    let tcp_stream = TcpStream::connect(addr).await.unwrap();
+    let tcp_stream = connect_with_retry("tcp listener", || TcpStream::connect(addr)).await;
     let server_name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
     let tls_stream = tls_connector.connect(server_name, tcp_stream).await.unwrap();
 
@@ -648,12 +715,13 @@ async fn multi_transport_shared_inbound_channel() {
     udp_client.send_to(b"OPTIONS sip:udp SIP/2.0\r\n\r\n", udp_addr).await.unwrap();
 
     // Send via TCP
-    let mut tcp_client = TcpStream::connect(tcp_addr).await.unwrap();
+    let mut tcp_client = connect_with_retry("tcp listener", || TcpStream::connect(tcp_addr)).await;
     tcp_client.write_all(b"OPTIONS sip:tcp SIP/2.0\r\n\r\n").await.unwrap();
 
     // Send via WS
     let url = format!("ws://127.0.0.1:{}", ws_addr.port());
-    let (mut ws_client, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let (mut ws_client, _) =
+        connect_with_retry("ws listener", || tokio_tungstenite::connect_async(&url)).await;
     ws_client.send(Message::text("OPTIONS sip:ws SIP/2.0\r\n\r\n")).await.unwrap();
 
     // Collect three messages from the shared channel


### PR DESCRIPTION
Two tests that failed at random, both for reasons unrelated to what they assert.
One of them aborted the 1.7.1 release cut.

## `free_port()` — the transport tests

```rust
fn free_port() -> SocketAddr {
    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
    listener.local_addr().unwrap()   // listener dropped here
}
```

Two compounding problems:

* The kernel auto-assigns from the **ephemeral range** (32768-60999). Between the
  probe closing and the real bind, any outbound socket in the process can take
  that exact port.
* `listen()` binds on a **spawned task** and only `error!`s on failure, so the
  caller never learns. The test then waited out its timeout against a listener
  that was never created and failed as `Connection refused` — pointing at the
  wrong thing entirely, which is why this read as "scheduler latency" for so
  long.

It also probed **TCP** to pick a port then bound **UDP** on it. Separate
namespaces: a free TCP port says nothing about UDP.

Ports now come from a counter *below* the ephemeral range, where nothing is
auto-assigned and only an explicit bind can take one, and are probed on both
namespaces. The three copies of the helper are down to two — one shared in
`transport::testutil`, one for `tests/`, which is a separate crate and cannot see
`#[cfg(test)]` items.

| | before | after |
|---|---|---|
| integration suite | **4 failures / 20 runs** | **0 / 25** |

Failures were spread across `multi_transport_shared_inbound_channel`,
`ws_roundtrip`, `tls_roundtrip`, `wss_roundtrip` and
`tcp_close_notifies_flow_failure` — one root cause, five symptoms.

## The Python thread-state guard

Different problem. It compares glibc in-use bytes across thread-churn batches,
but that counter is **process-global** and the parallel binary's other tests
allocate on the same order as the signal (~240 KB signal, 50-140 KB of
neighbours per window). It failed about one run in four — including the first
1.7.1 cut attempt, then passed 3/3 in isolation, which is exactly the shape that
wastes an afternoon.

Two changes:

* a **control arm** — spawn and join the same threads without touching Python —
  so the ambient cost of the window is measured and subtracted rather than
  assumed away. (Medians alone did *not* fix it: the noise is a steady
  background in every sample, not an outlier.)
* `#[ignore]`d with a CI step that runs it **alone**, the same way the
  CAP_NET_ADMIN tests already are. It measures a process-global counter, so it
  has to own the process.

Alone it is exact, every run:

```
ambient 0 B [0, 0, 0]; unpaired pin: 241664 B net over 256 threads
(944.0 B/thread) [241664, 241664, 241664]; paired pin/unpin: 0 B net [0, 0, 0]
```

**The property it proves is unchanged** — the leak must still reproduce, and
pairing must still remove essentially all of it. Nothing was loosened to make it
pass.

## Testing

- integration suite: 0 failures in 25 runs (was 4 in 20)
- lib suite: 0 failures in 20 runs (was 5 in 20)
- full `cargo test`: 0 failures in 12 runs
- the isolated guard: 0 failures in 15 runs
- `clippy --all-targets --all-features -D warnings` clean

## Left alone deliberately

`listen()` swallowing bind failures is a real wart — it returns `()` and only
logs — but making it report would change a signature every production caller
uses. Out of scope for a test fix; worth its own change if you want it.
