### PR TITLE
fix(transport): make listen.udp_recv_buffer_bytes a floor, not a fixed size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,21 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   process's steady state rather than a transient) and the RFC 5626 flow-teardown
   partition, which sized for "nothing removed" and kept the freed slots.
 
+- **`listen.udp_recv_buffer_bytes` is a floor now, so it stops shrinking the
+  receive queue on a tuned host.** siphon called `setsockopt(SO_RCVBUF)`
+  unconditionally, which made the 1 MiB default a *reduction* on any host whose
+  `net.core.rmem_default` was above 512 KiB. The two sides are not measured the
+  same way — an untouched socket carries `rmem_default` verbatim, while an
+  explicit request is doubled by the kernel — so 1 MiB against a 4 MiB default
+  landed at 2 MiB, halving the headroom the setting exists to provide. It did it
+  silently, too: nothing was clamped, so the read-back warning had nothing to
+  say, and `ss -uanm` was the only place the loss was visible.
+
+  The configured size is now the minimum: siphon reads what the socket already
+  carries and leaves a larger buffer alone. Deliberately conservative about the
+  doubling, so it can decline to raise a buffer already within 2x of the floor,
+  but it can never lower one. `0` still means "don't touch the socket at all".
+
 ## [1.8.0] — 2026-09-02
 
 _Codename: kees._

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -36,6 +36,9 @@ listen:
   # SO_REUSEPORT gives one socket per worker, so the real cost is this value
   # times the worker count, and socket buffers are charged to the process's
   # cgroup — raise it deliberately on a memory-capped deployment.
+  # This is a FLOOR, not a target: a host whose net.core.rmem_default is already
+  # larger keeps its bigger buffer, so the setting can only ever raise the queue
+  # on an untuned host, never shrink it on a tuned one.
   # net.core.rmem_max caps what the kernel will actually grant; siphon reads the
   # value back and warns when it was clamped.  Set 0 to leave the kernel default.
   udp_recv_buffer_bytes: 1048576

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,12 +372,16 @@ pub fn parse_dscp(value: &str) -> std::result::Result<u8, String> {
 }
 
 /// Convert a 6-bit DSCP value to the 8-bit TOS byte (RFC 2474 §3).
-/// Default UDP receive-buffer size: 1 MiB per listener socket.
+/// Default UDP receive-buffer floor: 1 MiB per listener socket.
 ///
 /// Roughly 5x the usual kernel default, which is enough to ride out a
 /// scheduler stall at the throughput siphon targets, while staying small
 /// enough that `worker_count` sockets do not meaningfully dent a
 /// memory-capped container's cgroup budget.
+///
+/// It is a floor rather than a fixed size precisely because it is a default:
+/// a host tuned above it has an operator's decision behind that number, and a
+/// shipped constant must not quietly override one.
 fn default_udp_recv_buffer_bytes() -> usize {
     1024 * 1024
 }
@@ -492,8 +496,15 @@ pub struct ListenConfig {
     /// the inbound side is unaffected.
     #[serde(default)]
     pub mtu: Option<u16>,
-    /// Receive-buffer size in bytes (`SO_RCVBUF`) for every UDP listener
-    /// socket. Default 1 MiB.
+    /// Minimum receive-buffer size in bytes (`SO_RCVBUF`) for every UDP
+    /// listener socket. Default 1 MiB.
+    ///
+    /// A **floor, not a target**: a host whose `net.core.rmem_default` already
+    /// exceeds this keeps its larger buffer. Applying it unconditionally would
+    /// shrink the queue on a tuned host, and silently, because an untouched
+    /// socket reports `rmem_default` raw while an explicit request comes back
+    /// doubled — so 1 MiB against a 4 MiB default lands at 2 MiB with nothing
+    /// clamped and no warning to show for it.
     ///
     /// The kernel default (`net.core.rmem_default`, typically ~212 KB) is a
     /// few hundred milliseconds of headroom at IMS registration rates, so a

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -192,10 +192,20 @@ fn create_reusable_udp_socket(
     UdpSocket::from_std(socket.into())
 }
 
-/// Request `SO_RCVBUF` and report what the kernel actually granted.
+/// Raise `SO_RCVBUF` to at least `requested` and report what the kernel granted.
 ///
-/// Best-effort: a listener that cannot get the buffer it asked for is still a
-/// working listener, so a failure here warns rather than aborting the bind.
+/// The configured size is a **floor, not a target**: a host already tuned above
+/// it keeps its larger buffer. Without that check the knob silently *shrinks*
+/// the queue on a tuned host, because the two sides of the comparison are not
+/// measured the same way — an untouched socket carries `net.core.rmem_default`
+/// verbatim, while an explicit `setsockopt` is doubled by the kernel. Asking
+/// for 1 MiB on a host defaulting to 4 MiB therefore lands at 2 MiB, and since
+/// nothing was clamped the read-back warning below stays quiet, so the operator
+/// has no way to notice the loss.
+///
+/// Best-effort throughout: a listener that cannot get the buffer it asked for
+/// is still a working listener, so a failure here warns rather than aborting
+/// the bind.
 ///
 /// Linux returns roughly double the requested size from `getsockopt` (the extra
 /// is bookkeeping overhead), so "at least what we asked for" is the honest
@@ -205,6 +215,27 @@ fn create_reusable_udp_socket(
 fn apply_recv_buffer(socket: &socket2::Socket, local_addr: SocketAddr, requested: usize) {
     if requested == 0 {
         return;
+    }
+    // Compare against the raw size the socket already carries. Deliberately
+    // conservative about the kernel's doubling: this can decline to raise a
+    // buffer that is already within 2x of the floor, but it can never lower
+    // one, which is the failure worth avoiding.
+    match socket.recv_buffer_size() {
+        Ok(existing) if existing >= requested => {
+            debug!(
+                "[udp {}] leaving SO_RCVBUF at the kernel's {} bytes — already at or above the \
+                 configured {} byte floor",
+                local_addr, existing, requested
+            );
+            return;
+        }
+        Ok(_) => {}
+        // Unreadable: fall through and ask anyway, which is what siphon did
+        // before the floor existed.
+        Err(error) => debug!(
+            "[udp {}] could not read the current SO_RCVBUF ({}) — requesting {} bytes anyway",
+            local_addr, error, requested
+        ),
     }
     if let Err(error) = socket.set_recv_buffer_size(requested) {
         warn!(
@@ -230,9 +261,11 @@ fn apply_recv_buffer(socket: &socket2::Socket, local_addr: SocketAddr, requested
 #[cfg(test)]
 mod tests {
     use super::*;
-    /// A listener asks the kernel for the configured `SO_RCVBUF` and gets at
-    /// least that much. Linux reports back roughly double the request, so the
-    /// assertion is "no less than asked", which is exactly the condition
+    /// A listener ends up with at least the configured floor, whether that
+    /// took a `setsockopt` or the host already gave it that much.
+    ///
+    /// Linux reports back roughly double an explicit request, so "no less than
+    /// asked" is the honest assertion, and it is exactly the condition
     /// `apply_recv_buffer` warns about when `net.core.rmem_max` clamps it.
     ///
     /// Uses a modest size so the test passes under a conservative `rmem_max`.
@@ -255,9 +288,39 @@ mod tests {
     }
 
     /// `0` is the documented "leave the kernel default alone" escape hatch, so
-    /// it must not fail the bind and must not raise the buffer.
+    /// it must not fail the bind and must leave the socket exactly where one
+    /// siphon never touched sits.
     #[tokio::test]
     async fn zero_recv_buffer_leaves_the_kernel_default() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr parses");
+
+        let untouched = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )
+        .expect("bare socket");
+        let untouched_size = untouched.recv_buffer_size().expect("SO_RCVBUF reads back");
+
+        let defaulted = create_reusable_udp_socket(addr, None, 0).expect("binds with 0");
+        let default_size = socket2::SockRef::from(&defaulted)
+            .recv_buffer_size()
+            .expect("SO_RCVBUF reads back");
+
+        assert_eq!(
+            default_size, untouched_size,
+            "0 must leave SO_RCVBUF at the kernel default"
+        );
+    }
+
+    /// A floor above what the host gives by default is a real lift.
+    ///
+    /// Derived from the observed default rather than hardcoded: `SO_RCVBUF` is
+    /// clamped to `net.core.rmem_max` and then doubled, so on a host whose
+    /// `net.core.rmem_default` is already large a fixed constant asserts
+    /// nothing.
+    #[tokio::test]
+    async fn a_floor_above_the_kernel_default_raises_the_buffer() {
         let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr parses");
 
         let defaulted = create_reusable_udp_socket(addr, None, 0).expect("binds with 0");
@@ -265,7 +328,7 @@ mod tests {
             .recv_buffer_size()
             .expect("SO_RCVBUF reads back");
 
-        let raised = create_reusable_udp_socket(addr, None, 4 * 1024 * 1024)
+        let raised = create_reusable_udp_socket(addr, None, default_size * 2)
             .expect("binds with an explicit size");
         let raised_size = socket2::SockRef::from(&raised)
             .recv_buffer_size()
@@ -273,8 +336,42 @@ mod tests {
 
         assert!(
             raised_size > default_size,
-            "an explicit request ({raised_size} B) should exceed the untouched default \
-             ({default_size} B)"
+            "a {} B floor on a host defaulting to {default_size} B should raise the buffer, \
+             got {raised_size} B",
+            default_size * 2
+        );
+    }
+
+    /// Regression: the configured size is a floor, not a target — a host tuned
+    /// above it keeps its larger buffer.
+    ///
+    /// siphon used to call `setsockopt` unconditionally. Because an untouched
+    /// socket reports `net.core.rmem_default` raw while an explicit request
+    /// comes back doubled, the 1 MiB default *halved* the receive queue on any
+    /// host tuned above 512 KiB, and did it silently: nothing was clamped, so
+    /// the read-back warning stayed quiet.
+    #[tokio::test]
+    async fn a_floor_below_the_kernel_default_does_not_shrink_the_buffer() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr parses");
+
+        let defaulted = create_reusable_udp_socket(addr, None, 0).expect("binds with 0");
+        let default_size = socket2::SockRef::from(&defaulted)
+            .recv_buffer_size()
+            .expect("SO_RCVBUF reads back");
+
+        let floor = default_size / 4;
+        let floored =
+            create_reusable_udp_socket(addr, None, floor).expect("binds with a low floor");
+        let floored_size = socket2::SockRef::from(&floored)
+            .recv_buffer_size()
+            .expect("SO_RCVBUF reads back");
+
+        assert_eq!(
+            floored_size,
+            default_size,
+            "a {floor} B floor on a host already giving {default_size} B must leave the socket \
+             alone; requesting it would have landed at about {} B",
+            floor * 2
         );
     }
 


### PR DESCRIPTION
## The bug

`listen.udp_recv_buffer_bytes` was applied unconditionally:

```rust
if requested == 0 { return; }
socket.set_recv_buffer_size(requested)   // no look at what the socket already had
```

The two sides of that comparison are not measured the same way. An untouched
socket carries `net.core.rmem_default` **verbatim**; an explicit `setsockopt` is
**doubled** by the kernel. So on a host with `rmem_default = 4 MiB`:

| | `sk_rcvbuf` |
|---|---|
| before the knob existed | 4 MiB |
| with the 1 MiB default | 2 MiB |

The default that was added to *raise* the receive queue on an untuned host
**halves** it on any host tuned above 512 KiB. The knob does the opposite of its
purpose on exactly the deployments that already cared enough to tune.

And it does it silently. Nothing was clamped, so the read-back warning correctly
stays quiet — `ss -uanm` is the only place the loss is visible. This shipped in
1.7.1 and is in 1.8.0.

## The fix

The configured size is a **floor**, not a target: read what the socket already
carries and leave a larger buffer alone.

Deliberately conservative about the kernel's doubling — the comparison is
against the raw value, so it can decline to raise a buffer that is already
within 2x of the floor, but it can never lower one. That is the right side to
err on: failing to raise costs headroom an operator can measure and configure,
while lowering silently discards a decision they already made.

`0` still means "don't touch the socket at all", and the clamp warning is
unchanged.

## Tests

- `a_floor_below_the_kernel_default_does_not_shrink_the_buffer` — the
  regression. It **reproduces** rather than merely asserting the fix: with the
  guard removed it fails with the halving in the message, so it cannot pass
  vacuously if the semantics regress again.

  ```
  assertion `left == right` failed: a 53248 B floor on a host already giving
  212992 B must leave the socket alone; requesting it would have landed at
  about 106496 B
    left: 106496
   right: 212992
  ```

- `a_floor_above_the_kernel_default_raises_the_buffer` — replaces the old
  `zero_recv_buffer_leaves_the_kernel_default` half that requested a hardcoded
  4 MiB. That constant asserted nothing on a host whose default is already at or
  above it, which is precisely the host this bug bites; the request is now
  derived from the observed default.

- `zero_recv_buffer_leaves_the_kernel_default` — now compares against a socket
  siphon never touched, rather than inferring "left alone" from a second
  socket it did touch.

Config docs and `siphon.yaml` updated to state the floor semantics.

- `cargo test` — 4,494 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
