### PR TITLE
perf(dispatcher): box the timer entry so the wheel stops retaining its peak footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Performance
+- **The dispatcher's timer wheel no longer retains its peak-concurrency
+  footprint either.** Same shape as the transaction map fixed alongside it:
+  `timer_wheel` is a `DashMap<String, TimerEntry>` holding a 176-byte
+  `TimerEntry` inline, so the bucket was 200 bytes. `hashbrown` sizes its bucket
+  array for the peak number of live entries and never shrinks it, and the wheel
+  carries roughly one entry per live transaction timer — so its count tracks
+  `rate x Timer J` the same way, and the array stayed at the busiest moment the
+  process ever saw for the rest of its life. Boxed, the bucket is 32 bytes.
+
+  Measured on the same experiment (100,000 registrations at 4,800 cps, then
+  fully de-registered), against `main` with only this change reverted:
+
+  | | peak RSS | drained RSS | drained live bytes |
+  |---|---|---|---|
+  | before | 289 MB | 153 MB | 80 MB |
+  | after | 267 MB | 121 MB | **47 MB** |
+
+  Post-drain live bytes fall 41 %. Cumulatively with the registrar and
+  transaction work in this release, the same workload goes from 563 MB peak
+  RSS / 158 MB retained to 267 MB / 47 MB.
+
+### Performance
 - **The transaction table no longer holds its peak-concurrency footprint for
   the life of the process.** `TransactionManager` stored the `Transaction`
   enum inline in its `DashMap`. A `Nist` carries two whole `SipMessage`s

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -118,7 +118,13 @@ struct DispatcherState {
     /// Transaction state machine manager.
     transaction_manager: Arc<TransactionManager>,
     /// Timer wheel — keyed by a unique timer ID string.
-    timer_wheel: Arc<DashMap<String, TimerEntry>>,
+    /// Boxed: `hashbrown` sizes its bucket array for peak concurrency and never
+    /// shrinks it, so an inline 176-byte `TimerEntry` meant a 200-byte bucket
+    /// retained for the life of the process at the busiest moment the box ever
+    /// saw. There is roughly one entry per live transaction timer, so the count
+    /// tracks `rate x Timer J` the same way the transaction map did. Boxed the
+    /// bucket is 32 bytes.
+    timer_wheel: Arc<DashMap<String, Box<TimerEntry>>>,
     /// RFC 3261 §17.1 retransmission schedules for siphon-originated B2BUA
     /// requests. The proxy datapath gets Timer A / Timer E from the client
     /// transactions it registers; the B2BUA registers none (it owns its legs
@@ -2085,7 +2091,9 @@ fn fire_expired_timers(state: &DispatcherState) {
 
     state.timer_wheel.retain(|_id, entry| {
         if now >= entry.fires_at {
-            fired.push(entry.clone());
+            // Deref out of the box: the wheel owns boxes, the fired list is
+            // consumed by value below.
+            fired.push((**entry).clone());
             false // remove from wheel
         } else {
             true
@@ -2257,7 +2265,7 @@ fn process_timer_actions_with_followups(
                 let timer_id = format!("{}:{:?}", key, name);
                 state.timer_wheel.insert(
                     timer_id,
-                    TimerEntry {
+                    Box::new(TimerEntry {
                         key: key.clone(),
                         name: *name,
                         fires_at: std::time::Instant::now() + *duration,
@@ -2265,7 +2273,7 @@ fn process_timer_actions_with_followups(
                         transport,
                         connection_id,
                         source_local_addr,
-                    },
+                    }),
                 );
             }
             Action::CancelTimer(name) => {
@@ -4368,7 +4376,7 @@ fn handle_request(
                     let timer_id = format!("{}:{:?}", key, name);
                     state.timer_wheel.insert(
                         timer_id,
-                        TimerEntry {
+                        Box::new(TimerEntry {
                             key: key.clone(),
                             name: *name,
                             fires_at: std::time::Instant::now() + *duration,
@@ -4379,7 +4387,7 @@ fn handle_request(
                             // Retransmit cached responses on the same SA's
                             // local endpoint (TS 33.203 §7.4).
                             source_local_addr: Some(inbound.local_addr),
-                        },
+                        }),
                     );
                 }
             }
@@ -5397,7 +5405,7 @@ fn relay_request(
                     let timer_id = format!("{}:{:?}", client_key, name);
                     state.timer_wheel.insert(
                         timer_id,
-                        TimerEntry {
+                        Box::new(TimerEntry {
                             key: client_key.clone(),
                             name: *name,
                             fires_at: std::time::Instant::now() + *duration,
@@ -5405,7 +5413,7 @@ fn relay_request(
                             transport: Some(outbound_transport),
                             connection_id: Some(placeholder_connection_id),
                             source_local_addr: retransmit_source,
-                        },
+                        }),
                     );
                 }
             }
@@ -5960,7 +5968,7 @@ fn relay_fork_branch(
                     let timer_id = format!("{}:{:?}", client_key, name);
                     state.timer_wheel.insert(
                         timer_id,
-                        TimerEntry {
+                        Box::new(TimerEntry {
                             key: client_key.clone(),
                             name: *name,
                             fires_at: std::time::Instant::now() + *duration,
@@ -5968,7 +5976,7 @@ fn relay_fork_branch(
                             transport: Some(outbound_transport),
                             connection_id: Some(placeholder_connection_id),
                             source_local_addr: retransmit_source,
-                        },
+                        }),
                     );
                 }
             }
@@ -6951,7 +6959,7 @@ fn handle_response(
                                 let timer_id = format!("{}:{:?}", key, name);
                                 state.timer_wheel.insert(
                                     timer_id,
-                                    TimerEntry {
+                                    Box::new(TimerEntry {
                                         key: key.clone(),
                                         name: *name,
                                         fires_at: std::time::Instant::now() + *duration,
@@ -6959,7 +6967,7 @@ fn handle_response(
                                         transport: None,
                                         connection_id: None,
                                         source_local_addr: None,
-                                    },
+                                    }),
                                 );
                             }
                             Action::ProtocolError(message) => {
@@ -27893,6 +27901,32 @@ fn handle_srs_bye(
 
 #[cfg(test)]
 mod tests {
+    /// The timer wheel stores a *pointer* to the entry, not the entry.
+    ///
+    /// Same shape as the transaction map: `hashbrown` sizes its bucket array
+    /// for peak concurrency and never shrinks it, and the wheel holds roughly
+    /// one entry per live transaction timer, so the count tracks
+    /// `rate x Timer J` too. Inline, a 176-byte `TimerEntry` made a 200-byte
+    /// bucket that the process kept at its busiest-ever moment for the rest of
+    /// its life.
+    #[test]
+    fn the_timer_wheel_stores_a_pointer_not_the_entry() {
+        let bucket = std::mem::size_of::<(String, Box<super::TimerEntry>)>();
+        let key_only = std::mem::size_of::<String>();
+        assert!(
+            bucket <= key_only + 16,
+            "wheel bucket is {bucket} B against a {key_only} B key — the entry is \
+             being stored inline again, and the table will retain it at peak \
+             concurrency forever"
+        );
+        let payload = std::mem::size_of::<super::TimerEntry>();
+        assert!(
+            payload >= 64,
+            "TimerEntry is down to {payload} B — re-check whether boxing still earns \
+             its indirection"
+        );
+    }
+
     use super::*;
     use crate::sip::builder::SipMessageBuilder;
     use crate::sip::message::Method;


### PR DESCRIPTION
Follow-up to #259, which named this as the next target and left it undone.

## Same defect, second table

`timer_wheel` is a `DashMap<String, TimerEntry>` storing the entry **inline**:

```
TimerEntry                = 176
(String, TimerEntry)      = 200      <- the bucket
(String, Box<TimerEntry>) =  32
```

`hashbrown` sizes its bucket array for the peak number of live entries and never
shrinks it. The wheel carries roughly one entry per live transaction timer, so
its count tracks `rate × Timer J` exactly the way the transaction map's did — the
array stays at the busiest moment the process ever saw for the rest of its life.

Invisible to any "does the store drain?" check, for the same reason as #259: the
store *does* drain. The array it drained out of does not.

## Measured

Same experiment (100,000 registrations at 4,800 cps, then fully de-registered),
same box, same binary — the only difference is this change reverted:

| | peak RSS | peak live | drained RSS | drained live |
|---|---|---|---|---|
| `main` @ 53c259a | 289 MB | 121 MB | 153 MB | 80 MB |
| + boxed | 267 MB | 100 MB | 121 MB | **47 MB** |
| | −8 % | −17 % | −21 % | **−41 %** |

Post-drain live bytes fall 41 %. That is the residue #259 left behind.

**Cumulative**, this release's registrar + transaction + wheel work on that same
workload:

| | peak RSS | drained RSS | drained live |
|---|---|---|---|
| before any of it | 563 MB | 292 MB | 158 MB |
| now | **267 MB** | **121 MB** | **47 MB** |
| | −53 % | −59 % | −70 % |

## Why boxing again rather than a shrink policy

Same reasoning as #259: a periodic `shrink_to_fit` needs a policy and rehashes a
live table on the hot path, whereas boxing removes the reason to shrink. It
should also be marginally faster — inserting a pointer instead of memcpying 176
bytes, and the same on every table growth.

## Tests

`the_timer_wheel_stores_a_pointer_not_the_entry` mirrors the transaction guard:
pins the bucket against the key size, and guards the premise that the payload is
still large enough for the indirection to pay.

The `retain` closure that harvests fired timers now derefs out of the box
(`(**entry).clone()`) — the wheel owns boxes, the fired list is consumed by
value.

- `cargo test --all-features` — 4,522 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

## What is left

47 MB still resident after a full drain against 8 MB at boot, so ~39 MB of
capacity high-water remains, now spread thin rather than concentrated: the other
per-transaction maps are already small-bucket (`PendingRequest` 56 B,
`cancelled_invites` 72 B) or already behind an `Arc` (the proxy session maps),
and the registrar's `bindings` array is ~6 MB at this population. No single next
target stands out the way these two did.

Touches the per-message timer path, so it wants the 16-row SIPp baseline on the
reference box before merge. I have not run it.
