### PR TITLE
fix(sip): refuse bare CR/LF in headers, and close the framer/parser length differentials

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1532,6 +1532,9 @@ jobs:
       - name: Run fuzz target — stream framing (60s)
         run: PYO3_PYTHON=python3.14 cargo +nightly fuzz run stream_framing_fuzz -- -max_total_time=60
 
+      - name: Run fuzz target — framer/parser agreement (60s)
+        run: PYO3_PYTHON=python3.14 cargo +nightly fuzz run framing_parser_agreement_fuzz -- -max_total_time=60
+
   # ── SIPp IPsec VoLTE test (self-hosted) ────────────────────────────────
   # IPsec XFRM SA installation needs CAP_NET_ADMIN, which GitHub-hosted runners
   # don't grant. Runs on the self-hosted `ipsec` runner (real xfrm) on trusted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Security
+- **Refused bare CR/LF in a SIP header block, and closed five framer/parser
+  disagreements it was hiding.** siphon's header-value scan runs to the next
+  CRLF, so a line ended with a bare LF was absorbed into the *previous* header's
+  value — while the stream framer's `Content-Length` scan split on LF and read
+  that same line as a header of its own. `X-Pad: a\nContent-Length: 4` +
+  `Content-Length: 0` framed as two different messages depending on which half
+  of siphon you asked, and an upstream proxy or load balancer that treats bare
+  LF as a terminator made a third reading. That is the shape request smuggling
+  is built out of. RFC 3261 §7.5 makes CRLF the only terminator, so a header
+  block containing a bare CR or LF is now refused; bodies are untouched.
+
+  A new fuzz target asserts the general invariant — *for any bytes the parser
+  accepts, the framer must compute the same message length* — and found four
+  more divergences, all fixed:
+
+  - A **folded continuation line carrying a `Content-Length`** was a header to
+    the framer and part of the previous value to the parser (133 bytes against
+    232).
+  - The reverse: a **folded `Content-Length` value** the parser read and the
+    framer did not.
+  - A **continuation line with nothing to continue** (the header section opening
+    with a fold) was promoted to a header by the parser and skipped as a fold by
+    the framer. Now refused.
+  - A **vertical tab in a header name**: `str::trim` is Unicode-aware and
+    stripped it, so `content-length\x0b` became `Content-Length` to the parser,
+    while the framer's ASCII trim left it alone. Header names are ASCII tokens
+    (§25.1), so the parser now trims ASCII too.
+
+### Fixed
+- **A header with an empty value no longer swallows the next header line.**
+  RFC 3261 §25.1 has `SWS = [LWS]` and `LWS = [*WSP CRLF] 1*WSP` — a CRLF after
+  the header colon is only whitespace when a space or tab follows it. siphon
+  accepted a bare one, so `X:\r\nContent-Length: 5\r\n\r\n` parsed as a single
+  header `X` with the value `Content-Length: 5` and no `Content-Length` at all.
+- **A UDP datagram prefixed with a stray CRLF is no longer dropped as a parse
+  error** (RFC 3261 §7.5). The stream transports drain keepalives in their own
+  read tasks, but the parser searched for the header/body boundary before
+  skipping the prefix and so found the prefix itself.
+
 - **Bounded stream message size (`security.max_message_bytes`).** A peer on a
   stream transport (TCP/TLS/WS/WSS) could declare an arbitrarily large
   `Content-Length`, send only the header block, and make the reader buffer

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,3 +24,10 @@ path = "fuzz_targets/stream_framing_fuzz.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "framing_parser_agreement_fuzz"
+path = "fuzz_targets/framing_parser_agreement_fuzz.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/framing_parser_agreement_fuzz.rs
+++ b/fuzz/fuzz_targets/framing_parser_agreement_fuzz.rs
@@ -1,0 +1,46 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use siphon::sip::parser::parse_sip_message_bytes;
+use siphon::transport::tcp::extract_sip_message_length;
+
+// Two components decide independently how long a message is: the stream framer
+// (which splits the accumulator and so decides where the *next* message starts)
+// and the parser (which decides what this message contains). If they ever
+// disagree, bytes one of them considers part of this message are, to the other,
+// the start of a new one — which is the shape request smuggling is built out
+// of, and how a bare LF used to hide a second Content-Length from the parser
+// while the framer counted it.
+//
+// So: for every input the parser accepts, the framer must agree on the total.
+fuzz_target!(|data: &[u8]| {
+    let Ok(parsed) = parse_sip_message_bytes(data) else {
+        // Refused inputs are fine — a message siphon will not parse is never
+        // dispatched, so there is no reading of it to disagree with.
+        return;
+    };
+
+    let framed = extract_sip_message_length(data)
+        .expect("the parser accepted these bytes, so an end-of-headers marker is present");
+
+    // Recompute the header block the same way both sides do: past any leading
+    // CRLF keepalives, up to and including the first end-of-headers marker.
+    let mut prefix = 0;
+    while data[prefix..].starts_with(b"\r\n") {
+        prefix += 2;
+    }
+    let header_len = prefix
+        + data[prefix..]
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .expect("parser accepted, so the marker is there")
+        + 4;
+
+    assert_eq!(
+        framed,
+        header_len + parsed.body.len(),
+        "framer and parser disagree on message length: framer {framed}, \
+         parser {header_len} header + {} body",
+        parsed.body.len(),
+    );
+});

--- a/src/sip/parser.rs
+++ b/src/sip/parser.rs
@@ -3,7 +3,7 @@
 use nom::{
     IResult, Parser,
     bytes::complete::{tag, take_until, take_while, take_while1},
-    character::complete::{char, space1, digit1, multispace0},
+    character::complete::{char, space1, digit1},
     sequence::{preceded, delimited},
     multi::many0,
     combinator::{opt, map_res},
@@ -31,18 +31,85 @@ pub fn parse_sip_message(input: &str) -> IResult<&str, SipMessage> {
     }))
 }
 
+/// Reject a header block whose lines are not all CRLF-terminated.
+///
+/// RFC 3261 §7.5 and the §25.1 grammar make CRLF the only line terminator in a
+/// SIP message: "The start-line, each message-header line, and the empty line
+/// MUST be terminated by a carriage-return line-feed sequence (CRLF)."
+///
+/// Enforcing that is a framing-consistency requirement, not pedantry. siphon's
+/// header-value scan continues to the next CRLF, so a line ended with a bare LF
+/// is absorbed into the *previous* header's value — while the stream framer's
+/// `Content-Length` scan splits on LF and reads that same line as a header of
+/// its own. Given
+///
+/// ```text
+/// X-Pad: a\nContent-Length: 4\r\nContent-Length: 0\r\n\r\nAAAA
+/// ```
+///
+/// the parser sees `Content-Length: 0` and a header `X-Pad` whose value happens
+/// to contain a newline, and the framer sees `Content-Length: 4`. Any upstream
+/// element that treats a bare LF as a terminator (proxies and load balancers
+/// commonly do) sees a different message again, which is the shape request
+/// smuggling is built out of. A bare CR is rejected on the same grounds.
+///
+/// Bodies are untouched — they are opaque octets, and RFC 4475's multipart case
+/// carries bare CR and LF inside one legitimately.
+fn validate_header_line_endings(header_bytes: &[u8]) -> Result<(), String> {
+    for (index, byte) in header_bytes.iter().enumerate() {
+        match byte {
+            b'\n' if index == 0 || header_bytes[index - 1] != b'\r' => {
+                return Err(format!(
+                    "bare LF at offset {index} in the header block; RFC 3261 §7.5 requires CRLF"
+                ));
+            }
+            b'\r' if header_bytes.get(index + 1) != Some(&b'\n') => {
+                return Err(format!(
+                    "bare CR at offset {index} in the header block; RFC 3261 §7.5 requires CRLF"
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Count the leading CRLF pairs a peer may send before the start-line
+/// (RFC 3261 §7.5). Only whole pairs count — a lone CR or LF at the front is
+/// not a keepalive and is left for [`validate_header_line_endings`] to refuse.
+pub(crate) fn leading_crlf_len(input: &[u8]) -> usize {
+    let mut offset = 0;
+    while input[offset..].starts_with(b"\r\n") {
+        offset += 2;
+    }
+    offset
+}
+
 /// Parse the start line and header block out of raw message bytes.
 ///
 /// Returns the parsed start line, the headers, and the index of the `\r\n\r\n`
 /// boundary. Shared by [`parse_sip_message_bytes`] and
 /// [`parse_sip_headers_only`], which differ only in how they treat the body.
 fn parse_header_block(input: &[u8]) -> Result<(StartLine, SipHeaders, usize), String> {
-    let boundary = find_header_boundary(input)
-        .ok_or_else(|| "no header/body boundary (\\r\\n\\r\\n) found".to_string())?;
+    // RFC 3261 §7.5: "Implementations processing SIP messages over
+    // stream-oriented transports MUST ignore any CRLF appearing before the
+    // start-line." Skip them *before* looking for the header/body boundary —
+    // searching first would find the leading CRLF pair itself and leave an
+    // empty start line. (The `trim_start_matches` further down was meant to
+    // cover this but can never fire, for exactly that reason.) The stream
+    // transports drain keepalives in their own read tasks, so in practice this
+    // is the UDP path, where a datagram prefixed with a stray CRLF used to be
+    // dropped as a parse error.
+    let prefix = leading_crlf_len(input);
+    let body = &input[prefix..];
+    let boundary = prefix
+        + find_header_boundary(body)
+            .ok_or_else(|| "no header/body boundary (\\r\\n\\r\\n) found".to_string())?;
 
     // Headers portion including the terminating \r\n\r\n must be valid UTF-8
     let header_end = boundary + 4; // include \r\n\r\n
-    let header_bytes = &input[..header_end.min(input.len())];
+    let header_bytes = &input[prefix..header_end.min(input.len())];
+    validate_header_line_endings(header_bytes)?;
     let header_str = std::str::from_utf8(header_bytes)
         .map_err(|error| format!("non-UTF8 in SIP headers: {error}"))?;
 
@@ -50,7 +117,7 @@ fn parse_header_block(input: &[u8]) -> Result<(StartLine, SipHeaders, usize), St
     // The text parser handles start line → headers → body in one pass.
     // We feed it the header portion only; it will see no body (Content-Length
     // references bytes beyond what we pass, so parse_body returns "").
-    let trimmed = header_str.trim_start_matches("\r\n");
+    let trimmed = header_str;
     let (_, start_line) = parse_start_line(trimmed)
         .map_err(|error| format!("start line parse error: {error}"))?;
     // Skip past start line to parse headers
@@ -455,8 +522,20 @@ fn parse_headers(input: &str) -> IResult<&str, SipHeaders> {
             return Ok((after, headers));
         }
 
-        // Skip leading whitespace (but NOT CRLF — those are checked above)
-        remaining = remaining.trim_start_matches([' ', '\t']);
+        // A line starting with SP or HTAB is a folded continuation (RFC 3261
+        // §7.3.1). `parse_header_line` consumes the continuations belonging to
+        // the header it just read, so reaching the top of this loop on one
+        // means it continues nothing — the header section opened with a fold.
+        // Trimming the whitespace away, as this used to, promoted that line to
+        // a header of its own, which the stream framer skips as a fold: the
+        // two then disagree about whether a `Content-Length` on it counts.
+        // There is no antecedent to fold into, so it is malformed either way.
+        if remaining.starts_with([' ', '\t']) {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Space,
+            )));
+        }
 
         match parse_header_line(remaining) {
             Ok((input, (name, value))) => {
@@ -481,7 +560,19 @@ fn parse_header_line(input: &str) -> IResult<&str, (String, String)> {
     // §3.1.1.1 ("TO :") and §3.1.1.7 ("v :", "Via  :") both exercise it.
     let (input, _) = take_while(|c: char| matches!(c, ' ' | '\t'))(input)?;
     let (input, _) = char(':')(input)?;
-    let (input, _) = multispace0(input)?;
+    // SWS, not "any whitespace". RFC 3261 §25.1 has `SWS = [LWS]` and
+    // `LWS = [*WSP CRLF] 1*WSP` — a CRLF may only appear inside linear
+    // whitespace when at least one space or tab follows it, which is exactly
+    // the folding rule the value loop below implements. `multispace0` accepted
+    // a bare CRLF here, so a header with an empty value swallowed the whole of
+    // the next line as its own value:
+    //
+    //     X:\r\nContent-Length: 5\r\n\r\n
+    //
+    // parsed as one header `X` with the value `Content-Length: 5` and no
+    // Content-Length at all, while the stream framer read the 5. Consume only
+    // spaces and tabs and let the fold loop decide about continuation lines.
+    let (input, _) = take_while(|c: char| matches!(c, ' ' | '\t'))(input)?;
 
     // Parse header value (may be folded with SP/TAB on next line)
     let mut value = String::new();
@@ -494,12 +585,12 @@ fn parse_header_line(input: &str) -> IResult<&str, (String, String)> {
         let (input, _) = parse_crlf(input)?;
 
         if input.is_empty() {
-            return Ok((input, (name.trim().to_string(), value.trim().to_string())));
+            return Ok((input, (name.trim_ascii().to_string(), value.trim().to_string())));
         }
 
         let trimmed = input.trim_start_matches([' ', '\t']);
         if trimmed.is_empty() {
-            return Ok((input, (name.trim().to_string(), value.trim().to_string())));
+            return Ok((input, (name.trim_ascii().to_string(), value.trim().to_string())));
         }
 
         if input.starts_with([' ', '\t']) {
@@ -507,7 +598,7 @@ fn parse_header_line(input: &str) -> IResult<&str, (String, String)> {
             value.push(' ');
             remaining = input;
         } else {
-            return Ok((input, (name.trim().to_string(), value.trim().to_string())));
+            return Ok((input, (name.trim_ascii().to_string(), value.trim().to_string())));
         }
     }
 }
@@ -548,6 +639,220 @@ fn parse_crlf(input: &str) -> IResult<&str, &str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- line-ending strictness in the header block (RFC 3261 §7.5) --------
+
+    /// The differential this rejection closes, stated as the two disagreeing
+    /// readings of one byte string.
+    ///
+    /// `parse_header_line` scans a value up to the next CRLF, so a bare LF is
+    /// absorbed into the preceding header's value — siphon used to read the
+    /// message below as `Content-Length: 0` with an `X-Pad` whose value
+    /// contained a newline. The stream framer's `Content-Length` scan splits on
+    /// LF, so it read `Content-Length: 4` off the same bytes. Two components of
+    /// the same proxy disagreed about where the message ended, and any upstream
+    /// element that treats a bare LF as a terminator made a third reading.
+    #[test]
+    fn bare_lf_smuggling_shape_is_refused() {
+        let smuggled = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/TCP host;branch=z9hG4bK1\r\n",
+            "X-Pad: a\nContent-Length: 4\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        )
+        .as_bytes();
+
+        let error = parse_sip_message_bytes(smuggled)
+            .expect_err("a header block with a bare LF must not parse");
+        assert!(error.contains("bare LF"), "unexpected error: {error}");
+
+        // And the framer really did read it the other way, which is why this
+        // has to be refused rather than reconciled.
+        assert_eq!(
+            crate::transport::tcp::extract_sip_message_length(smuggled),
+            Some(smuggled.len() + 4),
+            "precondition: the framer counts the smuggled Content-Length"
+        );
+    }
+
+    /// A bare CR is refused on the same grounds — it is the other half of a
+    /// terminator, and implementations differ on whether it ends a line.
+    #[test]
+    fn bare_cr_in_the_header_block_is_refused() {
+        let message = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/TCP host;branch=z9hG4bK1\rX-Pad: a\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        )
+        .as_bytes();
+        let error = parse_sip_message_bytes(message)
+            .expect_err("a header block with a bare CR must not parse");
+        assert!(error.contains("bare CR"), "unexpected error: {error}");
+    }
+
+    /// Bodies are opaque octets and are not held to CRLF framing. RFC 4475's
+    /// multipart case (`TC_MPART01`) carries bare CR and LF inside its body
+    /// legitimately, so the check must stop at the header/body boundary.
+    #[test]
+    fn bare_line_endings_are_allowed_in_the_body() {
+        let mut message = concat!(
+            "MESSAGE sip:bob@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/TCP host;branch=z9hG4bK1\r\n",
+            "Content-Type: application/octet-stream\r\n",
+            "Content-Length: 9\r\n",
+            "\r\n",
+        )
+        .as_bytes()
+        .to_vec();
+        message.extend_from_slice(b"a\nb\rc\r\nd\n");
+        let parsed = parse_sip_message_bytes(&message).expect("body octets are opaque");
+        assert_eq!(parsed.body, b"a\nb\rc\r\nd\n");
+    }
+
+    /// Ordinary CRLF messages, folded headers and the leading-CRLF keepalive
+    /// prefix (RFC 3261 §7.5) all still parse.
+    #[test]
+    fn well_formed_messages_still_parse() {
+        let folded = concat!(
+            "\r\n\r\n",
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "Via: SIP/2.0/TCP host;branch=z9hG4bK1\r\n",
+            "Subject: I know you are there,\r\n",
+            " \tpick up the phone\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        )
+        .as_bytes();
+        let parsed = parse_sip_message_bytes(folded).expect("folded headers are legal");
+        assert_eq!(
+            parsed.headers.get("Subject").map(String::as_str),
+            Some("I know you are there, pick up the phone")
+        );
+    }
+
+    /// `parse_sip_headers_only` shares the same check — the reject path must
+    /// not become a way to parse a message the main path refuses.
+    #[test]
+    fn headers_only_parse_applies_the_same_check() {
+        let smuggled = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "X-Pad: a\nContent-Length: 4\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        )
+        .as_bytes();
+        assert!(parse_sip_headers_only(smuggled).is_err());
+    }
+
+    // --- framer/parser agreement, each shape found by the fuzz target -------
+    //
+    // The invariant: for any bytes the parser accepts, the framer must compute
+    // the same total length. Where they differ, the bytes in between belong to
+    // this message for one of them and to the next message for the other.
+
+    /// Assert both sides read the same message length out of `raw`.
+    fn framer_and_parser_agree(raw: &[u8]) {
+        let parsed = parse_sip_message_bytes(raw).expect("fixture must parse");
+        let boundary = raw.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+        assert_eq!(
+            crate::transport::tcp::extract_sip_message_length(raw),
+            Some(boundary + parsed.body.len()),
+            "framer and parser disagree on message length"
+        );
+    }
+
+    /// A continuation line carrying a `Content-Length`. The parser folds it
+    /// into `Subject`; a naive line scan read it as a header of its own.
+    #[test]
+    fn folded_line_carrying_content_length_agrees() {
+        framer_and_parser_agree(
+            concat!(
+                "INVITE sip:bob@example.com SIP/2.0\r\n",
+                "Subject: hello\r\n",
+                " Content-Length: 99\r\n",
+                "Content-Length: 0\r\n",
+                "\r\n",
+            )
+            .as_bytes(),
+        );
+    }
+
+    /// The reverse: a `Content-Length` whose value is folded onto the next
+    /// line. The parser reads it; a naive line scan saw an empty value.
+    #[test]
+    fn folded_content_length_value_agrees() {
+        framer_and_parser_agree(
+            concat!(
+                "INVITE sip:bob@example.com SIP/2.0\r\n",
+                "Content-Length:\r\n",
+                "\t1\r\n",
+                "\r\n",
+                "A",
+            )
+            .as_bytes(),
+        );
+    }
+
+    /// RFC 3261 §25.1 `SWS = [LWS]`, `LWS = [*WSP CRLF] 1*WSP` — a CRLF after
+    /// the colon is only whitespace when a space or tab follows it. Accepting a
+    /// bare one made a header with an empty value swallow the whole next line,
+    /// so the message below parsed as a single header `X` with the value
+    /// `Content-Length: 5` and no Content-Length at all, while the framer read
+    /// the 5.
+    #[test]
+    fn empty_header_value_does_not_swallow_the_next_line() {
+        let raw = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "X:\r\n",
+            "Content-Length: 5\r\n",
+            "\r\n",
+            "AAAAA",
+        )
+        .as_bytes();
+        let parsed = parse_sip_message_bytes(raw).expect("fixture must parse");
+        assert_eq!(parsed.headers.get("X").map(String::as_str), Some(""));
+        assert_eq!(parsed.headers.content_length(), Some(5));
+        framer_and_parser_agree(raw);
+    }
+
+    /// A continuation line with nothing to continue — the header section opens
+    /// with a fold. The parser used to trim the leading whitespace and promote
+    /// it to a header (here a compact `l:`, i.e. Content-Length); the framer
+    /// skipped it as a fold.
+    #[test]
+    fn header_section_opening_with_a_fold_is_refused() {
+        let raw = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "\tl: 1\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n",
+        )
+        .as_bytes();
+        assert!(
+            parse_sip_message_bytes(raw).is_err(),
+            "a fold with no antecedent is malformed"
+        );
+    }
+
+    /// A vertical tab in a header name. `str::trim` is Unicode-aware and
+    /// stripped it, turning `content-length\\x0b` into `Content-Length`;
+    /// `[u8]::trim_ascii` in the framer does not treat VT as whitespace and
+    /// left the name alone. Header names are ASCII tokens (§25.1), so the
+    /// parser trims ASCII too and neither side calls this Content-Length.
+    #[test]
+    fn vertical_tab_in_a_header_name_is_not_content_length() {
+        let raw = concat!(
+            "INVITE sip:bob@example.com SIP/2.0\r\n",
+            "content-length\u{0b} : 5\r\n",
+            "\r\n",
+        )
+        .as_bytes();
+        let parsed = parse_sip_message_bytes(raw).expect("fixture must parse");
+        assert_eq!(parsed.headers.content_length(), None);
+        framer_and_parser_agree(raw);
+    }
 
     #[test]
     fn tel_uri_global_number() {

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -129,14 +129,23 @@ pub async fn listen(
 /// Content-Length is missing (assumes 0-length body in that case once
 /// the header block is complete).
 pub fn extract_sip_message_length(buffer: &[u8]) -> Option<usize> {
+    // Skip leading CRLF keepalives (RFC 3261 §7.5 / RFC 5626 §4.4.1) using the
+    // same helper the parser does. The stream readers drain them before framing
+    // so this rarely fires — but a framer and a parser that disagree about
+    // where a message *starts* is the same class of bug as disagreeing about
+    // where it ends, and sharing the helper makes them agree by construction
+    // rather than by one layer happening to sanitise for the other.
+    let prefix = crate::sip::parser::leading_crlf_len(buffer);
+    let rest = &buffer[prefix..];
+
     // Find end of headers
-    let header_end = buffer
+    let header_end = rest
         .windows(4)
         .position(|w| w == b"\r\n\r\n")?;
-    let headers_len = header_end + 4; // include the \r\n\r\n
+    let headers_len = prefix + header_end + 4; // include the \r\n\r\n
 
     // Parse Content-Length from header block
-    let header_block = &buffer[..header_end];
+    let header_block = &rest[..header_end];
     let content_length = extract_content_length(header_block).unwrap_or(0);
 
     // Saturate rather than wrap. `Content-Length: 18446744073709551615` parses
@@ -250,11 +259,13 @@ pub fn frame_sip_message(buffer: &[u8], max_message_bytes: usize) -> FrameVerdic
     };
     if len > max_message_bytes {
         // Safe: `extract_sip_message_length` returned `Some`, so `\r\n\r\n`
-        // is present and the header block is fully buffered.
-        let header_len = buffer
+        // is present and the header block is fully buffered. Measured past any
+        // leading CRLF keepalives, exactly as the length above was.
+        let prefix = crate::sip::parser::leading_crlf_len(buffer);
+        let header_len = buffer[prefix..]
             .windows(4)
             .position(|window| window == b"\r\n\r\n")
-            .map(|end| end + 4)
+            .map(|end| prefix + end + 4)
             .unwrap_or(buffer.len());
         return FrameVerdict::Oversized { declared: len, header_len };
     }
@@ -267,23 +278,64 @@ pub fn frame_sip_message(buffer: &[u8], max_message_bytes: usize) -> FrameVerdic
 
 /// Extract Content-Length value from raw header bytes.
 /// Handles both full name and compact form (`l:`).
+/// This scan runs *before* parsing, on bytes nobody has validated, and its
+/// answer decides where the next message starts. So it has to model lines the
+/// same way the parser does, or the two disagree about where this message ends
+/// — and the bytes in between are attacker-controlled and belong, to one of
+/// them, to the following message. Two shapes the fuzzer found:
+///
+/// ```text
+/// Subject: hello\r\n Content-Length: 99\r\nContent-Length: 0\r\n\r\n
+/// ```
+///
+/// The continuation line is part of `Subject` to the parser (RFC 3261 §7.3.1
+/// folding) and a header of its own to a naive line scan: 133 bytes against
+/// 232. And the reverse, a folded value the parser reads and a line scan does
+/// not:
+///
+/// ```text
+/// Content-Length:   \r\n\t   1\r\n\r\n
+/// ```
+///
+/// So: skip the start line (never a header, and a Request-URI contains a colon
+/// of its own), skip folded continuation lines, and fold their content into the
+/// value of the header they continue.
 fn extract_content_length(headers: &[u8]) -> Option<usize> {
-    // Search line-by-line for Content-Length or compact form "l:"
-    for line in headers.split(|&b| b == b'\n') {
-        let line = line.strip_suffix(b"\r").unwrap_or(line);
-        // Skip lines without a colon (request-line, empty lines from keepalive CRLFs)
-        let colon_pos = match line.iter().position(|&b| b == b':') {
-            Some(pos) => pos,
-            None => continue,
+    let mut lines = headers
+        .split(|&b| b == b'\n')
+        .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+        .filter(|line| !line.is_empty())
+        .peekable();
+
+    // The first non-empty line is the request/status line, not a header. (Any
+    // empty lines before it are the RFC 5626 §4.4.1 keepalive prefix.)
+    lines.next()?;
+
+    while let Some(line) = lines.next() {
+        // A continuation of a header we already rejected — skip it whole.
+        if matches!(line.first(), Some(b' ' | b'\t')) {
+            continue;
+        }
+        let Some(colon_pos) = line.iter().position(|&b| b == b':') else {
+            continue;
         };
         let (name, value) = line.split_at(colon_pos);
-        let value = &value[1..]; // skip the ':'
         let name_lower: Vec<u8> = name.iter().map(|b| b.to_ascii_lowercase()).collect();
-        let name_trimmed = name_lower.trim_ascii();
-        if name_trimmed == b"content-length" || name_trimmed == b"l" {
-            let value_str = std::str::from_utf8(value).ok()?;
-            return value_str.trim().parse().ok();
+        if name_lower.trim_ascii() != b"content-length" && name_lower.trim_ascii() != b"l" {
+            continue;
         }
+
+        // Fold the continuation lines into the value, as the parser does.
+        let mut value = value[1..].to_vec(); // skip the ':'
+        while lines
+            .peek()
+            .is_some_and(|next| matches!(next.first(), Some(b' ' | b'\t')))
+        {
+            value.push(b' ');
+            value.extend_from_slice(lines.next()?);
+        }
+        let value_str = std::str::from_utf8(&value).ok()?;
+        return value_str.trim().parse().ok();
     }
     None
 }


### PR DESCRIPTION
## The disagreement

siphon's header-value scan runs to the next CRLF, so a line ended with a **bare LF** is absorbed into the *previous* header's value. The stream framer's `Content-Length` scan splits on LF, so it reads that same line as a header of its own. Given:

```
X-Pad: a\nContent-Length: 4\r\nContent-Length: 0\r\n\r\nAAAA
```

- **Parser:** `Content-Length: 0`, and a header `X-Pad` whose value happens to contain a newline. Message is 133 bytes.
- **Framer:** `Content-Length: 4`. Message is 137 bytes.

Two halves of the same proxy disagree about where the message ends, and any upstream element that treats bare LF as a terminator (proxies and load balancers commonly do) makes a third reading. The bytes in between are attacker-controlled and belong, to one of them, to the *next* message. That is the shape request smuggling is built out of.

RFC 3261 §7.5 makes CRLF the only terminator, so a header block containing a bare CR or LF is now refused. Bodies are untouched — RFC 4475's `TC_MPART01` (a MUST-parse case) legitimately carries both inside its multipart body.

## The general invariant, and four more findings

Fixing one instance of a differential is not worth much, so `framing_parser_agreement_fuzz` asserts the general rule:

> For any bytes the parser accepts, the framer must compute the same message length.

It found four more, all fixed here:

| Shape | Parser saw | Framer saw |
|---|---|---|
| `Subject: hello\r\n Content-Length: 99\r\nContent-Length: 0` | fold into `Subject`, 133 bytes | a header, 232 bytes |
| `Content-Length:\r\n\t1` | folded value, `1` | empty value, `0` |
| header section opening with `\tl: 1` | trimmed the fold, promoted it to a header | skipped it as a fold |
| `content-length\x0b : 5` | `str::trim` is Unicode-aware and stripped the VT → `Content-Length` | `trim_ascii` leaves VT → not Content-Length |

Fixes, respectively: the framer skips the start line and folded continuations, and folds continuation lines into a value it *is* reading; a fold with no antecedent is refused (it is malformed either way); and the parser trims header names ASCII-only, since names are ASCII tokens (§25.1).

**11.6M fuzz runs clean** after the fixes.

## Two ordinary bugs found along the way

- **A header with an empty value swallowed the next header line.** §25.1 has `SWS = [LWS]` and `LWS = [*WSP CRLF] 1*WSP` — a CRLF after the header colon is only whitespace when a space or tab follows it, which is exactly the folding rule. `multispace0` accepted a bare one, so `X:\r\nContent-Length: 5\r\n\r\n` parsed as one header `X` with the value `Content-Length: 5` and **no Content-Length at all**. This is what the fuzzer was actually exploiting in finding #4 above, and it is a correctness bug in its own right — any empty-valued header ate its successor.
- **A UDP datagram prefixed with a stray CRLF was dropped as a parse error.** The parser searched for the header/body boundary *before* skipping the leading CRLFs, so it found the prefix itself and left an empty start line. (The `trim_start_matches("\r\n")` that was meant to cover this could never fire, for exactly that reason.) Stream transports drain keepalives in their own read tasks, so this only ever hit UDP.

Making the parser skip leading CRLFs would have introduced a *new* framer/parser disagreement about where a message starts, so `extract_sip_message_length` now shares the same `leading_crlf_len` helper — the two agree by construction rather than by one layer happening to sanitise for the other.

## Tests

- `bare_lf_smuggling_shape_is_refused` — the shape above, asserting the framer really did read it the other way (so the case for rejecting rather than reconciling is in the test).
- `bare_cr_in_the_header_block_is_refused`, `bare_line_endings_are_allowed_in_the_body`, `well_formed_messages_still_parse` (folding + keepalive prefix), `headers_only_parse_applies_the_same_check`.
- One regression test per fuzz finding, each asserting framer/parser agreement via a shared `framer_and_parser_agree` helper.
- New fuzz target in the CI fuzz job.

4427 tests green (RFC 4475 corpus and the parser proptests included), clippy clean.

## Compatibility

A peer that sends bare LF in headers now gets its message rejected rather than misparsed. No mainstream stack emits that — RFC 3261 requires CRLF, and every RFC 4475 case except the multipart *body* uses it. Worth knowing about all the same if anyone is fronting unusual equipment.
