### PR TITLE
feat(script): request.stop_propagation() so a handler can keep the decision it made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,35 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   PR that causes it. Both rows now say which.
 
 
+- **`request.stop_propagation()` — a handler can now keep its decision.**
+  Every `@proxy.on_request` whose filter matches runs, and they share one
+  request object with a **single action slot**: `reply()` / `relay()` / `fork()`
+  assign it rather than sending, and only its final value is executed. So a
+  later handler did not run *as well as* an earlier one — it silently replaced
+  the earlier one's routing decision, with registration order deciding. An
+  `@proxy.on_request("OPTIONS")` answering a health probe beside a bare
+  `@proxy.on_request` that relays meant the probe was **never answered**, only
+  forwarded. Calling `request.stop_propagation()` stops the chain so nothing can
+  overwrite the choice.
+
+  Opt-in: answering is not on its own a request to stop, since a metrics or
+  logging handler running afterwards is legitimate, and stopping by default
+  would silently drop it. Side effects (`set_header`, `record_route`, logging,
+  metrics) still run from every handler — only the routing decision is
+  last-writer-wins. Documented in the handler execution model and mirrored in
+  the SDK.
+
+  `@diameter.on_request` dispatches the single most specific match instead. That
+  difference is deliberate, and now says why: a Diameter request needs exactly
+  one answer, where a SIP request can legitimately interest several handlers at
+  once. Its docstring previously described the filter as mirroring
+  `@proxy.on_request("INVITE")`, which is true of the syntax and false of the
+  dispatch.
+
+  The Kamailio/OpenSIPS migration guide mapped `is_method("INVITE")` to
+  `@proxy.on_request("INVITE")`. Both of those have exactly one automatic route
+  block, so `is_method()` is an *exclusive branch*; the decorator is additive.
+  The guide now shows both correct forms.
 - **Control plane: `StasisEnd` now carries the SIP status on every teardown that
   had one.** `code` / `response` were only populated on the two originate paths;
   four more now report theirs — `487 Request Terminated` on a CANCEL in either

--- a/docs/handler-execution-model.md
+++ b/docs/handler-execution-model.md
@@ -41,6 +41,98 @@ The queue feeding the pool is **bounded** (`script.executor_queue_capacity`,
 default 1024): once the pool is at its thread cap *and* the queue is full, new
 jobs are shed.
 
+## Which handlers run, and which decision survives
+
+`@proxy.on_request` takes an optional method filter. A **filtered handler does
+not replace the unfiltered one — both run**, in registration order, and an
+unfiltered handler matches every method.
+
+That much is ordinary middleware. The part that surprises people is what
+happens to the *routing decision*.
+
+### One action slot, last writer wins
+
+Every handler that runs for a request shares **one request object with a single
+action slot**. `reply()`, `relay()`, `fork()` and `reject()` do not send
+anything — they **assign** that slot. The dispatcher executes its final value
+once, after every handler has returned.
+
+So handlers do not each act. They take turns overwriting one decision:
+
+```python
+@proxy.on_request("OPTIONS")
+def probe(request):
+    request.reply(200, "OK")       # ← discarded
+
+@proxy.on_request
+def route(request):
+    request.relay(NEXT_HOP)        # ← this is what happens
+```
+
+The health probe is **not answered and then relayed**. It is *only relayed* —
+the `reply(200)` is gone, silently, because a later handler assigned over it.
+Registration order decides, which is rarely what the author meant.
+
+Side effects are different: `set_header()`, `record_route()`, `log`, metrics and
+cache writes all happen, from every handler that runs. It is only the routing
+decision that is last-writer-wins.
+
+### Keeping your decision: `stop_propagation()`
+
+```python
+@proxy.on_request("OPTIONS")
+def probe(request):
+    request.reply(200, "OK")
+    request.stop_propagation()     # nothing may overwrite this
+```
+
+The dispatcher stops the chain and executes what this handler chose.
+
+It is opt-in on purpose. Answering is not on its own a request to stop — a
+metrics or logging handler running afterwards is legitimate, and stopping by
+default would silently drop it. Idempotent, and it leaves the chosen action
+alone.
+
+The alternative, if you would rather not register two handlers at all, is to
+branch inside one:
+
+```python
+@proxy.on_request
+def route(request):
+    if request.method == "OPTIONS" and not request.in_dialog:
+        request.reply(200, "OK")
+        return
+    request.relay(NEXT_HOP)
+```
+
+!!! note "Coming from Kamailio or OpenSIPS?"
+
+    There is no equivalent of this in either. Both have exactly **one**
+    automatic entry point — Kamailio's `request_route`, OpenSIPS's `route{}` —
+    and everything else (`route(NAME)`, `branch_route`, `failure_route`) is
+    invoked or armed explicitly. You branch inside the one route with
+    `if (is_method("INVITE"))`, so two blocks can never both claim a request.
+
+    siphon's model is closer to HTTP middleware: several handlers may match, and
+    `stop_propagation()` is the `next()`-style control that model needs.
+    `@proxy.on_request("INVITE")` is therefore **not** a drop-in for
+    `is_method("INVITE")` — the Kamailio form is an exclusive branch, the
+    decorator is additive.
+
+!!! warning "`@diameter.on_request` is the other way round"
+
+    The Diameter decorator takes a filter of the same shape
+    (`@diameter.on_request("ULR")`, `"ULR|AIR"`, `"S6a:ULR"`) but dispatches
+    **one** handler per request: the most specific filter that matches wins, and
+    an unfiltered `@diameter.on_request` is the lowest-specificity fallback that
+    runs only when nothing more specific matched.
+
+    The difference is deliberate rather than accidental. A Diameter request
+    needs exactly **one** answer, so one handler must own it. A SIP request can
+    legitimately interest several handlers at once — metrics, lawful intercept,
+    authentication, routing — so they compose. Worth knowing all the same if you
+    are porting a routing pattern between the two namespaces.
+
 ## The blocking contract — what script authors must know
 
 A handler may call Rust APIs that block the worker thread on I/O:

--- a/docs/migrating-from-kamailio-opensips.md
+++ b/docs/migrating-from-kamailio-opensips.md
@@ -40,8 +40,47 @@ a debugger, `pytest` — not an expression language.
 | `sl_send_reply()` / `t_reply()` | `request.reply(code, reason)` |
 | `$ru`, `$rU`, `$rd` | `request.ruri`, `request.ruri.user`, `request.ruri.host` |
 | `$fU`/`$tU`, `$ft`/`$tt` | `request.from_uri`/`to_uri`, `request.from_tag`/`to_tag` |
-| `is_method("INVITE")` | `@proxy.on_request("INVITE")` or `request.method == "INVITE"` |
+| `is_method("INVITE")` | `request.method == "INVITE"` inside one handler — **not** `@proxy.on_request("INVITE")`, see the note below |
 | `has_totag()` / loose-route dialog check | `request.in_dialog` |
+
+### One route block vs. several handlers
+
+The one structural difference worth reading before you port anything.
+
+Kamailio and OpenSIPS have exactly **one** automatic entry point — `request_route`
+and `route{}` respectively. Everything else (`route(NAME)`, `branch_route`,
+`failure_route`) is invoked or armed explicitly, so two blocks can never both
+claim a request. `is_method("INVITE")` is an **exclusive branch** inside that one
+route.
+
+SIPhon registers handlers, and **every** `@proxy.on_request` whose filter matches
+runs — an unfiltered one matches every method. So
+`@proxy.on_request("INVITE")` is *additive*, not a branch: it runs alongside your
+catch-all rather than instead of it. They also share a single action slot, so the
+last handler to call `reply()` / `relay()` / `fork()` is the one that takes
+effect; an earlier handler's decision is discarded silently.
+
+Two ways to write the Kamailio shape:
+
+```python
+# Closest to the original: one handler, branch inside it.
+@proxy.on_request
+def route(request):
+    if request.method == "INVITE":
+        ...
+        return
+    request.relay()
+```
+
+```python
+# Or keep the filtered handler and claim the outcome explicitly.
+@proxy.on_request("INVITE")
+def invites(request):
+    ...
+    request.stop_propagation()
+```
+
+See [Handler execution model](handler-execution-model.md) for the full rules.
 
 CANCEL handling, Max-Forwards enforcement, retransmission absorption and ACK-for-non-2xx
 are done by the SIPhon transaction layer automatically — you don't write routes for

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -128,6 +128,34 @@ class MockProxy:
             - ``@proxy.on_request()`` — same, explicit call
             - ``@proxy.on_request("REGISTER")`` — single method filter
             - ``@proxy.on_request("INVITE|SUBSCRIBE")`` — pipe-separated filter
+
+        **A filtered handler does not replace the unfiltered one — both run**,
+        in registration order; an unfiltered handler matches every method.
+
+        They also share **one action slot**. ``reply()`` / ``relay()`` /
+        ``fork()`` assign it rather than sending, and only its final value is
+        executed, so a later handler silently replaces an earlier one's routing
+        decision::
+
+            @proxy.on_request("OPTIONS")
+            def probe(request):
+                request.reply(200, "OK")      # discarded below
+
+            @proxy.on_request          # also runs for OPTIONS
+            def route(request):
+                request.relay(NEXT_HOP)
+
+        The probe is *not* answered and then relayed — it is only relayed. Use
+        ``request.stop_propagation()`` to keep a decision, or branch inside one
+        handler rather than registering two. Side effects (``set_header``,
+        ``record_route``, logging, metrics) do happen from every handler; it is
+        only the routing decision that is last-writer-wins.
+
+        (``@diameter.on_request`` takes a filter of the same shape but
+        dispatches only the single most specific match: a Diameter request needs
+        exactly one answer, where a SIP request can legitimately interest
+        several handlers at once.)
+
         """
         if fn_or_filter is None or callable(fn_or_filter):
             fn = fn_or_filter
@@ -5776,10 +5804,23 @@ class MockDiameter:
         ``await req.forward_to(peer, ...)``, ``req.answer(code)``, or ``None``
         (→ DIAMETER_UNABLE_TO_DELIVER, 3002).
 
-        An optional command filter scopes the handler (mirrors
-        ``@proxy.on_request("INVITE")``): bare ``@diameter.on_request`` (all),
-        ``@diameter.on_request("ULR")``, ``"ULR|AIR"``, or app-qualified
-        ``"S6a:ULR"``. The mock treats it as an identity decorator either way.
+        An optional command filter scopes the handler — bare
+        ``@diameter.on_request`` (all), ``@diameter.on_request("ULR")``,
+        ``"ULR|AIR"``, or app-qualified ``"S6a:ULR"``. The mock treats it as an
+        identity decorator either way.
+
+        The filter has the same *shape* as ``@proxy.on_request("INVITE")`` but
+        **not** the same dispatch rule: exactly one Diameter handler runs per
+        request — the most specific filter that matches — and a bare
+        ``@diameter.on_request`` is the lowest-specificity fallback, reached
+        only when nothing more specific matched. ``@proxy.on_request`` instead
+        runs *every* handler whose filter matches, unfiltered ones included.
+
+        Deliberate, not an inconsistency: a Diameter request needs exactly one
+        answer, so one handler must own it. A SIP request can legitimately
+        interest several handlers at once (metrics, lawful intercept,
+        authentication, routing), so they compose — and
+        ``request.stop_propagation()`` is how one of them claims the outcome.
 
         Example::
 

--- a/sdk/siphon_sdk/request.py
+++ b/sdk/siphon_sdk/request.py
@@ -376,6 +376,44 @@ class Request:
             reliable=reliable,
         ))
 
+    def stop_propagation(self) -> None:
+        """Stop siphon running any further handlers for this request.
+
+        Every ``@proxy.on_request`` handler whose filter matches runs, and they
+        share one request object with a **single action slot**. ``reply()`` /
+        ``relay()`` / ``fork()`` assign that slot rather than sending anything,
+        and only its final value is executed — so a later handler silently
+        replaces an earlier one's routing decision, with registration order
+        deciding::
+
+            @proxy.on_request("OPTIONS")
+            def probe(request):
+                request.reply(200, "OK")      # discarded below
+
+            @proxy.on_request
+            def route(request):
+                request.relay(NEXT_HOP)       # probe is forwarded, not answered
+
+        Calling ``request.stop_propagation()`` after the reply keeps it.
+
+        Opt-in on purpose: answering is not on its own a request to stop — a
+        metrics or logging handler running afterwards is legitimate. Idempotent,
+        and it leaves the chosen action alone.
+
+        Example::
+
+            @proxy.on_request("OPTIONS")
+            def probe(request):
+                request.reply(200, "OK")
+                request.stop_propagation()
+        """
+        self._propagation_stopped = True
+
+    @property
+    def propagation_stopped(self) -> bool:
+        """Whether a handler called :meth:`stop_propagation` on this request."""
+        return getattr(self, "_propagation_stopped", False)
+
     def relay(
         self,
         next_hop: Optional[str] = None,

--- a/sdk/tests/test_handler_selection.py
+++ b/sdk/tests/test_handler_selection.py
@@ -1,0 +1,134 @@
+"""Which `@proxy.on_request` handlers run for a given method.
+
+A filtered handler does not replace the unfiltered one — both run. That is
+easy to get wrong in a script (it silently doubles a side effect: a probe that
+is answered *and* relayed), and it is the opposite of the rule
+`@diameter.on_request` uses, so it is pinned here rather than left to the
+docstring.
+"""
+
+import pytest
+
+from siphon_sdk.mock_module import install, reset, get_registry
+
+
+@pytest.fixture(autouse=True)
+def _install():
+    install()
+    reset()
+    yield
+
+
+def _matching(method):
+    """The handlers siphon would run for `method`, in registration order."""
+    return [fn for fn, _is_async in get_registry().get("proxy.on_request", method)]
+
+
+class TestProxyOnRequestSelection:
+    def test_filtered_and_unfiltered_both_run(self):
+        from siphon import proxy
+
+        @proxy.on_request("OPTIONS")
+        def probe(request):
+            ...
+
+        @proxy.on_request
+        def route(request):
+            ...
+
+        assert _matching("OPTIONS") == [probe, route], (
+            "a filtered handler does not replace the unfiltered one"
+        )
+
+    def test_unfiltered_matches_every_method(self):
+        from siphon import proxy
+
+        @proxy.on_request
+        def route(request):
+            ...
+
+        for method in ("INVITE", "REGISTER", "OPTIONS", "MESSAGE", "NOTIFY"):
+            assert _matching(method) == [route]
+
+    def test_filtered_handler_does_not_run_for_other_methods(self):
+        from siphon import proxy
+
+        @proxy.on_request("REGISTER")
+        def register(request):
+            ...
+
+        assert _matching("REGISTER") == [register]
+        assert _matching("INVITE") == []
+
+    def test_pipe_separated_filter_matches_each_listed_method(self):
+        from siphon import proxy
+
+        @proxy.on_request("INVITE|SUBSCRIBE")
+        def some(request):
+            ...
+
+        assert _matching("INVITE") == [some]
+        assert _matching("SUBSCRIBE") == [some]
+        assert _matching("MESSAGE") == []
+
+    def test_handlers_run_in_registration_order(self):
+        from siphon import proxy
+
+        @proxy.on_request
+        def first(request):
+            ...
+
+        @proxy.on_request("INVITE")
+        def second(request):
+            ...
+
+        @proxy.on_request
+        def third(request):
+            ...
+
+        assert _matching("INVITE") == [first, second, third]
+
+    def test_branching_inside_one_handler_is_how_you_get_exclusivity(self):
+        """The documented remedy: one handler, a branch, no second registration."""
+        from siphon import proxy
+
+        @proxy.on_request
+        def route(request):
+            ...
+
+        assert _matching("OPTIONS") == [route]
+        assert _matching("INVITE") == [route]
+
+
+class TestStopPropagation:
+    """`stop_propagation()` is the other remedy: keep two handlers, but let the
+    first claim the outcome so the second cannot overwrite its action."""
+
+    def _request(self):
+        from siphon_sdk.request import Request
+        return Request(method="OPTIONS", ruri="sip:siphon.test")
+
+    def test_off_until_asked(self):
+        request = self._request()
+        assert not request.propagation_stopped
+
+    def test_replying_does_not_imply_stopping(self):
+        # Opt-in on purpose: a metrics handler after the reply is legitimate.
+        request = self._request()
+        request.reply(200, "OK")
+        assert not request.propagation_stopped
+
+    def test_stop_propagation_sets_the_flag(self):
+        request = self._request()
+        request.reply(200, "OK")
+        request.stop_propagation()
+        assert request.propagation_stopped
+
+    def test_is_idempotent_and_keeps_the_action(self):
+        request = self._request()
+        request.reply(486, "Busy Here")
+        request.stop_propagation()
+        request.stop_propagation()
+        assert request.propagation_stopped
+        assert request.actions[-1].kind == "reply"
+        assert request.actions[-1].status_code == 486

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -4419,6 +4419,16 @@ fn handle_request(
                     );
                 }
             }
+
+            // `request.stop_propagation()` — this handler owns the outcome.
+            // Every matching handler shares one action slot, and only its final
+            // value executes, so without this a later handler silently replaces
+            // an earlier one's decision (registration order decides). Checked
+            // after the handler returns so an async one has already been driven
+            // to completion above.
+            if py_request.borrow(python).is_propagation_stopped() {
+                break;
+            }
         }
 
         let mut borrowed = py_request.borrow_mut(python);

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -158,7 +158,16 @@ pub struct PyRequest {
     /// Whether Record-Route was requested.
     record_routed: bool,
     /// The action the script chose.
+    ///
+    /// One slot, shared by every handler that runs for this request, and
+    /// executed once after they all return. `reply()` / `relay()` / `fork()`
+    /// assign it rather than sending, so a later handler silently replaces an
+    /// earlier one's decision — [`Self::propagation_stopped`] is how a handler
+    /// keeps its own.
     action: RequestAction,
+    /// Set by `request.stop_propagation()`: the dispatcher runs no further
+    /// handlers for this request.
+    propagation_stopped: bool,
     /// Authenticated username (set after digest auth succeeds).
     auth_user: Option<String>,
     /// Local domains from config (for `ruri.is_local`).
@@ -224,6 +233,7 @@ impl PyRequest {
             source_port,
             record_routed: false,
             action: RequestAction::None,
+            propagation_stopped: false,
             auth_user: None,
             local_domains: None,
             self_identity: None,
@@ -279,6 +289,7 @@ impl PyRequest {
             source_port,
             record_routed: false,
             action: RequestAction::None,
+            propagation_stopped: false,
             auth_user: None,
             local_domains: Some(local_domains),
             self_identity: Some(Arc::new(identity)),
@@ -318,6 +329,12 @@ impl PyRequest {
     /// Inbound `ConnectionId.0` (Rust-side accessor).
     pub fn inbound_connection_id_u64(&self) -> Option<u64> {
         self.inbound_connection_id
+    }
+
+    /// Whether a handler asked the dispatcher to stop running the rest of the
+    /// chain for this request (`request.stop_propagation()`).
+    pub fn is_propagation_stopped(&self) -> bool {
+        self.propagation_stopped
     }
 
     /// Get the action the script chose.
@@ -920,6 +937,37 @@ impl PyRequest {
             reason: reason.to_string(),
             reliable,
         };
+    }
+
+    /// Stop the dispatcher running any further handlers for this request.
+    ///
+    /// Every ``@proxy.on_request`` handler whose filter matches runs, and they
+    /// share one request object with a **single action slot**. ``reply()`` /
+    /// ``relay()`` / ``fork()`` assign that slot rather than sending anything,
+    /// and only its final value is executed — so a later handler silently
+    /// replaces an earlier one's routing decision. Registration order decides,
+    /// which is rarely what the author meant:
+    ///
+    /// ```python,ignore
+    /// @proxy.on_request("OPTIONS")
+    /// def probe(request):
+    ///     request.reply(200, "OK")      # discarded below
+    ///
+    /// @proxy.on_request
+    /// def route(request):
+    ///     request.relay(NEXT_HOP)       # the probe is forwarded, not answered
+    /// ```
+    ///
+    /// Calling ``request.stop_propagation()`` after the reply keeps it: the
+    /// dispatcher stops the chain and executes what this handler chose.
+    ///
+    /// It is opt-in on purpose. Answering is not on its own a request to stop —
+    /// a metrics or logging handler running afterwards is legitimate, and
+    /// stopping by default would silently drop it.
+    ///
+    /// Idempotent, and it does not disturb the action already chosen.
+    fn stop_propagation(&mut self) {
+        self.propagation_stopped = true;
     }
 
     /// Relay the request to its Request-URI, or to an explicit next-hop,
@@ -1988,6 +2036,61 @@ mod tests {
                 reliable: false,
             }
         );
+    }
+
+    /// The hazard `stop_propagation` exists for.
+    ///
+    /// Every handler whose filter matches runs, and they share one request with
+    /// a single action slot. `reply()` and `relay()` both *assign* that slot —
+    /// neither sends anything — and the dispatcher executes only its final
+    /// value. So a later handler does not run "as well as" an earlier one: it
+    /// silently discards the earlier one's routing decision.
+    ///
+    /// The shape that bit the interop stack: an `@proxy.on_request("OPTIONS")`
+    /// answering a health probe, and a bare `@proxy.on_request` relaying. The
+    /// probe was never answered — it was forwarded to the next hop.
+    #[test]
+    fn a_later_action_silently_replaces_an_earlier_one() {
+        let mut request = make_request();
+
+        // Handler 1: "I have answered this."
+        request.reply(200, "OK", false);
+        assert!(matches!(*request.action(), RequestAction::Reply { code: 200, .. }));
+
+        // Handler 2, which never knew handler 1 ran.
+        request.relay(None, None, None, None, None).unwrap();
+        assert_eq!(
+            *request.action(),
+            RequestAction::Relay { next_hop: None, flow: None, send_socket: None },
+            "the reply is gone, not merged — only the last assignment executes"
+        );
+    }
+
+    /// `stop_propagation()` is how a handler keeps its decision: the dispatcher
+    /// stops running further handlers, so nothing can overwrite the slot.
+    #[test]
+    fn stop_propagation_is_off_until_a_handler_asks() {
+        let mut request = make_request();
+        assert!(!request.is_propagation_stopped());
+        request.reply(200, "OK", false);
+        assert!(
+            !request.is_propagation_stopped(),
+            "answering is not on its own a request to stop — a metrics handler \
+             after it is legitimate"
+        );
+        request.stop_propagation();
+        assert!(request.is_propagation_stopped());
+    }
+
+    /// Idempotent, and it does not disturb the action already chosen.
+    #[test]
+    fn stop_propagation_preserves_the_action_and_is_idempotent() {
+        let mut request = make_request();
+        request.reply(486, "Busy Here", false);
+        request.stop_propagation();
+        request.stop_propagation();
+        assert!(request.is_propagation_stopped());
+        assert!(matches!(*request.action(), RequestAction::Reply { code: 486, .. }));
     }
 
     #[test]


### PR DESCRIPTION
Reopened wider after checking what Kamailio and OpenSIPS actually do, and after finding that my first description of the behaviour was wrong in a way that mattered.

## Correction first

I originally wrote that an OPTIONS probe was "answered 200 **and** relayed downstream". It is not, and the truth is worse.

Every matching handler shares **one request object with a single action slot**. `reply()`, `relay()`, `fork()` and `reject()` do not send anything — they *assign* that slot (`request.rs`: `self.action = RequestAction::Reply{…}`). The dispatcher reads it once, after every handler has returned, and executes only the final value.

So handlers do not each act. They take turns overwriting one decision:

```python
@proxy.on_request("OPTIONS")
def probe(request):
    request.reply(200, "OK")       # ← discarded

@proxy.on_request
def route(request):
    request.relay(NEXT_HOP)        # ← this is what happens
```

The probe is **never answered**. It is forwarded. Registration order decides, and the loser's decision disappears without a trace — no warning, no metric.

Pinned by `a_later_action_silently_replaces_an_earlier_one`.

Side effects are different: `set_header()`, `record_route()`, logging, metrics and cache writes all happen from every handler. Only the routing decision is last-writer-wins.

## What Kamailio and OpenSIPS do

Neither can have this problem. Both have exactly **one** automatic entry point:

- **Kamailio** — "The only mandatory routing block is `request_route`". `route(NAME)`, `branch_route`, `failure_route`, `onreply_route` are all explicitly invoked or armed (`t_on_branch()`, `t_on_failure()`, `t_on_reply()`). No automatic cascading.
- **OpenSIPS** — one main `route{}` per request; "the implicit action after execution of the main route block is to drop the SIP request". `branch_route`/`failure_route` armed explicitly.

You branch inside the one route with `if (is_method("INVITE"))`, so two blocks can never both claim a request. siphon's model is HTTP-middleware-shaped instead — several handlers may match — but it had none of the control that model needs. Express gives you `next()`; siphon gave nothing.

## `request.stop_propagation()`

```python
@proxy.on_request("OPTIONS")
def probe(request):
    request.reply(200, "OK")
    request.stop_propagation()     # nothing may overwrite this
```

The dispatcher stops the chain and executes what this handler chose.

**Opt-in, deliberately.** Answering is not on its own a request to stop — a metrics or logging handler running afterwards is legitimate, and stopping by default would silently drop it. That also makes this a pure addition: no existing script changes behaviour.

I did not make the proxy most-specific-wins. That would silently stop running catch-all handlers for filtered methods — a breaking change with a silent failure mode, i.e. the same class of problem this PR is fixing.

## Why the Diameter difference is not an inconsistency

`@diameter.on_request` dispatches the single most specific match. That looked arbitrary next to the proxy's compose-everything, and the docstrings said only *what* differed.

It is defensible: **a Diameter request needs exactly one answer**, so one handler must own it. **A SIP request can legitimately interest several handlers at once** — metrics, lawful intercept, authentication, routing — so they compose, and `stop_propagation()` is how one of them claims the outcome when it wants to. Both docstrings now carry the reason rather than just the rule.

## The migration guide was actively wrong

| Kamailio / OpenSIPS | SIPhon (before) |
|---|---|
| `is_method("INVITE")` | `@proxy.on_request("INVITE")` **or** `request.method == "INVITE"` |

Presented as equivalents. They are not: `is_method()` is an exclusive branch inside the one route, the decorator is additive. An operator migrating by that table gets different behaviour, silently. The guide now shows both correct forms and explains the structural difference.

## Changes

- `request.stop_propagation()` + `is_propagation_stopped()`, and the dispatcher loop honouring it (checked after the handler returns, so async handlers are already driven to completion).
- `docs/handler-execution-model.md` — rewritten around the action slot, with the Kamailio/OpenSIPS note and the Diameter justification.
- `docs/migrating-from-kamailio-opensips.md` — corrected row plus a "one route block vs. several handlers" section.
- SDK: `stop_propagation()` mirrored on `Request`, both `on_request` docstrings corrected.
- Tests: 3 Rust (the overwrite hazard, opt-in, idempotence) + 10 SDK.

4064 Rust tests and 667 SDK tests green, clippy clean, doctests green.
