### PR TITLE
fix(b2bua): a media failure at answer must fail the call, not connect and bill it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1757,6 +1757,40 @@ jobs:
             siphon-rtpproxy-real.log
             rtpproxy-real.log
 
+  # ── A media failure at answer must fail the call, not connect and bill it ──
+  # @b2bua.on_answer is where the media backend is driven, so an answer the
+  # engine refuses surfaces there — and it surfaces BEFORE the A-leg 2xx is
+  # sent. Swallowing it answered the caller anyway and started the charging
+  # clock on a call with no media path in either direction, which then billed
+  # until the far end gave up. Deterministic and needs no capability: the B-leg
+  # answers for real, the handler fails, and both peers assert what they get —
+  # the caller demands a 500 (never a 2xx) and the answered callee demands the
+  # ACK *and* the BYE, so a run that leaves the callee's dialog established
+  # times out rather than passing quietly. Runs the binary natively rather than
+  # through compose because the scenario needs no second downstream.
+  sipp-b2bua-answer-fail:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Python 3.14 (free-threaded)
+        uses: deadsnakes/action@v3.2.0
+        with:
+          python-version: "3.14-dev"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install SIPp
+        run: sudo apt-get update && sudo apt-get install -y sip-tester
+
+      - name: Build siphon
+        run: PYO3_PYTHON=python3.14 cargo build --bin siphon
+
+      - name: A raised handler and call.terminate() must both fail the call
+        run: MODE=both PYO3_PYTHON=python3.14 scripts/b2bua_answer_fail_test.sh
+
   # ── Fuzz testing (nightly) ─────────────────────────────────────────────
   fuzz:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,40 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   107 MB to 30 MB.
 
 ### Fixed
+- **A media failure at answer no longer connects the call and starts charging.**
+  An exception out of `@b2bua.on_answer` was logged and then ignored: the A-leg
+  2xx went out a millisecond later, the ACK followed, and the charging clock
+  started on a call that had no media path in either direction and never could
+  have had one. That handler is where the media backend is driven, so an engine
+  that refuses the answer — a codec it will not bridge, a pipeline it cannot
+  build — surfaces exactly there, and it surfaces *before* the caller is
+  answered. Nothing treated it as fatal, so the call connected, billed for as
+  long as the far end kept it, and read as answered in every record.
+
+  A raise from `@b2bua.on_answer` is now a decision to fail the call. The caller
+  receives `500`; the answered B-leg is ACKed (RFC 3261 §13.2.2.4, which stops
+  its 200 retransmitting) and then BYEd (§15); `@b2bua.on_failure` fires so a
+  script's own per-call teardown still runs; the media session is released; and
+  any Ro reservation `call.ro_authorize()` opened is closed. The answer-time Rf
+  `ACR-START` and Ro `CCR-UPDATE` now follow that gate instead of preceding it,
+  so a call siphon is about to fail is never reported as answered in the first
+  place.
+
+  **Behaviour change.** A handler that raises used to leave the call connected;
+  it now fails it. A script doing work in `on_answer` that is allowed to throw
+  must catch its own exceptions. Note also that `@b2bua.on_failure` can now fire
+  for a call whose B-leg *did* answer and has already been BYEd, so a handler
+  must not assume there was never a B-leg.
+
+- **`call.terminate()` now works from `@b2bua.on_answer`.** The deferred action a
+  handler left behind was read back only for `call.refer()`; everything else was
+  discarded on the grounds that the call is already answered. That is true of the
+  B-leg and false of the A-leg, whose 2xx is only sent afterwards — so terminate
+  was both meaningful there and the one lever a script had to stop a call it had
+  just discovered could not work, and it was the one being dropped. An action
+  that genuinely has no effect once the B-leg has answered is now logged by name
+  rather than discarded silently.
+
 - **Registrar lookups now canonicalise the AoR they are given.** `bindings` and
   `aliases` are both keyed on the normalised form, but `Registrar`'s own lookup
   methods took the caller's string as-is, so an AoR that was not already

--- a/docs/cookbook/media-rtp.md
+++ b/docs/cookbook/media-rtp.md
@@ -145,6 +145,17 @@ A-leg Call-ID that matched the offer (see [the SBC recipe](sbc.md)).
     inactivity timeout. Handle every teardown path — `on_bye`, `on_failure`,
     `on_cancel` (proxy: `@proxy.on_cancel`) — or media lingers.
 
+!!! note "A failed `answer` in `@b2bua.on_answer` fails the call"
+    If `rtpengine.answer()` raises there, siphon does not connect the call: the
+    caller gets a `500`, the answered B-leg is ACKed and BYEd, `on_failure`
+    fires, and no answer-time charging is reported. That is deliberate — the
+    B-leg has answered but the A-leg has not yet, so this is the last point at
+    which a call with no media path can still be stopped rather than billed.
+    Catch the exception yourself only if you can actually recover; swallowing it
+    to keep the call up gives you a connected call that carries no audio in
+    either direction. `call.terminate()` from the same handler does the same
+    thing explicitly.
+
 ## Built-in profiles
 
 | Profile | Interworking |

--- a/scripts/b2bua_answer_fail.py
+++ b/scripts/b2bua_answer_fail.py
@@ -1,0 +1,53 @@
+"""B2BUA script for the answer-time failure SIPp test
+(scripts/b2bua_answer_fail_test.sh).
+
+`on_invite` dials a fixed callee that answers. `on_answer` then fails the call,
+in whichever way ``MODE`` selects:
+
+  ``raise``      the handler raises, standing in for a media backend that
+                 refused the answer — the shape of the real incident, where
+                 ``rtpengine.answer()`` could not build a pipeline for the
+                 negotiated codec.
+  ``terminate``  the handler calls ``call.terminate()``, the explicit form.
+
+Either way siphon must fail the caller and release the answered B-leg, instead
+of connecting a call that has no media path and letting it bill.
+"""
+
+import os
+
+from siphon import b2bua, log, proxy
+
+TARGET = os.environ.get("ANSWER_FAIL_TARGET", "sip:bob@127.0.0.1:5072")
+MODE = os.environ.get("MODE", "raise")
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    request.reply(200, "OK")
+
+
+@b2bua.on_invite
+def route(call):
+    call.dial(TARGET)
+
+
+@b2bua.on_answer
+def answered(call, reply):
+    if MODE == "terminate":
+        log.info(f"[{call.id}] answer refused by policy — terminating")
+        call.terminate()
+        return
+    # Stands in for a media backend that answered the offer with an error. The
+    # handler cannot recover, and what it must NOT do is let the call connect.
+    raise RuntimeError("media answer failed: no pipeline for the negotiated codec")
+
+
+@b2bua.on_failure
+def failed(call, code, reason):
+    log.info(f"[{call.id}] call failed {code} {reason}")
+
+
+@b2bua.on_bye
+def ended(call, initiator):
+    call.terminate()

--- a/scripts/b2bua_answer_fail_test.sh
+++ b/scripts/b2bua_answer_fail_test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Answer-time failure SIPp test (no docker).
+#
+# Runs siphon (B2BUA) + a callee that ANSWERS + a caller, with an
+# @b2bua.on_answer that fails. Asserts that siphon fails the caller (500) and
+# releases the answered B-leg (ACK then BYE), rather than forwarding the 2xx and
+# connecting a call that has no media path.
+#
+# Both failure shapes are covered:
+#   MODE=raise      (default) the handler raises — the real incident's shape,
+#                   a media backend that refused the answer.
+#   MODE=terminate  the handler calls call.terminate().
+#   MODE=both       run raise then terminate.
+#
+# Scope: this covers the SIP wire behaviour and that it came from the answer-time
+# gate. It does NOT cover the charging half of the same fix (no answer-time Rf
+# ACR-START / Ro CCR-UPDATE for a call that is about to fail) — this config has
+# no CDF or OCS peer, so those emissions are inert here and an assertion on them
+# would pass whatever the code did. Charging against a real CGRateS lives in
+# scripts/charging_test.sh.
+#
+# Requires: sipp on PATH, a built siphon binary (SIPHON_BIN=... or
+# target/debug/siphon), python3.
+set -u
+
+cd "$(dirname "$0")/.." || exit 2
+ROOT="$(pwd)"
+SIPHON="${SIPHON_BIN:-$ROOT/target/debug/siphon}"
+PY="${PYO3_PYTHON:-python3}"
+CONFIG="sipp/configs/siphon.answer-fail-test.yaml"
+
+run_mode() {
+  mode="$1"
+  log="$(mktemp -d)"
+  echo "=== mode: $mode (logs in $log) ==="
+
+  pids=()
+  cleanup() {
+    for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null; done
+    wait 2>/dev/null
+  }
+
+  # 1. siphon B2BUA, with on_answer failing in the selected way.
+  MODE="$mode" PYO3_PYTHON="$PY" "$SIPHON" -c "$CONFIG" > "$log/siphon.log" 2>&1 & pids+=($!)
+  sleep 3
+
+  # 2. the callee — answers 200, then must receive BOTH the ACK and the BYE.
+  #    It exits non-zero if the BYE never comes, which is the regression.
+  sipp -sf sipp/b2bua_answer_fail_uas.xml -i 127.0.0.1 -p 5072 -m 1 -timeout 20s -timeout_error \
+    -trace_err -error_file "$log/uas.err" -message_file "$log/uas.msg" \
+    > "$log/uas.log" 2>&1 & pids+=($!)
+  sleep 1
+
+  # 3. the caller — must receive 500, never a 2xx.
+  sipp 127.0.0.1:5060 -sf sipp/b2bua_answer_fail_uac.xml -i 127.0.0.1 -p 5090 -m 1 \
+    -timeout 20s -timeout_error \
+    -trace_err -error_file "$log/uac.err" -message_file "$log/uac.msg" \
+    > "$log/uac.log" 2>&1
+  uac_rc=$?
+
+  wait "${pids[1]}" 2>/dev/null; uas_rc=$?
+
+  # Prove the 500 came from the answer-time gate and not from something else
+  # failing the call earlier (a dial that never connected would also leave the
+  # caller with a failure, and would pass the wire assertions above while
+  # testing nothing).
+  gated=0
+  if grep -q "failing a call whose B-leg answered" "$log/siphon.log"; then
+    gated=1
+  fi
+
+  cleanup
+  echo "UAC exit=$uac_rc  UAS exit=$uas_rc  gate-fired=$gated"
+
+  if [ "$uac_rc" -eq 0 ] && [ "$uas_rc" -eq 0 ] && [ "$gated" -eq 1 ]; then
+    echo "PASS ($mode): caller got 500 from the answer-time gate, answered B-leg got ACK+BYE"
+    return 0
+  fi
+  echo "FAIL ($mode) — siphon log tail:"; tail -40 "$log/siphon.log"
+  echo "UAC err:"; cat "$log/uac.err" 2>/dev/null
+  echo "UAS err:"; cat "$log/uas.err" 2>/dev/null
+  return 1
+}
+
+MODE="${MODE:-raise}"
+rc=0
+if [ "$MODE" = "both" ]; then
+  run_mode raise || rc=1
+  run_mode terminate || rc=1
+else
+  run_mode "$MODE" || rc=1
+fi
+exit "$rc"

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -866,11 +866,24 @@ class Call:
     def terminate(self) -> None:
         """Terminate the call (send BYE to both legs).
 
+        Also honoured from ``@b2bua.on_answer``, where it fails the call rather
+        than connecting it: the B-leg has answered by then but the A-leg has
+        not — its 2xx is only sent once the handler returns — so the caller
+        receives a ``500``, the answered B-leg is ACKed and BYEd, and no
+        answer-time charging is reported. Use it when the handler discovers the
+        call cannot work, typically because the media backend refused the
+        answer. An exception out of the handler has the same effect.
+
         Example::
 
             @b2bua.on_bye
             def call_ended(call, initiator):
                 call.terminate()
+
+            @b2bua.on_answer
+            def answered(call, reply):
+                if not media_ok(reply):
+                    call.terminate()
         """
         self._state = "terminated"
         self._actions.append(Action(kind="terminate"))

--- a/sipp/b2bua_answer_fail_uac.xml
+++ b/sipp/b2bua_answer_fail_uac.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Answer-time failure test — the caller (A-leg).
+
+  INVITE -> 100 -> 180 -> 500 -> ACK.
+
+  The B-leg ANSWERS this call (see b2bua_answer_fail_uas.xml) and
+  @b2bua.on_answer then fails, either by raising or by calling
+  call.terminate(). The caller must receive a final failure response and no
+  2xx: a media session that could not be built is found out in that handler,
+  and it is found out BEFORE the A-leg 2xx is sent, so answering the caller
+  anyway produces a connected call with no media path in either direction that
+  bills until the far end gives up.
+
+  Receiving 200 here is the regression this scenario exists to catch.
+-->
+<scenario name="B2BUA answer-time failure UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-answer-fail-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="180" optional="true" />
+
+  <!-- The failure the caller must get instead of the B-leg's answer. -->
+  <recv response="500" rtd="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/b2bua_answer_fail_uas.xml
+++ b/sipp/b2bua_answer_fail_uas.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Answer-time failure test — the callee (B-leg), which ANSWERS.
+
+  Receive INVITE -> 100 -> 180 -> 200 (SDP) -> ACK -> BYE -> 200.
+
+  This leg genuinely answers, so its dialog is real and siphon owes it both an
+  ACK (RFC 3261 §13.2.2.4, which is what stops the 200 retransmitting) and then
+  a BYE (§15) once @b2bua.on_answer fails the call. The BYE is the half that
+  regressed: swallowing the handler failure left this dialog established with
+  nothing on either side ever releasing it.
+
+  Requiring both here is the point of the scenario — a run where the ACK
+  arrives and the BYE never does is the bug, and it times out rather than
+  passing quietly.
+-->
+<scenario name="B2BUA answer-time failure UAS">
+
+  <recv request="INVITE" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 100 Trying
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagB[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagB[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 8
+a=rtpmap:8 PCMA/8000
+]]>
+  </send>
+
+  <recv request="ACK" timeout="5000" />
+
+  <!-- The release siphon owes an answered leg it has decided to fail. -->
+  <recv request="BYE" timeout="5000" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/configs/siphon.answer-fail-test.yaml
+++ b/sipp/configs/siphon.answer-fail-test.yaml
@@ -1,0 +1,21 @@
+# siphon config for the answer-time failure SIPp test
+# (scripts/b2bua_answer_fail_test.sh). The B-leg answers and
+# @b2bua.on_answer then fails the call, either by raising or by calling
+# call.terminate(); siphon must fail the caller and BYE the answered B-leg
+# rather than connecting a call with no media path.
+
+listen:
+  udp:
+    - "127.0.0.1:5060"
+
+domain:
+  local:
+    - "127.0.0.1"
+
+advertised_address: "127.0.0.1"
+
+script:
+  path: "scripts/b2bua_answer_fail.py"
+
+log:
+  level: info

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17985,19 +17985,11 @@ fn handle_b2bua_response(
                     ro_stamp_winning_carrier(state, call_id, &route.carrier_id);
                 }
 
-                // Rf ACR-START on B2BUA call answer (TS 32.299 §6.2.2).
-                // Fire-and-forget per TS 32.299 §6.5.
-                if let Some(invite_arc) = &a_leg_invite {
-                    spawn_rf_b2bua_start(state, call_id, invite_arc);
-                }
-                // Ro is not *started* here — prepaid reserve-before-connect means the
-                // CCR-INITIAL already fired in `@b2bua.on_invite` via
-                // `call.ro_authorize()`, before the B-leg was dialed, and the re-auth
-                // loop it armed keeps running. But the answer is what starts the
-                // chargeable clock (TS 32.260 §5), so report it: a CCR-UPDATE carrying
-                // Time-Stamps tells the OCS when charging actually began, and under
-                // `ro.charge_from: answer` it is also what stops ring time being billed.
-                spawn_ro_b2bua_answer(state, call_id);
+                // Charging is NOT reported here. Both emissions below moved to after
+                // @b2bua.on_answer, because the handler is where the media backend is
+                // driven and so where a call that can never carry audio is found out:
+                // reporting the answer first billed a call siphon was about to fail.
+                // See the failure gate under the handler block.
 
                 // Wrap the 200 OK in Arc<Mutex<>> so Python handlers can modify SDP in-place
                 let response_arc = Arc::new(std::sync::Mutex::new(message.clone()));
@@ -18005,6 +17997,12 @@ fn handle_b2bua_response(
                 // A `call.refer()` issued from @b2bua.on_answer, held until the A-leg
                 // 2xx has been sent (see where it is taken, further down).
                 let mut deferred_outbound_refer: Option<crate::sip::headers::refer::ReferTo> = None;
+
+                // Set when an @b2bua.on_answer handler raised, or asked for the call to
+                // be terminated. Either way the A-leg is failed instead of answered —
+                // see the gate below the handler block.
+                let mut answer_handler_raised = false;
+                let mut answer_wants_terminate = false;
 
                 // Invoke @b2bua.on_answer handlers with (PyCall, PyReply)
                 let engine_state = state.engine.state();
@@ -18030,49 +18028,56 @@ fn handle_b2bua_response(
                                 response_source.port(),
                             );
 
-                        let answer_action = Python::attach(|python| -> Option<CallAction> {
-                            let call_obj = match Py::new(python, py_call) {
-                                Ok(obj) => obj,
-                                Err(error) => {
-                                    error!("failed to create PyCall for on_answer: {error}");
-                                    return None;
-                                }
-                            };
-                            let reply_obj = match Py::new(python, py_reply) {
-                                Ok(obj) => obj,
-                                Err(error) => {
-                                    error!("failed to create PyReply for on_answer: {error}");
-                                    return None;
-                                }
-                            };
+                        // `raised` reports whether ANY handler failed — a construction
+                        // error for the Python objects counts, since a handler that was
+                        // never called cannot have made the media decision the call
+                        // depends on.
+                        let (answer_action, raised) =
+                            Python::attach(|python| -> (Option<CallAction>, bool) {
+                                let call_obj = match Py::new(python, py_call) {
+                                    Ok(obj) => obj,
+                                    Err(error) => {
+                                        error!("failed to create PyCall for on_answer: {error}");
+                                        return (None, true);
+                                    }
+                                };
+                                let reply_obj = match Py::new(python, py_reply) {
+                                    Ok(obj) => obj,
+                                    Err(error) => {
+                                        error!("failed to create PyReply for on_answer: {error}");
+                                        return (None, true);
+                                    }
+                                };
 
-                            for handler in &handlers {
-                                let callable = handler.callable.bind(python);
-                                match callable
-                                    .call1((call_obj.bind(python), reply_obj.bind(python)))
-                                {
-                                    Ok(ret) => {
-                                        if handler.is_async {
-                                            if let Err(error) = run_coroutine(python, &ret) {
-                                                error!(
+                                let mut raised = false;
+                                for handler in &handlers {
+                                    let callable = handler.callable.bind(python);
+                                    match callable
+                                        .call1((call_obj.bind(python), reply_obj.bind(python)))
+                                    {
+                                        Ok(ret) => {
+                                            if handler.is_async {
+                                                if let Err(error) = run_coroutine(python, &ret) {
+                                                    error!(
                                                     "async B2BUA on_answer handler error: {error}"
                                                 );
+                                                    raised = true;
+                                                }
                                             }
                                         }
-                                    }
-                                    Err(error) => {
-                                        error!("B2BUA on_answer handler error: {error}");
+                                        Err(error) => {
+                                            error!("B2BUA on_answer handler error: {error}");
+                                            raised = true;
+                                        }
                                     }
                                 }
-                            }
-                            let borrowed = call_obj.borrow(python);
-                            Some(borrowed.action().clone())
-                        });
+                                let borrowed = call_obj.borrow(python);
+                                (Some(borrowed.action().clone()), raised)
+                            });
+                        answer_handler_raised = raised;
 
                         // Deferred call.refer() from @b2bua.on_answer: an outbound
-                        // REFER to the A-leg (the connected caller). Other deferred
-                        // actions on on_answer are not applicable (the call is already
-                        // answered) and are ignored.
+                        // REFER to the A-leg (the connected caller).
                         //
                         // NOT sent here. The A-leg 200 OK is only forwarded further
                         // down this function, so emitting the REFER at this point put
@@ -18081,13 +18086,71 @@ fn handle_b2bua_response(
                         // established (RFC 3261 §13.2.2.4 — the UAC confirms the dialog
                         // on the 2xx), which a real UA answers 481. Carried to after
                         // the 2xx send instead.
-                        if let Some(CallAction::SendRefer { refer_to }) = answer_action {
-                            deferred_outbound_refer = Some(refer_to);
+                        match classify_answer_action(answer_action) {
+                            AnswerAction::DeferRefer(refer_to) => {
+                                deferred_outbound_refer = Some(refer_to);
+                            }
+                            AnswerAction::Terminate => answer_wants_terminate = true,
+                            AnswerAction::Connect => {}
+                            AnswerAction::Inapplicable(action) => warn!(
+                                call_id = %call_id,
+                                action = ?action,
+                                "B2BUA: this call action has no effect from @b2bua.on_answer and was ignored"
+                            ),
                         }
                     } else {
                         warn!(call_id = %call_id, "B2BUA: no stored A-leg INVITE for on_answer");
                     }
                 }
+
+                // A failed @b2bua.on_answer must not resolve to a connected call.
+                //
+                // The handler is where the media backend is driven, so a media session
+                // that could not be built — a codec the engine will not bridge, an
+                // engine that refused the answer — surfaces here as a raise, and it
+                // surfaces BEFORE the A-leg 2xx goes out further down this function.
+                // Swallowing it answered the caller anyway and started the charging
+                // clock on a call with no media path in either direction, which then
+                // billed until the far end gave up. A raise is therefore a decision to
+                // fail the call, and `call.terminate()` says the same thing explicitly.
+                if answer_handler_raised || answer_wants_terminate {
+                    let cause = if answer_handler_raised {
+                        "@b2bua.on_answer handler raised"
+                    } else {
+                        "@b2bua.on_answer called call.terminate()"
+                    };
+                    b2bua_fail_after_answer(
+                        call_id,
+                        cause,
+                        &a_leg,
+                        a_leg_invite.as_ref(),
+                        a_leg_local_addr,
+                        b_leg_index,
+                        message,
+                        state,
+                    );
+                    return;
+                }
+
+                // Rf ACR-START on B2BUA call answer (TS 32.299 §6.2.2).
+                // Fire-and-forget per TS 32.299 §6.5.
+                //
+                // Reported here, after the gate above, rather than on arrival of the
+                // 2xx: an answer siphon is about to turn into a failure is not an
+                // answer, and a CDF/OCS that was told otherwise had no later record
+                // correcting it.
+                if let Some(invite_arc) = &a_leg_invite {
+                    spawn_rf_b2bua_start(state, call_id, invite_arc);
+                }
+                // Ro is not *started* here — prepaid reserve-before-connect means the
+                // CCR-INITIAL already fired in `@b2bua.on_invite` via
+                // `call.ro_authorize()`, before the B-leg was dialed, and the re-auth
+                // loop it armed keeps running. But the answer is what starts the
+                // chargeable clock (TS 32.260 §5), so report it: a CCR-UPDATE carrying
+                // Time-Stamps tells the OCS when charging actually began, and under
+                // `ro.charge_from: answer` it is also what stops ring time being billed.
+                spawn_ro_b2bua_answer(state, call_id);
+
                 // Resolve SRS URI from config when li.record() was called
                 let li_srs_uri = if li_record {
                     state.li_siprec_srs_uri.as_deref()
@@ -19670,19 +19733,25 @@ fn build_b2bua_ack_for_2xx(
     }
 }
 
-/// Handle a 2xx that raced an outbound CANCEL (RFC 3261 §9.1 glare).
+/// ACK a B-leg 2xx and, when asked, BYE the dialog that 2xx established.
 ///
-/// The callee answered the B-leg INVITE before our CANCEL landed, so the 2xx
-/// established a dialog even though the call is gone. ACK it (§13.2.2.4) to stop
-/// the 200 OK retransmissions, then — on the first 2xx only — BYE it (§15) to
-/// release the session. All dialog state comes from the captured leg plus this
-/// response (the remote tag / Contact were unknown when the INVITE was CANCELled).
-fn handle_zombie_cancelled_2xx(
+/// RFC 3261 §13.2.2.4 makes the ACK the UAC's confirmation of the dialog, and §15
+/// makes the BYE the only way to release it once confirmed — so a 2xx siphon does
+/// not intend to keep needs both, in that order, or the callee retransmits its 200
+/// and holds the session open with nothing ever releasing it.
+///
+/// Every piece of dialog state is taken from `response`, not from `leg`: both
+/// callers hold a leg captured *before* the answer, so the remote tag, the remote
+/// Contact and the route set (§12.1.2) exist only on the response, and the BYE's
+/// CSeq — which MUST exceed the INVITE's — has to be derived from the 2xx too.
+///
+/// Returns whether the BYE went out.
+fn b2bua_ack_and_bye_answered_leg(
     mut leg: crate::b2bua::actor::Leg,
-    first_2xx: bool,
     response: &SipMessage,
+    send_bye: bool,
     state: &DispatcherState,
-) {
+) -> bool {
     let transport = leg.transport.transport;
     let destination = leg.transport.remote_addr;
     // The socket this leg was dialled from (flow-pinned legs) — the ACK and BYE
@@ -19690,10 +19759,9 @@ fn handle_zombie_cancelled_2xx(
     let local_addr = leg.transport.local_addr;
     let (via_host, via_port) = b_leg_sent_by(local_addr, state, &transport);
 
-    // The raced 2xx established a dialog even though the call is gone, so it also
-    // established a route set (RFC 3261 §12.1.2) — the ACK below carries it, and
-    // the BYE needs it on the leg, which was captured at CANCEL time and predates
-    // this response.
+    // The 2xx established a dialog and with it a route set (RFC 3261 §12.1.2) — the
+    // ACK below carries it, and the BYE needs it on the leg, which predates this
+    // response and cannot have picked it up.
     let route_set = uac_route_set_from_record_routes(
         &response
             .headers
@@ -19704,16 +19772,16 @@ fn handle_zombie_cancelled_2xx(
     let (destination, transport) =
         resolve_in_dialog_destination(&route_set, state, destination, transport);
 
-    // ACK the 2xx on every match — a lost ACK leaves the callee retransmitting.
+    // ACK on every call — a lost ACK leaves the callee retransmitting.
     if let Some(ack) = build_b2bua_ack_for_2xx(response, transport, &via_host, via_port) {
         send_b2bua_to_bleg(ack, transport, destination, local_addr, state);
     }
 
-    if !first_2xx {
-        return; // retransmit — re-ACK only; the BYE already went out.
+    if !send_bye {
+        return false;
     }
 
-    // Fill the remote dialog identity from the 2xx (unknown at CANCEL time).
+    // Fill the remote dialog identity from the 2xx (unknown when the leg was captured).
     if let Some(tag) = crate::b2bua::actor::extract_to_tag(response) {
         leg.dialog.remote_tag = Some(tag);
     }
@@ -19730,13 +19798,241 @@ fn handle_zombie_cancelled_2xx(
         .unwrap_or(leg.dialog.local_cseq);
     leg.dialog.local_cseq = invite_cseq.saturating_add(1);
 
-    if let Some(bye) = build_b2bua_bye(&leg, state) {
-        send_b2bua_to_bleg(bye, transport, destination, local_addr, state);
+    match build_b2bua_bye(&leg, state) {
+        Some(bye) => {
+            send_b2bua_to_bleg(bye, transport, destination, local_addr, state);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Handle a 2xx that raced an outbound CANCEL (RFC 3261 §9.1 glare).
+///
+/// The callee answered the B-leg INVITE before our CANCEL landed, so the 2xx
+/// established a dialog even though the call is gone. ACK it (§13.2.2.4) to stop
+/// the 200 OK retransmissions, then — on the first 2xx only — BYE it (§15) to
+/// release the session. All dialog state comes from the captured leg plus this
+/// response (the remote tag / Contact were unknown when the INVITE was CANCELled).
+fn handle_zombie_cancelled_2xx(
+    leg: crate::b2bua::actor::Leg,
+    first_2xx: bool,
+    response: &SipMessage,
+    state: &DispatcherState,
+) {
+    let sip_call_id = leg.dialog.call_id.clone();
+    // A retransmit re-ACKs only — the BYE went out on the first 2xx.
+    if b2bua_ack_and_bye_answered_leg(leg, response, first_2xx, state) {
         debug!(
-            sip_call_id = %leg.dialog.call_id,
+            sip_call_id = %sip_call_id,
             "B2BUA: ACK+BYE for a 2xx that raced our CANCEL (RFC 3261 §9.1 glare)"
         );
     }
+}
+
+/// What `@b2bua.on_answer` does with the deferred action a handler left behind.
+#[derive(Debug, PartialEq)]
+enum AnswerAction {
+    /// Nothing deferred — carry on and connect the call.
+    Connect,
+    /// `call.refer()` — an outbound REFER to the caller, held until its 2xx is on
+    /// the wire (RFC 3261 §13.2.2.4: the UAC confirms the dialog on the 2xx, so a
+    /// REFER sent ahead of it is answered 481).
+    DeferRefer(crate::sip::headers::refer::ReferTo),
+    /// `call.terminate()` — fail the call instead of connecting it.
+    Terminate,
+    /// Not actionable once the B-leg has answered.
+    Inapplicable(CallAction),
+}
+
+/// Classify what a `@b2bua.on_answer` handler asked for.
+///
+/// `Terminate` is honoured from this handler, which it was not before: the
+/// comment that replaced it held that deferred actions cannot apply because "the
+/// call is already answered", and that is true of the B-leg and false of the A-leg
+/// — the caller's 2xx is only sent later in `handle_b2bua_response`. So a script
+/// that discovers in `on_answer` that the call cannot work (no media path, a
+/// policy check that needed the answer) can still stop it, and the action that
+/// says so is no longer dropped on the floor.
+fn classify_answer_action(action: Option<CallAction>) -> AnswerAction {
+    match action {
+        Some(CallAction::SendRefer { refer_to }) => AnswerAction::DeferRefer(refer_to),
+        Some(CallAction::Terminate) => AnswerAction::Terminate,
+        None | Some(CallAction::None) => AnswerAction::Connect,
+        Some(other) => AnswerAction::Inapplicable(other),
+    }
+}
+
+/// Fail a call whose B-leg has answered but whose `@b2bua.on_answer` did not
+/// survive — the handler raised, or it asked for the call to end.
+///
+/// The B-leg answered, so its dialog is real and has to be released properly
+/// (ACK per RFC 3261 §13.2.2.4, then BYE per §15). The A-leg has NOT been
+/// answered — its 2xx is only sent further down `handle_b2bua_response` — so the
+/// caller is still in an INVITE transaction and takes a final failure response
+/// instead, which is the whole point: no dialog is created toward the caller and
+/// nothing downstream treats the call as connected.
+///
+/// This mirrors the ordinary B-leg-failure teardown at the end of that function
+/// (script `on_failure`, CDR, the media safety-net, the Ro release), because the
+/// call has failed in exactly the sense those steps exist for. The one asymmetry
+/// worth knowing when writing a handler: `@b2bua.on_failure` fires here for a
+/// call whose B-leg *did* answer and has already been BYEd.
+#[allow(clippy::too_many_arguments)]
+fn b2bua_fail_after_answer(
+    call_id: &str,
+    cause: &str,
+    a_leg: &crate::b2bua::actor::Leg,
+    a_leg_invite: Option<&Arc<std::sync::Mutex<SipMessage>>>,
+    a_leg_local_addr: Option<SocketAddr>,
+    b_leg_index: Option<usize>,
+    response: &SipMessage,
+    state: &DispatcherState,
+) {
+    const STATUS: u16 = 500;
+    const REASON: &str = "Server Internal Error";
+
+    error!(
+        call_id = %call_id,
+        cause = %cause,
+        "B2BUA: failing a call whose B-leg answered — the caller gets {STATUS} and the answered B-leg is released"
+    );
+
+    // The caller's final response. Built from the stored A-leg INVITE, so it
+    // already carries the A-leg's own Via / From / To / Call-ID / CSeq and needs
+    // none of the B-leg sanitisation the forwarded-error path does. The To-tag is
+    // the A-leg dialog's own (RFC 3261 §8.2.6.2 — a UAS tags every response bar
+    // 100), the same tag its 2xx would have carried.
+    match a_leg_invite {
+        Some(invite_arc) => match invite_arc.lock() {
+            Ok(invite) => {
+                let mut failure =
+                    build_response(&invite, STATUS, REASON, state.server_header.as_deref(), &[]);
+                drop(invite);
+                if let Some(to) = failure.headers.to().cloned() {
+                    failure.headers.set(
+                        "To",
+                        crate::b2bua::actor::ensure_tag(&to, Some(&a_leg.dialog.local_tag)),
+                    );
+                }
+                send_message_from(
+                    failure,
+                    a_leg.transport.transport,
+                    a_leg.transport.remote_addr,
+                    a_leg.transport.connection_id,
+                    a_leg_local_addr,
+                    state,
+                );
+            }
+            Err(error) => error!(
+                call_id = %call_id,
+                "B2BUA: A-leg INVITE lock poisoned while failing an answered call: {error}"
+            ),
+        },
+        None => warn!(
+            call_id = %call_id,
+            "B2BUA: no stored A-leg INVITE — the caller cannot be sent a failure response"
+        ),
+    }
+
+    // Release the answered B-leg dialog. The leg is re-read here rather than
+    // carried in: `handle_b2bua_response` drops its actor reference before running
+    // Python, and the handler that just failed may itself have touched the call.
+    let b_leg = b_leg_index.and_then(|index| {
+        state
+            .call_actors
+            .get_call(call_id)
+            .and_then(|call| call.b_legs.get(index).cloned())
+    });
+    match b_leg {
+        Some(leg) => {
+            b2bua_ack_and_bye_answered_leg(leg, response, true, state);
+        }
+        None => warn!(
+            call_id = %call_id,
+            "B2BUA: answered B-leg is gone — its dialog cannot be released and may linger"
+        ),
+    }
+
+    // @b2bua.on_failure — the script's per-call teardown hook. Fired before the
+    // actor is removed so a handler can still read the call.
+    let engine_state = state.engine.state();
+    let handlers = engine_state.handlers_for(&HandlerKind::B2buaFailure);
+    if !handlers.is_empty() {
+        match a_leg_invite {
+            Some(invite_arc) => {
+                let py_call = PyCall::new(
+                    call_id.to_string(),
+                    Arc::clone(invite_arc),
+                    a_leg.transport.remote_addr.ip().to_string(),
+                    format!("{}", a_leg.transport.transport).to_lowercase(),
+                )
+                .with_flow(py_flow_from_leg(&a_leg.transport));
+
+                Python::attach(|python| {
+                    let call_obj = match Py::new(python, py_call) {
+                        Ok(obj) => obj,
+                        Err(error) => {
+                            error!("failed to create PyCall for on_failure: {error}");
+                            return;
+                        }
+                    };
+                    for handler in &handlers {
+                        let callable = handler.callable.bind(python);
+                        match callable.call1((call_obj.bind(python), STATUS, REASON)) {
+                            Ok(ret) => {
+                                if handler.is_async {
+                                    if let Err(error) = run_coroutine(python, &ret) {
+                                        error!("async B2BUA on_failure handler error: {error}");
+                                    }
+                                }
+                            }
+                            Err(error) => error!("B2BUA on_failure handler error: {error}"),
+                        }
+                    }
+                });
+            }
+            None => warn!(call_id = %call_id, "B2BUA: no stored A-leg INVITE for on_failure"),
+        }
+    }
+
+    // CDR: the answer stamp was already taken when the 2xx arrived, so finalise as
+    // a failure to correct it — the call never connected.
+    cdr_finalize_b2bua_fail(state, call_id, STATUS);
+
+    // Safety-net media release. `@b2bua.on_bye` never runs for this call (no BYE
+    // arrives from a caller that was never answered), so without this the media
+    // session outlives the call it belonged to.
+    let a_sip_call_id = a_leg.dialog.call_id.clone();
+    if let (Some(rtpengine_set), Some(media_sessions)) =
+        (&state.rtpengine_set, &state.rtpengine_sessions)
+    {
+        if let Some(session) = media_sessions.remove(&a_sip_call_id) {
+            let set = Arc::clone(rtpengine_set);
+            tokio::spawn(async move {
+                if let Err(error) = set.delete(session.rtpengine_id(), &session.from_tag).await {
+                    if error.is_call_not_found() {
+                        debug!(call_id = %session.call_id, "media delete after a failed answer: call already gone ({error})");
+                    } else {
+                        warn!(call_id = %session.call_id, "media delete after a failed answer failed: {error}");
+                    }
+                }
+            });
+        }
+    }
+
+    // Release any Ro reservation `call.ro_authorize()` made before the B-leg was
+    // dialed. The answer-time CCR-UPDATE is deliberately never sent on this path,
+    // so the OCS sees a reservation that opened and closed without a chargeable
+    // clock ever starting.
+    spawn_ro_b2bua_stop(
+        state,
+        call_id,
+        crate::diameter::rf::sip_status_to_cause_code(STATUS),
+    );
+
+    state.call_actors.remove_call(call_id);
+    state.call_event_receivers.remove(call_id);
 }
 
 /// ACK the final non-2xx that a CANCELled INVITE draws — in practice the
@@ -27898,6 +28194,65 @@ mod tests {
     use crate::sip::message::Method;
     use crate::sip::parser::parse_sip_message;
     use crate::sip::uri::SipUri;
+
+    /// `call.terminate()` from `@b2bua.on_answer` has to reach the dispatcher.
+    ///
+    /// The B-leg is answered by the time the handler runs, but the A-leg is not —
+    /// its 2xx is only sent later in `handle_b2bua_response` — so terminate is
+    /// still actionable there, and it is the only lever a script has once it has
+    /// discovered the call cannot carry audio. It used to be dropped along with
+    /// every non-REFER action.
+    #[test]
+    fn terminate_from_on_answer_is_actionable() {
+        assert_eq!(
+            classify_answer_action(Some(CallAction::Terminate)),
+            AnswerAction::Terminate
+        );
+    }
+
+    /// A handler that deferred nothing connects the call, whether it set the
+    /// idle action explicitly or the object was never touched at all.
+    #[test]
+    fn an_untouched_call_object_connects() {
+        assert_eq!(classify_answer_action(None), AnswerAction::Connect);
+        assert_eq!(
+            classify_answer_action(Some(CallAction::None)),
+            AnswerAction::Connect
+        );
+    }
+
+    /// `call.refer()` still defers rather than firing inside the handler — it is
+    /// sent only once the A-leg 2xx is on the wire, because a UAC confirms the
+    /// dialog on the 2xx (RFC 3261 §13.2.2.4) and answers an earlier REFER 481.
+    #[test]
+    fn refer_from_on_answer_is_deferred_with_its_target() {
+        let refer_to = crate::sip::headers::refer::ReferTo {
+            uri: "sip:transfer-target@example.invalid".to_string(),
+            replaces: None,
+        };
+        assert_eq!(
+            classify_answer_action(Some(CallAction::SendRefer {
+                refer_to: refer_to.clone()
+            })),
+            AnswerAction::DeferRefer(refer_to)
+        );
+    }
+
+    /// An action with no meaning after the B-leg answered is reported, not
+    /// silently discarded — the dispatcher warns naming the action, so a script
+    /// that tries one finds out from the log instead of from the absence of an
+    /// effect.
+    #[test]
+    fn an_inapplicable_action_is_surfaced_rather_than_dropped() {
+        let reject = CallAction::Reject {
+            code: 486,
+            reason: "Busy Here".to_string(),
+        };
+        assert_eq!(
+            classify_answer_action(Some(reject.clone())),
+            AnswerAction::Inapplicable(reject)
+        );
+    }
 
     /// `Supported` is a list header: the option tag goes *inside* the value the
     /// caller already advertised, never on a second line.


### PR DESCRIPTION
Three consecutive outbound calls answered, billed 36 seconds each and carried no
audio in either direction. Seven things had to line up; these are the two in the
B2BUA answer path, and they are the pair that turns a media failure into a billed
silent call.

## An exception out of `@b2bua.on_answer` connected the call anyway

`rtpengine.answer()` raised inside the handler. The dispatcher logged it and
carried on: the A-leg 200 reached the caller a millisecond later, the ACK
followed, and the charging clock started 4 ms after the error.

That handler is where the media backend is driven, so an engine that refuses the
answer — a codec it will not bridge, a pipeline it cannot build — surfaces
exactly there, and it surfaces **before** the caller is answered. It is the last
point at which a call with no media path can still be stopped rather than billed
until the far end gives up. Nothing treated it as fatal, so the call connected
and read as answered in every record.

A raise is now a decision to fail the call:

- the caller receives `500`
- the answered B-leg is ACKed (RFC 3261 §13.2.2.4, which stops its 200
  retransmitting) and then BYEd (§15)
- `@b2bua.on_failure` fires, so a script's own per-call teardown still runs
- the media session is released and any Ro reservation `call.ro_authorize()`
  opened is closed
- the answer-time Rf `ACR-START` and Ro `CCR-UPDATE` now follow that gate instead
  of preceding it, so a call siphon is about to fail is never reported as
  answered in the first place

## `call.terminate()` from `@b2bua.on_answer` was silently ignored

The deferred action a handler left behind was read back only for `call.refer()`;
everything else was dropped on the grounds that the call is already answered.
That holds for the B-leg and not for the A-leg, whose 2xx is only sent afterwards
— so terminate was both meaningful there and the one lever a script had to stop a
call it had just discovered could not work, and it was the one being discarded.
An action that genuinely has no effect once the B-leg has answered is now logged
by name rather than dropped silently.

## Behaviour change

A handler that raises used to leave the call connected; it now fails it. A script
doing work in `on_answer` that is allowed to throw must catch its own exceptions.
`@b2bua.on_failure` can also now fire for a call whose B-leg *did* answer and has
already been BYEd, so a handler must not assume there was never a B-leg.

## Tests

- Four unit tests on the action classification, including that terminate is
  actionable and that an inapplicable action is surfaced rather than dropped.
- A SIPp pair (`sipp/b2bua_answer_fail_{uac,uas}.xml`) with its own CI job,
  covering both failure shapes. The callee answers for real and demands the ACK
  **and** the BYE; the caller demands a `500` and never a 2xx. Both peers fail on
  the previous behaviour, which is how the scenario was checked before the fix
  went in — it also asserts the 500 came from the answer-time gate rather than
  from something failing the call earlier.

The ACK+BYE the CANCEL-glare path already performed is factored out and shared
rather than duplicated.

Scope note: the SIPp harness covers the wire behaviour, not the charging
reorder — that config has no CDF or OCS peer, so those emissions are inert there
and an assertion on them would pass whatever the code did. Charging against a
real CGRateS stays in `scripts/charging_test.sh`.