### PR TITLE
fix(registrar): stop reserving four contact slots for every one-binding AoR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,28 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   `recv` and aborted the run as unexpected. Test-side only — siphon sends
   exactly one BYE and retransmits it correctly per RFC 3261 §17.1.
 
+- **The registrar reserved four contact slots for every AoR that only ever
+  holds one.** `Vec::push` on an empty vec allocates `MIN_NON_ZERO_CAP` slots
+  rather than one, which is 4 for any element of 1 KiB or less. `Contact` is
+  ~480 bytes, so an ordinary single-binding registration asked for 1,920 bytes
+  — rounded up to a 2 KiB allocator size class — to hold 480 bytes of contact,
+  and three quarters of the registrar's largest per-AoR allocation was capacity
+  that the overwhelming majority of AoRs never use. At a million bindings that
+  is over a gigabyte.
+
+  Bindings are now appended through a helper that reserves exactly, so a
+  one-contact AoR occupies one slot. `reserve_exact` is a no-op when there is
+  already room, so a multi-device AoR grows one slot at a time instead of
+  doubling — a fine trade here, since a REGISTER that adds a device is rare
+  next to one that refreshes an existing binding, and a refresh replaces in
+  place without reallocating at all.
+
+  Two paths that build a binding list wholesale were right-sized the same way:
+  restoring from a Redis/Postgres snapshot at boot (previously grown from empty,
+  one push at a time, which on a restart carrying a large binding set is the
+  process's steady state rather than a transient) and the RFC 5626 flow-teardown
+  partition, which sized for "nothing removed" and kept the freed slots.
+
 ## [1.8.0] — 2026-09-02
 
 _Codename: kees._

--- a/src/registrar/backend.rs
+++ b/src/registrar/backend.rs
@@ -1410,12 +1410,18 @@ pub async fn restore_from_backend<B: RegistrarBackend>(
 
     for aor in &aors {
         let stored = backend.load(aor).await?;
-        let mut contacts_for_aor = Vec::new();
+        // Sized from the snapshot, then trimmed to what survived: an expired
+        // `StoredContact` decodes to `None` and is dropped. Growing from empty
+        // instead would round the common single-binding AoR up to four slots
+        // (see `push_binding`), which on a restart carrying a large binding
+        // set is the process's steady state, not a transient.
+        let mut contacts_for_aor = Vec::with_capacity(stored.len());
         for sc in &stored {
             if let Some(contact) = sc.to_contact() {
                 contacts_for_aor.push(contact);
             }
         }
+        contacts_for_aor.shrink_to_fit();
         if !contacts_for_aor.is_empty() {
             // Sort by q-value descending (same as Registrar::save)
             contacts_for_aor
@@ -1960,6 +1966,51 @@ mod tests {
         assert!(registrar.is_registered("sip:alice@example.com"));
         assert!(registrar.is_registered("sip:bob@example.com"));
         assert_eq!(registrar.lookup("sip:bob@example.com").len(), 2);
+    }
+
+    /// A restart carrying a large binding set must not re-create the
+    /// over-allocation `push_binding` exists to avoid: a restored one-binding
+    /// AoR gets one slot, and an AoR whose snapshot held an expired contact is
+    /// trimmed to what actually survived rather than keeping the dead slot
+    /// reserved for the life of the process.
+    #[tokio::test]
+    async fn restored_bindings_are_not_over_allocated() {
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let backend = MemoryBackend::new();
+        backend
+            .save("sip:alice@example.com", &[sample_stored_contact()])
+            .await
+            .unwrap();
+
+        // Two stored, one already expired: the survivor must not keep the
+        // slot the dead one was sized for.
+        let mut expired = sample_stored_contact();
+        expired.uri = "sip:bob@10.0.0.9".to_string();
+        expired.expires_at = Some(now_epoch.saturating_sub(60));
+        let mut live = sample_stored_contact();
+        live.uri = "sip:bob@10.0.0.2".to_string();
+        backend
+            .save("sip:bob@example.com", &[expired, live])
+            .await
+            .unwrap();
+
+        let registrar = Registrar::default();
+        restore_from_backend(&backend, &registrar).await.unwrap();
+
+        for aor in ["sip:alice@example.com", "sip:bob@example.com"] {
+            let entry = registrar.bindings.get(aor).expect("binding restored");
+            assert_eq!(entry.value().len(), 1, "{aor} restored one live contact");
+            assert_eq!(
+                entry.value().capacity(),
+                1,
+                "{aor} reserved {} slots for one contact",
+                entry.value().capacity()
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -186,6 +186,27 @@ pub struct Contact {
     pub kind: ContactKind,
 }
 
+/// Append a binding without letting `Vec` round the capacity up to four.
+///
+/// `Vec::push` on an empty vec allocates `MIN_NON_ZERO_CAP` slots, which is 4
+/// for any element of 1 KiB or less. `Contact` is ~480 bytes, so the ordinary
+/// one-binding AoR — which is nearly every AoR — reserved ~1.9 KB (rounded up
+/// to a 2 KiB allocator size class) to hold 480 bytes of contact. Three
+/// quarters of the registrar's largest allocation was capacity that the vast
+/// majority of AoRs never use, and at a million bindings that is well over a
+/// gigabyte.
+///
+/// `reserve_exact` is a no-op whenever there is already room, so the cost is
+/// paid only when the vec is actually full: a multi-device AoR grows one slot
+/// at a time instead of doubling. That trade is fine here — a REGISTER that
+/// adds a device is rare next to one that refreshes an existing binding (which
+/// replaces in place and never reallocates at all), and `max_contacts` bounds
+/// the copying.
+fn push_binding(contacts: &mut Vec<Contact>, contact: Contact) {
+    contacts.reserve_exact(1);
+    contacts.push(contact);
+}
+
 /// Order routable bindings the way a terminating request should try them:
 /// highest q first (RFC 3261 §20.10 — the caller's declared preference), and
 /// within one q value the most recently registered binding first.
@@ -833,7 +854,7 @@ impl Registrar {
                     max: self.config.max_contacts,
                 });
             }
-            contacts.push(contact);
+            push_binding(contacts, contact);
         }
 
         // Sort by q-value descending
@@ -1380,7 +1401,7 @@ impl Registrar {
         } else {
             // No max_contacts cap for AS records — iFC chains can ramp
             // up legitimate AS counts.  Operator can enforce upstream.
-            contacts.push(contact);
+            push_binding(contacts, contact);
         }
 
         let stored: Vec<_> = contacts
@@ -1714,6 +1735,10 @@ impl Registrar {
                     }
                 }
                 changed = kept.len() < before;
+                // Sized for the worst case (nothing removed); hand back only
+                // what survived, so a teardown that drops bindings does not
+                // leave the freed slots reserved for the lifetime of the AoR.
+                kept.shrink_to_fit();
                 *entry.value_mut() = kept;
                 // Cascade-clear orphaned AS records once no UE binding survives.
                 let any_ue_left = entry
@@ -1892,7 +1917,7 @@ impl Registrar {
         {
             *existing = contact;
         } else {
-            contacts.push(contact);
+            push_binding(contacts, contact);
         }
     }
 
@@ -2615,6 +2640,100 @@ mod tests {
         // The new connection's failure does.
         assert_eq!(registrar.unregister_flow(8), 1);
         assert!(!registrar.is_registered("sip:a@example.com"));
+    }
+
+    /// A one-binding AoR — nearly every AoR — must not reserve room for four.
+    ///
+    /// `Vec::push` on an empty vec jumps straight to capacity 4 for any element
+    /// of 1 KiB or less, and `Contact` is ~480 bytes, so the ordinary
+    /// registration used to reserve ~1.9 KB (a 2 KiB allocator size class) to
+    /// hold one contact. Asserting the exact capacity rather than an upper
+    /// bound is deliberate: the whole point is that nothing is reserved
+    /// speculatively.
+    #[test]
+    fn a_single_binding_reserves_exactly_one_slot() {
+        let registrar = Registrar::default();
+        registrar
+            .save(
+                "sip:alice@example.com",
+                contact_uri("alice", "10.0.0.1"),
+                3600,
+                1.0,
+                "call-1".into(),
+                1,
+            )
+            .unwrap();
+
+        let entry = registrar
+            .bindings
+            .get("sip:alice@example.com")
+            .expect("binding saved");
+        assert_eq!(entry.value().len(), 1);
+        assert_eq!(
+            entry.value().capacity(),
+            1,
+            "a single binding reserved {} slots of {} bytes each",
+            entry.value().capacity(),
+            std::mem::size_of::<Contact>()
+        );
+    }
+
+    /// Right-sizing must not cost a multi-device AoR any bindings: exact growth
+    /// is still growth.
+    #[test]
+    fn additional_bindings_still_grow_the_vec() {
+        let registrar = Registrar::default();
+        for (index, host) in ["10.0.0.1", "10.0.0.2", "10.0.0.3"].iter().enumerate() {
+            registrar
+                .save(
+                    "sip:alice@example.com",
+                    contact_uri("alice", host),
+                    3600,
+                    1.0,
+                    format!("call-{index}"),
+                    index as u32 + 1,
+                )
+                .unwrap();
+        }
+
+        let contacts = registrar.lookup("sip:alice@example.com");
+        assert_eq!(contacts.len(), 3, "all three devices stay registered");
+
+        let entry = registrar
+            .bindings
+            .get("sip:alice@example.com")
+            .expect("binding saved");
+        assert_eq!(
+            entry.value().capacity(),
+            3,
+            "three bindings should occupy three slots, not a doubled four"
+        );
+    }
+
+    /// A refresh replaces in place, so it must not reallocate — the capacity
+    /// after re-REGISTERing the same contact is still one.
+    #[test]
+    fn a_refresh_does_not_grow_the_binding_vec() {
+        let registrar = Registrar::default();
+        for cseq in 1..=5 {
+            registrar
+                .save(
+                    "sip:alice@example.com",
+                    contact_uri("alice", "10.0.0.1"),
+                    3600,
+                    1.0,
+                    "call-1".into(),
+                    cseq,
+                )
+                .unwrap();
+        }
+
+        let entry = registrar
+            .bindings
+            .get("sip:alice@example.com")
+            .expect("binding saved");
+        assert_eq!(entry.value().len(), 1, "a refresh replaces, never appends");
+        assert_eq!(entry.value().capacity(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## The waste

`Vec::push` on an empty vec does not allocate one slot — it allocates
`MIN_NON_ZERO_CAP`, which is **4** for any element of 1 KiB or less:

```
size_of::<Contact>()   = 480
Vec cap after one push = 4  ->  1920 bytes reserved to hold 480
```

`bindings` is `DashMap<Aor, Vec<Contact>>` and every insert path was
`.or_default()` … `.push(contact)`, so the ordinary single-binding AoR — which
is nearly every AoR — reserved 1,920 bytes (rounded to a 2 KiB allocator size
class) for one 480-byte contact. Three quarters of the registrar's largest
per-AoR allocation was capacity that the overwhelming majority of AoRs never
use.

## Measured

200,000 single-binding AoRs, RSS delta, same binary either side of the one-line
helper:

| | bytes / AoR | 200k AoRs |
|---|---|---|
| before | 2,192 | 428 MB |
| after | **751** | **147 MB** |

**−66%**, or ~1.44 KB per binding. At a million bindings that is about 1.4 GB.

The measurement is on the system allocator — `#[global_allocator]` is set in
`main.rs` only, so a test binary does not run on jemalloc. glibc rounds
1920 → 1936 and 480 → 496, a 1,440 B difference, which is what the numbers
show. Under jemalloc the size classes are 2048 and 512, so the real saving in
the shipped binary is if anything slightly larger.

## The change

A `push_binding` helper that `reserve_exact`s before pushing. It is a no-op
whenever there is already room, so the cost falls only where the vec is
genuinely full: a multi-device AoR grows one slot at a time instead of
doubling. That trade is right here — a REGISTER that *adds* a device is rare
next to one that refreshes an existing binding, and a refresh replaces in place
and never reallocates at all (there is a test for that).

Two paths that build a binding list wholesale get the same treatment:

- **Redis/Postgres boot restore** — grown from empty, one push at a time. On a
  restart carrying a large binding set that is the process's steady state, not
  a transient. Now sized from the snapshot and trimmed to what survived (an
  expired `StoredContact` decodes to `None` and is dropped).
- **RFC 5626 flow teardown** — the kept/removed partition sized for "nothing
  removed" and then kept the freed slots for the life of the AoR.

## Tests

Exact capacity assertions, not upper bounds — the whole point is that nothing
is reserved speculatively. All four fail on the old code rather than passing
vacuously:

```
assertion `left == right` failed: a single binding reserved 4 slots of 480 bytes each
  left: 4
 right: 1
```

- `a_single_binding_reserves_exactly_one_slot`
- `additional_bindings_still_grow_the_vec` — three devices, three slots, no
  doubling, and none of them lost
- `a_refresh_does_not_grow_the_binding_vec` — five re-REGISTERs, still one slot
- `restored_bindings_are_not_over_allocated` — covers both the plain restore
  and the snapshot-held-an-expired-contact case

## Scope

This is the allocation-site fix only. `Contact` itself is still 480 bytes and
carries a few fields worth revisiting separately — `instance_epoch` is a
per-process constant UUID stored as an owned `String` on every contact, and
`source_transport` is an `Option<String>` where an enum would do. Those are a
wider refactor and a smaller number; keeping them out of this one.

- `cargo test` — 4,496 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
