### PR TITLE
chore: ignore the cargo fmt reformat in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,15 @@
+# Commits that changed formatting only, and would otherwise bury the real
+# author of every line they touched.
+#
+# Enable locally, once per clone:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# GitHub honours this file automatically in its blame view.
+
+# style: cargo fmt --all, and gate on it in CI like siphon-rtp (#249)
+# 208 files reformatted on rustfmt defaults. The same commit carries the CI
+# gate and two small code changes the reformat forced, so blame on those few
+# lines still lands here — git can only skip a revision for lines it modified,
+# not for lines it introduced.
+1dba47657ba2f239fc5207a07aecab9abdd4a4dd


### PR DESCRIPTION
Follow-up to #249, which could not carry this itself — squash-merge rewrites the SHA, so an entry added in that PR would have pointed at a commit that never existed on `main`.

Points at `1dba476`, the commit as it actually landed. Verified: `git blame` on a reformatted line now names the real author again instead of the reformat.

Enable locally with `git config blame.ignoreRevsFile .git-blame-ignore-revs` (in the file's own header). GitHub picks it up automatically in its blame view.

One caveat noted in the file: `1dba476` also carries the CI gate and the two small code changes the reformat forced, so blame on those few lines still lands there — git can only skip a revision for lines it *modified*, not for lines it introduced.