### PR TITLE
fix(b2bua): a transfer offered the target the survivor's stale media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Fixed
+- **A transfer offered the target the survivor's *original* media, not its
+  current media.** siphon tracked the SDP of whichever leg **offered** a
+  re-INVITE or UPDATE, never of the leg that merely **answered** one. So a leg
+  that only ever answers stayed frozen at whatever it answered the first INVITE
+  with. On a Teams trunk that call is set up `a=recvonly`, the carrier answers
+  `a=sendonly`, and a re-INVITE a couple of minutes later takes both sides to
+  `sendrecv` — but the carrier leg was still remembered as `sendonly`. Transfer
+  then, and the target is offered that stale direction: it answers `recvonly`,
+  the survivor is re-INVITEd `recvonly` in turn, and both remaining parties sit
+  half-duplex — one able only to send, the other only to receive — with no hold
+  signalled anywhere for either of them to display. Which leg went stale depended
+  on who offered the re-INVITE, which is why this only broke transfers initiated
+  from one side of the call. The answerer's own SDP is now tracked too, raw and
+  before any rewrite, exactly as the offerer's already was.
 - **Two tests that failed at random, both for reasons unrelated to what they
   assert.** `free_port()` bound port 0, read the address and dropped the socket:
   the kernel auto-assigns from the ephemeral range, so between the probe closing

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -15526,6 +15526,28 @@ fn handle_b2bua_response(
             sanitize_b2bua_response(message, state, resp_transport, if is_a2b { a_leg_local_addr } else { None }, a_leg_supports_100rel, call_id);
         }
 
+        // Track the ANSWERER's own endpoint SDP — raw, before the rtpengine
+        // rewrite just below — so a later siphon-terminated transfer offers this
+        // leg's *current* media if it turns out to be the survivor.
+        //
+        // The offer side of a re-INVITE was already tracked, but only for the leg
+        // that offered (`handle_b2bua_reinvite`). A leg that merely *answers* kept
+        // whatever it had answered the ORIGINAL INVITE with, which goes wrong the
+        // moment the two disagree: a call that starts `a=recvonly` and is later
+        // re-INVITEd to `sendrecv` leaves the answering leg still remembered as
+        // `sendonly`, and the transfer then offers the target that stale
+        // direction. Both surviving parties end up half-duplex — one able only to
+        // send, the other only to receive — with no hold signalled anywhere for
+        // either of them to display.
+        //
+        // Which leg goes stale depends on who offered the re-INVITE, which is why
+        // this only broke transfers initiated from one side.
+        if (200..300).contains(&status_code) && !message.body.is_empty() {
+            state
+                .call_actors
+                .set_leg_last_sdp(call_id, !is_a2b, &message.body);
+        }
+
         // RTPEngine: rewrite re-INVITE 2xx response SDP through answer.
         // Mirrors the offer processing done on the request side.
         if (200..300).contains(&status_code) && !message.body.is_empty() {

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -2225,6 +2225,52 @@ fn promoting_the_transfer_target_retires_the_referrers_call_id() {
     assert!(store.get_call(&call_id).is_some());
 }
 
+/// The media a transfer hands to its target must be the survivor's CURRENT
+/// media, not whatever it answered the original INVITE with.
+///
+/// The shape that broke a live Teams trunk: the call is set up `recvonly`, so
+/// the callee answers `sendonly`; a re-INVITE later takes it to `sendrecv`, and
+/// the callee answers that too. If only the *offerer's* SDP is tracked, the
+/// callee is still remembered as `sendonly` — and a transfer then offers the
+/// target that stale direction, leaving both survivors half-duplex with no hold
+/// signalled for either of them to show.
+#[test]
+fn a_leg_that_only_answers_still_tracks_its_current_media() {
+    const ORIGINAL_ANSWER: &[u8] = b"v=0\r\no=callee 1 1 IN IP4 192.0.2.2\r\nm=audio 5000 RTP/AVP 0\r\na=sendonly\r\n";
+    const REINVITE_ANSWER: &[u8] = b"v=0\r\no=callee 1 2 IN IP4 192.0.2.2\r\nm=audio 5000 RTP/AVP 0\r\na=sendrecv\r\n";
+
+    let store = CallActorStore::new();
+    let call_id = store.create_call(make_a_leg("stale-sdp@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+
+    // The callee answers the initial INVITE `sendonly` (mirroring a `recvonly`
+    // offer) — that is its media at the time and is recorded.
+    store.set_leg_last_sdp(&call_id, false, ORIGINAL_ANSWER);
+    assert_eq!(
+        store.clone_leg(&call_id, false).and_then(|leg| leg.last_sdp),
+        Some(ORIGINAL_ANSWER.to_vec())
+    );
+
+    // The caller re-INVITEs to `sendrecv`; the callee ANSWERS. It never offered,
+    // so tracking only offers would leave it frozen at `sendonly`.
+    store.set_leg_last_sdp(&call_id, false, REINVITE_ANSWER);
+
+    let survivor_sdp = store
+        .clone_leg(&call_id, false)
+        .and_then(|leg| leg.last_sdp)
+        .expect("the survivor must have media to hand to a transfer target");
+    assert_eq!(
+        survivor_sdp,
+        REINVITE_ANSWER.to_vec(),
+        "a transfer would offer the target the survivor's stale direction"
+    );
+    assert!(
+        String::from_utf8_lossy(&survivor_sdp).contains("a=sendrecv"),
+        "the survivor is two-way by now and the target must be offered that"
+    );
+}
+
 #[test]
 fn transfer_referrer_bye_is_recognised_and_flags_the_subscription() {
     // The Teams blind-transfer shape: A REFERs, siphon dials the target, and A


### PR DESCRIPTION
Reported from a live Teams trunk: after a transfer, **both** remaining parties
end up on hold — each playing its own hold music — while neither end signals hold,
so neither shows it. Reproducible in one direction only: it breaks when Teams
initiates the transfer, and works when the other side does.

## What the capture shows

| frame | | direction |
|---|---|---|
| 1 | caller's initial INVITE | `a=recvonly` |
| 7 | callee answers | `a=sendonly` ← recorded as the callee's media |
| 11 | caller re-INVITEs, ~2 min later | `a=sendrecv` |
| 15 | callee answers the re-INVITE | (absent ⇒ `sendrecv`) ← **not recorded** |
| **24** | **siphon → transfer target** | **`a=sendonly`** |
| 30 | target answers | `a=recvonly` |
| 32 | siphon re-INVITEs the survivor | `a=recvonly` |

Frame 24 offers the target media that was current 116 seconds and one re-INVITE
earlier.

## Root cause

A siphon-terminated transfer offers the target the surviving leg's last known
SDP. That was tracked for whichever leg **offered** a re-INVITE or UPDATE — and
only for that leg. A leg that merely **answers** was never updated, so it stayed
frozen at whatever it answered the original INVITE with.

Here the caller offered, so its leg refreshed; the callee only ever answered, so
its leg did not. The transfer then handed the target `sendonly`, the target
answered `recvonly`, the survivor was re-INVITEd `recvonly` in turn, and the two
remaining parties finished half-duplex — one able only to send, the other only
to receive. No hold was signalled to either, which is why nothing displayed it.

**That is also why it was direction-dependent.** Whichever leg offers the
re-INVITE stays fresh; the other goes stale. Transfer away from the fresh leg and
it works, transfer away from the stale one and it does not.

## The fix

The answerer's SDP is tracked too, raw and before the rtpengine rewrite, exactly
as the offerer's already was. One `set_leg_last_sdp` at the point in the
re-INVITE response path where the body is still the answering endpoint's own.

## Testing

- New regression test walking the exact shape: a leg answers `sendonly`, a later
  re-INVITE is answered `sendrecv`, and the media a transfer would hand its
  target must be the second — asserting on the direction attribute, since that is
  what actually broke
- 3976 lib + 359 integration green, `clippy --all-targets --all-features
  -D warnings` clean

## Not covered here

No end-to-end SIPp gate. Reproducing it needs a call that is answered in one
direction, re-INVITEd to another, and *then* transferred — three-party with a
mid-call renegotiation, which none of the existing transfer scenarios set up.
Worth building, but it is a scenario of its own rather than a tweak to an
existing one.