### PR TITLE
perf(transaction): box the transaction so the table stops retaining its peak footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Performance
+- **The transaction table no longer holds its peak-concurrency footprint for
+  the life of the process.** `TransactionManager` stored the `Transaction`
+  enum inline in its `DashMap`. A `Nist` carries two whole `SipMessage`s
+  (`original_request` for the synthesised 100, `last_response` for
+  retransmission), which makes `Transaction` 536 bytes and the hash bucket 608.
+  `hashbrown` sizes its bucket array for the peak number of live entries and
+  never shrinks it, so a box that once ran at N concurrent transactions kept
+  `N/0.875` rounded up to a power of two, times 608 bytes, forever — while
+  `siphon_transactions_active` read 0 the whole time.
+
+  Concurrency is `rate x Timer J` (32 s), so the retention is set by the
+  busiest 32 seconds the process ever saw and grows linearly with offered load.
+  Transactions are now boxed: the bucket is 80 bytes, and the 536-byte payload
+  comes off the memcpy path that every insert and every table growth paid.
+
+- **siphon's own binary now uses siphon's own allocator tuning.** `src/main.rs`
+  installed jemalloc with a bare `#[global_allocator]` and never set
+  `malloc_conf`, so it ran jemalloc's stock `background_thread:false` +
+  `dirty_decay_ms:10000` — freed pages are returned only opportunistically,
+  while an arena is being allocated *into*, which is the opposite of what a
+  process does just after a burst. It now goes through `install_allocator!()`,
+  the same macro siphon already ships for downstream binaries. Scope: the
+  published container image builds `siphon-bin`, which already called the
+  macro, so this closes the gap for a source-built root `siphon-sip` binary
+  (`cargo install siphon-sip`), not for the official image.
+
+  Measured together, 100,000 registrations driven at 4,800 cps and then
+  fully de-registered:
+
+  | | peak RSS | drained RSS | drained live bytes |
+  |---|---|---|---|
+  | before | 563 MB | 292 MB | 158 MB |
+  | after | 452 MB | 158 MB | 83 MB |
+
+  Boxing accounts for the live-bytes drop (158 → 81 MB on its own), the decay
+  tuning for the resident drop (267 → 158 MB on its own). Against the
+  rate-independent floor of 51 MB, the concurrency-driven retention falls from
+  107 MB to 30 MB.
+
 ### Fixed
 - **Registrar lookups now canonicalise the AoR they are given.** `bindings` and
   `aliases` are both keyed on the normalised form, but `Registrar`'s own lookup

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,16 @@ use siphon::SiphonServer;
 // Use jemalloc as the global allocator — eliminates glibc malloc arena
 // contention that dominates the flame graph above ~10k cps on multi-core
 // machines. See `Cargo.toml` for the rationale.
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+//
+// Via the macro rather than a bare `#[global_allocator]`, so siphon's own
+// binary gets the same page-decay tuning siphon ships for everyone else's.
+// A bare attribute leaves `malloc_conf` unset, which means jemalloc's stock
+// `background_thread:false` and `dirty_decay_ms:10000`: freed pages are only
+// returned opportunistically, while an arena is being allocated *into*. A
+// process that has just finished a burst is doing the opposite of that, so
+// exactly when there is most to give back, nothing is running to give it —
+// which is how RSS stays at its high-water mark long after the work is done.
+siphon::install_allocator!();
 
 #[derive(Parser)]
 #[command(

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -47,9 +47,24 @@ pub struct ServerTransactionOutcome {
 }
 
 /// The transaction manager — holds all active transactions.
+///
+/// The map stores each transaction **boxed**. `Transaction` is 536 bytes —
+/// a `Nist` carries two whole `SipMessage`s inline (`original_request` for the
+/// synthesised 100, `last_response` for retransmission) — and storing that
+/// inline made the hash table's bucket 608 bytes. A `hashbrown` table sizes its
+/// bucket array for the peak number of live entries and **never shrinks it**,
+/// so a box that once ran at N concurrent transactions holds
+/// `N/0.875` rounded to a power of two, times 608 bytes, for the rest of the
+/// process's life — with `transactions_active` reading 0 the whole time.
+///
+/// Concurrency is `rate x Timer J` (32 s), so the retention is set by the
+/// busiest 32 seconds the process ever saw: at 5k cps that is ~160 MB, and it
+/// grows linearly with offered load. Boxing takes the bucket to 80 bytes and
+/// the retention with it, and moves the 536-byte payload off the memcpy path
+/// that every insert and every table growth pays.
 #[derive(Debug)]
 pub struct TransactionManager {
-    transactions: DashMap<TransactionKey, Transaction>,
+    transactions: DashMap<TransactionKey, Box<Transaction>>,
     timers: TimerConfig,
 }
 
@@ -159,7 +174,7 @@ impl TransactionManager {
         // duplicate of a request already in flight and must be absorbed.
         match self.transactions.entry(key.clone()) {
             Entry::Vacant(slot) => {
-                slot.insert(transaction);
+                slot.insert(Box::new(transaction));
                 Ok(ServerTransactionOutcome {
                     key,
                     actions,
@@ -195,7 +210,7 @@ impl TransactionManager {
             None => return Ok(None),
         };
 
-        let actions = match &mut *entry {
+        let actions = match &mut **entry {
             Transaction::Ist(ist) => ist.process(IstEvent::AckReceived(request.clone())),
             _ => {
                 // Not an IST — nothing to absorb
@@ -233,7 +248,7 @@ impl TransactionManager {
             None => return Ok(None),
         };
 
-        let actions = match &mut *entry {
+        let actions = match &mut **entry {
             Transaction::Ist(ist) => ist.process(IstEvent::InviteRetransmit(request.clone())),
             Transaction::Nist(nist) => nist.process(NistEvent::RequestRetransmit(request.clone())),
             _ => {
@@ -285,7 +300,7 @@ impl TransactionManager {
         // timers and leaving the request unanswered. Surface it instead.
         match self.transactions.entry(key.clone()) {
             Entry::Vacant(slot) => {
-                slot.insert(transaction);
+                slot.insert(Box::new(transaction));
                 Ok((key, actions))
             }
             Entry::Occupied(_) => Err(format!(
@@ -307,7 +322,7 @@ impl TransactionManager {
             .get_mut(key)
             .ok_or_else(|| format!("no transaction for key {key}"))?;
 
-        let actions = match (&mut *entry, event) {
+        let actions = match (&mut **entry, event) {
             (Transaction::Ist(ist), ServerEvent::Ist(event)) => ist.process(event),
             (Transaction::Nist(nist), ServerEvent::Nist(event)) => nist.process(event),
             _ => return Err("event type mismatch for transaction".to_string()),
@@ -335,7 +350,7 @@ impl TransactionManager {
             .get_mut(key)
             .ok_or_else(|| format!("no transaction for key {key}"))?;
 
-        let actions = match (&mut *entry, event) {
+        let actions = match (&mut **entry, event) {
             (Transaction::Ict(ict), ClientEvent::Ict(event)) => ict.process(event),
             (Transaction::Nict(nict), ClientEvent::Nict(event)) => nict.process(event),
             _ => return Err("event type mismatch for transaction".to_string()),
@@ -355,7 +370,7 @@ impl TransactionManager {
     pub fn remove(&self, key: &TransactionKey) -> Option<Transaction> {
         self.transactions
             .remove(key)
-            .map(|(_, transaction)| transaction)
+            .map(|(_, transaction)| *transaction)
     }
 }
 
@@ -437,6 +452,33 @@ mod tests {
         let key = TransactionManager::key_from_message(&options_request()).unwrap();
         assert_eq!(key.branch, "z9hG4bK-opts");
         assert_eq!(key.method, Method::Options);
+    }
+
+    /// The map stores a *pointer* to the transaction, not the transaction.
+    ///
+    /// `hashbrown` sizes its bucket array for the peak number of live entries
+    /// and never shrinks it, so whatever the value type costs per bucket is
+    /// retained for the life of the process at the high-water concurrency.
+    /// Concurrency here is `rate x Timer J` (32 s), which means inlining a
+    /// 536-byte `Transaction` cost ~160 MB at 5k cps and grew linearly with
+    /// offered load — all of it while `count()` reported 0.
+    #[test]
+    fn the_transaction_map_stores_a_pointer_not_the_transaction() {
+        let bucket = std::mem::size_of::<(TransactionKey, Box<Transaction>)>();
+        let key_only = std::mem::size_of::<TransactionKey>();
+        assert!(
+            bucket <= key_only + 16,
+            "map bucket is {bucket} B against a {key_only} B key — the transaction \
+             is being stored inline again, and the table will retain it at peak \
+             concurrency forever"
+        );
+        // Guard the premise as well: boxing only pays while the payload is big.
+        let payload = std::mem::size_of::<Transaction>();
+        assert!(
+            payload >= 256,
+            "Transaction is down to {payload} B — re-check whether boxing still earns \
+             its indirection"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Branched off `main`, independent of the registrar stack (#253→#256).

## What retains the memory

`TransactionManager` is a `DashMap<TransactionKey, Transaction>` storing the
enum **inline**. Measured:

```
SipMessage      = 216
Transaction     = 536      (Nist: original_request + last_response, both inline)
bucket          = 608      (TransactionKey 72 + Transaction 536)
```

`hashbrown` sizes its bucket array for the peak number of live entries and
**never shrinks it**. Concurrency here is `rate × Timer J` (32 s), so the
retention is set by the busiest 32 seconds the process ever saw, grows linearly
with offered load, and is held for the life of the process — the whole time with
`siphon_transactions_active` reading **0**.

That is why it reads as a leak from outside and why no "does the store drain to
zero?" check finds it: the store *does* drain. The array it drained out of does
not.

## Measured

400k unique REGISTERs, then de-register all, on a 24-core box. Three
register→drain cycles on unmodified `main`:

| | cycle 1 | cycle 2 | cycle 3 |
|---|---|---|---|
| live bytes after full drain | 439 MB | 506 MB | 510 MB |

Converging, so it is bounded high-water capacity rather than an unbounded leak —
but ~510 MB held permanently with nothing registered, against 8 MB at boot.

**Isolating the cause.** Same 100k population, only the *rate* changed, so only
peak concurrency differs:

| rate | drained live bytes |
|---|---|
| 4,800 cps | 158 MB |
| 400 cps | **51 MB** |

107 MB of the residue tracks concurrency, not registration count. That is the
bucket array.

**After.** Same 100k @ 4,800 cps experiment:

| arm | peak RSS | drained RSS | drained live bytes |
|---|---|---|---|
| main | 563 MB | 292 MB | 158 MB |
| boxed only | 535 MB | 267 MB | **81 MB** |
| boxed + decay tuning | **452 MB** | **158 MB** | 83 MB |

The two changes do different jobs. Boxing moves live bytes (158 → 81 MB);
the allocator config moves resident (267 → 158 MB). Against the 51 MB
rate-independent floor, concurrency-driven retention falls **107 MB → 30 MB
(−72%)**.

## The second change, honestly scoped

`src/main.rs` installed jemalloc with a bare `#[global_allocator]` and never set
`malloc_conf`, so it ran stock `background_thread:false` +
`dirty_decay_ms:10000`: freed pages come back only opportunistically, while an
arena is being allocated *into* — the opposite of what a process is doing right
after a burst. It now goes through `install_allocator!()`, which siphon already
ships for downstream binaries.

**This does not change the published image.** That builds `siphon-bin`
(Dockerfile:3), which already calls the macro. It closes the gap for a
source-built root binary (`cargo install siphon-sip`), and stops the two
binaries silently differing.

## Why boxing rather than a periodic `shrink_to_fit`

A shrink needs a policy (when? how empty?) and rehashes a live table on the hot
path. Boxing removes the reason to shrink: the retained array is 80 B/entry
instead of 608, so even a bad high-water mark costs little. It should also be
faster on insert and on table growth — a pointer move instead of a 536-byte
memcpy.

## Tests

`the_transaction_map_stores_a_pointer_not_the_transaction` pins the bucket
against the key size and guards the premise (`Transaction` still large enough
for the indirection to pay). Existing coverage already asserts `count()` returns
to 0 per transaction, which is what made this invisible — so the new test targets
the footprint, not the drain.

- `cargo test` — 4,496 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

## Not done here

- The 51 MB rate-independent floor and the ~30 MB that remains: `timer_wheel`
  (`DashMap<String, TimerEntry>`, one entry per transaction timer) has the same
  inline-value shape and is the obvious next one.
- This touches the per-message transaction path, so it wants the 16-row SIPp
  baseline on the reference box before merge. I have not run it.
