### PR TITLE
fix(transport): bound stream message size so one connection cannot exhaust memory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1526,8 +1526,11 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 
-      - name: Run fuzz target (60s)
+      - name: Run fuzz target — SIP parser (60s)
         run: PYO3_PYTHON=python3.14 cargo +nightly fuzz run sip_parser_fuzz -- -max_total_time=60
+
+      - name: Run fuzz target — stream framing (60s)
+        run: PYO3_PYTHON=python3.14 cargo +nightly fuzz run stream_framing_fuzz -- -max_total_time=60
 
   # ── SIPp IPsec VoLTE test (self-hosted) ────────────────────────────────
   # IPsec XFRM SA installation needs CAP_NET_ADMIN, which GitHub-hosted runners

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 fuzz/target/
+fuzz/artifacts/
+fuzz/corpus/
 sbom.spdx.json
 sbom.cdx.json
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Security
+- **Bounded stream message size (`security.max_message_bytes`).** A peer on a
+  stream transport (TCP/TLS/WS/WSS) could declare an arbitrarily large
+  `Content-Length`, send only the header block, and make the reader buffer
+  toward the declared size. The existing 64 KB guard covers only a header block
+  with no end-of-headers marker, so it did not apply once `\r\n\r\n` had been
+  seen — roughly 200 bytes on one connection was enough to drive multi-GB
+  growth, before any parsing, authentication or rate limiting ran. Framing now
+  enforces a ceiling (default 256 KB, minimum 4096, configurable) across the
+  inbound listeners *and* the outbound connection pool, which had no guard at
+  all. An over-sized request is answered `513 Message Too Large` (RFC 3261
+  §21.4.11) and the connection is closed, so a legitimately over-sized body is
+  a diagnosable configuration problem rather than an unexplained reset.
+- **Fixed a wrapping length calculation in the stream framer.** A
+  `Content-Length` near `usize::MAX` overflowed the headers-plus-body sum.
+  Release builds do not enable overflow checks, so it wrapped silently to one
+  byte short of the header block: the framer sliced a truncated message and
+  desynchronised the stream on a value the peer chose. The sum now saturates,
+  so an unrepresentable declaration is refused as over-sized. Found by the new
+  framing fuzz target.
+
+### Added
+- **Framing fuzz target (`stream_framing_fuzz`).** Fuzzes the stream framer's
+  invariants — a framed length never exceeds the buffer or the ceiling, and a
+  refused message's header block stays inside the buffer — alongside the
+  existing parser target in CI.
+
 ### Fixed
 - **Two tests that failed at random, both for reasons unrelated to what they
   assert.** `free_port()` bound port 0, read the address and dropped the socket:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -157,6 +157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -175,8 +176,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1473,6 +1476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,7 +1955,7 @@ dependencies = [
  "bitflags",
  "hex",
  "procfs-core",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2431,8 +2440,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2715,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226aef8325e781c170039a9a580312c28aa52aa6dac5c5f797a0df9a513f1309"
+checksum = "4bb75fb1c1bb6292201107966cd3e252d3ed56361315c270e297861557b8855c"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -2727,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-sip"
-version = "1.5.1"
+version = "1.7.1"
 dependencies = [
  "aes",
  "arc-swap",
@@ -2742,6 +2764,9 @@ dependencies = [
  "getrandom 0.4.3",
  "hickory-resolver",
  "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "indexmap",
  "ipnet",
  "libc",
@@ -2767,6 +2792,7 @@ dependencies = [
  "sha2 0.11.0",
  "siphon-rtp-proto",
  "socket2",
+ "tempfile",
  "thiserror 2.0.19",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
@@ -2779,6 +2805,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uppsala",
  "uuid",
  "webpki-roots",
  "x509-cert",
@@ -2971,6 +2998,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -3439,6 +3479,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uppsala"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b83b4950a552cd9812b6afd150ea10729617d28208bba122912eb196c2261d4d"
 
 [[package]]
 name = "url"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,3 +17,10 @@ path = "fuzz_targets/sip_parser_fuzz.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "stream_framing_fuzz"
+path = "fuzz_targets/stream_framing_fuzz.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/stream_framing_fuzz.rs
+++ b/fuzz/fuzz_targets/stream_framing_fuzz.rs
@@ -1,0 +1,38 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use siphon::security::DEFAULT_MAX_MESSAGE_BYTES;
+use siphon::transport::tcp::{frame_sip_message, FrameVerdict};
+
+// The stream framer decides, from attacker-controlled bytes, how many of them
+// make up one message — before any parsing, authentication or rate limiting
+// runs. Its invariants are what keep a peer from steering the reader into
+// buffering without bound or slicing outside the buffer.
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+    for limit in [64usize, 4096, DEFAULT_MAX_MESSAGE_BYTES] {
+        match frame_sip_message(data, limit) {
+            FrameVerdict::Complete { len } => {
+                // The caller does `accumulator.split_to(len)`, so a len past
+                // the end of the buffer would panic, and a len over the limit
+                // would defeat the ceiling.
+                assert!(len <= data.len(), "framed {len} bytes out of {}", data.len());
+                assert!(len <= limit, "framed {len} bytes over the {limit} limit");
+            }
+            FrameVerdict::Oversized { declared, header_len } => {
+                // The caller parses `accumulator[..header_len]` to address its
+                // 513, so the header block must be inside the buffer, and the
+                // refusal must be justified by the declared size.
+                assert!(
+                    header_len <= data.len(),
+                    "header block {header_len} bytes out of {}",
+                    data.len()
+                );
+                assert!(declared > limit, "refused {declared} bytes under the {limit} limit");
+            }
+            FrameVerdict::NeedMore | FrameVerdict::Garbage => {}
+        }
+    }
+});

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -402,6 +402,14 @@ auth:
 #   trusted_cidrs:              # never rate-limited and never auto-banned
 #     - "10.0.0.0/8"            # own infra: AS, BGCF, trunks, monitoring
 #
+#   max_message_bytes: 262144   # largest single SIP message on a stream
+#                               # transport (TCP/TLS/WS/WSS). A peer declaring a
+#                               # larger Content-Length is answered 513 Message
+#                               # Too Large and disconnected, so no single
+#                               # connection can drive unbounded memory growth.
+#                               # Default 262144 (256 KB); minimum 4096. Applies
+#                               # even with no security block configured.
+#
 #   failed_auth_ban:            # auto-ban scanners at accept (TCP/TLS/UDP/WS/SCTP)
 #     threshold: 10             # weighted failures within window_secs before a ban
 #     window_secs: 600          # sliding window for counting failures (default 600)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1476,7 +1476,18 @@ pub struct SecurityConfig {
     /// abusive traffic never reaches siphon's socket (Linux only, needs
     /// `CAP_NET_ADMIN`). Falls back to the userspace ACL when unavailable.
     pub firewall: Option<FirewallConfig>,
+    /// Largest single SIP message accepted on a stream transport (TCP/TLS/WS/
+    /// WSS), in bytes. A peer that declares a larger `Content-Length` is
+    /// answered 513 and disconnected rather than buffered, so one connection
+    /// cannot drive unbounded memory growth. Defaults to
+    /// [`crate::security::DEFAULT_MAX_MESSAGE_BYTES`] (256 KB).
+    pub max_message_bytes: Option<usize>,
 }
+
+/// Smallest accepted `security.max_message_bytes`. A REGISTER or INVITE with a
+/// digest challenge, a Route set and a modest SDP body sits comfortably under
+/// 4 KB; anything below this is an operator typo, not a policy.
+pub const MIN_MAX_MESSAGE_BYTES: usize = 4 * 1024;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct FirewallConfig {
@@ -4031,7 +4042,30 @@ impl Config {
             .map_err(|e| SiphonError::Config(format!("invalid siphon.yaml: {e}")))?;
         config.validate_media_profiles()?;
         config.validate_lawful_intercept()?;
+        config.validate_max_message_bytes()?;
         Ok(config)
+    }
+
+    /// Reject a message-size ceiling too small to carry a SIP message.
+    ///
+    /// The ceiling bounds what one stream connection can make siphon buffer,
+    /// so it is load-bearing for availability. A value below
+    /// [`MIN_MAX_MESSAGE_BYTES`] would refuse ordinary INVITEs — an operator
+    /// typo that turns into a total outage — so it is refused at load rather
+    /// than answering 513 to every call.
+    fn validate_max_message_bytes(&self) -> Result<()> {
+        let Some(limit) = self.security.as_ref().and_then(|sec| sec.max_message_bytes) else {
+            return Ok(());
+        };
+        if limit < MIN_MAX_MESSAGE_BYTES {
+            return Err(SiphonError::Config(format!(
+                "security.max_message_bytes is {limit}, below the {MIN_MAX_MESSAGE_BYTES} byte \
+                 floor — a SIP INVITE with authentication and SDP does not fit, so every call \
+                 would be answered 513 Message Too Large. Raise it or remove the field to take \
+                 the default."
+            )));
+        }
+        Ok(())
     }
 
     /// Reject an X3 content-delivery configuration the media backend cannot honour.

--- a/src/security.rs
+++ b/src/security.rs
@@ -62,6 +62,32 @@ pub fn security_filter() -> Option<&'static Arc<SecurityFilter>> {
     SECURITY_FILTER.get()
 }
 
+/// Default ceiling on a single SIP message over a stream transport, in bytes.
+///
+/// Comfortably above anything legitimate — a VoLTE INVITE with a full P-header
+/// set is a few KB, and even SIPREC metadata (RFC 7865) runs to tens of KB —
+/// while bounding what one connection can make siphon buffer. Raise it with
+/// `security.max_message_bytes` if a deployment genuinely carries larger
+/// bodies.
+pub const DEFAULT_MAX_MESSAGE_BYTES: usize = 256 * 1024;
+
+/// Process-wide stream message-size ceiling. Unset until startup installs the
+/// configured value, so every read-path check is a cheap `OnceLock` read that
+/// falls back to [`DEFAULT_MAX_MESSAGE_BYTES`]. Mirrors [`AUTO_BAN`].
+static MAX_MESSAGE_BYTES: OnceLock<usize> = OnceLock::new();
+
+/// Install the process-wide message-size ceiling (idempotent — a second call is
+/// a no-op). Called once at server startup before any traffic is accepted.
+pub fn set_max_message_bytes(limit: usize) {
+    let _ = MAX_MESSAGE_BYTES.set(limit);
+}
+
+/// The configured stream message-size ceiling, or [`DEFAULT_MAX_MESSAGE_BYTES`]
+/// when none was installed. Read on every stream framing attempt.
+pub fn max_message_bytes() -> usize {
+    MAX_MESSAGE_BYTES.get().copied().unwrap_or(DEFAULT_MAX_MESSAGE_BYTES)
+}
+
 /// Record one failed/timed-out transport handshake (TLS / WSS TLS / WS upgrade)
 /// from `source` as an auto-ban signal, and bump the handshake-failure metric.
 ///
@@ -749,6 +775,7 @@ mod tests {
         trusted_cidrs: Vec<&str>,
     ) -> SecurityConfig {
         SecurityConfig {
+            max_message_bytes: None,
             rate_limit,
             scanner_block: if user_agents.is_empty() {
                 None

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use pyo3::prelude::*;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::config::{self, Config};
 use crate::hep::HepSender;
@@ -1127,6 +1127,19 @@ impl SiphonServer {
 
         // --- Build transport ACL ---
         let transport_acl = build_transport_acl(&config, kernel_firewall.clone());
+
+        // --- Stream message-size ceiling ---
+        // Always installed (unlike the opt-in guards below): a stream reader
+        // that trusts a peer's declared Content-Length has no upper bound on
+        // what one connection can make it buffer, so the ceiling has to hold
+        // even when no `security:` block is configured at all.
+        let max_message_bytes = config
+            .security
+            .as_ref()
+            .and_then(|sec| sec.max_message_bytes)
+            .unwrap_or(crate::security::DEFAULT_MAX_MESSAGE_BYTES);
+        crate::security::set_max_message_bytes(max_message_bytes);
+        debug!(max_message_bytes, "stream message-size ceiling installed");
 
         // --- Auto-ban (failed_auth_ban scanner protection) ---
         // Opt-in: only installed when configured. Once installed, the auth path

--- a/src/sip/parser.rs
+++ b/src/sip/parser.rs
@@ -31,13 +31,12 @@ pub fn parse_sip_message(input: &str) -> IResult<&str, SipMessage> {
     }))
 }
 
-/// Parse a SIP message from raw bytes, supporting binary bodies.
+/// Parse the start line and header block out of raw message bytes.
 ///
-/// Headers are ASCII/UTF-8 per RFC 3261. The body after the blank line
-/// (`\r\n\r\n`) is treated as opaque bytes — not validated as UTF-8.
-/// This supports binary content types like `application/vnd.3gpp.sms`.
-pub fn parse_sip_message_bytes(input: &[u8]) -> Result<SipMessage, String> {
-    // Find the header/body boundary
+/// Returns the parsed start line, the headers, and the index of the `\r\n\r\n`
+/// boundary. Shared by [`parse_sip_message_bytes`] and
+/// [`parse_sip_headers_only`], which differ only in how they treat the body.
+fn parse_header_block(input: &[u8]) -> Result<(StartLine, SipHeaders, usize), String> {
     let boundary = find_header_boundary(input)
         .ok_or_else(|| "no header/body boundary (\\r\\n\\r\\n) found".to_string())?;
 
@@ -60,6 +59,31 @@ pub fn parse_sip_message_bytes(input: &[u8]) -> Result<SipMessage, String> {
         .unwrap_or("");
     let (_, headers) = parse_headers(after_start_line)
         .map_err(|error| format!("header parse error: {error}"))?;
+
+    Ok((start_line, headers, boundary))
+}
+
+/// Parse only the header block, ignoring `Content-Length` entirely. The
+/// returned message always has an empty body.
+///
+/// [`parse_sip_message_bytes`] rejects a `Content-Length` larger than the body
+/// actually received (RFC 4475 §3.1.2.2), which is right for a message on its
+/// way upstream but wrong for the one caller that has deliberately refused to
+/// read the body: the stream framer rejecting an over-sized declaration still
+/// needs the Via / From / To / Call-ID / CSeq set to address its 513 response
+/// back at the sender.
+pub fn parse_sip_headers_only(input: &[u8]) -> Result<SipMessage, String> {
+    let (start_line, headers, _) = parse_header_block(input)?;
+    Ok(SipMessage { start_line, headers, body: Vec::new() })
+}
+
+/// Parse a SIP message from raw bytes, supporting binary bodies.
+///
+/// Headers are ASCII/UTF-8 per RFC 3261. The body after the blank line
+/// (`\r\n\r\n`) is treated as opaque bytes — not validated as UTF-8.
+/// This supports binary content types like `application/vnd.3gpp.sms`.
+pub fn parse_sip_message_bytes(input: &[u8]) -> Result<SipMessage, String> {
+    let (start_line, headers, boundary) = parse_header_block(input)?;
 
     // Body is raw bytes after the \r\n\r\n boundary
     let body_start = boundary + 4;

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -29,7 +29,7 @@ use crate::transport::{
     configure_tcp_socket, next_connection_id,
 };
 use crate::transport::crlf_keepalive::{drain_leading_crlf_keepalives, CrlfPongTracker};
-use crate::transport::tcp::extract_sip_message_length;
+use crate::transport::tcp::{frame_sip_message, FrameVerdict};
 
 /// Idle timeout for pooled outbound connections (shorter than inbound).
 ///
@@ -570,9 +570,36 @@ impl ConnectionPool {
                             if accumulator.is_empty() {
                                 break;
                             }
-                            let message_len = match extract_sip_message_length(&accumulator) {
-                                Some(len) if len <= accumulator.len() => len,
-                                _ => break, // incomplete — wait for more bytes
+                            // Same ceiling as the inbound listeners: an
+                            // upstream that declares a huge Content-Length (or
+                            // never terminates its header block) would
+                            // otherwise grow this accumulator without bound.
+                            // No 513 here — the pool reads responses, and a
+                            // response is not something to answer.
+                            let message_len = match frame_sip_message(
+                                &accumulator,
+                                crate::security::max_message_bytes(),
+                            ) {
+                                FrameVerdict::Complete { len } => len,
+                                FrameVerdict::NeedMore => break,
+                                FrameVerdict::Oversized { declared, .. } => {
+                                    warn!(
+                                        declared,
+                                        limit = crate::security::max_message_bytes(),
+                                        "pool: {} peer {} declared an oversized message; dropping connection",
+                                        "TCP",
+                                        destination
+                                    );
+                                    break;
+                                }
+                                FrameVerdict::Garbage => {
+                                    warn!(
+                                        "pool: non-SIP bytes from {} peer {}; dropping connection",
+                                        "TCP",
+                                        destination
+                                    );
+                                    break;
+                                }
                             };
                             let data = accumulator.split_to(message_len).freeze();
                             let message = InboundMessage {
@@ -826,9 +853,36 @@ impl ConnectionPool {
                             if accumulator.is_empty() {
                                 break;
                             }
-                            let message_len = match extract_sip_message_length(&accumulator) {
-                                Some(len) if len <= accumulator.len() => len,
-                                _ => break,
+                            // Same ceiling as the inbound listeners: an
+                            // upstream that declares a huge Content-Length (or
+                            // never terminates its header block) would
+                            // otherwise grow this accumulator without bound.
+                            // No 513 here — the pool reads responses, and a
+                            // response is not something to answer.
+                            let message_len = match frame_sip_message(
+                                &accumulator,
+                                crate::security::max_message_bytes(),
+                            ) {
+                                FrameVerdict::Complete { len } => len,
+                                FrameVerdict::NeedMore => break,
+                                FrameVerdict::Oversized { declared, .. } => {
+                                    warn!(
+                                        declared,
+                                        limit = crate::security::max_message_bytes(),
+                                        "pool: {} peer {} declared an oversized message; dropping connection",
+                                        "TLS",
+                                        destination
+                                    );
+                                    break;
+                                }
+                                FrameVerdict::Garbage => {
+                                    warn!(
+                                        "pool: non-SIP bytes from {} peer {}; dropping connection",
+                                        "TLS",
+                                        destination
+                                    );
+                                    break;
+                                }
                             };
                             let data = accumulator.split_to(message_len).freeze();
                             let message = InboundMessage {

--- a/src/transport/stream.rs
+++ b/src/transport/stream.rs
@@ -29,7 +29,7 @@ use tracing::{debug, error, warn};
 
 use crate::transport::crlf_keepalive::{drain_leading_crlf_keepalives, CrlfPongTracker};
 use crate::transport::pool::ConnectionPool;
-use crate::transport::tcp::{classify_incomplete_stream, extract_sip_message_length, StreamVerdict};
+use crate::transport::tcp::{frame_sip_message, FrameVerdict};
 use crate::transport::{
     ConnectionId, InboundMessage, OutboundMessage, StreamConnections, Transport,
     CONNECTION_IDLE_TIMEOUT,
@@ -225,22 +225,57 @@ pub(crate) async fn serve_sip_stream<R, W>(
                 if accumulator.is_empty() {
                     break;
                 }
-                let message_len = match extract_sip_message_length(&accumulator) {
-                    Some(len) if len <= accumulator.len() => len,
-                    // Header block complete, body still arriving — wait.
-                    Some(_) => break,
-                    None => match classify_incomplete_stream(&accumulator) {
-                        // SIP still arriving — need more data.
-                        StreamVerdict::MaybeSip => break,
-                        StreamVerdict::Garbage => {
-                            warn!("non-SIP bytes from {remote_addr} on {transport} {connection_id:?}; dropping connection");
-                            crate::security::record_malformed_message(
-                                remote_addr.ip(),
-                                &transport.to_string(),
-                            );
-                            return; // close the connection
+                let message_len = match frame_sip_message(
+                    &accumulator,
+                    crate::security::max_message_bytes(),
+                ) {
+                    FrameVerdict::Complete { len } => len,
+                    // Still arriving (or header block done, body in flight).
+                    FrameVerdict::NeedMore => break,
+                    // RFC 3261 §21.4.11 — the peer declared more than we will
+                    // buffer. The header block is already complete, so answer
+                    // 513 rather than resetting the connection out from under
+                    // a peer that would otherwise have no idea why: a legit
+                    // oversized body (large SIPREC metadata, say) is then an
+                    // obvious configuration problem instead of a mystery RST.
+                    // The connection still closes, because the body we refuse
+                    // to buffer is exactly what we would have to read to find
+                    // the next message boundary.
+                    FrameVerdict::Oversized { declared, header_len } => {
+                        warn!(
+                            declared,
+                            limit = crate::security::max_message_bytes(),
+                            "message from {remote_addr} on {transport} {connection_id:?} exceeds \
+                             security.max_message_bytes; answering 513 and dropping connection"
+                        );
+                        if let Ok(request) =
+                            crate::sip::parser::parse_sip_headers_only(&accumulator[..header_len])
+                        {
+                            if request.is_request() {
+                                let reject = crate::sip::builder::build_response_skeleton(
+                                    &request,
+                                    513,
+                                    "Message Too Large",
+                                );
+                                let _ = keepalive_writer
+                                    .send(Bytes::from(reject.to_bytes()))
+                                    .await;
+                            }
                         }
-                    },
+                        crate::security::record_malformed_message(
+                            remote_addr.ip(),
+                            &transport.to_string(),
+                        );
+                        return; // close the connection
+                    }
+                    FrameVerdict::Garbage => {
+                        warn!("non-SIP bytes from {remote_addr} on {transport} {connection_id:?}; dropping connection");
+                        crate::security::record_malformed_message(
+                            remote_addr.ip(),
+                            &transport.to_string(),
+                        );
+                        return; // close the connection
+                    }
                 };
                 let data = accumulator.split_to(message_len).freeze();
                 let message = InboundMessage {
@@ -289,7 +324,7 @@ pub(crate) async fn serve_sip_stream<R, W>(
     });
 
     // Write task.
-    let write_task = tokio::spawn(async move {
+    let mut write_task = tokio::spawn(async move {
         while let Some(data) = outbound_rx.recv().await {
             if let Err(error) = writer.write_all(&data).await {
                 warn!("{transport} write error on {connection_id:?}: {error}");
@@ -300,8 +335,17 @@ pub(crate) async fn serve_sip_stream<R, W>(
 
     // Wait for either half to close, then clean up.
     tokio::select! {
-        _ = read_task => {}
-        _ = write_task => {}
+        _ = read_task => {
+            // The read half can queue a final response on its way out — a 513
+            // for an oversized declaration, say. Dropping the write half here
+            // would discard it and the peer would see a bare connection reset
+            // with no idea why, so instead close the channel (the read half's
+            // sender went with the task; this drops the map's copy) and give
+            // the writer a bounded window to flush what is already queued.
+            connection_map.remove(&connection_id);
+            let _ = tokio::time::timeout(FINAL_WRITE_GRACE, &mut write_task).await;
+        }
+        _ = &mut write_task => {}
     }
 
     connection_map.remove(&connection_id);
@@ -319,6 +363,12 @@ pub(crate) async fn serve_sip_stream<R, W>(
 // ---------------------------------------------------------------------------
 // Protocol sniffing — raw SIP vs SIP-over-WebSocket on one socket
 // ---------------------------------------------------------------------------
+
+/// How long the write half may take to flush a response the read half queued
+/// immediately before closing the connection. Bounded so a peer that has
+/// stopped reading cannot pin the task open, but generous enough for one small
+/// response on a live socket.
+const FINAL_WRITE_GRACE: Duration = Duration::from_secs(1);
 
 /// How long a freshly accepted connection may stay silent before it is assumed
 /// to be raw SIP.
@@ -581,6 +631,7 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for PrefixedStream<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::transport::tcp::extract_sip_message_length;
 
     const INVITE: &[u8] = concat!(
         "INVITE sip:bob@biloxi.com SIP/2.0\r\n",

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -128,7 +128,7 @@ pub async fn listen(
 /// Returns `None` if the headers are not yet complete or if
 /// Content-Length is missing (assumes 0-length body in that case once
 /// the header block is complete).
-pub(crate) fn extract_sip_message_length(buffer: &[u8]) -> Option<usize> {
+pub fn extract_sip_message_length(buffer: &[u8]) -> Option<usize> {
     // Find end of headers
     let header_end = buffer
         .windows(4)
@@ -139,7 +139,15 @@ pub(crate) fn extract_sip_message_length(buffer: &[u8]) -> Option<usize> {
     let header_block = &buffer[..header_end];
     let content_length = extract_content_length(header_block).unwrap_or(0);
 
-    Some(headers_len + content_length)
+    // Saturate rather than wrap. `Content-Length: 18446744073709551615` parses
+    // as a valid `usize`, and `headers_len + content_length` then overflows —
+    // which panics in debug but *wraps* in release (the release profile does
+    // not enable overflow-checks), reporting a length one byte short of the
+    // header block. The framer would hand the parser a truncated header block
+    // and leave the tail of the `\r\n\r\n` in the accumulator, desynchronising
+    // the stream from a value the peer chose. Saturating puts the result above
+    // any ceiling instead, so the message is refused as oversized.
+    Some(headers_len.saturating_add(content_length))
 }
 
 /// Maximum bytes of an incomplete (no `\r\n\r\n` yet) stream message before it
@@ -202,6 +210,58 @@ pub(crate) fn classify_incomplete_stream(buffer: &[u8]) -> StreamVerdict {
         // First line still arriving and free of control bytes — keep reading
         // (bounded by the size cap above and the connection idle timeout).
         None => StreamVerdict::MaybeSip,
+    }
+}
+
+/// Verdict for one framing attempt over a stream accumulator.
+///
+/// Replaces the old "`Option<usize>` plus a separate garbage classification"
+/// pair so that every stream reader — inbound listeners and the outbound
+/// connection pool alike — goes through one place that also enforces the
+/// message-size ceiling. Without that ceiling a peer can declare a huge
+/// `Content-Length`, send only the header block, and make the reader buffer
+/// toward the declared size: the end-of-headers marker has already been seen,
+/// so [`MAX_INCOMPLETE_HEADER_BYTES`] no longer applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameVerdict {
+    /// A complete SIP message occupies the first `len` bytes of the buffer.
+    Complete { len: usize },
+    /// Not a complete message yet, and still plausibly SIP — keep reading.
+    NeedMore,
+    /// The header block is complete but the declared total exceeds the
+    /// ceiling. `header_len` bounds the (already buffered) header block so the
+    /// caller can parse it and answer 513 before closing the connection.
+    Oversized { declared: usize, header_len: usize },
+    /// Definitely not SIP, or an over-long header block — drop the connection.
+    Garbage,
+}
+
+/// Frame one SIP message out of a stream accumulator, refusing anything whose
+/// declared total exceeds `max_message_bytes`.
+///
+/// The caller must have already drained leading CRLF keepalives (RFC 5626
+/// §4.4.1) and confirmed the buffer is non-empty.
+pub fn frame_sip_message(buffer: &[u8], max_message_bytes: usize) -> FrameVerdict {
+    let Some(len) = extract_sip_message_length(buffer) else {
+        return match classify_incomplete_stream(buffer) {
+            StreamVerdict::MaybeSip => FrameVerdict::NeedMore,
+            StreamVerdict::Garbage => FrameVerdict::Garbage,
+        };
+    };
+    if len > max_message_bytes {
+        // Safe: `extract_sip_message_length` returned `Some`, so `\r\n\r\n`
+        // is present and the header block is fully buffered.
+        let header_len = buffer
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|end| end + 4)
+            .unwrap_or(buffer.len());
+        return FrameVerdict::Oversized { declared: len, header_len };
+    }
+    if len <= buffer.len() {
+        FrameVerdict::Complete { len }
+    } else {
+        FrameVerdict::NeedMore
     }
 }
 
@@ -390,6 +450,124 @@ mod tests {
         assert_eq!(extract_content_length(headers), Some(200));
     }
 
+    // --- message-size ceiling (frame_sip_message) ---------------------------
+
+    const CEILING: usize = 256 * 1024;
+
+    /// The shape this ceiling exists to stop: a peer sends a ~200 byte header
+    /// block declaring a body far larger than anything SIP carries, then
+    /// dribbles it. Before the ceiling the reader saw `\r\n\r\n` (so the
+    /// over-long-header guard no longer applied) and buffered toward the
+    /// declared size, so one connection could drive multi-GB growth.
+    #[test]
+    fn oversized_declared_content_length_is_refused_not_buffered() {
+        let attack = b"INVITE sip:bob@example.com SIP/2.0\r\n\
+                       Via: SIP/2.0/TCP host;branch=z9hG4bK1\r\n\
+                       Content-Length: 4000000000\r\n\
+                       \r\n";
+        match frame_sip_message(attack, CEILING) {
+            FrameVerdict::Oversized { declared, header_len } => {
+                assert_eq!(declared, 4_000_000_000 + attack.len());
+                // The whole header block is buffered, so the caller can parse
+                // it and answer 513 before closing.
+                assert_eq!(header_len, attack.len());
+            }
+            other => panic!("expected Oversized, got {other:?}"),
+        }
+    }
+
+    /// A `Content-Length` near `usize::MAX` must not wrap the headers+body sum.
+    /// Found by the framing fuzz target: the sum overflowed, and because the
+    /// release profile leaves overflow-checks off it wrapped silently to
+    /// `headers_len - 1`, so the framer sliced a truncated header block and
+    /// desynchronised the stream on a value the peer controls.
+    #[test]
+    fn absurd_content_length_saturates_instead_of_wrapping() {
+        let attack = b"INVITE sip:bob@example.com SIP/2.0\r\n\
+                       Content-Length: 18446744073709551615\r\n\
+                       \r\n";
+        assert_eq!(extract_sip_message_length(attack), Some(usize::MAX));
+        assert!(
+            matches!(frame_sip_message(attack, CEILING), FrameVerdict::Oversized { .. }),
+            "an unrepresentable declaration must be refused, never framed short"
+        );
+    }
+
+    /// A message exactly at the ceiling is still accepted — the check is
+    /// "greater than", so the documented limit is inclusive.
+    #[test]
+    fn message_exactly_at_the_ceiling_is_accepted() {
+        let headers = b"INVITE sip:bob@example.com SIP/2.0\r\nContent-Length: 10\r\n\r\n";
+        let mut message = headers.to_vec();
+        message.extend_from_slice(b"0123456789");
+        let limit = message.len();
+        assert_eq!(
+            frame_sip_message(&message, limit),
+            FrameVerdict::Complete { len: message.len() }
+        );
+        assert!(matches!(
+            frame_sip_message(&message, limit - 1),
+            FrameVerdict::Oversized { .. }
+        ));
+    }
+
+    /// An ordinary message still frames, and a partially-arrived body still
+    /// asks for more rather than being mistaken for an attack.
+    #[test]
+    fn ordinary_message_frames_and_partial_body_waits() {
+        let headers = b"INVITE sip:bob@example.com SIP/2.0\r\nContent-Length: 4\r\n\r\n";
+        let mut complete = headers.to_vec();
+        complete.extend_from_slice(b"AAAA");
+        assert_eq!(
+            frame_sip_message(&complete, CEILING),
+            FrameVerdict::Complete { len: complete.len() }
+        );
+
+        let mut partial = headers.to_vec();
+        partial.extend_from_slice(b"AA");
+        assert_eq!(frame_sip_message(&partial, CEILING), FrameVerdict::NeedMore);
+    }
+
+    /// The pre-existing `classify_incomplete_stream` guards still fire through
+    /// the new entry point, unchanged: they apply only while the header block
+    /// is incomplete (a buffer that already holds `\r\n\r\n` frames as a
+    /// message and is judged further up the stack).
+    #[test]
+    fn frame_sip_message_preserves_garbage_classification() {
+        // A complete non-SIP first line, still mid-header-block.
+        assert_eq!(
+            frame_sip_message(b"GET /index.html HTTP/1.1\r\nHost: example", CEILING),
+            FrameVerdict::Garbage
+        );
+        // A binary probe (TLS ClientHello on the plaintext port).
+        assert_eq!(
+            frame_sip_message(&[0x16, 0x03, 0x01, 0x00, 0x2f], CEILING),
+            FrameVerdict::Garbage
+        );
+        // A genuine SIP message still arriving is not garbage.
+        assert_eq!(
+            frame_sip_message(b"INVITE sip:bob@example.com SIP/2.0\r\nVia: SIP", CEILING),
+            FrameVerdict::NeedMore
+        );
+        // Over-long header block with no end-of-headers is still refused.
+        let mut flood = b"INVITE sip:bob@example.com SIP/2.0\r\n".to_vec();
+        flood.resize(MAX_INCOMPLETE_HEADER_BYTES + 1, b'x');
+        assert_eq!(frame_sip_message(&flood, CEILING), FrameVerdict::Garbage);
+    }
+
+    /// The ceiling counts headers *and* body, so a message whose header block
+    /// alone is under the incomplete-header cap can still be refused on its
+    /// declared total.
+    #[test]
+    fn ceiling_covers_headers_plus_body() {
+        let message = b"INVITE sip:bob@example.com SIP/2.0\r\nContent-Length: 5000\r\n\r\n";
+        assert!(message.len() < MAX_INCOMPLETE_HEADER_BYTES);
+        assert!(matches!(
+            frame_sip_message(message, 4096),
+            FrameVerdict::Oversized { .. }
+        ));
+    }
+
     // --- end to end: the listener only serves connections that speak SIP ----
 
     /// Bind a port, release it, and start a TCP SIP listener on it.
@@ -448,6 +626,51 @@ mod tests {
         .unwrap();
         assert_eq!(read, 0, "a SIP port must not answer a probe");
         assert!(inbound_rx.is_empty(), "the probe must never reach the dispatcher");
+    }
+
+    /// End to end on a real listener: an oversized declaration is answered
+    /// 513, never dispatched, and the connection is closed — so the body the
+    /// peer promised is never buffered.
+    #[tokio::test]
+    async fn listener_answers_513_and_closes_on_an_oversized_declaration() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let (addr, inbound_rx) = spawn_listener().await;
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let attack = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/TCP 10.0.0.1:5060;branch=z9hG4bK-oversize\r\n",
+            "From: <sip:alice@example.com>;tag=abc123\r\n",
+            "To: <sip:bob@example.com>\r\n",
+            "Call-ID: oversize-test@example.com\r\n",
+            "CSeq: 1 INVITE\r\n",
+            "Content-Length: 4000000000\r\n",
+            "\r\n",
+        );
+        client.write_all(attack.as_bytes()).await.unwrap();
+
+        let mut response = Vec::new();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            client.read_to_end(&mut response),
+        )
+        .await
+        .expect("the connection must be closed, not held open buffering")
+        .unwrap();
+
+        let response = String::from_utf8_lossy(&response);
+        assert!(
+            response.starts_with("SIP/2.0 513 "),
+            "expected a 513, got: {response}"
+        );
+        assert!(
+            response.contains("branch=z9hG4bK-oversize"),
+            "the 513 must be routable back to the sender: {response}"
+        );
+        assert!(
+            inbound_rx.try_recv().is_err(),
+            "an oversized message must never reach the dispatcher"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

A peer on a stream transport (TCP/TLS/WS/WSS) can declare an arbitrarily large `Content-Length`, send only the header block, and make the reader buffer toward the declared size.

```
INVITE sip:bob@example.com SIP/2.0
Via: SIP/2.0/TCP host;branch=z9hG4bK1
Content-Length: 4000000000

<then dribble, or send nothing at all>
```

`MAX_INCOMPLETE_HEADER_BYTES` (64 KB) guards only a header block with **no** end-of-headers marker, so it stops applying the moment `\r\n\r\n` arrives. From there `extract_sip_message_length` returns `headers + declared`, the read loop takes the `Some(_) => break` arm ("body still arriving — wait"), and `accumulator.extend_from_slice` runs unbounded. Roughly 200 bytes on one connection, before any parsing, authentication or rate limiting.

The outbound connection pool had it worse: its two read loops were `_ => break` with no `classify_incomplete_stream` guard either, so an upstream peer could walk the same path *and* the slow-loris one.

## Change

Framing now goes through a single `frame_sip_message(buffer, max_message_bytes) -> FrameVerdict`, used by the inbound listeners and both pool read loops, that folds in the existing garbage classification and adds the ceiling.

- `security.max_message_bytes` — default 256 KB, always installed even with no `security:` block, minimum 4096 refused at config load so a typo cannot `513` every call on the node.
- An over-sized **request** is answered `513 Message Too Large` (RFC 3261 §21.4.11) and then the connection closes. A silent RST would leave an operator whose SIPREC metadata genuinely outgrew the limit with nothing to go on; a 513 names the problem. The pool paths do not answer — they read responses.
- The connection still closes rather than resyncing, because the body we are refusing to buffer is exactly what we would have to read to find the next message boundary.

Two things fell out of the 513:

- The read half queues its response and returns, and the old `select!` dropped the write half with it, so the response never reached the wire. The read arm now closes the channel and gives the writer a bounded grace period to flush.
- `parse_sip_message_bytes` rightly rejects a `Content-Length` longer than the body it actually received (RFC 4475 §3.1.2.2) — which is precisely the message being declined. Added `parse_sip_headers_only`, sharing the header-block parse, for the one caller that has deliberately not read the body but still needs Via/From/To/Call-ID/CSeq to address its response.

## Overflow, found by the new fuzz target

`stream_framing_fuzz` asserts the framer's invariants (a framed length never exceeds the buffer or the ceiling; a refused message's header block stays inside the buffer). It found a crash within a minute:

```
Content-Length: 18446744073709551615
```

parses as a valid `usize`, and `headers_len + content_length` overflows. The release profile does not set `overflow-checks`, so in shipped builds it **wrapped silently** to one byte short of the header block — the framer sliced a truncated message and desynchronised the stream on a value the peer chose. Now saturates, so an unrepresentable declaration is refused as over-sized. Kept as a unit test.

## Tests

- `oversized_declared_content_length_is_refused_not_buffered` — the attack shape.
- `listener_answers_513_and_closes_on_an_oversized_declaration` — end to end against a real listener: 513 on the wire carrying the sender's branch, nothing dispatched, connection closed.
- `message_exactly_at_the_ceiling_is_accepted`, `ceiling_covers_headers_plus_body`, `ordinary_message_frames_and_partial_body_waits` — boundary behaviour.
- `frame_sip_message_preserves_garbage_classification` — the pre-existing guards still fire unchanged through the new entry point.
- `absurd_content_length_saturates_instead_of_wrapping` — the fuzz finding.
- New fuzz target wired into the CI fuzz job next to the parser one.

4408 tests green, clippy clean, fuzzer clean over 3.5M runs after the fix.

## Note for operators

Default 256 KB is comfortably above anything legitimate (a VoLTE INVITE with a full P-header set is a few KB; SIPREC metadata runs to tens of KB). Deployments carrying larger bodies raise `security.max_message_bytes`.
