### PR TITLE
docs(matrix): say what evidence each readiness level carries, and what none of them carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
-### Fixed
-- **A retransmitted CANCEL is absorbed and answered 200, not 481.** RFC 3261
-  §9.2 makes a CANCEL a request with its own server transaction, which absorbs
-  retransmissions and answers them from its cached response. siphon intercepts
-  CANCEL *before* transaction creation, so that transaction never exists and
-  nothing absorbed the retransmission. On the proxy path the first CANCEL
-  removed the session, so the second fell through to `481 Call/Transaction Does
-  Not Exist` — for a CANCEL that had in fact been accepted, on a call already
-  487'd. Over UDP that is the ordinary case rather than an edge: Timer E
-  retransmits the CANCEL at 500 ms whenever the 200 is lost.
-
-  Worse in the narrow window before the session is removed, where a second copy
-  repeated the whole thing — re-forwarding the CANCEL downstream and putting a
-  **second 487 on one INVITE server transaction**, which §17.2.1 does not allow.
-  Acceptance is now recorded for 64×T1 (Timer J), the window that transaction
-  would have held its cached response. The B2BUA path already answered 200 to a
-  CANCEL for a call no longer Calling/Ringing and is unchanged.
-
-
 ### Security
 - **Refused bare CR/LF in a SIP header block, and closed five framer/parser
   disagreements it was hiding.** siphon's header-value scan runs to the next
@@ -135,10 +116,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   script again. Previously this degradation was invisible outside a debug log.
   The gap is now stated in the feature-readiness matrix; the `transaction::key`
   module documentation had claimed a fallback that was never implemented.
-- **Framing fuzz target (`stream_framing_fuzz`).** Fuzzes the stream framer's
-  invariants — a framed length never exceeds the buffer or the ceiling, and a
-  refused message's header block stays inside the buffer — alongside the
-  existing parser target in CI.
 - **Control plane: `ring` is its own verb, split from `progress`.** RFC 3261
   §13.2.1 makes the `180 Ringing` the "callee is being alerted" signal and
   §21.1.2 gives it no session semantics; RFC 3960 §3.1 puts early media on the
@@ -167,7 +144,78 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   parser's Content-Length check — but a non-zero counter means a peer is sending
   UDP well past the point RFC 3261 §18.1.1 requires it to switch to TCP.
 
+- **Framing fuzz target (`stream_framing_fuzz`).** Fuzzes the stream framer's
+  invariants — a framed length never exceeds the buffer or the ceiling, and a
+  refused message's header block stays inside the buffer — alongside the
+  existing parser target in CI.
+- **`bridge` — joining two legs siphon already owns.** `originate` shipped the
+  ability to place a call; nothing could connect one to another, which is what a
+  transfer, a callback-and-connect and an attended hand-off all need. The verb
+  is on the external control rail (`bridge` / `unbridge`, addressing two
+  channels the same application owns) with an in-process twin
+  (`await b2bua.bridge(call_id, with_call_id)` / `b2bua.unbridge(call_id)`).
+
+  A bridge is two RFC 3261 §14 re-INVITEs across two confirmed dialogs, because
+  siphon is a B2BUA and each leg is its own offer/answer context (RFC 3264 §8):
+  the named `with` leg is re-offered first with the anchor's current media, then
+  the anchor with the answer that came back. That order is the one where a
+  failure costs least — a peer that refuses leaves the anchor untouched and both
+  calls exactly as they were.
+
+  Media attachments come off **both** legs before anything is re-pointed, and
+  each teardown is awaited and its reply checked: an announcement still playing
+  replaces a leg's outgoing audio, and a WebSocket bridge makes the engine its
+  far side, so either one still live when the bridge forms is one-way audio. An
+  anchor already relaying between two parties is then renegotiated with
+  `reoffer` on the ports it already holds; one the engine answered itself
+  (`answer_local`, which is how every controller-owned leg starts) has no far
+  leg to answer and is instead deleted and offered onto a fresh engine call-id,
+  with the store key staying the leg's SIP Call-ID so every media verb still
+  resolves.
+
+  `unbridge` parts the pair without ending it — both legs stay answered, owned
+  and held (`a=sendonly`, RFC 3264 §8.4; RFC 6337 §3.1 prefers that to
+  `c=0.0.0.0`) — and `on_peer_hangup` (`hangup` by default, or `hold`) decides
+  what becomes of the survivor when the other party leaves.
+
+  Refusals are typed and separately actionable rather than one generic error:
+  `not_found` (no such leg), `invalid_state` (not answered, already bridged,
+  re-INVITE outstanding per RFC 3261 §14.1, no media description, or an
+  `unbridge` of a leg that never was), `bad_request` (the same leg twice, or an
+  unknown `on_peer_hangup`), `forbidden` (the other leg belongs to another
+  application) and `unsupported_verb` (the media backend refused a step). The
+  reply reports only that the media was re-pointed and the first re-INVITE is on
+  the wire; the verdict arrives as `ChannelBridged` / `BridgeFailed` on both
+  channels, and `ChannelUnbridged` when the pair is parted.
+
+  Covered by a SIPp mode (`scripts/run-tests.sh --bridge`, CI job `sipp-bridge`)
+  that joins two legs, parts them, joins them again and asserts on three
+  independent oracles — the SIP wire, the application's own verdict, and the
+  media engine's per-leg packet counters, the last of which is what says audio
+  actually flowed in both directions rather than the command having returned ok.
+
 ### Changed
+- **The feature-readiness matrix now says what evidence each level carries, and
+  what none of them carry.** `Implemented` spanned everything from "has unit
+  tests" to "has an end-to-end SIPp scenario that runs on every pull request",
+  which is too wide a range for an operator to act on. The legend now lists the
+  gates weakest to strongest and when each runs, and states plainly that **no
+  level asserts interoperability with an independent implementation** — SIPp is
+  a message generator, not a SIP element, so a feature can pass every gate and
+  still be wrong in a way only another stack would notice.
+
+  It also records which SIPp scenarios do not run per-PR. Four have no runner at
+  all (`b2bua-refer-outbound`, `b2bua-reinvite-bleg`, `b2bua-reinvite-breject`,
+  `b2bua-reinvite-reject`), so the behaviour they describe is currently asserted
+  by nothing.
+- **Corrected the PRACK and Session Timers rows in the README**, which said
+  "Parser tests" while the matrix described full B2BUA 100rel interworking — the
+  two documents disagreed. Session timers have an end-to-end SIPp scenario that
+  runs on every PR; PRACK has one that is driven by `scripts/run-tests.sh` and
+  **not** by CI, so a regression in the 100rel interworking is not caught on the
+  PR that causes it. Both rows now say which.
+
+
 - **Control plane: `StasisEnd` now carries the SIP status on every teardown that
   had one.** `code` / `response` were only populated on the two originate paths;
   four more now report theirs — `487 Request Terminated` on a CANCEL in either
@@ -187,6 +235,22 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   than breaking an exhaustive `match`.
 
 ### Fixed
+- **A retransmitted CANCEL is absorbed and answered 200, not 481.** RFC 3261
+  §9.2 makes a CANCEL a request with its own server transaction, which absorbs
+  retransmissions and answers them from its cached response. siphon intercepts
+  CANCEL *before* transaction creation, so that transaction never exists and
+  nothing absorbed the retransmission. On the proxy path the first CANCEL
+  removed the session, so the second fell through to `481 Call/Transaction Does
+  Not Exist` — for a CANCEL that had in fact been accepted, on a call already
+  487'd. Over UDP that is the ordinary case rather than an edge: Timer E
+  retransmits the CANCEL at 500 ms whenever the 200 is lost.
+
+  Worse in the narrow window before the session is removed, where a second copy
+  repeated the whole thing — re-forwarding the CANCEL downstream and putting a
+  **second 487 on one INVITE server transaction**, which §17.2.1 does not allow.
+  Acceptance is now recorded for 64×T1 (Timer J), the window that transaction
+  would have held its cached response. The B2BUA path already answered 200 to a
+  CANCEL for a call no longer Calling/Ringing and is unchanged.
 - **A bridge no longer sends the wrong media detach, leaving the WebSocket
   server owning a leg it was about to renegotiate.** `bridge` tears every
   attachment off both legs before it re-points the media, but it decided what
@@ -252,59 +316,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   now captured before the rewrite. The siphon-originated path was already safe,
   but only because its response skips sanitize entirely.
 
-### Added
-- **Framing fuzz target (`stream_framing_fuzz`).** Fuzzes the stream framer's
-  invariants — a framed length never exceeds the buffer or the ceiling, and a
-  refused message's header block stays inside the buffer — alongside the
-  existing parser target in CI.
-### Added
-- **`bridge` — joining two legs siphon already owns.** `originate` shipped the
-  ability to place a call; nothing could connect one to another, which is what a
-  transfer, a callback-and-connect and an attended hand-off all need. The verb
-  is on the external control rail (`bridge` / `unbridge`, addressing two
-  channels the same application owns) with an in-process twin
-  (`await b2bua.bridge(call_id, with_call_id)` / `b2bua.unbridge(call_id)`).
-
-  A bridge is two RFC 3261 §14 re-INVITEs across two confirmed dialogs, because
-  siphon is a B2BUA and each leg is its own offer/answer context (RFC 3264 §8):
-  the named `with` leg is re-offered first with the anchor's current media, then
-  the anchor with the answer that came back. That order is the one where a
-  failure costs least — a peer that refuses leaves the anchor untouched and both
-  calls exactly as they were.
-
-  Media attachments come off **both** legs before anything is re-pointed, and
-  each teardown is awaited and its reply checked: an announcement still playing
-  replaces a leg's outgoing audio, and a WebSocket bridge makes the engine its
-  far side, so either one still live when the bridge forms is one-way audio. An
-  anchor already relaying between two parties is then renegotiated with
-  `reoffer` on the ports it already holds; one the engine answered itself
-  (`answer_local`, which is how every controller-owned leg starts) has no far
-  leg to answer and is instead deleted and offered onto a fresh engine call-id,
-  with the store key staying the leg's SIP Call-ID so every media verb still
-  resolves.
-
-  `unbridge` parts the pair without ending it — both legs stay answered, owned
-  and held (`a=sendonly`, RFC 3264 §8.4; RFC 6337 §3.1 prefers that to
-  `c=0.0.0.0`) — and `on_peer_hangup` (`hangup` by default, or `hold`) decides
-  what becomes of the survivor when the other party leaves.
-
-  Refusals are typed and separately actionable rather than one generic error:
-  `not_found` (no such leg), `invalid_state` (not answered, already bridged,
-  re-INVITE outstanding per RFC 3261 §14.1, no media description, or an
-  `unbridge` of a leg that never was), `bad_request` (the same leg twice, or an
-  unknown `on_peer_hangup`), `forbidden` (the other leg belongs to another
-  application) and `unsupported_verb` (the media backend refused a step). The
-  reply reports only that the media was re-pointed and the first re-INVITE is on
-  the wire; the verdict arrives as `ChannelBridged` / `BridgeFailed` on both
-  channels, and `ChannelUnbridged` when the pair is parted.
-
-  Covered by a SIPp mode (`scripts/run-tests.sh --bridge`, CI job `sipp-bridge`)
-  that joins two legs, parts them, joins them again and asserts on three
-  independent oracles — the SIP wire, the application's own verdict, and the
-  media engine's per-leg packet counters, the last of which is what says audio
-  actually flowed in both directions rather than the command having returned ok.
-
-### Fixed
 - **The B-leg INVITE no longer carries the session-timer headers twice.** The
   B-leg INVITE is cloned from the caller's, so whatever it asked for is already
   on it — a Teams INVITE arrives with `Session-Expires: 3600`, `Min-SE: 300` and
@@ -352,6 +363,7 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   it alone, as the CAP_NET_ADMIN tests already are. Alone it is exact: ambient
   0 B, 241664 B leaked, 0 B retained, every run. The guard is unchanged in what
   it proves.
+
 ## [1.7.1] — 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ This isn't a replacement for Kamailio or OpenSIPS. It's what happens when someon
 | **Outbound / Flow Tokens** | RFC 5626 | Unit tests |
 | **DNS SRV/NAPTR** | RFC 3263 | Unit + integration tests |
 | **ENUM** | RFC 6116 | Unit tests |
-| **PRACK (Reliable Provisionals)** | RFC 3262 | Parser tests |
-| **Session Timers** | RFC 4028 | Parser tests |
+| **PRACK (Reliable Provisionals)** | RFC 3262 | Unit tests + SIPp scenario (not in CI — see matrix) |
+| **Session Timers** | RFC 4028 | Unit + integration tests + SIPp scenario |
 | **RTPEngine Media Anchoring** | — (RTPEngine NG protocol) | Unit + integration tests |
 | **SDP Codec Filtering** | RFC 4566 | Unit + integration tests |
 | **Gateway / Load Balancing** | — | Unit + integration tests |

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -4,11 +4,43 @@
 
 This document tracks the maturity of every SIPhon feature across three readiness levels. SIPhon runs in production today in a residential SIP registrar/proxy role and a 3GPP IMS deployment exercising Diameter Cx/Sh/Rx, iFC, IPsec, and 5G SBI policy control. Features validated on live traffic are marked Production.
 
-| Readiness | Meaning |
-|-----------|---------|
-| **Production** | Running on live traffic today |
-| **Implemented** | Code-complete, unit/integration tested, not yet production-deployed |
-| **Planned** | Partially wired or design-only |
+| Readiness | Meaning | Evidence behind it |
+|-----------|---------|--------------------|
+| **Production** | Running on live traffic today | Everything below, plus a deployment carrying real calls |
+| **Implemented** | Code-complete and tested, not yet production-deployed | At least unit/integration tests; often a SIPp scenario too — but see below, the level does not say which |
+| **Planned** | Partially wired or design-only | None yet |
+| **Not implemented** | Named here because its absence is worth knowing | n/a |
+
+### What these levels do not tell you
+
+**"Implemented" spans a wide range of evidence.** A row backed by unit tests
+only and a row backed by a SIPp scenario that runs on every pull request both
+read `Implemented`. When a row's evidence matters to you, the Notes column
+names it — most rows say which tests exist — but the level alone will not.
+
+The gates, weakest to strongest:
+
+| Gate | What it proves | When it runs |
+|------|----------------|--------------|
+| Unit / integration tests | The code does what its author intended | Every PR |
+| RFC 4475 corpus + parser proptests | Adversarial messages parse or are refused per the RFC | Every PR |
+| Fuzz targets | The parser and stream framer survive hostile input, and agree with each other | Every PR (60 s each) |
+| SIPp scenarios | The feature works end to end against a message generator | **Most on every PR; some only via `scripts/run-tests.sh`** |
+| Throughput + memory-leak baseline | 16 rows of proxy/B2BUA × UDP/TCP hold with zero failures and flat allocation | Release cut |
+| Live traffic | It survives real endpoints | Production rows only |
+
+**No level asserts interoperability with an independent implementation.** SIPp
+is a message generator, not a SIP element: it builds no route set, matches no
+CANCEL to a transaction, and has no opinion about a Record-Route it did not
+write. A feature can pass every gate above and still be wrong in a way only
+another stack would notice. Closing that is what `interop/` is for; until it
+covers a feature, read `Implemented` as "correct by siphon's own account".
+
+**Some SIPp scenarios do not run per-PR.** They exist and pass when invoked, but
+a regression in them is caught at a release cut or by hand, not on the PR that
+causes it. Four have no runner at all — `b2bua-refer-outbound`,
+`b2bua-reinvite-bleg`, `b2bua-reinvite-breject`, `b2bua-reinvite-reject` — so
+the behaviour they describe is currently asserted by nothing.
 
 ---
 
@@ -29,8 +61,8 @@ This document tracks the maturity of every SIPhon feature across three readiness
 | Call transfer (REFER, RFC 3515) | Implemented | B2BUA `@b2bua.on_refer` | |
 | Cancel teardown hook | Implemented | `@proxy.on_cancel` / `@b2bua.on_cancel` | Fires once when a relayed (proxy) or B2BUA INVITE is CANCELled before a final response (RFC 3261 §9) — the only script teardown signal for a cancelled-before-answer call, which neither `on_reply`/`on_failure` (proxy: the 487 is generated at the transaction layer, never reaching a reply handler) nor `on_bye` (b2bua: no dialog was ever established) deliver. Receives the original INVITE (proxy `fn(request)`) / the Call (b2bua `fn(call)`); fire-and-forget, does not gate the 487. Exists to release per-call resources no BYE will ever clear (Diameter Rx/N5 QoS sessions, rtpengine media anchors). The B2BUA hook fires only in Calling/Ringing, so a 2xx that wins the cancel/answer glare (independently ACK+BYE'd by `handle_zombie_cancelled_2xx`) never triggers it — no answered call is torn down. Engine-registration unit tests (`script::engine::tests::{proxy,b2bua}_on_cancel_decorator_registers_handler`) + SDK dispatch tests (`sdk/tests/test_on_cancel.py`). |
 | Reply-time proxy reject | Implemented | `reply.reject(code, reason)` (in `@proxy.on_reply`) | Fail an in-progress proxied INVITE from the reply context — the proxy-side equivalent of B2BUA `call.reject()`, needed because IMS P-CSCF media authorization (N5 `sbi.create_session` / Rx `diameter.rx_aar`) runs at answer time, when the negotiated SDP is available, and a failure must reject the leg (e.g. `503`) rather than proceed medialess. On a **provisional (1xx)** — typically a reliable `183` in the VoLTE preconditions / early-media flow where the SDP answer rides the provisional — records the reject and returns `True`; the dispatcher then sends `code reason` upstream to the UAC via the server transaction (retransmission + UAC-ACK absorption) and CANCELs every pending downstream branch (reusing `cancel_fork_branches`, RFC 3261 §9). The straggler `487` the CANCEL draws back is absorbed via a new `ProxySession.final_response_sent` guard (the single-target relay path has no fork-aggregator `final_forwarded` to dedup it), so no second final reaches the UAC. On a **final (≥200)** — UAS already answered — it is a no-op returning `False` (a proxy cannot retract a 2xx); the script branches on the bool (log + `reply.relay()`, best-effort). Takes precedence over `relay()`. Unit-tested (`script::api::reply::tests` decision logic + `proxy::session::tests` flag) + SDK-mirrored/tested (`reply.reject`, `sdk/tests/test_reply_reject.py`). End-to-end SIPp-validated (`sipp/reject_{uac,uas}.xml` + `reject_proxy.py`): caller gets `100`→`503 Media Authorization Failed` (To-tag added, 183 suppressed), UAS gets the CANCEL on the INVITE's Via branch (RFC 3261 §9.1) and its `487` is ACKed and absorbed — both endpoints 1 Successful / 0 Failed / 0 Retrans / 0 Unexpected, siphon 0 WARN/ERROR. SIPp validation also surfaced + fixed a pre-existing loop: a non-compliant ACK (fresh branch instead of the INVITE's, §17.1.1.3) carrying the 503's To-tag + an R-URI pointing at the proxy was matched by `by_dialog_key` and relayed to the proxy's own address in `handle_ack_via_session`, stacking a Via per hop until the datagram exceeded the 8192-byte UDP buffer (truncated → parse-error drop). Two guards: (1) reject now drops the dead `by_dialog_key` entry (`ProxySessionStore::remove_dialog_key` — a rejected INVITE forms no dialog), and (2) `handle_ack_via_session` reuses the existing `is_own_address` loop check to silently drop an ACK whose resolved next-hop is one of our own listeners (RFC 3261 §16.3). |
-| Session timers (RFC 4028) | Implemented | `session_timer:` | UAC/UAS/B2BUA refresher modes |
-| PRACK (RFC 3262) | Implemented | Core | Reliable provisional responses; B2BUA terminates 100rel per-leg — auto-PRACKs a reliable-provisional B-leg and strips `Require:100rel`/`RSeq` toward a non-100rel A-leg (framework-auto, preset-independent) |
+| Session timers (RFC 4028) | Implemented | `session_timer:` | UAC/UAS/B2BUA refresher modes. End-to-end SIPp scenario (`b2bua-session-timer`) runs on every PR. |
+| PRACK (RFC 3262) | Implemented | Core | Reliable provisional responses; B2BUA terminates 100rel per-leg — auto-PRACKs a reliable-provisional B-leg and strips `Require:100rel`/`RSeq` toward a non-100rel A-leg (framework-auto, preset-independent). **Evidence caveat:** the end-to-end SIPp scenario (`b2bua-reliable-prov`, run against a dedicated `sip-trunk-edge@2026` instance) is driven by `scripts/run-tests.sh`, **not** by CI — so a regression in the 100rel interworking is not caught on the PR that causes it. |
 | E.164 number normalization (identity headers) | Implemented | `numbering:` / `number_policies:` / `request.rewrite_identities()` / `call.dial(number_policy=…)` | One call reformats every dialable identity userpart (`From`, `To`, `P-Asserted-Identity`, `P-Preferred-Identity`, Request-URI, opt-in `Referred-By`/`Remote-Party-ID`) into `e164`/`plain`/`international`/`national` under a home numbering plan + named versioned presets. Display names, tags, hosts, non-numbers and `preserve_users` service/emergency codes untouched; a national form of a foreign number falls back to the international access form. `numbers.parse(raw, home=)` exposes `.e164`/`.plain`/`.international`/`.national`/`.cc`/`.nsn`/`.format()`. B2BUA `number_policy=` (or `b2bua.default_number_policy`) normalizes the A-leg identities that flow to the B-leg plus the dial/fork target. Opt-in `diversion:` extends to `Diversion` (RFC 5806) / `History-Info` (RFC 7044) with structured per-entry rewrites preserving `index`/`reason`/embedded escaped `cause`/ordering and privacy-restricted entries (`respect_privacy`). Rust unit + KAV-vector + script-engine end-to-end tests; SDK-mirrored + tested (`sdk/tests/test_numbers.py`). |
 
 ## Transports


### PR DESCRIPTION
The last item from the hardening review. The original finding was small — the README said PRACK was "Parser tests" while the matrix described full B2BUA 100rel interworking — but the reason the two could disagree for that long is the interesting part.

## The problem with `Implemented`

285 rows, 85 `Production`, 151 `Implemented`, 2 `Planned`. That middle bucket spans everything from "has unit tests" to "has an end-to-end SIPp scenario that runs on every pull request". An operator reading `Implemented` learns almost nothing, and a stale row can sit there indefinitely because nothing about the level contradicts it.

I did not re-grade 285 rows. Doing that honestly means examining the evidence behind each one, and guessing would make the matrix worse, not better. Instead the legend now says what the levels **do** assert and — more usefully — what they don't.

## What changed

**The gates, weakest to strongest, and when each runs:** unit/integration tests, the RFC 4475 corpus and parser proptests, the fuzz targets, SIPp scenarios, the throughput and memory-leak baseline, live traffic. Each row's Notes column mostly already names its evidence; the legend now tells you to read it, because the level won't.

**No level asserts third-party interoperability.** Stated explicitly. SIPp is a message generator, not a SIP element — it builds no route set, matches no CANCEL to a transaction, and has no opinion about a Record-Route it did not write. A feature can pass every gate above and still be wrong in a way only another stack would notice. Until `interop/` covers a feature, `Implemented` means "correct by siphon's own account".

**Which SIPp scenarios don't run per-PR.** Some exist and pass when invoked but are driven by `scripts/run-tests.sh` rather than CI, so a regression is caught at a release cut or by hand. Four have **no runner at all**:

- `b2bua-refer-outbound`
- `b2bua-reinvite-bleg`
- `b2bua-reinvite-breject`
- `b2bua-reinvite-reject`

The behaviour those describe is currently asserted by nothing. (Measured, not guessed: 54 profiles defined in `sipp/docker-compose.yaml`, cross-referenced against `ci.yaml` and every `scripts/*.sh`.)

## The two rows that started it

- **Session Timers** — README said "Parser tests". It has an end-to-end SIPp scenario (`b2bua-session-timer`) that runs on every PR. README corrected; matrix row now names the scenario.
- **PRACK** — README said "Parser tests"; the matrix described the full 100rel interworking with no caveat. Both were misleading. The scenario (`b2bua-reliable-prov`, against a dedicated `sip-trunk-edge@2026` instance) exists and is real, but is driven by `run-tests.sh` and **not** by CI — so a regression in the interworking is not caught on the PR that causes it. Both rows now say so.

I could not verify the PRACK scenario green locally: another session's containers are attached to `sipp_sipnet`, so a clean isolated run would have disturbed their work. The claim above is from static cross-referencing only, which is why I did not wire it into CI in this PR — wiring a job I haven't seen pass would break the pipeline for everyone. Worth doing as a follow-up once the machine is free; if it turns out to be red, that is a finding in its own right.

## Scope

Docs only — `docs/feature-readiness-matrix.md`, `README.md`, `CHANGELOG.md`. No code, no tests.
