### PR TITLE
fix(deps): bump yanked chacha20 in the control-sdk lockfile

### DIFF
--- a/siphon-control-sdk/Cargo.lock
+++ b/siphon-control-sdk/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
`chacha20` 0.10.1 was yanked, so `cargo-deny advisories (control-sdk)` fails on main — the v1.8.0 release run is red on it.

Lockfile-only bump to 0.10.2 (semver-compatible, no manifest change). `cargo deny check advisories` passes and the control-sdk workspace builds.

Tiny dep bump rather than feature work, so admin-merging per the usual convention for advisory/yank bumps.