### PR TITLE
docs(config): say which codec ops engage the transcoder and which only reshape the far offer

### DIFF
--- a/siphon.yaml
+++ b/siphon.yaml
@@ -677,6 +677,30 @@ auth:
 #   ignore     treat as though the offer never contained them
 #   set        options for accepted transcoding codecs (bitrate/rate/channels)
 #
+# Which of these engage the TRANSCODER, and which only reshape what the far side
+# is offered, is the distinction worth knowing before reaching for one:
+#
+#   strip / offer / except / ignore   edit the offer the far side sees. The near
+#                                     leg follows whatever the far side then
+#                                     ANSWERS with (RFC 3264 §6.1 — the
+#                                     answerer's selection is the format for the
+#                                     stream), so no transcoder is engaged and
+#                                     the call relays.
+#   mask / consume / accept           deliberately keep the codec on the near leg
+#                                     while hiding it from the far side, so the
+#                                     two sides differ and the engine bridges
+#                                     them. That IS the transcode request.
+#   transcode                         adds a codec the offerer never listed, so
+#                                     the far side can select something the near
+#                                     side cannot send. Also a transcode request.
+#
+# So to keep a codec off a carrier that cannot take it, `strip` it — the call
+# then settles on whatever the carrier does answer, with no transcoding involved.
+# Reach for `mask` / `consume` only when you actually want the engine to bridge
+# two different codecs, and check the engine has that codec pair (rtpengine needs
+# a --with-transcoding build; the native engine transcodes what its codec set
+# supports and names the codec when it will not).
+#
 # Put it on the OFFER half — both engines apply codec manipulation to the offer
 # and ignore most of it on an answer:
 #


### PR DESCRIPTION
The `CODEC MANIPULATION` block in `siphon.yaml` lists nine keys with one line
each and nothing distinguishing the two kinds of thing they do.

Read as written, `strip` — "remove these from the outgoing SDP" — is the obvious
way to keep a codec off a carrier that cannot take it, and `mask` / `consume`
read as near-identical wording for the same idea. They are not the same idea:

- `strip` / `offer` / `except` / `ignore` edit **the offer the far side sees**.
  The near leg then follows whatever the far side answers with (RFC 3264 §6.1 —
  the answerer's selection is the format for the stream), so no transcoder is
  engaged and the call relays.
- `mask` / `consume` / `accept` deliberately **keep the codec on the near leg**
  while hiding it from the far side, so the two sides differ and the engine has
  to bridge them. That is the transcode request itself, and it needs the engine
  to actually have that codec pair.
- `transcode` adds a codec the offerer never listed, so the far side can select
  something the near side cannot send. Also a transcode request.

An operator reaching for the wrong one gets either a transcode they did not ask
for, or — where the engine has no pipeline for that pair — a call that answers
and carries nothing. The block now states which keys are which, and points at
`strip` for the keep-it-off-this-carrier case.

Comment-only; `siphon.yaml` still parses. No CHANGELOG entry since nothing
observable changed — happy to add one if you'd rather every doc PR carried one.