### PR TITLE
test(interop): run siphon against an independent SIP proxy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1507,6 +1507,38 @@ jobs:
             siphon-rtpproxy-real.log
             rtpproxy-real.log
 
+  # ── Interoperability: siphon against an independent SIP proxy ──────────
+  # sipp/ proves siphon does what siphon intends — every message on the wire is
+  # siphon's own, and SIPp has no opinion about a Record-Route it did not write,
+  # so a header that is subtly wrong but self-consistent passes. Kamailio shares
+  # no code with siphon, so a route set the two build together only works if
+  # siphon's half is genuinely conformant. See interop/README.md.
+  interop:
+    runs-on: ubuntu-latest
+    needs: build-image
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Load the siphon image
+        uses: ./.github/actions/load-siphon-image
+
+      - name: siphon and Kamailio interop chains
+        run: ./interop/run.sh
+
+      - name: Collect logs
+        if: always()
+        run: |
+          docker compose -f interop/docker-compose.yaml --profile forward logs > interop-forward.log 2>&1 || true
+          docker compose -f interop/docker-compose.yaml --profile reverse logs > interop-reverse.log 2>&1 || true
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: interop-logs
+          path: interop-*.log
+          if-no-files-found: ignore
+
   # ── Fuzz testing (nightly) ─────────────────────────────────────────────
   fuzz:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+- **Interoperability tests against an independent SIP proxy (`interop/`).** The
+  SIPp suite proves siphon does what siphon intends: every message on the wire
+  is siphon's own, and SIPp is a message generator rather than a SIP element —
+  it builds no route set, matches no CANCEL to a transaction, and has no opinion
+  about a Record-Route it did not write. A header that is subtly wrong but
+  self-consistent passes.
+
+  Kamailio is now the oracle. Two chains run in CI, both proxies Record-Routing
+  so every call builds a route set jointly:
+
+  ```
+  forward:  SIPp UAC -> siphon -> Kamailio -> SIPp UAS
+  reverse:  SIPp UAC -> Kamailio -> siphon -> SIPp UAS
+  ```
+
+  Forward proves siphon's Record-Route is loose-routable by Kamailio; reverse
+  proves siphon can loose-route Kamailio's; a third chain CANCELs an alerting
+  call across both hops. The scenarios assert no header text — the ACK and BYE
+  are addressed at the remote target carrying the jointly-built route set, so a
+  Record-Route the other proxy cannot read shows up as a BYE that never arrives.
+
+  `interop/run.sh` requires each chain to report at least one *successful* call
+  rather than just a zero exit code, because SIPp exits 0 when no call failed —
+  including when no call ever completed. Verified by negative control.
+
+
 ### Security
 - **Bounded stream message size (`security.max_message_bytes`).** A peer on a
   stream transport (TCP/TLS/WS/WSS) could declare an arbitrarily large

--- a/interop/README.md
+++ b/interop/README.md
@@ -1,0 +1,101 @@
+# Interoperability tests
+
+siphon against a SIP proxy that shares none of its code.
+
+```
+interop/run.sh                # every chain
+interop/run.sh forward        # one chain
+```
+
+## Why this is not covered by the SIPp suite
+
+`sipp/` proves siphon does what siphon intends. Every message on the wire is
+produced by siphon and consumed by SIPp, which is a message generator rather
+than a SIP element: it does not build a route set, does not match a CANCEL to a
+transaction, and does not have an opinion about a Record-Route it did not write.
+So a header that is subtly wrong but self-consistent passes.
+
+That is the gap this fills. Kamailio is the oracle, not the subject: it shares
+no code with siphon, so a route set the two of them build **together** only
+works if siphon's half is genuinely conformant rather than merely internally
+consistent.
+
+## The chains
+
+Two, because the bug classes differ by position in the path:
+
+```
+forward:  SIPp UAC ──▶ siphon ──▶ Kamailio ──▶ SIPp UAS
+reverse:  SIPp UAC ──▶ Kamailio ──▶ siphon ──▶ SIPp UAS
+```
+
+Both proxies Record-Route, so every call builds a route set jointly. In the
+forward chain siphon's Record-Route has to be loose-routable **by Kamailio**; in
+the reverse chain siphon has to loose-route **Kamailio's**. Running only one
+proves only one half.
+
+| Chain | What it exercises |
+|---|---|
+| `forward` | INVITE → 180 → 200 → ACK → BYE → 200. siphon's Record-Route read by Kamailio; the in-dialog BYE traversing both in reverse. |
+| `reverse` | The same call with the proxies swapped: Kamailio's Record-Route read by siphon. |
+| `cancel` | CANCEL of an alerting call across both hops (RFC 3261 §9). |
+
+## How the scenarios assert
+
+They do not compare header text. The UAC sends its ACK and BYE to `[next_url]`
+(the callee's Contact — the remote target, RFC 3261 §12.2.1.1) carrying
+`[routes]`, the route set SIPp assembled from the Record-Route headers the two
+proxies wrote. If either proxy writes a Record-Route the other cannot
+loose-route, the BYE does not arrive and the scenario fails on the missing 200.
+
+That is a sharper test than string comparison and it is the failure an operator
+actually sees. The same goes for CANCEL: it is matched by the topmost Via
+branch, which every hop rewrites, so the 487 only comes back if each proxy
+cancelled the branch it *sent* rather than the one it received.
+
+## The false-green guard
+
+`run.sh` requires each chain to report **at least one successful call**, not
+just a zero exit code. SIPp exits 0 when no call *failed*, which includes the
+case where no call ever completed — so a run torn down early (by
+`--abort-on-container-exit` firing on some other container) reads as green while
+proving nothing. This is not hypothetical: it happened while building this
+harness, and the run looked passing.
+
+Verified by negative control — pointing the UAC at an address nothing listens on
+gives `FAIL forward: exit=255 successful_calls=0`.
+
+## Layout
+
+```
+interop/
+  run.sh                     the entry point; gates on successful calls
+  docker-compose.yaml        both chains, on their own subnet (172.28.0.0/24)
+  configs/                   siphon config for its hop
+  scripts/                   the siphon routing script (Record-Route + relay)
+  kamailio/kamailio.cfg      the independent proxy, kept as small as it can be
+  scenarios/                 SIPp UAC/UAS scenarios
+```
+
+The subnet is deliberately its own, so this stack runs alongside `sipp/`
+(172.20.0.0/24) and the MTU stack (172.30.0.0/24).
+
+## Adding a peer
+
+The two chains are the shape; a second implementation is a third and fourth. To
+add OpenSIPS, Asterisk or FreeSWITCH, add a service with a config that
+Record-Routes and forwards to `INTEROP_NEXT_HOP`, and reuse the scenarios
+unchanged — they assert nothing implementation-specific. The most valuable next
+peers, roughly in order: OpenSIPS (same class of element, different codebase),
+Asterisk or FreeSWITCH (a B2BUA rather than a proxy, so re-INVITE and transfer
+come into scope), and a WebRTC stack over WSS.
+
+## What is not covered yet
+
+Named so nobody reads a green run as more than it is:
+
+- TLS and WebSocket transports — UDP only today.
+- Forking, re-INVITE, session timers, PRACK, REFER across the chain.
+- Authentication between the proxies.
+- Any peer other than Kamailio.
+- Load. These are one-call correctness runs, not throughput.

--- a/interop/configs/siphon.interop.yaml
+++ b/interop/configs/siphon.interop.yaml
@@ -1,0 +1,38 @@
+# siphon.interop.yaml — siphon as one hop of a two-proxy interop chain.
+#
+# Used with: interop/docker-compose.yaml
+# Script:    interop/scripts/interop_proxy.py
+#
+# `domain.local` deliberately holds only the served domain, not siphon's own IP.
+# That is what an operator actually writes, and it is the shape that catches a
+# proxy which fails to recognise its own Record-Route — the same reasoning as
+# sipp/configs/siphon.routing-test.yaml. Here it matters more: the route set is
+# built jointly with a proxy that shares none of siphon's code, so a
+# self-identity bug shows up as a BYE that never arrives rather than as a
+# header that merely looks odd.
+
+listen:
+  udp:
+    - "0.0.0.0:5060"
+  tcp:
+    - "0.0.0.0:5060"
+
+domain:
+  local:
+    - "siphon.interop"
+
+# Pinned so the Record-Route siphon writes is reachable from the other
+# container, rather than carrying 0.0.0.0.
+advertised_address: "${SIPHON_ADVERTISED_ADDRESS}"
+
+script:
+  path: "/etc/siphon/interop/interop_proxy.py"
+  reload: auto
+
+registrar:
+  backend: memory
+  default_expires: 3600
+
+log:
+  level: info
+  format: pretty

--- a/interop/docker-compose.yaml
+++ b/interop/docker-compose.yaml
@@ -1,0 +1,223 @@
+# interop/docker-compose.yaml — siphon against an independent SIP proxy.
+#
+# Two chains, both directions, because the bug classes differ by position:
+#
+#   forward:  SIPp UAC -> siphon -> Kamailio -> SIPp UAS
+#   reverse:  SIPp UAC -> Kamailio -> siphon -> SIPp UAS
+#
+# Both proxies Record-Route, so every call builds a route set jointly. In the
+# forward chain siphon's Record-Route has to be loose-routable by Kamailio; in
+# the reverse chain siphon has to loose-route Kamailio's. Only running both
+# proves both halves.
+#
+# Usage:
+#   docker compose -f interop/docker-compose.yaml build
+#   docker compose -f interop/docker-compose.yaml --profile forward up \
+#     --abort-on-container-exit --exit-code-from interop-uac-forward
+#   docker compose -f interop/docker-compose.yaml --profile reverse up \
+#     --abort-on-container-exit --exit-code-from interop-uac-reverse
+#   docker compose -f interop/docker-compose.yaml down -v
+#
+# The subnet is deliberately its own, so this stack can run alongside the
+# functional one in sipp/ (172.20.0.0/24) and the MTU one (172.30.0.0/24).
+
+x-kamailio-entrypoint: &kamailio-entrypoint
+  # kamailio.cfg is mounted read-only and carries a placeholder next hop, so one
+  # config serves both chain directions. Substituted into a writable copy at
+  # start rather than templated at build time, which keeps the file in the repo
+  # readable as a config rather than as a template.
+  entrypoint:
+    - /bin/sh
+    - -c
+    - |
+      sed "s|INTEROP_NEXT_HOP|$${INTEROP_NEXT_HOP}|" /etc/kamailio/kamailio.cfg.in > /tmp/kamailio.cfg
+      exec kamailio -DD -E -f /tmp/kamailio.cfg
+
+services:
+  # ── Chain: SIPp -> siphon -> Kamailio -> SIPp ─────────────────────────────
+  siphon-forward:
+    image: interop-siphon
+    build:
+      context: ..
+    container_name: interop-siphon-forward
+    environment:
+      SIPHON_ADVERTISED_ADDRESS: "172.28.0.10"
+      INTEROP_NEXT_HOP: "sip:172.28.0.20:5060"
+    volumes:
+      - ./configs/siphon.interop.yaml:/etc/siphon/siphon.yaml:ro
+      - ./scripts:/etc/siphon/interop:ro
+    networks:
+      interop:
+        ipv4_address: 172.28.0.10
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.interop SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.interop>;tag=hc\\r\\nTo: <sip:siphon.interop>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles: ["forward", "cancel"]
+
+  kamailio-forward:
+    image: ghcr.io/kamailio/kamailio-ci:5.8-alpine
+    container_name: interop-kamailio-forward
+    environment:
+      INTEROP_NEXT_HOP: "172.28.0.31:5060"
+    volumes:
+      - ./kamailio/kamailio.cfg:/etc/kamailio/kamailio.cfg.in:ro
+    <<: *kamailio-entrypoint
+    networks:
+      interop:
+        ipv4_address: 172.28.0.20
+    profiles: ["forward", "cancel"]
+
+  interop-uas-forward:
+    image: ctaloi/sipp:latest
+    container_name: interop-uas-forward
+    volumes:
+      - ./scenarios:/scenarios:ro
+    command: >
+      -sf /scenarios/uas_invite_bye.xml
+      -i 172.28.0.31 -p 5060 -m 1 -timeout 90s -timeout_error
+      -trace_err -error_file /dev/stderr
+    networks:
+      interop:
+        ipv4_address: 172.28.0.31
+    profiles: ["forward"]
+
+  interop-uac-forward:
+    image: ctaloi/sipp:latest
+    container_name: interop-uac-forward
+    depends_on:
+      siphon-forward:
+        condition: service_healthy
+      kamailio-forward:
+        condition: service_started
+      interop-uas-forward:
+        condition: service_started
+    volumes:
+      - ./scenarios:/scenarios:ro
+    command: >
+      -sf /scenarios/uac_invite_bye.xml
+      172.28.0.10:5060
+      -i 172.28.0.30 -p 5060 -m 1 -r 1 -timeout 30s -timeout_error
+      -trace_err -error_file /dev/stderr
+    networks:
+      interop:
+        ipv4_address: 172.28.0.30
+    profiles: ["forward"]
+
+  # ── Chain: SIPp -> Kamailio -> siphon -> SIPp ─────────────────────────────
+  kamailio-reverse:
+    image: ghcr.io/kamailio/kamailio-ci:5.8-alpine
+    container_name: interop-kamailio-reverse
+    environment:
+      INTEROP_NEXT_HOP: "172.28.0.11:5060"
+    volumes:
+      - ./kamailio/kamailio.cfg:/etc/kamailio/kamailio.cfg.in:ro
+    <<: *kamailio-entrypoint
+    networks:
+      interop:
+        ipv4_address: 172.28.0.21
+    profiles: ["reverse"]
+
+  siphon-reverse:
+    image: interop-siphon
+    build:
+      context: ..
+    container_name: interop-siphon-reverse
+    environment:
+      SIPHON_ADVERTISED_ADDRESS: "172.28.0.11"
+      INTEROP_NEXT_HOP: "sip:172.28.0.41:5060"
+    volumes:
+      - ./configs/siphon.interop.yaml:/etc/siphon/siphon.yaml:ro
+      - ./scripts:/etc/siphon/interop:ro
+    networks:
+      interop:
+        ipv4_address: 172.28.0.11
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b'OPTIONS sip:siphon.interop SIP/2.0\\r\\nVia: SIP/2.0/UDP 127.0.0.1:15060;branch=z9hG4bK-hc\\r\\nFrom: <sip:hc@siphon.interop>;tag=hc\\r\\nTo: <sip:siphon.interop>\\r\\nCall-ID: hc@check\\r\\nCSeq: 1 OPTIONS\\r\\nMax-Forwards: 1\\r\\nContent-Length: 0\\r\\n\\r\\n', ('127.0.0.1',5060)); s.recv(1024); s.close()\""]
+      interval: 3s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+    profiles: ["reverse"]
+
+  interop-uas-reverse:
+    image: ctaloi/sipp:latest
+    container_name: interop-uas-reverse
+    volumes:
+      - ./scenarios:/scenarios:ro
+    command: >
+      -sf /scenarios/uas_invite_bye.xml
+      -i 172.28.0.41 -p 5060 -m 1 -timeout 90s -timeout_error
+      -trace_err -error_file /dev/stderr
+    networks:
+      interop:
+        ipv4_address: 172.28.0.41
+    profiles: ["reverse"]
+
+  interop-uac-reverse:
+    image: ctaloi/sipp:latest
+    container_name: interop-uac-reverse
+    depends_on:
+      siphon-reverse:
+        condition: service_healthy
+      kamailio-reverse:
+        condition: service_started
+      interop-uas-reverse:
+        condition: service_started
+    volumes:
+      - ./scenarios:/scenarios:ro
+    command: >
+      -sf /scenarios/uac_invite_bye.xml
+      172.28.0.21:5060
+      -i 172.28.0.40 -p 5060 -m 1 -r 1 -timeout 30s -timeout_error
+      -trace_err -error_file /dev/stderr
+    networks:
+      interop:
+        ipv4_address: 172.28.0.40
+    profiles: ["reverse"]
+
+  # ── CANCEL across the forward chain ───────────────────────────────────────
+  interop-uas-cancel:
+    image: ctaloi/sipp:latest
+    container_name: interop-uas-cancel
+    volumes:
+      - ./scenarios:/scenarios:ro
+    command: >
+      -sf /scenarios/uas_cancel.xml
+      -i 172.28.0.31 -p 5060 -m 1 -timeout 90s -timeout_error
+      -trace_err -error_file /dev/stderr
+    networks:
+      interop:
+        ipv4_address: 172.28.0.31
+    profiles: ["cancel"]
+
+  interop-uac-cancel:
+    image: ctaloi/sipp:latest
+    container_name: interop-uac-cancel
+    depends_on:
+      siphon-forward:
+        condition: service_healthy
+      kamailio-forward:
+        condition: service_started
+      interop-uas-cancel:
+        condition: service_started
+    volumes:
+      - ./scenarios:/scenarios:ro
+    command: >
+      -sf /scenarios/uac_cancel.xml
+      172.28.0.10:5060
+      -i 172.28.0.30 -p 5060 -m 1 -r 1 -timeout 30s -timeout_error
+      -trace_err -error_file /dev/stderr
+    networks:
+      interop:
+        ipv4_address: 172.28.0.30
+    profiles: ["cancel"]
+
+networks:
+  interop:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24

--- a/interop/kamailio/kamailio.cfg
+++ b/interop/kamailio/kamailio.cfg
@@ -1,0 +1,102 @@
+#!KAMAILIO
+#
+# Minimal stateful Record-Routing proxy — the independent half of the interop
+# chain.
+#
+# Kamailio is the oracle here, not the subject: it shares none of siphon's
+# code, so a route set the two of them build together only works if siphon's
+# Record-Route is genuinely RFC 3261 §16.6/§16.12 conformant rather than merely
+# self-consistent. Kept as small as it can be while still being a real proxy —
+# record_route(), loose_route(), and a transaction layer.
+#
+# INTEROP_NEXT_HOP is substituted at container start (see docker-compose.yaml).
+
+debug=2
+log_stderror=yes
+memdbg=5
+memlog=5
+fork=yes
+children=2
+auto_aliases=no
+
+listen=udp:0.0.0.0:5060
+listen=tcp:0.0.0.0:5060
+
+loadmodule "jsonrpcs.so"
+loadmodule "kex.so"
+loadmodule "corex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "maxfwd.so"
+loadmodule "textops.so"
+loadmodule "siputils.so"
+loadmodule "xlog.so"
+loadmodule "sanity.so"
+loadmodule "ctl.so"
+
+modparam("rr", "enable_full_lr", 0)
+modparam("rr", "append_fromtag", 1)
+
+request_route {
+    # One line per inbound request. Without it a message that Kamailio drops is
+    # indistinguishable from one that never arrived, which is most of the
+    # debugging effort in a chained-proxy stack.
+    xlog("L_INFO", "kamailio recv: $rm $ru from $si:$sp (call-id $ci)\n");
+
+    # RFC 3261 §16.3 — hop count.
+    if (!mf_process_maxfwd_header("10")) {
+        sl_send_reply("483", "Too Many Hops");
+        exit;
+    }
+
+    if (!sanity_check("1511", "7")) {
+        xlog("L_WARN", "malformed request from $si\n");
+        exit;
+    }
+
+    # Healthcheck probe — answered locally, never forwarded.
+    if (is_method("OPTIONS") && !has_totag()) {
+        sl_send_reply("200", "OK");
+        exit;
+    }
+
+    # In-dialog: follow the route set built with the other proxy.
+    if (has_totag()) {
+        if (loose_route()) {
+            route(RELAY);
+        } else {
+            sl_send_reply("404", "Not Here");
+        }
+        exit;
+    }
+
+    # CANCEL matches the INVITE transaction (RFC 3261 §9.2).
+    if (is_method("CANCEL")) {
+        if (t_check_trans()) {
+            route(RELAY);
+        }
+        exit;
+    }
+    t_check_trans();
+
+    # ACK for a 2xx is end-to-end and arrives with a to-tag, so it is handled
+    # by the in-dialog branch above; anything reaching here is stray.
+    if (is_method("ACK")) {
+        exit;
+    }
+
+    # Initial request: stay in the path for the dialog, then forward.
+    record_route();
+    $du = "sip:INTEROP_NEXT_HOP";
+    route(RELAY);
+}
+
+route[RELAY] {
+    if (!t_relay()) {
+        sl_reply_error();
+    }
+    exit;
+}

--- a/interop/run.sh
+++ b/interop/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Run the siphon <-> Kamailio interop suite.
+#
+#   interop/run.sh              # every chain
+#   interop/run.sh forward      # one chain
+#
+# Exits non-zero if any chain fails.
+#
+# Why this wrapper exists rather than a bare `docker compose up`: SIPp exits 0
+# when no call *failed*, which includes the case where no call ever completed.
+# A run torn down early — by `--abort-on-container-exit` firing on some other
+# container — therefore reads as green while proving nothing. So each chain is
+# additionally required to report at least one successful call.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+COMPOSE=(docker compose -f interop/docker-compose.yaml)
+
+CHAINS=("$@")
+if [ ${#CHAINS[@]} -eq 0 ]; then
+    CHAINS=(forward reverse cancel)
+fi
+
+# UAC service per chain — the container whose exit code decides the run.
+uac_for() {
+    case "$1" in
+        forward) echo "interop-uac-forward" ;;
+        reverse) echo "interop-uac-reverse" ;;
+        cancel)  echo "interop-uac-cancel" ;;
+        *) echo "unknown chain: $1" >&2; exit 2 ;;
+    esac
+}
+
+cleanup() {
+    for chain in "${CHAINS[@]}"; do
+        "${COMPOSE[@]}" --profile "$chain" down -v --remove-orphans >/dev/null 2>&1 || true
+    done
+}
+trap cleanup EXIT
+
+echo "==> building the siphon image under test"
+"${COMPOSE[@]}" --profile forward build siphon-forward
+
+failures=0
+for chain in "${CHAINS[@]}"; do
+    uac="$(uac_for "$chain")"
+    log="$(mktemp)"
+
+    echo
+    echo "==> chain: ${chain}"
+    # Each chain starts from a clean stack: the SIPp endpoints run with -m 1 and
+    # exit after one call, so a reused stack silently answers nothing.
+    "${COMPOSE[@]}" --profile "$chain" down -v --remove-orphans >/dev/null 2>&1 || true
+
+    status=0
+    "${COMPOSE[@]}" --profile "$chain" up \
+        --abort-on-container-exit --exit-code-from "$uac" >"$log" 2>&1 || status=$?
+
+    # The cumulative "Successful call" figure from the UAC's final stats block.
+    # SIPp prints `| Counter | periodic | cumulative` and compose prefixes each
+    # line with the service name, so the cumulative figure is the last field
+    # however many columns the prefix adds.
+    # `|| true`: a chain that never got as far as printing a stats block is the
+    # loudest failure there is, and grep exiting 1 under `pipefail` would abort
+    # the script before it could say so.
+    successful="$(grep "$uac" "$log" \
+        | grep -E '\|[[:space:]]+Successful call' \
+        | tail -1 \
+        | awk -F'|' '{gsub(/[^0-9]/, "", $NF); print $NF}' || true)"
+    successful="${successful:-0}"
+
+    if [ "$status" -ne 0 ] || [ "$successful" -lt 1 ]; then
+        echo "FAIL ${chain}: exit=${status} successful_calls=${successful}"
+        echo "---- last 60 lines ----"
+        tail -60 "$log"
+        failures=$((failures + 1))
+    else
+        echo "PASS ${chain}: ${successful} successful call(s)"
+    fi
+    rm -f "$log"
+done
+
+echo
+if [ "$failures" -ne 0 ]; then
+    echo "${failures} chain(s) failed"
+    exit 1
+fi
+echo "all chains passed"

--- a/interop/scenarios/uac_cancel.xml
+++ b/interop/scenarios/uac_cancel.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- CANCEL across the two-proxy chain (RFC 3261 §9).
+
+     CANCEL is matched to the INVITE by the topmost Via branch (§9.2), which
+     every hop rewrites — so this only completes if each proxy CANCELs the
+     branch it actually *sent* downstream, not the one it received.
+     Cross-implementation is where that goes wrong: a proxy that mints a fresh
+     branch for its CANCEL leaves the far end ringing, and the caller sees no
+     487.
+
+     §9.1 requires the UAC's CANCEL to reuse the INVITE's branch, and SIPp's
+     `[branch]` is per-message, so the branch is assigned to a variable once and
+     reused for the INVITE, the CANCEL and the ACK for the 487 (§17.1.1.3). -->
+<scenario name="interop UAC: CANCEL an alerting call across two proxies">
+
+  <nop>
+    <action>
+      <assignstr assign_to="1" value="z9hG4bK-[pid]-[call_number]-interop-inv" />
+    </action>
+  </nop>
+
+  <send retrans="500">
+    <![CDATA[
+      INVITE sip:callee@siphon.interop SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[$1]
+      From: <sip:caller@siphon.interop>;tag=[call_number]
+      To: <sip:callee@siphon.interop>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+      Max-Forwards: 70
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[local_ip_type] [local_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+    ]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="180" />
+
+  <pause milliseconds="300" />
+
+  <send>
+    <![CDATA[
+      CANCEL sip:callee@siphon.interop SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[$1]
+      From: <sip:caller@siphon.interop>;tag=[call_number]
+      To: <sip:callee@siphon.interop>
+      Call-ID: [call_id]
+      CSeq: 1 CANCEL
+      Max-Forwards: 70
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <recv response="200" />
+
+  <!-- The 487 only comes back if the CANCEL reached the UAS, which needs every
+       hop to have cancelled the branch it sent. -->
+  <recv response="487" />
+
+  <send>
+    <![CDATA[
+      ACK sip:callee@siphon.interop SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[$1]
+      From: <sip:caller@siphon.interop>;tag=[call_number]
+      To: <sip:callee@siphon.interop>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Max-Forwards: 70
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <ResponseTimeRepartition value="10, 20, 50, 100, 200, 500, 1000"/>
+</scenario>

--- a/interop/scenarios/uac_invite_bye.xml
+++ b/interop/scenarios/uac_invite_bye.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- INVITE -> 180 -> 200 -> ACK -> BYE -> 200, driven through a chain of two
+     proxies that both Record-Route.
+
+     There is not one header assertion in here, on purpose. The ACK and the BYE
+     carry `[routes]` — the route set SIPp built from the Record-Route headers
+     the two proxies wrote — and are addressed at `[next_url]`, the callee's
+     Contact, which is what a real UAC uses as the in-dialog request URI
+     (RFC 3261 §12.2.1.1: the remote target, not the original AoR). If either proxy writes a Record-Route the
+     other cannot loose-route, the BYE does not arrive and the scenario fails on
+     the missing 200. That is a sharper test than comparing header text, and it
+     is the failure an operator actually sees. -->
+<scenario name="interop UAC: INVITE/BYE through two Record-Routing proxies">
+
+  <send retrans="500">
+    <![CDATA[
+      INVITE sip:callee@siphon.interop SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:caller@siphon.interop>;tag=[call_number]
+      To: <sip:callee@siphon.interop>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+      Max-Forwards: 70
+      Subject: interop
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=caller 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[local_ip_type] [local_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+    ]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="180" optional="true" />
+  <recv response="200" rtd="true" rrs="true" />
+
+  <send>
+    <![CDATA[
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:caller@siphon.interop>;tag=[call_number]
+      To: <sip:callee@siphon.interop>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: <sip:caller@[local_ip]:[local_port];transport=[transport]>
+      Max-Forwards: 70
+      [routes]
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+      BYE [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:caller@siphon.interop>;tag=[call_number]
+      To: <sip:callee@siphon.interop>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 2 BYE
+      Max-Forwards: 70
+      [routes]
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <!-- The whole point: this 200 only arrives if the BYE traversed both
+       proxies in reverse using the route set they jointly built. -->
+  <recv response="200" crlf="true" />
+
+  <ResponseTimeRepartition value="10, 20, 50, 100, 200, 500, 1000"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000"/>
+</scenario>

--- a/interop/scenarios/uas_cancel.xml
+++ b/interop/scenarios/uas_cancel.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Rings, then expects the CANCEL to arrive. If either proxy fails to cancel
+     the branch it sent, this times out on the CANCEL and the phone would have
+     kept ringing after the caller hung up. -->
+<scenario name="interop UAS: ring, expect CANCEL, answer 487">
+
+  <recv request="INVITE" crlf="true" />
+
+  <send>
+    <![CDATA[
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Record-Route:]
+      Contact: <sip:callee@[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <recv request="CANCEL" crlf="true" />
+
+  <send>
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+      SIP/2.0 487 Request Terminated
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      CSeq: 1 INVITE
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <recv request="ACK" crlf="true" />
+
+  <ResponseTimeRepartition value="10, 20, 50, 100, 200, 500, 1000"/>
+</scenario>

--- a/interop/scenarios/uas_invite_bye.xml
+++ b/interop/scenarios/uas_invite_bye.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- The far end of the two-proxy chain. Answers, then waits for the BYE that
+     only arrives if both proxies loose-routed it back. -->
+<scenario name="interop UAS: answer and expect the in-dialog BYE">
+
+  <recv request="INVITE" crlf="true" />
+
+  <send>
+    <![CDATA[
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Record-Route:]
+      Contact: <sip:callee@[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Record-Route:]
+      Contact: <sip:callee@[local_ip]:[local_port];transport=[transport]>
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=callee 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[local_ip_type] [local_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+    ]]>
+  </send>
+
+  <recv request="ACK" rtd="true" crlf="true" />
+
+  <recv request="BYE" crlf="true" />
+
+  <send>
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <ResponseTimeRepartition value="10, 20, 50, 100, 200, 500, 1000"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000"/>
+</scenario>

--- a/interop/scripts/interop_proxy.py
+++ b/interop/scripts/interop_proxy.py
@@ -1,0 +1,50 @@
+"""Record-Routing relay for the siphon <-> third-party proxy interop stack.
+
+Deliberately the smallest proxy that still exercises the thing under test: a
+stateful, Record-Routing hop that forwards initial requests to a fixed next hop
+and loose-routes everything in-dialog.
+
+The point is not the routing logic — it is that the route set siphon *writes*
+can be read back by a proxy that shares none of siphon's code, and that a route
+set written by that proxy can be read back by siphon. An in-dialog BYE only
+reaches the far end if both halves agree, so the SIPp scenarios need no header
+assertions: the call either completes end to end or it does not.
+
+The next hop comes from the environment so one script serves both chain
+directions (siphon-in-front and siphon-behind).
+"""
+import os
+
+from siphon import proxy
+
+NEXT_HOP = os.environ["INTEROP_NEXT_HOP"]  # e.g. "sip:172.28.0.20:5060"
+
+
+# One handler, not one per method. `@proxy.on_request` with no filter matches
+# *every* method, and a filtered `@proxy.on_request("OPTIONS")` alongside it does
+# not replace it — both run. Registering both meant the healthcheck OPTIONS was
+# answered 200 locally *and* relayed to the next hop, which in the reverse chain
+# is the SIPp UAS: it consumed its one scripted call on the healthcheck and was
+# gone before the test INVITE arrived.
+@proxy.on_request
+def on_request(request):
+    # Container healthcheck probe — answered locally, never relayed.
+    if request.method == "OPTIONS" and not request.in_dialog:
+        request.reply(200, "OK")
+        return
+
+    # In-dialog: follow the route set the two proxies built between them.
+    #
+    # loose_route() consumes only the Route entries that identify us (RFC 3261
+    # §16.4); a False return means the top Route belongs to the other proxy and
+    # relay() follows it (§16.6), so forward either way. Note it also returns
+    # True when there is no Route at all, which is why the in-dialog test is
+    # `request.in_dialog` and not the loose_route() return.
+    if request.in_dialog:
+        request.loose_route()
+        request.relay()
+        return
+
+    # Initial request: stay in the path for the whole dialog, then forward.
+    request.record_route()
+    request.relay(NEXT_HOP)


### PR DESCRIPTION
You said interop was expensive but important. This is the first increment, running in CI.

## The gap it fills

`sipp/` proves siphon does what siphon intends. Every message on the wire is produced by siphon and consumed by SIPp — which is a message *generator*, not a SIP element. It builds no route set, matches no CANCEL to a transaction, and has no opinion about a Record-Route it did not write. So a header that is subtly wrong but self-consistent passes.

Kamailio is the oracle here, not the subject. It shares no code with siphon, so a route set the two of them build **together** only works if siphon's half is genuinely conformant rather than merely internally consistent.

## Two chains, because position matters

```
forward:  SIPp UAC ──▶ siphon ──▶ Kamailio ──▶ SIPp UAS
reverse:  SIPp UAC ──▶ Kamailio ──▶ siphon ──▶ SIPp UAS
```

Both proxies Record-Route. Forward proves siphon's Record-Route is loose-routable **by Kamailio**; reverse proves siphon can loose-route **Kamailio's**. Running one proves half. A third chain CANCELs an alerting call across both hops — CANCEL is matched by the topmost Via branch, which every hop rewrites, so the 487 only comes back if each proxy cancelled the branch it *sent*.

## The scenarios assert nothing about header text

The ACK and BYE go to `[next_url]` (the callee's Contact — the remote target, RFC 3261 §12.2.1.1) carrying `[routes]`, the set SIPp assembled from the Record-Routes the two proxies wrote. A Record-Route the other proxy cannot read shows up as a BYE that never arrives. Sharper than string comparison, and it is the failure an operator actually sees.

That also means the scenarios are peer-agnostic: adding OpenSIPS or Asterisk is a compose service plus a config, not new scenarios.

## The false-green guard

`run.sh` requires each chain to report at least one **successful** call, not just a zero exit code. SIPp exits 0 when no call *failed*, which includes the case where no call ever completed.

This is not hypothetical — it bit me while building this. A run where the UAS exited first tore the stack down via `--abort-on-container-exit` before the UAC's own timeout could turn an abandoned call into a failure, and the whole thing reported success with `Successful call: 0`. Two fixes: the UAS now outlives the UAC (90s vs 30s) so the UAC always decides, and the runner checks the count.

Verified by negative control — pointing the UAC at an address nothing listens on gives `FAIL forward: exit=255 successful_calls=0`.

## Result

```
==> chain: forward
PASS forward: 1 successful call(s)
==> chain: reverse
PASS reverse: 1 successful call(s)
==> chain: cancel
PASS cancel: 1 successful call(s)
all chains passed
```

No siphon defects surfaced. Every failure along the way was mine — the in-dialog R-URI, SIPp's `rrs="true"` capture, the CANCEL branch, and one worth calling out below.

## One API subtlety worth knowing

`@proxy.on_request` with no filter matches **every** method, and a
`@proxy.on_request("OPTIONS")` alongside it does not replace it — both run
(`ScriptState::proxy_request_handlers` returns `ProxyRequest(None)` unconditionally). My first script registered both, so the healthcheck OPTIONS was answered 200 locally *and* relayed to the next hop. In the reverse chain that next hop is the SIPp UAS, which consumed its one scripted call on the healthcheck and was gone before the test INVITE arrived.

Correct behaviour, and arguably the only sane one — but it cost an hour, and nothing in the scripting docs says the two compose rather than override. Might be worth a line in the API reference; happy to send that separately.

## Not covered yet

Named in the README so a green run is not read as more than it is: TLS and WebSocket transports (UDP only), forking, re-INVITE, session timers, PRACK, REFER across the chain, authentication between the proxies, any peer other than Kamailio, and load. The README also ranks the next peers worth adding — OpenSIPS first (same class of element, different codebase), then a B2BUA like Asterisk or FreeSWITCH, which brings re-INVITE and transfer into scope.

Runtime is about 90 seconds for all three chains.
