### PR TITLE
fix(sip): refuse ambiguous and unbounded message shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,36 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
     stripped it, so `content-length\x0b` became `Content-Length` to the parser,
     while the framer's ASCII trim left it alone. Header names are ASCII tokens
     (§25.1), so the parser now trims ASCII too.
+- **Refused ambiguous and abusive message shapes.** `validate_message` now
+  checks a message's shape before any check that reads a particular field:
+  - **A duplicated single-instance header field is `400 Bad Request`** (To,
+    From, Call-ID, CSeq, Max-Forwards, Content-Length). RFC 3261 §8.1.1 defines
+    these as single-instance, and RFC 4475 names the response rather than leaving
+    it to the application layer: §3.3.8 "would respond with a 400 Bad Request
+    error", §3.3.9 "should respond with an error". Which copy applies is undefined and implementations
+    disagree — siphon reads the first, and an upstream that reads the last
+    routes, bills or authorizes the same message against a different identity.
+    Content-Length matters twice over: it is what the stream framer reads to
+    decide where the *next* message starts, which is the classic
+    message-smuggling shape.
+  - **A Via stack over 100 deep, or a message with over 256 header fields, is
+    `513 Message Too Large`.** Nothing bounded either. `security.max_message_bytes`
+    bounds the octets, but 256 KB is still ~8000 one-byte headers, and
+    Max-Forwards bounds the hops a request may still take, not the stack a peer
+    simply asserts it already traversed — every entry of which is re-serialized
+    on each forward. The limits sit an order of magnitude above real traffic (an
+    IMS INVITE with a full P-header set runs to about forty headers).
+
+  The two RFC 4475 fixtures for these cases (`TC_MULTI01_I`, `TC_MCL01_I`) were
+  classified as "parses" because siphon had no such check; they are now
+  classified as the RFC classifies them.
+
+  Known gap: §3.3.9 also says that over TCP "the framing error is not
+  recoverable, and the connection should be closed". siphon answers 400 and
+  leaves the connection open — the dispatcher has no way to close an inbound
+  stream connection. Its own framing stays consistent (framer and parser both
+  read the first Content-Length); what is unrecoverable is the disagreement with
+  a peer that meant the second.
 
 ### Added
 - **`siphon_requests_without_branch_total`.** Counts inbound requests whose
@@ -43,13 +73,10 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   script again. Previously this degradation was invisible outside a debug log.
   The gap is now stated in the feature-readiness matrix; the `transaction::key`
   module documentation had claimed a fallback that was never implemented.
-
-
 - **Framing fuzz target (`stream_framing_fuzz`).** Fuzzes the stream framer's
   invariants — a framed length never exceeds the buffer or the ceiling, and a
   refused message's header block stays inside the buffer — alongside the
   existing parser target in CI.
-
 - **Control plane: `ring` is its own verb, split from `progress`.** RFC 3261
   §13.2.1 makes the `180 Ringing` the "callee is being alerted" signal and
   §21.1.2 gives it no session semantics; RFC 3960 §3.1 puts early media on the
@@ -70,6 +97,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   that audio has reached the wire — a `url` source accepts before its body has
   arrived. A play the backend refuses pushes **no** event, so "no `PlayStarted`
   yet" always reads as "not started".
+- **`siphon_udp_datagrams_at_buffer_limit_total`.** `recv_from` reports the
+  bytes it copied, not the datagram's length, so a datagram that exactly fills
+  the receive buffer is indistinguishable from one the kernel truncated.
+  Previously this was invisible and surfaced only as an obscure parse error.
+  The message is still processed — a genuinely truncated one is refused by the
+  parser's Content-Length check — but a non-zero counter means a peer is sending
+  UDP well past the point RFC 3261 §18.1.1 requires it to switch to TCP.
 
 ### Changed
 - **Control plane: `StasisEnd` now carries the SIP status on every teardown that
@@ -105,7 +139,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   live one.** siphon picks its own branch, so a collision is not a peer
   retransmission — a blind `insert` destroyed a running transaction's timers and
   left its request unanswered.
-
 - **A header with an empty value no longer swallows the next header line.**
   RFC 3261 §25.1 has `SWS = [LWS]` and `LWS = [*WSP CRLF] 1*WSP` — a CRLF after
   the header colon is only whitespace when a space or tab follows it. siphon
@@ -115,7 +148,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   error** (RFC 3261 §7.5). The stream transports drain keepalives in their own
   read tasks, but the parser searched for the header/body boundary before
   skipping the prefix and so found the prefix itself.
-
 - **Bounded stream message size (`security.max_message_bytes`).** A peer on a
   stream transport (TCP/TLS/WS/WSS) could declare an arbitrarily large
   `Content-Length`, send only the header block, and make the reader buffer
@@ -135,7 +167,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   desynchronised the stream on a value the peer chose. The sum now saturates,
   so an unrepresentable declaration is refused as over-sized. Found by the new
   framing fuzz target.
-
 - **The ACK for a bridged re-INVITE was addressed to siphon itself.** RFC 3261
   §13.2.2.4 puts the responder's own remote target in the ACK's Request-URI, and
   siphon read it from the 200 OK — but only *after* `sanitize_b2bua_response` had
@@ -194,7 +225,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   it alone, as the CAP_NET_ADMIN tests already are. Alone it is exact: ambient
   0 B, 241664 B leaked, 0 B retained, every run. The guard is unchanged in what
   it proves.
-
 ## [1.7.1] — 2026-09-01
 
 ### Added

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -215,6 +215,13 @@ pub struct SiphonMetrics {
     /// each one runs the script again. A non-zero rate means a legacy or
     /// broken peer is on the network.
     pub requests_without_branch_total: IntCounter,
+    /// Total inbound UDP datagrams that exactly filled the receive buffer, so
+    /// the kernel may have discarded a tail siphon will never see. RFC 3261
+    /// §18.1.1 requires a UAC to switch to a congestion-controlled transport
+    /// well before this size, so a non-zero value means a peer is sending
+    /// oversized UDP — the messages are still processed, and a truncated one is
+    /// then refused by the parser's Content-Length check rather than acted on.
+    pub udp_datagrams_at_buffer_limit_total: IntCounter,
     /// Total inbound requests dropped because the source's User-Agent matched a
     /// `security.scanner_block` signature (sipvicious, friendly-scanner, …).
     pub scanner_blocked_total: IntCounter,
@@ -479,6 +486,11 @@ impl SiphonMetrics {
             "Total inbound requests with no branch parameter in the topmost Via, processed statelessly because no server transaction can be keyed for them (no RFC 2543 legacy matching)",
         )?;
 
+        let udp_datagrams_at_buffer_limit_total = IntCounter::new(
+            "siphon_udp_datagrams_at_buffer_limit_total",
+            "Total inbound UDP datagrams that exactly filled the receive buffer and may have been truncated by the kernel",
+        )?;
+
         let scanner_blocked_total = IntCounter::new(
             "siphon_scanner_blocked_total",
             "Total inbound requests dropped because the source User-Agent matched a security.scanner_block signature",
@@ -654,6 +666,7 @@ impl SiphonMetrics {
         registry.register(Box::new(credential_failures_total.clone()))?;
         registry.register(Box::new(malformed_messages_total.clone()))?;
         registry.register(Box::new(requests_without_branch_total.clone()))?;
+        registry.register(Box::new(udp_datagrams_at_buffer_limit_total.clone()))?;
         registry.register(Box::new(scanner_blocked_total.clone()))?;
         registry.register(Box::new(rate_limited_total.clone()))?;
         registry.register(Box::new(firewall_commands_dropped_total.clone()))?;
@@ -713,6 +726,7 @@ impl SiphonMetrics {
             credential_failures_total,
             malformed_messages_total,
             requests_without_branch_total,
+            udp_datagrams_at_buffer_limit_total,
             scanner_blocked_total,
             rate_limited_total,
             firewall_commands_dropped_total,

--- a/src/sip/validate.rs
+++ b/src/sip/validate.rs
@@ -37,6 +37,29 @@ const ADDRESS_HEADERS: &[&str] = &[
 /// unsigned integer and MUST be less than 2**31".
 const MAX_CSEQ: u64 = 1 << 31;
 
+/// Header fields RFC 3261 §8.1.1 defines as single-instance. A second copy has
+/// no defined meaning and implementations disagree about which one wins, so a
+/// message carrying one is ambiguous rather than merely unusual.
+/// Content-Length is here for a second reason on top of ambiguity: it is the
+/// field the stream framer reads to decide where the *next* message starts, so
+/// two of them is the classic message-smuggling shape. siphon's framer and
+/// parser both take the first, but an upstream that takes the last then reads a
+/// different message out of the same bytes (RFC 4475 §3.3.9).
+const SINGLE_INSTANCE_HEADERS: &[&str] =
+    &["To", "From", "Call-ID", "CSeq", "Max-Forwards", "Content-Length"];
+
+/// Most header fields one message may carry. A VoLTE INVITE with a full IMS
+/// P-header set runs to about forty; this is an order of magnitude of headroom
+/// and still bounds the per-hop cost of forwarding a message built to be
+/// expensive.
+const MAX_HEADER_FIELDS: usize = 256;
+
+/// Deepest Via stack accepted. Max-Forwards bounds the hops a request may
+/// *take*; nothing bounds the stack a peer simply asserts it already took, and
+/// every one of them is re-serialized on each forward. Comfortably above the
+/// default Max-Forwards of 70.
+const MAX_VIA_DEPTH: usize = 100;
+
 /// A parseable message that must still be refused, with the status RFC 3261
 /// requires the element to answer.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +80,15 @@ impl Rejection {
             detail: detail.into(),
         }
     }
+
+    /// RFC 3261 §21.4.11 — the message exceeded what this element will process.
+    fn too_large(detail: impl Into<String>) -> Self {
+        Self {
+            status: 513,
+            reason: "Message Too Large",
+            detail: detail.into(),
+        }
+    }
 }
 
 /// Validate a parsed message against RFC 3261.
@@ -65,12 +97,65 @@ impl Rejection {
 /// the element owes the peer; a response that fails validation is discarded
 /// rather than answered, since there is nothing to answer.
 pub fn validate_message(message: &SipMessage) -> Result<(), Rejection> {
+    validate_message_shape(message)?;
     validate_version(message)?;
     validate_cseq(message)?;
     validate_date(message)?;
     validate_request_uri(message)?;
     validate_address_headers(message)?;
     validate_parameters(message)?;
+    Ok(())
+}
+
+/// Reject a message whose *shape* is abusive or ambiguous, before any check
+/// that reads a particular field.
+///
+/// Two different concerns, both cheap and both absent until now:
+///
+/// **Ambiguity.** RFC 3261 §8.1.1 lists To, From, Call-ID, CSeq and
+/// Max-Forwards as single-instance header fields. A message carrying two of one
+/// of them has no defined meaning, and worse, no two implementations agree on
+/// which one wins — siphon reads the first, and an upstream that reads the last
+/// routes, bills or authorizes the same message against a different identity.
+/// A proxy is exactly the place that must not paper over it.
+///
+/// **Cost.** Nothing bounded how many headers a message could carry or how deep
+/// a Via stack could be, so a single well-formed message could be built to make
+/// every downstream hop allocate and re-serialize an arbitrary amount of work.
+/// `security.max_message_bytes` bounds the octets on a stream transport, but a
+/// 256 KB message is still ~8000 one-byte headers, and Max-Forwards bounds hops
+/// rather than the Via stack a peer may simply assert.
+fn validate_message_shape(message: &SipMessage) -> Result<(), Rejection> {
+    for name in SINGLE_INSTANCE_HEADERS {
+        if let Some(values) = message.headers.get_all(name) {
+            if values.len() > 1 {
+                return Err(Rejection::bad_request(format!(
+                    "{name} appears {} times; RFC 3261 §8.1.1 makes it single-instance, so \
+                     which one applies is undefined and implementations disagree",
+                    values.len()
+                )));
+            }
+        }
+    }
+
+    let header_count: usize = message.headers.iter().map(|(_, values)| values.len()).sum();
+    if header_count > MAX_HEADER_FIELDS {
+        return Err(Rejection::too_large(format!(
+            "{header_count} header fields exceeds the {MAX_HEADER_FIELDS} limit"
+        )));
+    }
+
+    if let Some(vias) = message.headers.get_all("Via") {
+        // One header line may carry several comma-separated Via values
+        // (§7.3.1), so count the values, not the lines.
+        let depth: usize = vias.iter().map(|value| value.matches(',').count() + 1).sum();
+        if depth > MAX_VIA_DEPTH {
+            return Err(Rejection::too_large(format!(
+                "Via stack is {depth} deep, over the {MAX_VIA_DEPTH} limit"
+            )));
+        }
+    }
+
     Ok(())
 }
 
@@ -298,6 +383,84 @@ mod tests {
     #[test]
     fn well_formed_request_passes() {
         assert_eq!(validate(WELL_FORMED), Ok(()));
+    }
+
+    // --- message shape ------------------------------------------------------
+
+    /// RFC 4475 §3.3.8 — "an element receiving this request should respond with
+    /// a 400 (Bad Request)". Which copy applies is undefined, and siphon
+    /// reading the first while an upstream reads the last means the same
+    /// message is routed, billed or authorized against two identities.
+    #[test]
+    fn a_duplicated_single_instance_header_is_400() {
+        for name in SINGLE_INSTANCE_HEADERS {
+            let line = match *name {
+                "To" => "To: <sip:other@example.net>\r\n",
+                "From" => "From: <sip:other@example.net>;tag=2\r\n",
+                "Call-ID" => "Call-ID: second@example.com\r\n",
+                "CSeq" => "CSeq: 2 INVITE\r\n",
+                "Max-Forwards" => "Max-Forwards: 5\r\n",
+                "Content-Length" => "Content-Length: 0\r\n",
+                other => panic!("no fixture line for {other}"),
+            };
+            let raw = WELL_FORMED.replace("Via:", &format!("{line}Via:"));
+            let rejection = validate(&raw)
+                .expect_err(&format!("a second {name} must be refused"));
+            assert_eq!(rejection.status, 400, "{name}: {}", rejection.detail);
+            assert!(rejection.detail.contains(name), "{}", rejection.detail);
+        }
+    }
+
+    /// The Via stack a peer asserts it already traversed is not bounded by
+    /// Max-Forwards (which bounds hops still to come), and every entry is
+    /// re-serialized on each forward.
+    #[test]
+    fn an_over_deep_via_stack_is_513() {
+        let stack: String = (0..MAX_VIA_DEPTH + 1)
+            .map(|n| format!("Via: SIP/2.0/UDP host{n}.example.com;branch=z9hG4bK{n}\r\n"))
+            .collect();
+        let raw = WELL_FORMED.replace("Via: SIP/2.0/UDP host.example.com;branch=z9hG4bK1\r\n", &stack);
+        let rejection = validate(&raw).expect_err("an over-deep Via stack must be refused");
+        assert_eq!(rejection.status, 513);
+
+        // Comma-separated values on one line count the same (RFC 3261 §7.3.1).
+        let folded: String = (0..MAX_VIA_DEPTH + 1)
+            .map(|n| format!("SIP/2.0/UDP host{n}.example.com;branch=z9hG4bK{n}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let raw = WELL_FORMED.replace(
+            "Via: SIP/2.0/UDP host.example.com;branch=z9hG4bK1\r\n",
+            &format!("Via: {folded}\r\n"),
+        );
+        assert_eq!(
+            validate(&raw).expect_err("comma-separated Vias count too").status,
+            513
+        );
+    }
+
+    #[test]
+    fn too_many_header_fields_is_513() {
+        let padding: String = (0..MAX_HEADER_FIELDS)
+            .map(|n| format!("X-Pad-{n}: x\r\n"))
+            .collect();
+        let raw = WELL_FORMED.replace("Via:", &format!("{padding}Via:"));
+        let rejection = validate(&raw).expect_err("a message of pure padding must be refused");
+        assert_eq!(rejection.status, 513);
+    }
+
+    /// The limits have to sit far enough above real traffic that ordinary
+    /// messages cannot trip them — an IMS INVITE with a full P-header set and a
+    /// realistic Via stack passes with room to spare.
+    #[test]
+    fn ordinary_traffic_is_nowhere_near_the_limits() {
+        let vias: String = (0..8)
+            .map(|n| format!("Via: SIP/2.0/UDP p{n}.ims.example.com;branch=z9hG4bK{n}\r\n"))
+            .collect();
+        let p_headers: String = (0..30)
+            .map(|n| format!("P-Header-{n}: value\r\n"))
+            .collect();
+        let raw = WELL_FORMED.replace("Via:", &format!("{vias}{p_headers}Via:"));
+        assert_eq!(validate(&raw), Ok(()));
     }
 
     #[test]

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -61,6 +61,32 @@ pub async fn listen(
                                 if !acl.is_allowed(remote_addr.ip()) {
                                     continue;
                                 }
+                                if size == buffer.len() {
+                                    // `recv_from` reports the bytes it copied,
+                                    // not the datagram's length, so a datagram
+                                    // that exactly fills the buffer is
+                                    // indistinguishable from one the kernel
+                                    // truncated. Say so rather than leaving an
+                                    // operator to work backwards from a parse
+                                    // error: RFC 3261 §18.1.1 requires a UAC to
+                                    // move to a congestion-controlled transport
+                                    // well below this size, so either way the
+                                    // peer is doing something it should not.
+                                    // The message is still processed — a
+                                    // genuinely truncated one is refused by the
+                                    // parser's Content-Length check (RFC 4475
+                                    // §3.1.2.2) rather than acted on.
+                                    warn!(
+                                        remote = %remote_addr,
+                                        bytes = size,
+                                        "UDP datagram filled the receive buffer — it may have been \
+                                         truncated by the kernel; the peer should be using TCP \
+                                         (RFC 3261 §18.1.1)"
+                                    );
+                                    if let Some(metrics) = crate::metrics::try_metrics() {
+                                        metrics.udp_datagrams_at_buffer_limit_total.inc();
+                                    }
+                                }
                                 buffer.truncate(size);
                                 let data = buffer.freeze();
 

--- a/tests/rfc4475/corpus_tests.rs
+++ b/tests/rfc4475/corpus_tests.rs
@@ -26,8 +26,12 @@
 //! * **§3.2 / §3.3 / §3.4** — `Expect::Parse`. §3.3 is explicitly
 //!   "Application-Layer Semantics": these messages parse and validate, and the
 //!   torture is above both (missing required header fields, unknown schemes,
-//!   multiple Content-Length, RFC 2543 syntax, ...). Refusing them here would
-//!   be wrong — the application layer decides the response.
+//!   RFC 2543 syntax, ...). Refusing them here would be wrong — the application
+//!   layer decides the response. The two exceptions are §3.3.8 and §3.3.9,
+//!   where the RFC names the response itself ("would respond with a 400 Bad
+//!   Request error" / "should respond with an error") rather than leaving it to
+//!   the application: a header field that may appear once appearing twice is
+//!   ambiguous to every hop, not just to this one, so it is refused.
 //!
 //! Note that this classification is *not* the same as the `_V` / `_I` suffix
 //! carried by the upstream filenames. That suffix records whether the source
@@ -48,7 +52,9 @@ use siphon::sip::validate::validate_message;
 enum Expect {
     /// Syntactically well-formed: the parser must accept it.
     Parse,
-    /// Syntactically invalid: the parser must reject it with an error.
+    /// Must not reach routing: refused either by the parser (syntactically
+    /// invalid) or by `validate_message` (parseable but invalid, which RFC 4475
+    /// §3.3 answers with a status rather than a parse failure).
     Reject,
 }
 
@@ -384,18 +390,41 @@ const CORPUS: &[Case] = &[
         expect: Expect::Parse,
         bytes: include_bytes!("corpus/TC_REGAUT01_V.dat"),
     },
+    // The two §3.3 cases where the RFC names a response rather than leaving it
+    // to the application layer, so the blanket "§3.3 → Parse" rule above does
+    // not hold for them. Both messages parse, and are then refused for carrying
+    // two of a header field that may only appear once:
+    //
+    //   §3.3.8 "An element receiving this request would respond with a 400 Bad
+    //           Request error."
+    //   §3.3.9 "An element receiving this message should respond with an error.
+    //           This request appeared over UDP, so the remainder of the datagram
+    //           can simply be discarded. If a request like this arrives over
+    //           TCP, the framing error is not recoverable, and the connection
+    //           should be closed."
+    //
+    // siphon answers 400 for both. It does NOT yet close the connection on the
+    // §3.3.9 TCP case — the dispatcher has no way to close an inbound stream
+    // connection, so that half of §3.3.9 is an open gap (the framing itself is
+    // consistent, since siphon's framer and parser both read the first
+    // Content-Length; what is unrecoverable is the disagreement with a peer
+    // that meant the second).
+    //
+    // Both were classified `Parse` while siphon had no duplicate check at all;
+    // the check now exists, so the classification follows the RFC rather than
+    // the implementation.
     Case {
         file: "TC_MULTI01_I.dat",
         section: "3.3.8",
         title: "Multiple Values in Single Value Required Fields",
-        expect: Expect::Parse,
+        expect: Expect::Reject,
         bytes: include_bytes!("corpus/TC_MULTI01_I.dat"),
     },
     Case {
         file: "TC_MCL01_I.dat",
         section: "3.3.9",
         title: "Multiple Content-Length Values",
-        expect: Expect::Parse,
+        expect: Expect::Reject,
         bytes: include_bytes!("corpus/TC_MCL01_I.dat"),
     },
     Case {


### PR DESCRIPTION
`validate_message` checked fields — version, CSeq, Date, R-URI, address headers, parameters — and never the *shape* they arrived in. Two things fell through.

## Ambiguity: duplicated single-instance headers → 400

RFC 3261 §8.1.1 defines To, From, Call-ID, CSeq and Max-Forwards as single-instance. A message carrying two of one of them has no defined meaning, and no two implementations agree on which wins. siphon reads the first; an upstream that reads the last routes, bills or authorizes **the same message against a different identity**.

`Content-Length` is in the list for a second reason: it is what the stream framer reads to decide where the *next* message starts. siphon's framer and parser both take the first, so they agree with each other — but an upstream that takes the last reads a different message out of the same bytes. That is the classic message-smuggling shape, and a proxy is exactly the place that must not paper over it.

RFC 4475 names the response for both cases, rather than leaving it to the application layer the way it does for the rest of §3.3:

- §3.3.8 *Multiple Values in Single Value Required Fields* — "An element receiving this request would respond with a 400 Bad Request error."
- §3.3.9 *Multiple Content-Length Values* — "An element receiving this message should respond with an error. This request appeared over UDP, so the remainder of the datagram can simply be discarded. If a request like this arrives over TCP, the framing error is not recoverable, and the connection should be closed."

**Known gap, stated rather than implied:** siphon answers 400 for both but does **not** close the connection on the §3.3.9 TCP case, because the dispatcher has no way to close an inbound stream connection — that needs a close channel plumbed from dispatcher to the transport read task, which is its own change. siphon's own framing stays consistent (framer and parser both read the first Content-Length); what is unrecoverable is the disagreement with a peer that meant the second. Happy to do the plumbing as a follow-up if you want full §3.3.9.

Both fixtures (`TC_MULTI01_I`, `TC_MCL01_I`) were classified `Expect::Parse` in the corpus harness. They passed because siphon had no such check, i.e. the classification was written against the implementation rather than against the RFC. They are now classified as the RFC classifies them. (Flagging that explicitly since "don't fix a test to make it pass" is the rule — this is the provably-more-spec-compliant exception, and the RFC text is quoted at the fixtures.)

## Cost: unbounded structure → 513

Nothing bounded how many header fields a message could carry, or how deep a Via stack could be.

- `security.max_message_bytes` bounds the *octets*, not the structure — 256 KB is still about 8000 one-byte headers.
- Max-Forwards bounds the hops a request may still **take**. It says nothing about the stack a peer simply asserts it already traversed, and every entry of that stack is re-serialized on each forward.

So: 256 header fields, Via depth 100 (comma-separated values on one line count individually, per §7.3.1), both `513 Message Too Large` (§21.4.11). An IMS INVITE with a full P-header set runs to about forty headers, so there is an order of magnitude of headroom — and `ordinary_traffic_is_nowhere_near_the_limits` pins that so the limits cannot quietly drift down onto real traffic.

## UDP truncation is now visible

`recv_from` reports the bytes it copied, not the datagram's length, so a datagram that exactly fills the 8192-byte buffer is indistinguishable from one the kernel truncated. Until now that was invisible, surfacing only as an obscure "SIP parse error" some way downstream.

`siphon_udp_datagrams_at_buffer_limit_total` counts it, with a warning that names the cause. **Behaviour is unchanged** — the message is still processed, because a genuinely truncated one is already refused by the parser's Content-Length check (RFC 4475 §3.1.2.2), and dropping on the heuristic would discard a legitimate exactly-8192-byte datagram.

I deliberately did not grow or pool the receive buffer here. Growing it to 64 KB means zeroing 64 KB per datagram (2.6 GB/s at 40k cps), and reusing one across `tokio::select!` iterations is the change the perf log records as tried, reverted, and the cause of stuck calls at 28k cps. Not something to retry as a drive-by. A peer sending >8 KB over UDP is already well past where RFC 3261 §18.1.1 requires it to switch to TCP; the counter tells you whether that is actually happening before anyone spends effort on it.

## Tests

`a_duplicated_single_instance_header_is_400` (every header in the list), `an_over_deep_via_stack_is_513` (both line-per-Via and comma-separated), `too_many_header_fields_is_513`, `ordinary_traffic_is_nowhere_near_the_limits`. Full suite green including the RFC 4475 corpus and the parser proptests; clippy clean.
