### PR TITLE
fix(b2bua): ACK a bridged re-INVITE at the responder, not at ourselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Fixed
+- **The ACK for a bridged re-INVITE was addressed to siphon itself.** RFC 3261
+  §13.2.2.4 puts the responder's own remote target in the ACK's Request-URI, and
+  siphon read it from the 200 OK — but only *after* `sanitize_b2bua_response` had
+  rewritten that response's `Contact` to point at siphon, which is correct for
+  the copy forwarded to the other leg and wrong for the ACK going back to the
+  responder. The far end therefore did not accept the ACK and retransmitted its
+  200 until the retransmission handler sent a second, correct one. The call
+  survived, so this cost a retransmit and the delay before it rather than the
+  dialog, which is why it went unnoticed on every hold and resume. The Contact is
+  now captured before the rewrite. The siphon-originated path was already safe,
+  but only because its response skips sanitize entirely.
 - **The B-leg INVITE no longer carries the session-timer headers twice.** The
   B-leg INVITE is cloned from the caller's, so whatever it asked for is already
   on it — a Teams INVITE arrives with `Session-Expires: 3600`, `Min-SE: 300` and

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -15556,6 +15556,25 @@ fn handle_b2bua_response(
             message.headers.set("CSeq", cseq.clone());
         }
 
+        // The responder's OWN Contact, taken before the sanitize below overwrites
+        // it. That rewrite points Contact at siphon, which is right for the copy
+        // forwarded to the other leg — in-dialog requests have to come back here
+        // — but the ACK goes back to the responder, and RFC 3261 §13.2.2.4 wants
+        // its Request-URI to be that party's remote target. Reading it afterwards
+        // addressed the ACK to siphon's own URI, so the responder did not accept
+        // it and retransmitted its 200 until the retransmission handler above
+        // sent a second, correct ACK. Self-correcting, at the cost of a
+        // retransmit and the delay before it.
+        //
+        // The siphon-originated case was safe only because its response skips
+        // sanitize entirely; the bridged case — every ordinary hold and resume —
+        // was not.
+        let responder_contact = message
+            .headers
+            .get("Contact")
+            .or_else(|| message.headers.get("m"))
+            .cloned();
+
         // A-facing (is_a2b) response: anchor Contact to the A-leg's arrival socket;
         // B-facing: leave it to via_port (the B-side advertised address). Skipped
         // for a siphon-originated re-INVITE — its response is absorbed, not
@@ -15649,11 +15668,12 @@ fn handle_b2bua_response(
                     let cseq_num = responder_cseq_num.clone();
                     let from = message.headers.from().cloned().unwrap_or_default();
                     let to = message.headers.to().cloned().unwrap_or_default();
-                    // RURI: extract Contact from the 200 OK message directly
-                    // (RFC 3261 §12.2.1.1), with fallback to stored remote_contact.
-                    let ack_uri = message.headers.get("Contact")
-                        .or_else(|| message.headers.get("m"))
-                        .map(|c| crate::b2bua::actor::extract_contact_uri(c))
+                    // RURI: the responder's own Contact as it arrived (RFC 3261
+                    // §12.2.1.1), captured above before sanitize rewrote it to
+                    // siphon's address — reading `message` here addressed the ACK
+                    // to ourselves. Falls back to the stored remote_contact.
+                    let ack_uri = responder_contact.as_deref()
+                        .map(crate::b2bua::actor::extract_contact_uri)
                         .and_then(|u| parse_uri_standalone(&u).ok())
                         .or_else(|| if is_a2b {
                             b_leg_remote_contact.as_deref()


### PR DESCRIPTION
Spotted in the same traces as #233 and #234: siphon ACKs a re-INVITE at **its
own address**.

```
callee -> siphon   200 OK   Contact: <sip:198.51.100.20:5072>
siphon -> callee   ACK sip:siphon.example:5061;transport=tls   <- siphon's OWN URI
callee -> siphon   200 OK   (retransmitted — the ACK was not accepted)
siphon -> callee   ACK sip:198.51.100.20:5072                  <- correct, from the
                                                                  retransmission path
```

RFC 3261 §13.2.2.4 puts the responder's own remote target in the ACK's
Request-URI. siphon reads it from the 200 OK — the intent is right and the
comment says so — but only **after** `sanitize_b2bua_response` has rewritten that
response's `Contact` to point at siphon. That rewrite is correct for the copy
being forwarded to the other leg, since in-dialog requests have to come back
here; it is wrong for the ACK going back to the responder.

The far end therefore rejects the ACK and retransmits its 200 until the
retransmission handler sends a second, correct one. **The dialog survives**, so
the cost is a retransmit and the ~500 ms before it rather than the call — which
is why it has gone unnoticed on every hold and resume.

## The fix

Capture the responder's `Contact` before the rewrite and use that for the ACK.

Two details worth noting:

* The **siphon-originated** path was already safe, but only by accident of
  skipping `sanitize` entirely — its own comment says "the ACK needs the
  responder's own Contact intact". So the hazard was known; the bridged path just
  was not covered.
* The **retransmission** handler builds its ACK before any sanitize runs, which
  is why its ACK is correct and the call recovers. Left untouched.

## Testing

- 3977 lib + 358 integration green, `clippy --all-targets --all-features
  -D warnings` clean

No end-to-end gate: reproducing it needs a bridged re-INVITE (hold/resume mid-call)
and an assertion on the ACK's Request-URI, which no existing scenario does. Worth
adding with the mid-call-renegotiation scenario #234 also wants.