### PR TITLE
perf(script): re-derive the always-on Python worker floor (8 to 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,26 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   200,000 single-binding AoRs with an instance identity configured: **777 → 641
   bytes per AoR, a 17.5% reduction**, on top of the single-slot change above.
 
+### Changed
+- **The always-on Python worker floor is re-derived against the corrected
+  per-worker heap.** `MIN_CORE_THREADS` is a floor on the worker *count*, and
+  8 was chosen when a warm worker was believed to cost ~2 MB — effectively a bet
+  that the pool's always-on heap would sit near 16 MB. `PER_WORKER_HEAP_MB` was
+  later measured at ~8 MB and the constant raised to 10, but the count was never
+  revisited, so the same floor came to mean a much larger always-on commitment
+  on every instance, 2 cores or 32. It is now 4: still double the 2-thread
+  baseline the floor exists to avoid, and on any box with 2 or more cores
+  `2 x cpus` already meets it, so the floor stops binding exactly where it was
+  costing the most for the least reason.
+
+  Measured on a 2-CPU box, `pool_size` 8 → 4 and thread count 17 → 13. The RSS
+  effect is smaller than the arithmetic suggests: ~2 MB at boot and ~7 MB after
+  40,000 handled requests, because a worker's mimalloc heap grows with the work
+  it does rather than being committed up front — with half the workers, each
+  one does twice the work. `PER_WORKER_HEAP_MB` describes a long-running IMS
+  deployment's steady state, not a fixed per-worker cost, so it should not be
+  read as "workers x 10 MB" on a lightly-loaded instance.
+
 ### Fixed
 - **A siphon-originated REFER no longer overtakes the answer it depends on.**
   A `call.refer()` issued from `@b2bua.on_answer` was emitted at the point the

--- a/src/script/py_executor.rs
+++ b/src/script/py_executor.rs
@@ -120,7 +120,23 @@ const MIN_MAX_THREADS: usize = 32;
 /// Always-on core-worker floor. A small container (`cpus: 0.5`) reports
 /// `available_parallelism() == 1`, which `2×` alone would make a 2-thread
 /// baseline — too small for the hot inbound path.
-const MIN_CORE_THREADS: usize = 8;
+///
+/// Re-derived from the corrected per-worker heap. This is a floor on the worker
+/// *count*, and it was chosen as 8 when a warm worker was believed to cost
+/// ~2 MB — i.e. it was really a bet that the pool's always-on heap would sit
+/// around 16 MB. [`PER_WORKER_HEAP_MB`] was later measured at ~8 MB and the
+/// constant raised to 10, but this count was never revisited, so the same floor
+/// silently came to mean ~80 MB of always-on heap — on every instance, whether
+/// it has 2 cores or 32.
+///
+/// The memory budget cannot rescue it either: on a container started without a
+/// cgroup limit (the default `docker run` shape) the budget falls back to host
+/// RAM, and 30 % of a normal host never binds. So the count is the whole story,
+/// and 4 is the re-derivation: half the always-on cost, still double the
+/// 2-thread baseline the floor exists to avoid, and on any box with 2 or more
+/// cores `2 x cpus` already meets it, so the floor stops binding exactly where
+/// it was costing the most for the least reason.
+const MIN_CORE_THREADS: usize = 4;
 
 /// cgroup v1 reports "no limit" as a page-aligned value near `i64::MAX`
 /// (`PAGE_COUNTER_MAX × PAGE_SIZE`, ≈ 9.22e18). A real memory limit — even a
@@ -184,7 +200,7 @@ pub fn resolve_sizing(
         ((budget / per_worker_bytes as f64) as usize).max(1)
     });
 
-    // Core: 2× CPUs floored at 8, but never above what the memory budget affords.
+    // Core: 2× CPUs floored at MIN_CORE_THREADS, never above what the budget affords.
     let cpu_core = cpus.saturating_mul(2).max(MIN_CORE_THREADS);
     let core_threads = sync_pool_size
         .unwrap_or(match mem_cap {
@@ -1147,10 +1163,40 @@ mod tests {
     fn resolve_sizing_512mb_caps_max_to_memory_budget() {
         let sizing = resolve_sizing(2, Some(512 * MB), None, None);
         // mem budget = 512×0.30 / 10 MB ≈ 15.
-        assert_eq!(sizing.core_threads, 8); // min(max(8, 2×2)=8, 15)
+        // min(max(MIN_CORE_THREADS=4, 2×2)=4, 15). Was 8 while the floor was 8;
+        // the floor is now 4, so a 2-core NF starts at its CPU-derived 4 rather
+        // than being pushed up to 8 always-on workers by the floor alone.
+        assert_eq!(sizing.core_threads, 4);
         assert_eq!(sizing.max_threads, 15);
         assert_eq!(sizing.bound, SizingBound::Memory);
         assert!((12..=16).contains(&sizing.max_threads));
+    }
+
+    /// The always-on floor is a memory commitment, not just a thread count.
+    ///
+    /// A 1-core container gets exactly the floor, and `floor x
+    /// PER_WORKER_HEAP_MB` is heap resident from boot on every instance whether
+    /// it ever serves a request. Pinned because this number drifted once
+    /// already: the count was chosen against a ~2 MB per-worker belief and
+    /// survived the correction to ~10 MB unchanged, quadrupling the commitment
+    /// with nothing failing.
+    #[test]
+    fn the_always_on_floor_stays_within_its_memory_budget() {
+        let sizing = resolve_sizing(1, None, None, None);
+        assert_eq!(sizing.core_threads, MIN_CORE_THREADS);
+
+        let always_on_mb = sizing.core_threads as u64 * PER_WORKER_HEAP_MB;
+        assert!(
+            always_on_mb <= 40,
+            "a 1-core instance commits {always_on_mb} MB of always-on Python heap at \
+             boot — re-derive MIN_CORE_THREADS against PER_WORKER_HEAP_MB rather than \
+             raising this bound"
+        );
+        // ...while staying above the 2-thread baseline the floor exists to avoid.
+        assert!(
+            sizing.core_threads > 2,
+            "the floor must still lift a 1-core box off the 2-thread baseline"
+        );
     }
 
     /// A 256 MB NF budgets even fewer workers (~7).


### PR DESCRIPTION
## The defect

`MIN_CORE_THREADS` is a floor on the worker **count**. 8 was chosen when a warm
worker was believed to cost ~2 MB — so it was really a bet that the pool's
always-on heap would sit near 16 MB.

`PER_WORKER_HEAP_MB` was later measured at ~8 MB and the constant raised to 10.
The count was never revisited. So the same floor came to mean a much larger
always-on commitment, on every instance, 2 cores or 32.

The memory budget cannot rescue it. A container started without a cgroup limit
— the default `docker run` shape — falls back to host RAM in
`read_memory_limit_bytes()`, and `core_threads = cpu_core.min(cap)` does apply
the budget to the floor. But 30 % of a normal host's RAM never binds, so the
count is the whole story.

## The change

`MIN_CORE_THREADS` 8 → 4. Still double the 2-thread baseline the floor exists to
avoid, and on any box with 2 or more cores `2 x cpus` already meets it — so the
floor stops binding exactly where it was costing the most for the least reason.

## Measured, including where the arithmetic misleads

2-CPU box (`taskset -c 0,1`), same config both arms:

| | `pool_size` | threads | RSS cold | RSS after 40k requests |
|---|---|---|---|---|
| before | 8 | 17 | 46 MB | 102 MB |
| after | 4 | 13 | 44 MB | 95 MB |

**~2 MB at boot, ~7 MB warm — not the ~40 MB that "4 fewer workers x 10 MB"
would predict.** A worker's mimalloc heap grows with the work it does rather
than being committed up front, so with half the workers each one does twice the
work and the heaps grow correspondingly. `PER_WORKER_HEAP_MB` describes a
long-running IMS deployment's steady state; it is not a fixed per-worker cost
and should not be read as `workers x 10 MB` on a lightly-loaded instance.

I'm reporting that plainly because the same reasoning ("N workers x 8 MB") is
what makes an idle instance's Python footprint look like a pool-sizing problem
when most of it is interpreter and stdlib, which no pool setting touches.

The change still stands on its own: the count was derived from a per-worker
figure that turned out 4-5x wrong, and 4 fewer always-on threads is also 4 fewer
runnable threads on a 2-core box.

## Tests

- `resolve_sizing_512mb_caps_max_to_memory_budget` pinned `core=8` for a 2-core
  NF. Updated **deliberately** to 4, with the derivation in the comment — the
  assertion encoded the old default, and the new value is the point of the
  change.
- `the_always_on_floor_stays_within_its_memory_budget` is new: it pins the
  floor's *memory commitment*, not just its count, so the two cannot drift apart
  again the way they did here. It fails if someone raises the count without
  re-deriving against `PER_WORKER_HEAP_MB`.

- `cargo test --all-features` — 4,510 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

## Judgement needed

This is a throughput-relevant default for small containers, and the 16-row SIPp
baseline runs on a big box where the floor never binds — so nothing in CI
exercises the case this changes. Worth your call on whether 4 is the right
number before merge.
