### PR TITLE
feat(b2bua): record every carrier an LCR sequence burned, and report the failover at info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,36 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   rate-independent floor of 51 MB, the concurrency-driven retention falls from
   107 MB to 30 MB.
 
+### Added
+- **An LCR failover now leaves a trace, and a record.** A call whose first
+  carrier returned `500` and which then answered on the second showed nothing of
+  it at `log.level: info` — the four lines describing the failover were `debug`,
+  and the only thing kept was `best_error`, a single code that exists to pick
+  what the A-leg gets once every carrier is exhausted. A completed call that
+  burned a carrier on its way recorded that nowhere, so a failing carrier could
+  not be alerted on, trended, or taken to the carrier.
+
+  - Each failed attempt is now recorded against the carrier that was in flight
+    (`carrier_id`, `status`, `elapsed_ms`; a ring timeout as `408`) and reported
+    at `info` along with the advance to the next carrier.
+  - `call.route_attempts` exposes that list to scripts wherever the `Call` is —
+    notably in `@b2bua.on_answer`, so a call that *answered* after failing over
+    can still name what it burned. `call.active_route` is unchanged and still
+    names the winner.
+  - `@b2bua.on_route_failure(call, route, code)` fires once per failed attempt,
+    including the last. It fires for every non-2xx a carrier returns — a
+    definitive `486` as much as a `503` — which is the same set
+    `route_attempts` records, so the two can never disagree; filter on `code`
+    for what you treat as a carrier's fault. Purely a notification: the failover
+    decision is already made and raising in it does not change the call.
+  - With `cdr.auto_emit` on, the attempts are stamped onto the CDR as
+    `lcr_attempts` (a compact JSON array), alongside the winning carrier's
+    existing `cdr_fields`.
+
+  `best_error` is now derived from the attempt list rather than accumulated
+  alongside it, so the code the caller receives and the per-attempt record
+  cannot drift apart. Selection is unchanged (6xx > 5xx > 4xx).
+
 ### Fixed
 - **A media failure at answer no longer connects the call and starts charging.**
   An exception out of `@b2bua.on_answer` was logged and then ignored: the A-leg

--- a/docs/cookbook/least-cost-routing.md
+++ b/docs/cookbook/least-cost-routing.md
@@ -94,6 +94,43 @@ Full example: [`examples/lcr_b2bua.py`](https://github.com/siphon-project/siphon
 - The A-leg receives a failure only once **every** carrier is exhausted;
   `@b2bua.on_failure` fires once, with the last carrier's response.
 - On answer, `call.active_route` is the carrier that won.
+- `call.route_attempts` lists the carriers it **burned** to get there — one
+  entry per failed attempt (`carrier_id`, `status`, `elapsed_ms`), oldest
+  first. Empty when the first carrier answered.
+
+## Seeing a failover happen
+
+A failover is an operational event, so it is reported at `info`: siphon logs
+each failed attempt with its carrier, status and elapsed time, and logs the
+advance to the next carrier.
+
+Two ways to keep it rather than just read it:
+
+```python
+@b2bua.on_route_failure
+def carrier_failed(call, route, code):
+    """Fires once per failed attempt, including the last."""
+    if code in (408, 503):                      # what YOU count as the carrier's fault
+        carrier_failures.labels(carrier=route.carrier_id).inc()
+
+@b2bua.on_answer
+def answered(call, reply):
+    for attempt in call.route_attempts:
+        log.warn(f"burned {attempt['carrier_id']} "
+                 f"{attempt['status']} after {attempt['elapsed_ms']}ms")
+```
+
+`@b2bua.on_route_failure` fires for **every** non-2xx a carrier returns — a
+definitive `486 Busy` as much as a `503`, and a ring timeout as `408`. That is
+the same set `call.route_attempts` records, so the two never disagree; filter on
+`code` for what you actually treat as a carrier health signal. It is purely a
+notification: the failover decision is already made, and raising in it does not
+change the call.
+
+When `cdr.auto_emit` is on, the same list is stamped onto the CDR as
+`lcr_attempts` (a compact JSON array), alongside the winning carrier's
+`cdr_fields` — so a completed call that burned a carrier records that in the
+billing pipeline instead of only in the log.
 
 `call.fork(strategy="sequential")` uses the same engine for a bare target list
 (this now actually fails over — previously the strategy was ignored). Captured

--- a/scripts/lcr_test.py
+++ b/scripts/lcr_test.py
@@ -25,11 +25,23 @@ async def route(call):
     call.route(decision.routes)
 
 
+@b2bua.on_route_failure
+def carrier_failed(call, route, code):
+    log.info(f"[{call.id}] carrier {route.carrier_id} failed {code}")
+
+
 @b2bua.on_answer
 def answered(call, reply):
     route = call.active_route
     if route:
         log.info(f"[{call.id}] answered via {route.carrier_id}")
+    # The carriers burned on the way to that answer — nothing recorded these
+    # before, so a completed call that failed over left no trace of it.
+    for attempt in call.route_attempts:
+        log.info(
+            f"[{call.id}] burned {attempt['carrier_id']} "
+            f"{attempt['status']} after {attempt['elapsed_ms']}ms"
+        )
 
 
 @b2bua.on_failure

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -71,6 +71,7 @@ class Call:
         refer_side: Optional[str] = None,
         transport: str = "udp",
         active_route: Optional[Route] = None,
+        route_attempts: Optional[list[dict]] = None,
         flow: Optional[Flow] = None,
     ) -> None:
         self._id = call_id or str(uuid.uuid4())
@@ -102,6 +103,10 @@ class Call:
         # dispatcher sets this on the on_answer/on_bye Call; in tests pass
         # ``active_route=`` (or set ``call._active_route``) to simulate the winner.
         self._active_route = active_route
+        # LCR: the carriers that FAILED before the sequence settled. The
+        # dispatcher fills this from the call actor's recorded attempts; pass
+        # ``route_attempts=`` to simulate a call that failed over.
+        self._route_attempts: list[dict] = list(route_attempts) if route_attempts else []
         # Ro reserve-before-connect gate: the result ``ro_authorize`` returns
         # (default a grant), and a record of each call for test assertions.
         self._ro_authorize_result: Optional[dict] = None
@@ -118,6 +123,28 @@ class Call:
         (``call.route(...)``), or ``None`` for a non-LCR call. Read in
         ``@b2bua.on_answer`` / ``on_bye`` to stamp the carrier onto a CDR."""
         return self._active_route
+
+    @property
+    def route_attempts(self) -> list[dict]:
+        """Every carrier attempt that FAILED before this call settled, oldest
+        first — the counterpart to :attr:`active_route`, which names only the
+        winner.
+
+        Each entry is a dict with ``carrier_id``, ``status`` and
+        ``elapsed_ms``. Empty for a non-LCR call, and for an LCR call whose
+        first carrier answered. Available wherever the ``Call`` is, so a call
+        that answered *after* burning a carrier can still record which one it
+        burned — siphon stamps the same list onto the CDR as ``lcr_attempts``.
+
+        Example::
+
+            @b2bua.on_answer
+            def answered(call, reply):
+                for attempt in call.route_attempts:
+                    log.warn(f"carrier {attempt['carrier_id']} failed "
+                             f"{attempt['status']} after {attempt['elapsed_ms']}ms")
+        """
+        return self._route_attempts
 
     @property
     def id(self) -> str:

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -1062,6 +1062,36 @@ class MockB2bua:
         _registry.register("b2bua.on_cancel", None, fn, is_async)
         return fn
 
+    @staticmethod
+    def on_route_failure(fn: Callable) -> Callable:
+        """Register handler for one failed carrier of an LCR sequence.
+
+        Handler signature: ``(call, route, code) -> None``
+
+        Fires once per failed attempt of a ``call.route(...)`` sequential
+        failover — including the last one, and for every non-2xx a carrier
+        returns (a definitive ``486`` as much as a ``503``) plus a ring
+        timeout, reported as ``408``. That is the same set
+        :attr:`~siphon_sdk.call.Call.route_attempts` records, so the two can
+        never disagree; filter on ``code`` for whatever you count as the
+        carrier's fault.
+
+        Purely a notification: the failover decision is already made by the
+        time this runs, and unlike ``@b2bua.on_answer`` raising here does not
+        change the call's outcome. Use it to count a carrier out, alert, or
+        feed your own health view.
+
+        Example::
+
+            @b2bua.on_route_failure
+            def carrier_failed(call, route, code):
+                if code in (408, 503):
+                    log.warn(f"carrier {route.carrier_id} failed {code}")
+        """
+        is_async = asyncio.iscoroutinefunction(fn)
+        _registry.register("b2bua.on_route_failure", None, fn, is_async)
+        return fn
+
 
 # ---------------------------------------------------------------------------
 # Registrar namespace

--- a/sdk/tests/test_lcr.py
+++ b/sdk/tests/test_lcr.py
@@ -76,6 +76,56 @@ class TestCallRoute:
         with pytest.raises(ValueError):
             Call().route([Route(carrier_id="a", next_hop="sip:h")], send_socket="bad")
 
+    def test_route_attempts_default_empty(self):
+        # Read on every Call a script sees, LCR or not, so it must never be None.
+        assert Call().route_attempts == []
+
+    def test_route_attempts_records_the_carriers_that_were_burned(self):
+        # The counterpart to active_route: a call that ANSWERED after failing
+        # over still names the carrier it burned, which is the record that did
+        # not exist before.
+        call = Call(
+            active_route=Route(carrier_id="carrier-b"),
+            route_attempts=[
+                {"carrier_id": "carrier-a", "status": 503, "elapsed_ms": 1204},
+            ],
+        )
+        assert call.active_route.carrier_id == "carrier-b"
+        assert [a["carrier_id"] for a in call.route_attempts] == ["carrier-a"]
+        assert call.route_attempts[0]["status"] == 503
+        assert call.route_attempts[0]["elapsed_ms"] == 1204
+
+
+class TestOnRouteFailure:
+    """`@b2bua.on_route_failure` — one carrier of a sequence failed."""
+
+    def setup_method(self):
+        mock_module.install()
+        mock_module.reset()
+
+    def test_decorator_registers_under_the_engine_event_name(self):
+        # The name has to match what the Rust side maps to
+        # HandlerKind::B2buaRouteFailure, or a script that tests green here
+        # registers a handler the engine never calls.
+        from siphon import b2bua
+
+        @b2bua.on_route_failure
+        def carrier_failed(call, route, code):
+            pass
+
+        registered = mock_module._registry.get("b2bua.on_route_failure")
+        assert [fn for fn, _ in registered] == [carrier_failed]
+
+    def test_async_handler_is_recorded_as_async(self):
+        from siphon import b2bua
+
+        @b2bua.on_route_failure
+        async def carrier_failed(call, route, code):
+            pass
+
+        registered = mock_module._registry.get("b2bua.on_route_failure")
+        assert [is_async for _, is_async in registered] == [True]
+
 
 class TestMockLcrNamespace:
     def setup_method(self):

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -906,12 +906,11 @@ pub struct PendingReplaces {
 ///
 /// Carriers are tried one at a time in order: [`active`](Self::active) is the
 /// attempt currently in flight (or the winner after a 2xx), [`pending`](Self::pending)
-/// holds the not-yet-tried carriers (front = next), and [`best_error`](Self::best_error)
-/// accumulates the highest-priority failure so a fully-exhausted sequence
-/// surfaces the right code to the A-leg. When `None` on a [`CallActor`], the call
-/// is a plain single dial or a parallel fork (no failover). Each attempt is a
-/// fresh B-leg dialog (`b2bua_send_b_leg_invite` mints a new Call-ID/From-tag/
-/// CSeq per call), so no carrier ever sees a reused Call-ID.
+/// holds the not-yet-tried carriers (front = next), and [`attempts`](Self::attempts)
+/// records every carrier that failed. When `None` on a [`CallActor`], the call is a
+/// plain single dial or a parallel fork (no failover). Each attempt is a fresh
+/// B-leg dialog (`b2bua_send_b_leg_invite` mints a new Call-ID/From-tag/CSeq per
+/// call), so no carrier ever sees a reused Call-ID.
 #[derive(Debug, Default)]
 pub struct RouteSequenceState {
     /// Carriers still to try, front = next attempt.
@@ -919,12 +918,36 @@ pub struct RouteSequenceState {
     /// The carrier currently in flight — becomes the winner on a 2xx answer.
     /// Surfaced to scripts as `call.active_route` for CDR/charging.
     pub active: Option<crate::lcr::Route>,
-    /// Highest-priority error across failed attempts (6xx > 5xx > 4xx).
-    pub best_error: Option<u16>,
+    /// Every failed attempt, in the order they were tried.
+    ///
+    /// This used to be a single `best_error: Option<u16>`, which is all the
+    /// A-leg needs (the code sent once every carrier is exhausted) and nothing
+    /// an operator needs: a call that burned a carrier on its way to answering
+    /// recorded that nowhere, so a failing carrier could not be alerted on,
+    /// trended, or taken to the carrier. The best error is now derived from
+    /// this — see [`CallActor::best_route_error`].
+    pub attempts: Vec<RouteAttempt>,
+    /// When the in-flight attempt was dialled, for its elapsed time.
+    pub active_since: Option<std::time::Instant>,
     /// Call-level send-socket egress pin applied to every attempt.
     pub send_socket: Option<String>,
     /// Ring timeout (seconds) for a route that omits its own `timeout_secs`.
     pub default_timeout: u32,
+}
+
+/// One failed carrier attempt in a sequential failover sequence.
+///
+/// Surfaced to scripts as `call.route_attempts`, to `@b2bua.on_route_failure`,
+/// and onto the CDR as `lcr_attempts`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteAttempt {
+    /// The carrier that was tried (`Route::carrier_id`).
+    pub carrier_id: String,
+    /// Its final status. A ring timeout is recorded as `408`, the code the
+    /// attempt effectively ended on.
+    pub status: u16,
+    /// How long the attempt was in flight, in milliseconds.
+    pub elapsed_ms: u64,
 }
 
 #[derive(Debug)]
@@ -1149,21 +1172,39 @@ impl CallActor {
         let sequence = self.route_sequence.as_mut()?;
         let route = sequence.pending.pop_front()?;
         sequence.active = Some(route.clone());
+        sequence.active_since = Some(std::time::Instant::now());
         Some(route)
     }
 
-    /// Record a failed attempt's status code, keeping the highest-priority one
-    /// (6xx > 5xx > 4xx). No-op for a non-sequential call.
-    pub fn record_route_failure(&mut self, status_code: u16) {
-        if let Some(sequence) = self.route_sequence.as_mut() {
-            let keep = match sequence.best_error {
-                Some(existing) if error_priority(existing) >= error_priority(status_code) => {
-                    existing
-                }
-                _ => status_code,
-            };
-            sequence.best_error = Some(keep);
-        }
+    /// Record a failed attempt against the carrier that was in flight. No-op for
+    /// a non-sequential call.
+    ///
+    /// Returns the attempt, so the caller can log it and hand it to
+    /// `@b2bua.on_route_failure` without re-reading the actor.
+    pub fn record_route_failure(&mut self, status_code: u16) -> Option<RouteAttempt> {
+        let sequence = self.route_sequence.as_mut()?;
+        let attempt = RouteAttempt {
+            carrier_id: sequence
+                .active
+                .as_ref()
+                .map(|route| route.carrier_id.clone())
+                .unwrap_or_default(),
+            status: status_code,
+            elapsed_ms: sequence
+                .active_since
+                .map(|since| since.elapsed().as_millis() as u64)
+                .unwrap_or_default(),
+        };
+        sequence.attempts.push(attempt.clone());
+        Some(attempt)
+    }
+
+    /// Every failed attempt so far, in the order they were tried.
+    pub fn route_attempts(&self) -> &[RouteAttempt] {
+        self.route_sequence
+            .as_ref()
+            .map(|sequence| sequence.attempts.as_slice())
+            .unwrap_or_default()
     }
 
     /// Whether more carriers remain to try in the failover queue.
@@ -1178,9 +1219,22 @@ impl CallActor {
         self.route_sequence.is_some()
     }
 
-    /// The best (highest-priority) error seen across exhausted attempts.
+    /// The best (highest-priority) error seen across exhausted attempts
+    /// (6xx > 5xx > 4xx), which is the code a fully-exhausted sequence surfaces
+    /// to the A-leg. Derived from [`RouteSequenceState::attempts`] rather than
+    /// accumulated, so the per-attempt record and the code the caller gets can
+    /// never disagree.
     pub fn best_route_error(&self) -> Option<u16> {
-        self.route_sequence.as_ref().and_then(|s| s.best_error)
+        self.route_attempts()
+            .iter()
+            .map(|attempt| attempt.status)
+            .reduce(|best, status| {
+                if error_priority(best) >= error_priority(status) {
+                    best
+                } else {
+                    status
+                }
+            })
     }
 
     /// The carrier currently in flight / that won (for `call.active_route`).
@@ -2319,11 +2373,20 @@ impl CallActorStore {
         self.calls.get_mut(call_id)?.take_next_route()
     }
 
-    /// Record a failed attempt's status code for a call's failover sequence.
-    pub fn record_route_failure(&self, call_id: &str, status_code: u16) {
-        if let Some(mut call) = self.calls.get_mut(call_id) {
-            call.record_route_failure(status_code);
-        }
+    /// Record a failed attempt against a call's in-flight carrier, returning it
+    /// so the caller can log it and dispatch `@b2bua.on_route_failure`.
+    pub fn record_route_failure(&self, call_id: &str, status_code: u16) -> Option<RouteAttempt> {
+        self.calls
+            .get_mut(call_id)?
+            .record_route_failure(status_code)
+    }
+
+    /// Every failed attempt of a call's failover sequence, in order tried.
+    pub fn route_attempts(&self, call_id: &str) -> Vec<RouteAttempt> {
+        self.calls
+            .get(call_id)
+            .map(|call| call.route_attempts().to_vec())
+            .unwrap_or_default()
     }
 
     /// Whether a call has more carriers to try in its failover queue.
@@ -3353,6 +3416,61 @@ mod tests {
         // 6xx outranks everything.
         actor.record_route_failure(603);
         assert_eq!(actor.best_route_error(), Some(603));
+    }
+
+    /// Each failure is recorded against the carrier that was actually in
+    /// flight, in the order tried — the record that used to be collapsed into a
+    /// single best-error code, so a call that burned a carrier on its way to
+    /// answering said nothing about which one.
+    #[test]
+    fn every_attempt_is_recorded_against_the_carrier_that_was_tried() {
+        let mut actor = CallActor::new(make_a_leg());
+        actor.route_sequence = Some(RouteSequenceState {
+            pending: [lcr_route("a"), lcr_route("b"), lcr_route("c")]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        });
+
+        actor.take_next_route().expect("carrier a");
+        let first = actor.record_route_failure(503).expect("attempt recorded");
+        assert_eq!(first.carrier_id, "a");
+        assert_eq!(first.status, 503);
+
+        actor.take_next_route().expect("carrier b");
+        // A ring timeout is recorded like any other failure, as 408.
+        let second = actor.record_route_failure(408).expect("attempt recorded");
+        assert_eq!(second.carrier_id, "b");
+        assert_eq!(second.status, 408);
+
+        // Carrier c is dialled and answers, so it is never recorded as an
+        // attempt — it is the winner, and reaches a script as `active_route`.
+        actor.take_next_route().expect("carrier c");
+
+        let carriers: Vec<&str> = actor
+            .route_attempts()
+            .iter()
+            .map(|attempt| attempt.carrier_id.as_str())
+            .collect();
+        assert_eq!(carriers, ["a", "b"]);
+        assert_eq!(
+            actor.active_route().map(|route| route.carrier_id.as_str()),
+            Some("c"),
+            "the answering carrier is the winner, not an attempt"
+        );
+        // Derived from the attempts, so the code the A-leg would get and the
+        // per-attempt record cannot disagree.
+        assert_eq!(actor.best_route_error(), Some(503));
+    }
+
+    /// A call with no failover sequence has nothing to report, and asking must
+    /// not be an error — every `Call` handed to a script reads this property,
+    /// LCR or not.
+    #[test]
+    fn a_non_lcr_call_reports_no_attempts() {
+        let mut actor = CallActor::new(make_a_leg());
+        assert!(actor.route_attempts().is_empty());
+        assert!(actor.record_route_failure(503).is_none());
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11372,6 +11372,42 @@ fn cdr_stamp_route_fields(
     }
 }
 
+/// Stamp the carriers a sequential-failover call BURNED onto its CDR, as
+/// `lcr_attempts`.
+///
+/// The winner already reaches the record through `cdr_stamp_route_fields`; this
+/// is the other half, and the half that was missing — a completed call that
+/// burned a carrier on the way recorded that nowhere, so a failing carrier could
+/// not be trended or taken to the carrier. Serialised as a compact JSON array
+/// because `Cdr.extra` is a flat string map.
+fn cdr_stamp_route_attempts(state: &DispatcherState, internal_call_id: &str) {
+    if !crate::cdr::auto_emit_enabled() {
+        return;
+    }
+    let attempts = state.call_actors.route_attempts(internal_call_id);
+    if attempts.is_empty() {
+        return;
+    }
+    let rendered = attempts
+        .iter()
+        .map(|attempt| {
+            format!(
+                r#"{{"carrier_id":{},"status":{},"elapsed_ms":{}}}"#,
+                serde_json::Value::String(attempt.carrier_id.clone()),
+                attempt.status,
+                attempt.elapsed_ms
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    if let Some(mut session) = state.cdr_sessions.get_mut(internal_call_id) {
+        session.merge_extra(&std::collections::HashMap::from([(
+            "lcr_attempts".to_string(),
+            format!("[{rendered}]"),
+        )]));
+    }
+}
+
 /// B2BUA CDR STOP — a BYE tore the call down. `from_a_leg` gives the side.
 fn cdr_finalize_b2bua_stop(
     state: &DispatcherState,
@@ -13861,7 +13897,21 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
     // ring timeout. If more carriers remain and 408 is a reroute cause for this
     // carrier, CANCEL this attempt and advance instead of failing the call.
     if state.call_actors.has_pending_routes(call_id) && b2bua_status_reroutes(call_id, 408, state) {
-        state.call_actors.record_route_failure(call_id, 408);
+        // A ring timeout is recorded as 408 — the code the attempt effectively
+        // ended on, and the one the A-leg would have seen had the queue been
+        // exhausted here.
+        let timed_out_route = state.call_actors.active_route(call_id);
+        if let Some(attempt) = state.call_actors.record_route_failure(call_id, 408) {
+            info!(
+                call_id = %call_id,
+                carrier = %attempt.carrier_id,
+                elapsed_ms = attempt.elapsed_ms,
+                "LCR: carrier ring-timeout"
+            );
+        }
+        if let Some(route) = &timed_out_route {
+            b2bua_dispatch_route_failure(call_id, route, 408, &a_leg, a_leg_invite.as_ref(), state);
+        }
         // CANCEL the timed-out carrier's pending B-leg(s) (RFC 3261 §9.1) and
         // mark them cancelled so their stray 487s are absorbed.
         for (cancel_msg, transport, dest, local) in &cancel_targets {
@@ -13876,7 +13926,7 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
             _ => false,
         };
         if advanced {
-            debug!(call_id = %call_id, "LCR: carrier ring-timeout, advanced to next carrier");
+            info!(call_id = %call_id, "LCR: advanced to next carrier after ring-timeout");
             return;
         }
         // else fall through to the normal 408 teardown (queue exhausted).
@@ -14736,7 +14786,8 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                 crate::b2bua::actor::RouteSequenceState {
                     pending: routes.into(),
                     active: None,
-                    best_error: None,
+                    attempts: Vec::new(),
+                    active_since: None,
                     send_socket,
                     default_timeout,
                 },
@@ -17992,6 +18043,7 @@ fn handle_b2bua_response(
                     cdr_stamp_route_fields(state, call_id, &route.cdr_fields);
                     ro_stamp_winning_carrier(state, call_id, &route.carrier_id);
                 }
+                cdr_stamp_route_attempts(state, call_id);
 
                 // Charging is NOT reported here. Both emissions below moved to after
                 // @b2bua.on_answer, because the handler is where the media backend is
@@ -18025,10 +18077,14 @@ fn handle_b2bua_response(
                         )
                         .with_flow(py_flow_from_leg(&a_leg.transport));
                         // LCR: surface the carrier that won as `call.active_route` so the
-                        // script can stamp it onto a CDR / charging record.
+                        // script can stamp it onto a CDR / charging record, and the
+                        // carriers it had to burn to get there as `call.route_attempts`
+                        // — an answered call that failed over used to record that
+                        // nowhere.
                         if let Some(route) = state.call_actors.active_route(call_id) {
                             py_call.set_active_route(route);
                         }
+                        py_call.set_route_attempts(state.call_actors.route_attempts(call_id));
                         let py_reply = PyReply::new(Arc::clone(&response_arc))
                             .with_a_leg(Arc::clone(invite_arc))
                             .with_response_source(
@@ -19403,11 +19459,36 @@ fn handle_b2bua_response(
                             );
                             send_b2bua_to_bleg(ack, b_transport, b_dest, b_leg_local_addr, state);
                         }
-                        debug!(call_id = %call_id, status = status_code,
+                        info!(call_id = %call_id, status = status_code,
                     "LCR: absorbing straggler carrier response (cancelled / post-answer / 487)");
                         return;
                     }
-                    state.call_actors.record_route_failure(call_id, status_code);
+                    // Record the attempt against the carrier that was in flight, then
+                    // report it. A carrier failing is an operational event — it used to
+                    // be visible only at debug, so an answered call that burned a
+                    // carrier on the way left nothing to alert on or trend.
+                    let failed_route = state.call_actors.active_route(call_id);
+                    if let Some(attempt) =
+                        state.call_actors.record_route_failure(call_id, status_code)
+                    {
+                        info!(
+                            call_id = %call_id,
+                            carrier = %attempt.carrier_id,
+                            status = status_code,
+                            elapsed_ms = attempt.elapsed_ms,
+                            "LCR: carrier attempt failed"
+                        );
+                    }
+                    if let Some(route) = &failed_route {
+                        b2bua_dispatch_route_failure(
+                            call_id,
+                            route,
+                            status_code,
+                            &a_leg,
+                            a_leg_invite.as_ref(),
+                            state,
+                        );
+                    }
                     // Fail over only on a configured reroute cause (per-route from the
                     // API > per-gateway override > global set). A definitive response
                     // (486 Busy, 603 Decline, …) is forwarded to the A-leg as-is —
@@ -19438,12 +19519,12 @@ fn handle_b2bua_response(
                             _ => false,
                         };
                         if advanced {
-                            debug!(call_id = %call_id, status = status_code,
-                        "LCR: carrier failed, advanced to next carrier");
+                            info!(call_id = %call_id, status = status_code,
+                        "LCR: advanced to next carrier");
                             return;
                         }
                     }
-                    debug!(call_id = %call_id, status = status_code, reroute,
+                    info!(call_id = %call_id, status = status_code, reroute,
                 "LCR: forwarding carrier response to A-leg (definitive or exhausted)");
                 }
 
@@ -19452,6 +19533,9 @@ fn handle_b2bua_response(
                 // written for the failed call either way. Skipped for a relayed challenge
                 // (the call has not failed).
                 if !relay_challenge {
+                    // Every carrier tried, before the record is closed — an exhausted
+                    // sequence is exactly where the attempt list matters most.
+                    cdr_stamp_route_attempts(state, call_id);
                     cdr_finalize_b2bua_fail(state, call_id, status_code);
                 }
 
@@ -19466,13 +19550,16 @@ fn handle_b2bua_response(
                     };
 
                     if let Some(invite_arc) = &a_leg_invite {
-                        let py_call = PyCall::new(
+                        let mut py_call = PyCall::new(
                             call_id.to_string(),
                             Arc::clone(invite_arc),
                             a_leg.transport.remote_addr.ip().to_string(),
                             format!("{}", a_leg.transport.transport).to_lowercase(),
                         )
                         .with_flow(py_flow_from_leg(&a_leg.transport));
+                        // Every carrier tried, so a handler for an exhausted sequence
+                        // can report which ones failed and how, not just the best code.
+                        py_call.set_route_attempts(state.call_actors.route_attempts(call_id));
 
                         Python::attach(|python| {
                             let call_obj = match Py::new(python, py_call) {
@@ -19624,6 +19711,78 @@ fn handle_b2bua_response(
             }
         } // end ResponseClass::Failed
     } // end match class
+}
+
+/// Invoke `@b2bua.on_route_failure` for one failed carrier of a sequential
+/// failover sequence.
+///
+/// Fires once per failed attempt, including the last one before the A-leg is
+/// given up on, and for every non-2xx a carrier returns — a definitive `486`
+/// as much as a `503`. That is deliberate: the same set is what
+/// `call.route_attempts` records, so the hook and the attempt list can never
+/// disagree, and the script filters on `code` for whatever it counts as a
+/// carrier's fault.
+///
+/// Purely a notification. The failover decision has already been made by the
+/// time this runs, and unlike `@b2bua.on_answer` a raise here does not change
+/// the call's outcome — it is logged and the sequence carries on.
+fn b2bua_dispatch_route_failure(
+    call_id: &str,
+    route: &crate::lcr::Route,
+    status_code: u16,
+    a_leg: &crate::b2bua::actor::Leg,
+    a_leg_invite: Option<&Arc<std::sync::Mutex<SipMessage>>>,
+    state: &DispatcherState,
+) {
+    let engine_state = state.engine.state();
+    let handlers = engine_state.handlers_for(&HandlerKind::B2buaRouteFailure);
+    if handlers.is_empty() {
+        return;
+    }
+    let Some(invite_arc) = a_leg_invite else {
+        warn!(call_id = %call_id, "B2BUA: no stored A-leg INVITE for on_route_failure");
+        return;
+    };
+
+    let mut py_call = PyCall::new(
+        call_id.to_string(),
+        Arc::clone(invite_arc),
+        a_leg.transport.remote_addr.ip().to_string(),
+        format!("{}", a_leg.transport.transport).to_lowercase(),
+    )
+    .with_flow(py_flow_from_leg(&a_leg.transport));
+    py_call.set_route_attempts(state.call_actors.route_attempts(call_id));
+    let py_route = crate::script::api::lcr::PyRoute::from_route(route.clone());
+
+    Python::attach(|python| {
+        let call_obj = match Py::new(python, py_call) {
+            Ok(obj) => obj,
+            Err(error) => {
+                error!("failed to create PyCall for on_route_failure: {error}");
+                return;
+            }
+        };
+        let route_obj = match Py::new(python, py_route) {
+            Ok(obj) => obj,
+            Err(error) => {
+                error!("failed to create PyRoute for on_route_failure: {error}");
+                return;
+            }
+        };
+        for handler in &handlers {
+            let callable = handler.callable.bind(python);
+            match callable.call1((call_obj.bind(python), route_obj.bind(python), status_code)) {
+                Ok(ret) => {
+                    if handler.is_async {
+                        if let Err(error) = run_coroutine(python, &ret) {
+                            error!("async B2BUA on_route_failure handler error: {error}");
+                        }
+                    }
+                }
+                Err(error) => error!("B2BUA on_route_failure handler error: {error}"),
+            }
+        }
+    });
 }
 
 /// Schedule cleanup of zombie re-INVITE entries after Timer H (32 seconds).
@@ -21833,7 +21992,8 @@ pub fn b2bua_route_call(
         crate::b2bua::actor::RouteSequenceState {
             pending: routes.into(),
             active: None,
-            best_error: None,
+            attempts: Vec::new(),
+            active_since: None,
             send_socket: None,
             default_timeout,
         },

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -6,6 +6,7 @@
 use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 use super::sip_uri::PySipUri;
 use crate::sip::message::SipMessage;
@@ -344,6 +345,12 @@ pub struct PyCall {
     /// `route_sequence.active`. Read by scripts via `call.active_route` to stamp
     /// the winning carrier onto a CDR / charging record.
     active_route: Option<crate::lcr::Route>,
+    /// Every carrier that FAILED before the sequence settled — injected by the
+    /// dispatcher from the call actor's `route_sequence.attempts`. Read by
+    /// scripts via `call.route_attempts`, the counterpart to `active_route`:
+    /// that one names the carrier that carried the call, this one names the
+    /// carriers it had to burn to get there.
+    route_attempts: Vec<crate::b2bua::actor::RouteAttempt>,
     /// Username verified by `auth.require_proxy_digest(call, …)` /
     /// `require_www_digest` on the A-leg INVITE. `None` until a challenge is
     /// answered correctly. The B2BUA twin of `request.auth_user`; the
@@ -443,6 +450,7 @@ impl PyCall {
             header_policy_input: None,
             auth_passthrough_flag: false,
             active_route: None,
+            route_attempts: Vec::new(),
             auth_user: None,
         }
     }
@@ -485,6 +493,12 @@ impl PyCall {
     /// the handler `Call`.
     pub fn set_active_route(&mut self, route: crate::lcr::Route) {
         self.active_route = Some(route);
+    }
+
+    /// Attach the failed carrier attempts read off the call actor, for
+    /// `call.route_attempts`.
+    pub fn set_route_attempts(&mut self, attempts: Vec<crate::b2bua::actor::RouteAttempt>) {
+        self.route_attempts = attempts;
     }
 
     /// Build an [`LcrRequest`](crate::lcr::LcrRequest) from this call for
@@ -1787,6 +1801,37 @@ impl PyCall {
         self.active_route
             .as_ref()
             .map(|route| super::lcr::PyRoute::from_route(route.clone()))
+    }
+
+    /// Every carrier attempt that FAILED before this call settled, oldest first
+    /// — the counterpart to `active_route`, which names only the winner.
+    ///
+    /// Each entry is a dict with `carrier_id`, `status` and `elapsed_ms`. Empty
+    /// for a non-LCR call, and for an LCR call whose first carrier answered.
+    /// Available wherever the `Call` is (`@b2bua.on_answer`, `on_failure`,
+    /// `on_bye`, `on_route_failure`), so a call that answered *after* burning a
+    /// carrier can still record which one it burned — siphon stamps the same
+    /// list onto the CDR as `lcr_attempts`.
+    ///
+    /// ```python
+    /// @b2bua.on_answer
+    /// def answered(call, reply):
+    ///     for attempt in call.route_attempts:
+    ///         log.warn(f"carrier {attempt['carrier_id']} failed "
+    ///                  f"{attempt['status']} after {attempt['elapsed_ms']}ms")
+    /// ```
+    #[getter]
+    fn route_attempts<'py>(&self, python: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
+        self.route_attempts
+            .iter()
+            .map(|attempt| {
+                let entry = PyDict::new(python);
+                entry.set_item("carrier_id", &attempt.carrier_id)?;
+                entry.set_item("status", attempt.status)?;
+                entry.set_item("elapsed_ms", attempt.elapsed_ms)?;
+                Ok(entry)
+            })
+            .collect()
     }
 
     /// The Refer-To URI (only set during @b2bua.on_refer handler).

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -468,6 +468,35 @@ class _B2buaNamespace:
         _registry.register("b2bua.on_cancel", None, fn, is_async)
         return fn
 
+    @staticmethod
+    def on_route_failure(fn):
+        """Register handler for one failed carrier of an LCR sequence.
+
+        Fires once per failed attempt of a ``call.route(...)`` sequential
+        failover — including the last one, and for every non-2xx a carrier
+        returns (a definitive ``486`` as much as a ``503``) plus a ring
+        timeout, reported as ``408``. That is the same set ``call.route_attempts``
+        records, so the two can never disagree; filter on ``code`` for
+        whatever you count as the carrier's fault.
+
+        Purely a notification: the failover decision is already made by the
+        time this runs, and unlike ``@b2bua.on_answer`` raising here does not
+        change the call's outcome. Use it to count a carrier out, alert, or
+        feed your own health view.
+
+        Usage:
+            @b2bua.on_route_failure
+            def carrier_failed(call, route, code):
+                if code in (408, 503):
+                    metrics.counter("carrier_failures_total",
+                                    "carrier failures",
+                                    labels=["carrier"]).labels(
+                                        carrier=route.carrier_id).inc()
+        """
+        is_async = _asyncio.iscoroutinefunction(fn)
+        _registry.register("b2bua.on_route_failure", None, fn, is_async)
+        return fn
+
 
 # ---------------------------------------------------------------------------
 # Registrar namespace (stubs — wired to Rust in Phase 4)

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -71,6 +71,12 @@ pub enum HandlerKind {
     B2buaBye,
     /// `@b2bua.on_refer` — call transfer (RFC 3515).
     B2buaRefer,
+    /// `@b2bua.on_route_failure` — one carrier of a `call.route(...)` sequential
+    /// failover returned a non-2xx (or rang out). Fires once per failed attempt,
+    /// including the last, so a script can count a carrier out or feed its own
+    /// health view. Purely a notification: the failover decision is already made
+    /// and a raise here does not change it.
+    B2buaRouteFailure,
     /// `@b2bua.on_cancel` — an unanswered call (Calling/Ringing) was
     /// CANCELled. Fires once per call with the Call object so a B2BUA
     /// script can release per-call resources (rtpengine media, QoS) that
@@ -455,6 +461,7 @@ impl ScriptState {
                     | HandlerKind::B2buaFailure
                     | HandlerKind::B2buaBye
                     | HandlerKind::B2buaRefer
+                    | HandlerKind::B2buaRouteFailure
             )
         })
     }
@@ -1223,6 +1230,7 @@ fn extract_handlers(_python: Python<'_>, registry: &Bound<'_, PyAny>) -> Result<
             "b2bua.on_failure" => HandlerKind::B2buaFailure,
             "b2bua.on_bye" => HandlerKind::B2buaBye,
             "b2bua.on_refer" => HandlerKind::B2buaRefer,
+            "b2bua.on_route_failure" => HandlerKind::B2buaRouteFailure,
             "b2bua.on_cancel" => HandlerKind::B2buaCancel,
             "registrar.on_change" => HandlerKind::RegistrarOnChange,
             "registration.on_change" => HandlerKind::RegistrantOnChange,


### PR DESCRIPTION
A call whose first carrier returned `500` failed over correctly to the second and
answered. At `log.level: info` there was no sign it ever happened, and afterwards
no record of it anywhere. An operator reading the log could not tell whether the
first carrier was tried, whether it failed, or why.

Three reasons, all of them addressed here:

1. **The engine logged it at debug.** The four lines describing a failover — the
   failed attempt, the advance, the straggler absorb, the ring timeout — were all
   `debug!`. A carrier failing is an operational event, not a debug detail.
2. **Nothing kept it.** `RouteSequenceState` collapsed every failed attempt into
   one `best_error: Option<u16>`, which exists solely to pick the code the A-leg
   gets once every carrier is exhausted. A completed call that burned a carrier
   recorded that nowhere — not in the log, not on the `Call`, not in the CDR — so
   a failing carrier could not be alerted on, trended, or taken to the carrier.
3. **No script hook.** `@b2bua.on_failure` fires only once the whole sequence is
   exhausted, so a `500`-then-`200` hit nothing at all.

## What changed

- Each failed attempt is recorded against the carrier that was actually in
  flight — `carrier_id`, `status`, `elapsed_ms` — and reported at `info`
  alongside the advance. A ring timeout is recorded as `408`, the code the
  attempt effectively ended on.
- **`call.route_attempts`** exposes that list to scripts wherever the `Call` is,
  notably in `@b2bua.on_answer`, so a call that *answered* after failing over can
  still name what it burned. `call.active_route` is unchanged and still names the
  winner; this is its counterpart.
- **`@b2bua.on_route_failure(call, route, code)`** fires once per failed attempt,
  including the last.
- With `cdr.auto_emit` on, the same list is stamped onto the CDR as
  `lcr_attempts` (a compact JSON array), beside the winning carrier's existing
  `cdr_fields`.

Two deliberate choices worth flagging in review:

- The hook fires for **every** non-2xx a carrier returns, a definitive `486` as
  much as a `503`. That is the same set `route_attempts` records, so the hook and
  the list can never disagree, and the script filters on `code` for whatever it
  counts as the carrier's fault.
- It is purely a notification. The failover decision is already made by the time
  it runs, and unlike `@b2bua.on_answer` a raise in it does not change the call's
  outcome.

`best_error` is now **derived** from the attempt list rather than accumulated
alongside it, so the code the caller receives and the per-attempt record cannot
drift apart. Selection is unchanged (6xx > 5xx > 4xx) and the existing priority
test is kept as the guard.

## Verification

Unit tests cover attempts being recorded against the right carrier in order, the
winner not being recorded as an attempt, a ring timeout landing as `408`, and a
non-LCR call reporting nothing rather than erroring. SDK tests cover the new
property and that the decorator registers under the name the engine maps to.

Checked end to end through the existing LCR harness on both failover shapes — the
`503` reject and the silent-carrier ring timeout:

```
INFO siphon::dispatcher: LCR: carrier attempt failed carrier=carrier-a status=503 elapsed_ms=2
INFO siphon::script:     carrier carrier-a failed 503
INFO siphon::dispatcher: LCR: advanced to next carrier status=503
INFO siphon::script:     answered via carrier-b
INFO siphon::script:     burned carrier-a 503 after 2ms
```

and the timeout mode, where the attempt lands as `408` after the configured 3 s
ring:

```
INFO siphon::dispatcher: LCR: carrier ring-timeout carrier=carrier-a elapsed_ms=3470
INFO siphon::script:     carrier carrier-a failed 408
INFO siphon::script:     burned carrier-a 408 after 3470ms
```