### PR TITLE
test(sipp): fix the referrer-bye flake — carol hanging up inside siphon's re-bridge exchange

### DIFF
--- a/sipp/b2bua_refer_referrer_bye_carol_uas.xml
+++ b/sipp/b2bua_refer_referrer_bye_carol_uas.xml
@@ -74,7 +74,24 @@ a=sendrecv
        §13.2.2.4). Without the fix this never arrives. -->
   <recv request="ACK" timeout="5000" />
 
-  <!-- Carol hangs up; siphon tears down the surviving far leg (bob). -->
+  <!-- Carol hangs up; siphon tears down the surviving far leg (bob).
+
+       The pause is load-bearing, not padding. Hanging up in the same
+       microsecond as the ACK puts carol's BYE inside siphon's re-bridge
+       re-INVITE exchange with bob, so siphon emits an ACK (for bob's 200) and a
+       BYE to bob from two independent inbound events. On UDP those are two
+       separately enqueued datagrams with no ordering guarantee — siphon's UDP
+       workers share the outbound receiver MPMC-style and race to send_to (see
+       `OutboundMessage::followups`). Either order is correct and a stray ACK is
+       a no-op for a real UA (RFC 3261 §17.1.1.3 gives an ACK no response,
+       ever), but SIPp fails the reordered case as a dead call — this was the
+       job's intermittent failure, reproducing about one run in six.
+
+       A real call has talk time. Giving carol some removes the manufactured
+       race without weakening anything: bob must still receive the BYE and
+       answer it, and carol must still get its 200. -->
+  <pause milliseconds="500" />
+
   <send retrans="500">
     <![CDATA[
 BYE [$remote_contact] SIP/2.0


### PR DESCRIPTION
Chased the `sipp-b2bua-refer` flake that has main red. Reproduced it locally at **1 failure in 6 runs**, root-caused it, and it is now **0 in 12**.

## What was actually happening

`bob-uas` exits 255 after reporting `1 successful, 0 failed` — the scenario completes, then dies. SIPp's error line names the cause:

```
Dead call b2b-8338e3a4… (successful), received 'ACK sip:bob@172.20.0.52:5060'
```

siphon's own log, all inside one millisecond:

```
.199107  sent siphon-originated re-INVITE → bob      (re-bridging the survivor)
.199117  transfer completed — target active, referrer released
.199264  processing request BYE ← carol              (the target hangs up)
.199315  received B-leg response 200                 (bob answers the re-INVITE)
.199384  sent ACK to responder for re-INVITE 2xx  → bob
.199399  sending BYE to B-leg                     → bob
```

Two messages to bob, **15 µs apart, from two independent inbound events**: bob's own 200 produces the ACK, carol's BYE produces the BYE. They are separately enqueued datagrams, and siphon's UDP workers share the outbound receiver MPMC-style and race to `send_to` — the ordering caveat is documented on `OutboundMessage::followups` in `src/transport/mod.rs`.

When the BYE wins the race, bob completes its scenario and the trailing ACK lands on a dead call.

## Why this is not a siphon defect

Both orders are correct on the wire, and a stray ACK is a no-op for a real UA — RFC 3261 §17.1.1.3 gives an ACK no response, ever. Whichever arrives first, bob tears the dialog down correctly and the call ends cleanly. SIPp is simply stricter than a UA here.

`followups` cannot fix it either: it orders frames enqueued *together*, and these come from two separate dispatcher invocations.

## The fix

Carol was sending BYE in the same microsecond as the ACK that completes her transfer, which is what puts her BYE inside siphon's re-bridge exchange with bob. A real call has talk time; she now gets 500 ms of it.

That removes the manufactured race without weakening anything: **bob must still receive the BYE and answer it, and carol must still get her 200.** The assertion is untouched — only the timing that made two legal orderings collide.

Measured: **1/6 failing before, 0/12 after.**

## What I did not fix

The same job failed once in CI on a different container — `bleg-ack-peer`, the callee-ACK repro. I ran it 8 times locally (480 calls) and could not reproduce it. That is a separate, rarer intermittent and I am not claiming it fixed. If it recurs it wants its own chase; the 60-call repro is timing-sensitive and a loaded GitHub runner is a plausible trigger.

## Approach note

My first attempt was a trailing `<recv request="ACK" optional="true" timeout="2000"/>` on bob to absorb the reordered ACK. That made it **worse** — 9/10 failing — because `optional="true"` in SIPp means "skip if a *different* message arrives", not "skip if nothing arrives", so it became a mandatory 2 s wait that timed out whenever the ACK had already been consumed in order. Reverted, and worth knowing before anyone reaches for the same idiom.
