### PR TITLE
fix(cdr): script cdr.write attaches to the auto-emitted record instead of writing a second one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Changed
+- **`cdr.write(request|call, extra=…)` now attaches to the auto-emitted CDR
+  instead of writing a second record.** With `cdr.auto_emit: true`, siphon
+  already tracks a record for the call from the INVITE; a script's `extra`
+  fields are merged into it and emitted once at teardown, on the record that
+  also carries `timestamp_start` / `timestamp_answer` / `timestamp_end`,
+  `duration_secs`, `response_code` and `disconnect_initiator`.
+
+  Before, the script's call queued a separate record built from the identity
+  fields alone — no timings, no duration, `response_code: 0` — so attaching
+  billing metadata to a call produced two rows the collector had to join on
+  Call-ID, one of which was meaningless on its own. Repeat calls now merge on
+  top of each other (last write wins per key).
+
+  A standalone record is still written when there is nothing to merge into:
+  `auto_emit` off, a request the auto-emit hooks do not track (a MESSAGE, an
+  out-of-dialog request), or a call already finalized. **Operators counting CDR
+  rows per call will see one row where they saw two**; the fields are unchanged
+  and now all on the same row.
+
+- **The auto-emitted CDR carries the Rf correlation.** `rf_session_id` /
+  `rf_result_code` (TS 32.299) were stamped only onto a script-written record,
+  so an operator running auto-emit never saw them. The auto-emitted record now
+  resolves them at teardown — including for a B2BUA call, whose accounting
+  record is keyed on the internal call id rather than either leg's dialog, a
+  key the stamp never offered.
+
+- **A proxy call's CDR record is opened before the script handler runs and
+  finalized after it.** It used to be opened after the handler (only for an
+  INVITE the proxy forwarded) and, on the BYE, written before the handler — so
+  a `cdr.write(request, extra=…)` from either handler had nothing to attach to.
+  Both ends now bracket the handler, and the record is still written when the
+  script drops or rejects the BYE.
+
+  An INVITE the proxy does not forward still produces no CDR, as before —
+  unless the script attached fields to it, which is a deliberate ask for a
+  record of the attempt. That record now carries the code the script answered
+  (a 403, a 407) instead of the `response_code: 0` a script-built record had.
+
 ### Performance
 - **The dispatcher's timer wheel no longer retains its peak-concurrency
   footprint either.** Same shape as the transaction map fixed alongside it:

--- a/docs/cookbook/least-cost-routing.md
+++ b/docs/cookbook/least-cost-routing.md
@@ -220,7 +220,10 @@ The carrier that won is on `call.active_route` (a `Route`: `carrier_id`,
 `gateway_group`, `rate`, `currency`), so it flows into all three charging paths:
 
 - **CDR.** Stamp it into the record, as in the `@b2bua.on_answer` handler above:
-  `cdr.write(call, extra={"carrier_id": route.carrier_id, "rate": ...})`.
+  `cdr.write(call, extra={"carrier_id": route.carrier_id, "rate": ...})`. With
+  `cdr.auto_emit` on, that attaches to the record siphon is already keeping for
+  the call — the carrier fields and the call's duration land on one row, not
+  two.
 - **Rf offline.** Stamp the carrier's trunk group onto the offline record with
   `call.set_charging_param("outgoing-trunk-group-id", route.gateway_group)`. The
   Rf ACR auto-emit carries it as `Outgoing-Trunk-Group-Id` (TS 32.260).

--- a/docs/cookbook/monitoring.md
+++ b/docs/cookbook/monitoring.md
@@ -147,6 +147,22 @@ def answered(call, reply):
     cdr.write(call, extra={"billing_id": "B-12345"})
 ```
 
+With `auto_emit` on, that does **not** write a second record: siphon is already
+tracking one for the call, and `extra` is merged into it, so the fields land on
+the same row as `duration_secs`, `response_code` and `disconnect_initiator` when
+the call ends. Call it as often as you like — later fields merge on top, last
+write wins per key. A record of its own is written only when there is nothing to
+merge into: `auto_emit` off, or a request the auto-emit hooks do not track (a
+MESSAGE, an out-of-dialog request).
+
+So attach fields as soon as you know them (`@proxy.on_request("INVITE")`,
+`@b2bua.on_answer`) rather than trying to assemble a record at teardown — the
+teardown half is siphon's job.
+
+A call the proxy never forwards (the script answered a 403, or dropped it)
+normally produces no CDR at all. Calling `cdr.write()` on it is how you ask for
+one anyway — a blocked-call record, emitted with the code the script answered.
+
 Watch `siphon_cdr_sessions` (the live per-call tracking count): it returns to 0
 between calls, and a steady climb under flat load means a call teardown isn't
 being seen.

--- a/docs/feature-readiness-matrix.md
+++ b/docs/feature-readiness-matrix.md
@@ -211,7 +211,7 @@ All four, plus the reliable-provisional scenario that had been driven only by
 
 | Feature | Readiness | Config | Notes |
 |---------|-----------|--------|-------|
-| CDR generation | Implemented | `cdr:` | Auto-emit per call (`cdr.auto_emit`) — proxy + B2BUA, with duration + disconnect_initiator; plus script `cdr.write(request)` (proxy) / `cdr.write(call)` (B2BUA), additive |
+| CDR generation | Implemented | `cdr:` | Auto-emit per call (`cdr.auto_emit`) — proxy + B2BUA, with duration + disconnect_initiator + Rf correlation; script `cdr.write(request)` (proxy) / `cdr.write(call)` (B2BUA) merges its `extra` fields into that record, and writes one of its own only when no auto-emit record is tracked |
 | REGISTER CDRs | Implemented | `cdr.include_register` | With `auto_emit`, one CDR per registrar state change (`reg_event`) |
 | File backend (JSON-lines) | Implemented | `cdr.backend: file` | With rotation |
 | Syslog backend | Implemented | `cdr.backend: syslog` | UDP syslog |

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -4246,19 +4246,71 @@ class MockCdr:
 
         from siphon_sdk.mock_module import get_cdr
         cdrs = get_cdr().records  # list of written CDR dicts
+
+    With ``cdr.auto_emit`` on, the engine does not write a second record: it
+    merges ``extra`` into the record it is already tracking for the call, so the
+    fields are emitted once at teardown alongside the timings and the disconnect
+    side.  Set ``auto_emit = True`` on the mock to test a script against that
+    shape::
+
+        cdr_mock = get_cdr()
+        cdr_mock.auto_emit = True
+        ...                                     # run the handler
+        assert cdr_mock.pending[call.id]["billing_id"] == "B-12345"
+        cdr_mock.finalize(call)                 # stands in for the BYE
+        assert cdr_mock.records[0]["billing_id"] == "B-12345"
     """
 
     def __init__(self) -> None:
         self._enabled: bool = True
         self.records: list[dict] = []
+        # Mirrors `cdr.auto_emit` in siphon.yaml (off by default, as in the
+        # engine): when on, `write()` attaches to the tracked record instead of
+        # queueing one of its own.
+        self.auto_emit: bool = False
+        # Fields attached to a call whose record has not been emitted yet,
+        # keyed the way the engine keys `cdr_sessions`.
+        self.pending: dict[str, dict] = {}
 
     @property
     def enabled(self) -> bool:
         """Whether the CDR system is enabled."""
         return self._enabled
 
+    @staticmethod
+    def session_key(source: "Any") -> str:
+        """The key the engine tracks this call's auto-emit record under.
+
+        A B2BUA call is keyed on its internal call id (one record for two
+        dialogs); a proxy call on ``<Call-ID>\\0<From-tag>``.
+        """
+        if hasattr(source, "id") and hasattr(source, "state"):
+            return str(source.id)
+        from_tag = getattr(source, "from_tag", "") or ""
+        return f"{getattr(source, 'call_id', '')}\0{from_tag}"
+
+    def finalize(self, source: "Any", **fields: "Any") -> "dict | None":
+        """Emit the record tracked for ``source`` — the mock's stand-in for the
+        BYE that ends the call.  Returns the emitted record, or ``None`` when
+        nothing was tracked.
+        """
+        record = self.pending.pop(self.session_key(source), None)
+        if record is None:
+            return None
+        record.update(fields)
+        self.records.append(record)
+        return record
+
     def write(self, source: "Any", extra: "dict[str, str] | None" = None) -> bool:
-        """Write a CDR for the given request or B2BUA call.
+        """Write a CDR for the given request or B2BUA call — or attach the
+        fields to the record siphon is already keeping for it.
+
+        With ``cdr.auto_emit`` on (``auto_emit = True`` on this mock), ``extra``
+        is merged into the tracked record instead of queueing a second one, so
+        the fields are emitted once at teardown on the record that also carries
+        the timings, ``duration_secs``, ``response_code`` and
+        ``disconnect_initiator``.  A standalone record is still written when
+        there is nothing to merge into.
 
         Args:
             source: The SIP ``Request`` (proxy handlers) OR the B2BUA ``Call``
@@ -4267,7 +4319,8 @@ class MockCdr:
             extra: Optional dict of extra fields to include in the CDR.
 
         Returns:
-            True if the CDR was queued successfully.
+            True if the fields reached a CDR — merged into the tracked record,
+            or queued as a record of their own.
 
         Raises:
             TypeError: if ``source`` is neither a ``Request`` nor a ``Call``.
@@ -4309,13 +4362,24 @@ class MockCdr:
             "transport": transport,
         }
         if extra:
-            record.update(extra)
+            record.update({str(k): str(v) for k, v in extra.items()})
+
+        if self.auto_emit:
+            # Attach to the record the call is already accumulating; it is
+            # emitted when the call ends, not here.
+            tracked = self.pending.setdefault(self.session_key(source), record)
+            if tracked is not record and extra:
+                tracked.update({str(k): str(v) for k, v in extra.items()})
+            return True
+
         self.records.append(record)
         return True
 
     def clear(self) -> None:
         """Reset CDR records (test helper)."""
         self.records.clear()
+        self.pending.clear()
+        self.auto_emit = False
         self._enabled = True
 
 

--- a/sdk/tests/test_cdr_write.py
+++ b/sdk/tests/test_cdr_write.py
@@ -70,6 +70,44 @@ def test_write_from_call_defaults_transport_to_udp():
     assert cdr.records[-1]["transport"] == "udp"
 
 
+def test_auto_emit_merges_into_the_tracked_record():
+    """With auto_emit on, the fields attach to the record siphon already keeps
+    for the call — one row carrying both the script's fields and the timings,
+    not a billing row beside a duration row."""
+    cdr = get_cdr()
+    cdr.auto_emit = True
+    call = Call(call_id="call-3")
+
+    assert cdr.write(call, extra={"billing_id": "B-3"}) is True
+    assert cdr.records == [], "nothing is emitted until the call ends"
+    assert cdr.pending[call.id]["billing_id"] == "B-3"
+
+    # A second write merges on top rather than adding a record.
+    assert cdr.write(call, extra={"carrier_id": "carrier-a"}) is True
+    assert cdr.records == []
+
+    # The BYE emits the one record.
+    record = cdr.finalize(call, duration_secs=42.0, disconnect_initiator="caller")
+    assert record is not None
+    assert cdr.records == [record]
+    assert record["billing_id"] == "B-3"
+    assert record["carrier_id"] == "carrier-a"
+    assert record["duration_secs"] == 42.0
+    assert record["disconnect_initiator"] == "caller"
+
+
+def test_auto_emit_keys_a_proxy_request_on_the_dialog():
+    cdr = get_cdr()
+    cdr.auto_emit = True
+    request = Request(
+        method="BYE",
+        call_id="cid-9",
+        from_tag="tag-caller",
+    )
+    assert cdr.write(request, extra={"billing_id": "B-9"}) is True
+    assert cdr.pending["cid-9\0tag-caller"]["billing_id"] == "B-9"
+
+
 def test_write_rejects_other_types():
     cdr = get_cdr()
     with pytest.raises(TypeError):

--- a/src/cdr/mod.rs
+++ b/src/cdr/mod.rs
@@ -31,7 +31,8 @@
 //! }
 //! ```
 
-use std::sync::OnceLock;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 use std::time::{Instant, SystemTime};
 
 use serde::Serialize;
@@ -286,8 +287,13 @@ pub struct CdrSession {
     /// When this session was created — the orphan-sweep backstop keys off it.
     created_at: Instant,
     /// Extra fields auto-stamped onto the finalized CDR (e.g. LCR route
-    /// `cdr_fields` from the winning carrier). Merged into `Cdr.extra`.
+    /// `cdr_fields` from the winning carrier, or a script's
+    /// `cdr.write(…, extra=…)`). Merged into `Cdr.extra`.
     extra: std::collections::HashMap<String, String>,
+    /// Rf-session storage keys to resolve at `finalize` so the record carries
+    /// `rf_session_id` / `rf_result_code`. Filled by the dispatcher when the
+    /// session is created; empty when Rf is not in play.
+    rf_keys: Vec<String>,
 }
 
 impl CdrSession {
@@ -318,15 +324,36 @@ impl CdrSession {
             response_code: 0,
             created_at: Instant::now(),
             extra: std::collections::HashMap::new(),
+            rf_keys: Vec::new(),
         }
+    }
+
+    /// Record the Rf-session storage keys this call's accounting record can be
+    /// found under, so [`finalize`](Self::finalize) can stamp `rf_session_id` /
+    /// `rf_result_code` onto the CDR.
+    pub fn set_rf_keys(&mut self, keys: Vec<String>) {
+        self.rf_keys = keys;
+    }
+
+    /// The Rf-session storage keys recorded by [`set_rf_keys`](Self::set_rf_keys).
+    pub fn rf_keys(&self) -> &[String] {
+        &self.rf_keys
+    }
+
+    /// Whether anything has been merged into this session's extra fields.
+    ///
+    /// On the proxy path that means exactly one thing: a script called
+    /// `cdr.write(request, extra=…)` against this call.
+    pub fn has_extra_fields(&self) -> bool {
+        !self.extra.is_empty()
     }
 
     /// Record the authenticated username after the fact.
     ///
-    /// The proxy path knows `auth_user` before the session is built, but a
-    /// B2BUA call is tracked at INVITE time — *before* `@b2bua.on_invite` runs
+    /// Both paths track the call at INVITE time — *before* the script handler
+    /// runs, so that `cdr.write(…, extra=…)` from it has a record to attach to
     /// — so a caller authenticated inside that handler
-    /// (`auth.require_proxy_digest(call, …)`) can only be stamped on once the
+    /// (`auth.require_proxy_digest(…)`) can only be stamped on once the
     /// handler returns.
     pub fn set_auth_user(&mut self, auth_user: String) {
         self.auth_user = Some(auth_user);
@@ -395,7 +422,65 @@ impl CdrSession {
         cdr.disconnect_initiator = Some(disconnect_initiator.to_string());
         cdr.sip_reason = sip_reason;
         cdr.extra = self.extra;
+        // Rf correlation (TS 32.299): the accounting record for this dialog is
+        // still tracked at teardown — `spawn_rf_*_stop` removes it only after
+        // ACR-STOP completes — so the CDR can name the Diameter session it
+        // belongs to. Stamped here rather than by the script API because the
+        // auto-emitted record is now the only record a script's
+        // `cdr.write(…, extra=…)` contributes to.
+        for key in &self.rf_keys {
+            if let Some((session_id, result_code)) =
+                crate::diameter::rf_service::lookup_rf_for_dialog(key)
+            {
+                cdr.rf_session_id = Some(session_id);
+                cdr.rf_result_code = result_code;
+                break;
+            }
+        }
         cdr
+    }
+}
+
+// ── Script → auto-emit CDR extra-field channel ───────────────────────
+//
+// `cdr.write(request|call, extra=…)` must land on the record the auto-emit
+// hooks already track for that call rather than beside it: a second record
+// carrying only the script's fields has no timings, no duration and no
+// disconnect side, so it is meaningless on its own and forces the collector to
+// join two rows per call.
+//
+// The tracked `CdrSession`s live in `DispatcherState` (which sweeps and gauges
+// them), so the dispatcher installs a merger here at startup and this module
+// calls it without knowing where the sessions are held — the same shape as
+// `rf_service`'s CDR auto-stamp registry, and for the same reason (threading
+// the dispatcher state into this module would create a cycle).
+
+type CdrExtraMerger =
+    Arc<dyn Fn(&[String], &HashMap<String, String>) -> bool + Send + Sync + 'static>;
+
+static CDR_EXTRA_MERGER: OnceLock<CdrExtraMerger> = OnceLock::new();
+
+/// Install the dispatcher's auto-emit session merger. Idempotent (the
+/// dispatcher only runs once per process); later calls are ignored.
+pub fn install_extra_merger(merger: CdrExtraMerger) {
+    let _ = CDR_EXTRA_MERGER.set(merger);
+}
+
+/// Merge `extra` into the tracked auto-emit CDR session that the first
+/// resolving key of `keys` names.
+///
+/// Returns `true` when a session took the fields — the caller must then NOT
+/// write a record of its own, because the fields will be emitted on the
+/// auto-emitted CDR at teardown, alongside the timings and disconnect side.
+/// `false` means no session is tracked (auto-emit off, a non-INVITE, or a call
+/// that already finalized) and the caller owns the record.
+pub fn merge_extra_into_session(keys: &[String], extra: &HashMap<String, String>) -> bool {
+    // No `auto_emit_enabled()` short-circuit needed: every tracking hook
+    // early-returns when auto-emit is off, so the session map is empty and the
+    // merger answers false on its own.
+    match CDR_EXTRA_MERGER.get() {
+        Some(merger) => merger(keys, extra),
+        None => false,
     }
 }
 
@@ -818,6 +903,123 @@ fn is_leap_year(year: i64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A session as the auto-emit hooks track it: answered, then torn down.
+    fn tracked_session() -> CdrSession {
+        CdrSession::new(
+            "a84b4c76e66710@192.0.2.100".to_string(),
+            "sip:alice@example.com".to_string(),
+            "sip:bob@example.com".to_string(),
+            "sip:bob@192.0.2.1:5060".to_string(),
+            "192.0.2.100".to_string(),
+            "udp".to_string(),
+            Some("Test UA/1.0".to_string()),
+            None,
+        )
+    }
+
+    /// `cdr.write(request|call, extra=…)` must land on the record the call is
+    /// already accumulating, so the operator gets ONE row carrying both the
+    /// script's fields and the timings — not a billing row with no duration
+    /// beside a duration row with no billing fields.
+    #[test]
+    fn script_extras_merge_into_the_tracked_session() {
+        use std::sync::Mutex;
+
+        // Stands in for `DispatcherState::cdr_sessions`, which is where the
+        // real merger (installed by the dispatcher) looks.
+        static SESSIONS: OnceLock<Mutex<std::collections::HashMap<String, CdrSession>>> =
+            OnceLock::new();
+        let sessions = SESSIONS.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+        sessions
+            .lock()
+            .expect("sessions lock")
+            .insert("call-1\0tag-A".to_string(), tracked_session());
+
+        install_extra_merger(Arc::new(|keys: &[String], extra: &HashMap<String, String>| {
+            let mut guard = match SESSIONS.get() {
+                Some(store) => store.lock().expect("sessions lock"),
+                None => return false,
+            };
+            for key in keys {
+                if let Some(session) = guard.get_mut(key) {
+                    session.merge_extra(extra);
+                    return true;
+                }
+            }
+            false
+        }));
+
+        let extra = HashMap::from([
+            ("billing_id".to_string(), "B-12345".to_string()),
+            ("carrier_id".to_string(), "carrier-a".to_string()),
+        ]);
+
+        // A key that resolves: the fields are taken, and the caller is told
+        // NOT to write a record of its own.
+        assert!(merge_extra_into_session(
+            &["call-1\0tag-A".to_string()],
+            &extra
+        ));
+
+        // A key that does not (auto-emit off, an untracked request, a call
+        // already finalized): the caller owns the record.
+        assert!(!merge_extra_into_session(
+            &["call-2\0tag-Z".to_string()],
+            &extra
+        ));
+
+        // The one emitted record carries both halves.
+        let mut session = sessions
+            .lock()
+            .expect("sessions lock")
+            .remove("call-1\0tag-A")
+            .expect("session still tracked");
+        session.mark_answered(200);
+        let cdr = session.finalize("caller", None, None);
+
+        assert_eq!(cdr.extra.get("billing_id").map(String::as_str), Some("B-12345"));
+        assert_eq!(
+            cdr.extra.get("carrier_id").map(String::as_str),
+            Some("carrier-a")
+        );
+        assert_eq!(cdr.response_code, 200);
+        assert!(cdr.timestamp_start.is_some());
+        assert!(cdr.timestamp_answer.is_some());
+        assert!(cdr.timestamp_end.is_some());
+        assert_eq!(cdr.disconnect_initiator.as_deref(), Some("caller"));
+    }
+
+    /// The Rf correlation used to be stamped only by the script's own record,
+    /// so an auto-emitted CDR never carried it. Now that the script's fields
+    /// merge into that record, it has to resolve the stamp itself.
+    #[test]
+    fn finalize_stamps_the_rf_session_it_is_keyed_under() {
+        crate::diameter::rf_service::install_rf_lookup(Arc::new(|key: &str| {
+            if key == "b2bua:call-uuid-1" {
+                Some(("cdf.example;1;1;acct".to_string(), Some(2001)))
+            } else {
+                None
+            }
+        }));
+
+        let mut session = tracked_session();
+        session.set_rf_keys(vec![
+            "dialog:no-such\0tag:orig".to_string(),
+            "b2bua:call-uuid-1".to_string(),
+        ]);
+        let cdr = session.finalize("callee", Some(200), None);
+        assert_eq!(cdr.rf_session_id.as_deref(), Some("cdf.example;1;1;acct"));
+        assert_eq!(cdr.rf_result_code, Some(2001));
+
+        // A call with no Rf record tracked is left unstamped rather than
+        // carrying another call's session id.
+        let mut orphan = tracked_session();
+        orphan.set_rf_keys(vec!["b2bua:call-uuid-2".to_string()]);
+        let cdr = orphan.finalize("caller", None, None);
+        assert!(cdr.rf_session_id.is_none());
+        assert!(cdr.rf_result_code.is_none());
+    }
 
     fn sample_cdr() -> Cdr {
         Cdr::new(

--- a/src/cdr/mod.rs
+++ b/src/cdr/mod.rs
@@ -936,19 +936,21 @@ mod tests {
             .expect("sessions lock")
             .insert("call-1\0tag-A".to_string(), tracked_session());
 
-        install_extra_merger(Arc::new(|keys: &[String], extra: &HashMap<String, String>| {
-            let mut guard = match SESSIONS.get() {
-                Some(store) => store.lock().expect("sessions lock"),
-                None => return false,
-            };
-            for key in keys {
-                if let Some(session) = guard.get_mut(key) {
-                    session.merge_extra(extra);
-                    return true;
+        install_extra_merger(Arc::new(
+            |keys: &[String], extra: &HashMap<String, String>| {
+                let mut guard = match SESSIONS.get() {
+                    Some(store) => store.lock().expect("sessions lock"),
+                    None => return false,
+                };
+                for key in keys {
+                    if let Some(session) = guard.get_mut(key) {
+                        session.merge_extra(extra);
+                        return true;
+                    }
                 }
-            }
-            false
-        }));
+                false
+            },
+        ));
 
         let extra = HashMap::from([
             ("billing_id".to_string(), "B-12345".to_string()),
@@ -978,7 +980,10 @@ mod tests {
         session.mark_answered(200);
         let cdr = session.finalize("caller", None, None);
 
-        assert_eq!(cdr.extra.get("billing_id").map(String::as_str), Some("B-12345"));
+        assert_eq!(
+            cdr.extra.get("billing_id").map(String::as_str),
+            Some("B-12345")
+        );
         assert_eq!(
             cdr.extra.get("carrier_id").map(String::as_str),
             Some("carrier-a")

--- a/src/diameter/rf_service.rs
+++ b/src/diameter/rf_service.rs
@@ -553,6 +553,16 @@ pub fn rf_dialog_key(call_id: &str, tag: &str, role: RfRole) -> String {
     format!("dialog:{call_id}\0{tag}:{}", role.as_suffix())
 }
 
+/// B2BUA Rf-session storage key, from the internal call UUID.
+///
+/// A B2BUA call is one accounting record covering two dialogs with two
+/// Call-IDs, so it is keyed on the call siphon owns rather than on either
+/// dialog. Lives here so the CDR auto-stamp can offer it as a lookup candidate
+/// alongside the dialog-derived keys.
+pub fn rf_b2bua_key(internal_call_id: &str) -> String {
+    format!("b2bua:{internal_call_id}")
+}
+
 /// Storage keys that should be inserted at ACR-START time for a given
 /// (icid, call_id, from_tag, role) tuple.  Returns either one key
 /// (dialog fallback only when ICID absent) or two keys (ICID primary
@@ -712,6 +722,13 @@ pub fn apply_charging_params(ims: &mut ImsChargingData, params: Vec<(String, Str
 /// `<Call-ID>\0<From-tag>` for proxy mode.  The CDR API tries the
 /// caller's tag first and falls back to the callee's tag for
 /// callee-initiated BYEs.
+/// Whether an Rf-session lookup is installed at all — i.e. whether this
+/// process can ever resolve an accounting record for a dialog. Lets the CDR
+/// path skip building lookup keys on a deployment with no Rf configured.
+pub fn rf_lookup_installed() -> bool {
+    RF_LOOKUP.get().is_some()
+}
+
 pub fn lookup_rf_for_dialog(dialog_key: &str) -> Option<(String, Option<u32>)> {
     RF_LOOKUP.get().and_then(|f| f(dialog_key))
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -11364,7 +11364,10 @@ enum CdrSettle {
 /// to it, because `cdr.write(request, extra=…)` on a call the script then
 /// rejects is a deliberate ask for a record of that attempt, and it is emitted
 /// carrying the code the script answered instead of a bare `0`.
-fn cdr_settle_decision(outcome: &ProxyInviteOutcome<'_>, script_attached_fields: bool) -> CdrSettle {
+fn cdr_settle_decision(
+    outcome: &ProxyInviteOutcome<'_>,
+    script_attached_fields: bool,
+) -> CdrSettle {
     match outcome {
         ProxyInviteOutcome::Forwarded { .. } => CdrSettle::Keep,
         ProxyInviteOutcome::Rejected { code } if script_attached_fields => CdrSettle::Emit {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -356,11 +356,6 @@ impl ProxyRfState {
     }
 }
 
-/// Format the B2BUA Rf-session key from the internal call UUID.
-fn rf_b2bua_key(internal_call_id: &str) -> String {
-    format!("b2bua:{internal_call_id}")
-}
-
 /// State for one outstanding reliable provisional response (RFC 3262 §3).
 pub struct ReliableProvisional {
     /// Notified by the dispatcher when a matching PRACK arrives, or when the
@@ -848,6 +843,25 @@ pub async fn run(
                 (session.session_id().to_string(), session.last_result_code())
             })
         }));
+    }
+
+    // Install the auto-emit CDR session merger so a script's
+    // `cdr.write(request|call, extra=…)` attaches its fields to the record
+    // this call is already accumulating instead of queueing a second,
+    // timing-less record beside it.
+    {
+        let cdr_sessions = Arc::clone(&state.cdr_sessions);
+        crate::cdr::install_extra_merger(Arc::new(
+            move |keys: &[String], extra: &std::collections::HashMap<String, String>| {
+                for key in keys {
+                    if let Some(mut session) = cdr_sessions.get_mut(key.as_str()) {
+                        session.merge_extra(extra);
+                        return true;
+                    }
+                }
+                false
+            },
+        ));
     }
 
     // Install the script → auto-emit charging-param channel so
@@ -4241,9 +4255,22 @@ fn handle_request(
     // is unaffected (spawn is fire-and-forget).
     if method == "BYE" {
         spawn_rf_proxy_stop_if_tracked(state, &message);
-        // CDR: write the call record on in-dialog BYE (cdr.auto_emit).
-        cdr_finalize_proxy_stop(state, &message);
     }
+    // CDR: the call record is written when this scope ends — i.e. *after* the
+    // script's BYE handler ran, so `cdr.write(request, extra=…)` from
+    // `@proxy.on_request("BYE")` still lands on it. A drop guard rather than a
+    // call at the end of the function because the record must be written on
+    // every exit path, including the one a dropped or rejected BYE takes —
+    // same "accounting closes regardless of what the script decides" rule as
+    // the ACR-STOP above.
+    let _cdr_stop_guard = if method == "BYE" && crate::cdr::auto_emit_enabled() {
+        CdrProxyStop::from_bye(&message).map(|parts| CdrProxyStopGuard {
+            sessions: Arc::clone(&state.cdr_sessions),
+            parts: Some(parts),
+        })
+    } else {
+        None
+    };
     if method == "UPDATE" && engine_state.has_b2bua_handlers() {
         // RFC 3311 in-dialog UPDATE belonging to a B2BUA call: bridge it
         // across like a re-INVITE. Calls that don't match a tracked B2BUA
@@ -4453,6 +4480,22 @@ fn handle_request(
         );
         return;
     }
+
+    // CDR: open the record before the script runs (cdr.auto_emit), so
+    // `cdr.write(request, extra=…)` from the handler attaches its fields to the
+    // call's own record instead of queueing a second, timing-less one beside
+    // it. Settled below once the script's decision is known — an INVITE the
+    // proxy never forwards is not a call and its record is dropped again.
+    let cdr_key = if method == "INVITE" {
+        cdr_track_proxy_start(
+            &state.cdr_sessions,
+            &message,
+            &inbound.remote_addr.ip().to_string(),
+            &format!("{}", inbound.transport).to_lowercase(),
+        )
+    } else {
+        None
+    };
 
     // Create PyRequest wrapping the message
     let transport_name = format!("{}", inbound.transport).to_lowercase();
@@ -4931,22 +4974,21 @@ fn handle_request(
         }
     }
 
-    // CDR: start tracking a relayed/forked INVITE so a record is written when
-    // the call ends (cdr.auto_emit). Only a dialog-forming INVITE that the
-    // proxy actually forwarded is tracked.
-    if method == "INVITE"
-        && matches!(
-            action,
-            RequestAction::Relay { .. } | RequestAction::Fork { .. }
-        )
-    {
-        cdr_track_proxy_start(
-            state,
-            &message_guard,
-            &inbound.remote_addr.ip().to_string(),
-            &format!("{}", inbound.transport).to_lowercase(),
-            auth_user.as_deref(),
-        );
+    // CDR: settle the record opened before the handler ran. A forwarded INVITE
+    // keeps it (and takes the identity the script authenticated); anything else
+    // is not a call, so the record is dropped — unless the script attached
+    // fields to it, which is an explicit ask for a record of the attempt.
+    if let Some(cdr_key) = &cdr_key {
+        let outcome = match &action {
+            RequestAction::Relay { .. } | RequestAction::Fork { .. } => {
+                ProxyInviteOutcome::Forwarded {
+                    auth_user: auth_user.as_deref(),
+                }
+            }
+            RequestAction::Reply { code, .. } => ProxyInviteOutcome::Rejected { code: *code },
+            _ => ProxyInviteOutcome::Dropped,
+        };
+        cdr_settle_proxy_start(&state.cdr_sessions, cdr_key, outcome);
     }
 
     // Flush deferred messages (e.g. in-dialog NOTIFY) after the reply/relay
@@ -7558,7 +7600,7 @@ fn handle_response(
                         // so the failed-call record is written exactly once.
                         if let Some(key) = &cdr_fail_key {
                             cdr_finalize(
-                                state,
+                                &state.cdr_sessions,
                                 key,
                                 cdr_disconnect_for_failure(best_code),
                                 Some(best_code),
@@ -11096,7 +11138,7 @@ fn cdr_session_from_invite(
         _ => String::new(),
     };
     let user_agent = invite.headers.get("User-Agent").map(|s| s.to_string());
-    let session = crate::cdr::CdrSession::new(
+    let mut session = crate::cdr::CdrSession::new(
         call_id.clone(),
         from_uri,
         to_uri,
@@ -11106,6 +11148,20 @@ fn cdr_session_from_invite(
         user_agent,
         auth_user,
     );
+    // Rf correlation: remember where this dialog's accounting record can be
+    // found so the finalized CDR can name it (TS 32.299). Resolved at teardown
+    // rather than now — ACR-START is spawned, so the session usually does not
+    // exist yet at INVITE time. Skipped entirely on a deployment with no Rf
+    // configured, where the keys would be eight allocations per call to look
+    // up a map that will never exist.
+    if crate::diameter::rf_service::rf_lookup_installed() {
+        session.set_rf_keys(crate::diameter::rf_service::rf_lookup_candidates(
+            rf_extract_icid(invite).as_deref(),
+            Some(call_id.as_str()),
+            Some(from_tag.as_str()),
+            None,
+        ));
+    }
     Some((cdr_dialog_key(&call_id, &from_tag), session))
 }
 
@@ -11118,14 +11174,18 @@ fn cdr_mark_answer(state: &DispatcherState, key: &str, response_code: u16) {
 
 /// Finalize a tracked CDR session (write the record + drop it). No-op if the
 /// call was never tracked (auto-emit off, or not an INVITE dialog).
+///
+/// Takes the session map rather than the whole dispatcher state so the BYE
+/// drop guard — which outlives the borrow of the message it was built from —
+/// can hold just the map.
 fn cdr_finalize(
-    state: &DispatcherState,
+    sessions: &DashMap<String, crate::cdr::CdrSession>,
     key: &str,
     disconnect_initiator: &str,
     response_code: Option<u16>,
     sip_reason: Option<String>,
 ) {
-    if let Some((_, session)) = state.cdr_sessions.remove(key) {
+    if let Some((_, session)) = sessions.remove(key) {
         let cdr = session.finalize(disconnect_initiator, response_code, sip_reason);
         crate::cdr::write(cdr);
     }
@@ -11238,25 +11298,114 @@ fn media_summary_to_cdr(summary: &crate::rtpengine::events::CallSummary) -> crat
     cdr
 }
 
-/// Proxy CDR START — the proxy is relaying/forking an INVITE. Records the call
-/// so a CDR can be emitted when it ends. Deduped so a retransmitted INVITE
-/// doesn't reset the start time.
+/// Proxy CDR START — open the record for an inbound INVITE, *before* the script
+/// handler runs, so `cdr.write(request, extra=…)` from that handler has a
+/// record to attach its fields to. What the script then decides is settled by
+/// [`cdr_settle_proxy_start`]: an INVITE the proxy does not forward has no call
+/// to account for and its record is dropped again (or emitted, when the script
+/// attached fields to it — it asked for a record for this attempt).
+///
+/// Returns the key of the record this call opened, or `None` when it opened
+/// none: auto-emit off, an INVITE without the Call-ID/From-tag to key on, or a
+/// re-INVITE on a dialog that is already tracked — the established call's
+/// record must survive whatever the script does with the re-INVITE, so it is
+/// neither re-stamped nor settled.
 fn cdr_track_proxy_start(
-    state: &DispatcherState,
+    sessions: &DashMap<String, crate::cdr::CdrSession>,
     invite: &SipMessage,
     source_ip: &str,
     transport: &str,
-    // Username the script authenticated the caller as, read after the handler
-    // ran. `None` when the call was never challenged.
-    auth_user: Option<&str>,
-) {
+) -> Option<String> {
     if !crate::cdr::auto_emit_enabled() {
-        return;
+        return None;
     }
-    if let Some((key, session)) =
-        cdr_session_from_invite(invite, source_ip, transport, auth_user.map(String::from))
-    {
-        state.cdr_sessions.entry(key).or_insert(session);
+    let (key, session) = cdr_session_from_invite(invite, source_ip, transport, None)?;
+    match sessions.entry(key.clone()) {
+        dashmap::mapref::entry::Entry::Occupied(_) => None,
+        dashmap::mapref::entry::Entry::Vacant(slot) => {
+            slot.insert(session);
+            Some(key)
+        }
+    }
+}
+
+/// What the script did with an INVITE whose CDR record was opened by
+/// [`cdr_track_proxy_start`].
+enum ProxyInviteOutcome<'a> {
+    /// Relayed or forked — this is a call, keep the record.
+    Forwarded {
+        // Username the script authenticated the caller as, read after the
+        // handler ran. `None` when the call was never challenged.
+        auth_user: Option<&'a str>,
+    },
+    /// Answered locally (a 403, a 407 challenge the UA will retry, …).
+    Rejected { code: u16 },
+    /// Silently dropped.
+    Dropped,
+}
+
+/// What happens to the record when the script's decision is in.
+#[derive(Debug, PartialEq, Eq)]
+enum CdrSettle {
+    /// This is a call — keep accumulating; the BYE finalizes it.
+    Keep,
+    /// Not a call, but the script asked for a record of the attempt.
+    Emit {
+        disconnect: &'static str,
+        code: Option<u16>,
+    },
+    /// Not a call and nothing was attached — the record never existed as far
+    /// as the operator is concerned.
+    Discard,
+}
+
+/// A forwarded INVITE keeps its record. An INVITE the proxy never forwarded is
+/// not a call, so its record is discarded — *unless* the script attached fields
+/// to it, because `cdr.write(request, extra=…)` on a call the script then
+/// rejects is a deliberate ask for a record of that attempt, and it is emitted
+/// carrying the code the script answered instead of a bare `0`.
+fn cdr_settle_decision(outcome: &ProxyInviteOutcome<'_>, script_attached_fields: bool) -> CdrSettle {
+    match outcome {
+        ProxyInviteOutcome::Forwarded { .. } => CdrSettle::Keep,
+        ProxyInviteOutcome::Rejected { code } if script_attached_fields => CdrSettle::Emit {
+            disconnect: cdr_disconnect_for_failure(*code),
+            code: Some(*code),
+        },
+        ProxyInviteOutcome::Dropped if script_attached_fields => CdrSettle::Emit {
+            disconnect: "error",
+            code: None,
+        },
+        _ => CdrSettle::Discard,
+    }
+}
+
+/// Keep, emit or discard the record [`cdr_track_proxy_start`] opened.
+fn cdr_settle_proxy_start(
+    sessions: &DashMap<String, crate::cdr::CdrSession>,
+    key: &str,
+    outcome: ProxyInviteOutcome<'_>,
+) {
+    let script_attached_fields = sessions
+        .get(key)
+        .is_some_and(|session| session.has_extra_fields());
+
+    match cdr_settle_decision(&outcome, script_attached_fields) {
+        CdrSettle::Keep => {
+            if let ProxyInviteOutcome::Forwarded {
+                auth_user: Some(auth_user),
+            } = outcome
+            {
+                if let Some(mut session) = sessions.get_mut(key) {
+                    session.set_auth_user(auth_user.to_string());
+                }
+            }
+        }
+        CdrSettle::Emit { disconnect, code } => {
+            cdr_finalize(sessions, key, disconnect, code, None);
+        }
+        CdrSettle::Discard => {
+            sessions.remove(key);
+        }
     }
 }
 
@@ -11277,31 +11426,272 @@ fn cdr_mark_proxy_answer(state: &DispatcherState, invite: &SipMessage, response_
 /// Proxy CDR STOP — an in-dialog BYE ended the call. Resolves the disconnecting
 /// side by which tag the BYE arrived under: the BYE's From-tag matches the
 /// INVITE's From-tag when the caller hangs up, else the callee did.
-fn cdr_finalize_proxy_stop(state: &DispatcherState, bye: &SipMessage) {
-    if !crate::cdr::auto_emit_enabled() {
-        return;
-    }
-    let Some(call_id) = bye.headers.get("Call-ID").map(|s| s.to_string()) else {
-        return;
-    };
-    let from_tag = bye.typed_from().ok().flatten().and_then(|na| na.tag);
-    let to_tag = bye.typed_to().ok().flatten().and_then(|na| na.tag);
-    let sip_reason = cdr_extract_reason(bye);
+///
+/// Owned rather than borrowed from the BYE because the record is finalized
+/// after the script handler has run, by which point the relay path has taken
+/// the message.
+struct CdrProxyStop {
+    call_id: String,
+    from_tag: Option<String>,
+    to_tag: Option<String>,
+    sip_reason: Option<String>,
+}
 
-    // Caller hung up: BYE From-tag == INVITE From-tag (the stored key).
-    if let Some(from_tag) = &from_tag {
-        let key = cdr_dialog_key(&call_id, from_tag);
-        if state.cdr_sessions.contains_key(&key) {
-            cdr_finalize(state, &key, "caller", None, sip_reason);
-            return;
+impl CdrProxyStop {
+    fn from_bye(bye: &SipMessage) -> Option<Self> {
+        Some(Self {
+            call_id: bye.headers.get("Call-ID").map(|s| s.to_string())?,
+            from_tag: bye.typed_from().ok().flatten().and_then(|na| na.tag),
+            to_tag: bye.typed_to().ok().flatten().and_then(|na| na.tag),
+            sip_reason: cdr_extract_reason(bye),
+        })
+    }
+
+    fn finalize(self, sessions: &DashMap<String, crate::cdr::CdrSession>) {
+        // Caller hung up: BYE From-tag == INVITE From-tag (the stored key).
+        if let Some(from_tag) = &self.from_tag {
+            let key = cdr_dialog_key(&self.call_id, from_tag);
+            if sessions.contains_key(&key) {
+                cdr_finalize(sessions, &key, "caller", None, self.sip_reason);
+                return;
+            }
+        }
+        // Callee hung up: BYE To-tag == INVITE From-tag.
+        if let Some(to_tag) = &self.to_tag {
+            let key = cdr_dialog_key(&self.call_id, to_tag);
+            if sessions.contains_key(&key) {
+                cdr_finalize(sessions, &key, "callee", None, self.sip_reason);
+            }
         }
     }
-    // Callee hung up: BYE To-tag == INVITE From-tag.
-    if let Some(to_tag) = &to_tag {
-        let key = cdr_dialog_key(&call_id, to_tag);
-        if state.cdr_sessions.contains_key(&key) {
-            cdr_finalize(state, &key, "callee", None, sip_reason);
+}
+
+/// Finalizes the proxy CDR when the BYE's request handling ends, whichever way
+/// it ends.
+///
+/// The record is written *after* the script's `@proxy.on_request("BYE")`
+/// handler has run, so a `cdr.write(request, extra=…)` in that handler still
+/// merges into it — attaching to the auto-emitted record is the whole contract
+/// of `cdr.write` under `auto_emit`, and a record finalized before the handler
+/// would leave that call with nothing to attach to. It is a drop guard rather
+/// than a call at the end of the function because the record must be written
+/// even when the script drops or rejects the BYE, or the handler panics — the
+/// same "accounting closes regardless of what the script decides" rule the Rf
+/// ACR-STOP above follows.
+struct CdrProxyStopGuard {
+    sessions: Arc<DashMap<String, crate::cdr::CdrSession>>,
+    parts: Option<CdrProxyStop>,
+}
+
+impl Drop for CdrProxyStopGuard {
+    fn drop(&mut self) {
+        if let Some(parts) = self.parts.take() {
+            parts.finalize(&self.sessions);
         }
+    }
+}
+
+#[cfg(test)]
+mod cdr_proxy_tests {
+    use super::*;
+    use crate::sip::builder::SipMessageBuilder;
+    use crate::sip::uri::SipUri;
+
+    const CALL_ID: &str = "call-cdr-stop-1";
+    const CALLER_TAG: &str = "tag-caller";
+    const CALLEE_TAG: &str = "tag-callee";
+
+    /// A BYE on the established dialog. `from_caller` picks the direction: the
+    /// hanging-up side is always the one in the From header (RFC 3261 §15.1).
+    fn bye(from_caller: bool) -> SipMessage {
+        let (from_tag, to_tag) = if from_caller {
+            (CALLER_TAG, CALLEE_TAG)
+        } else {
+            (CALLEE_TAG, CALLER_TAG)
+        };
+        SipMessageBuilder::new()
+            .request(
+                Method::Bye,
+                SipUri::new("example.com".to_string()).with_user("bob".to_string()),
+            )
+            .via("SIP/2.0/UDP 192.0.2.1:5060;branch=z9hG4bK-bye".to_string())
+            .from(format!("<sip:alice@example.com>;tag={from_tag}"))
+            .to(format!("<sip:bob@example.com>;tag={to_tag}"))
+            .call_id(CALL_ID.to_string())
+            .cseq("2 BYE".to_string())
+            .content_length(0)
+            .build()
+            .expect("BYE builds")
+    }
+
+    /// The dispatcher keys a proxy call on the INVITE's From-tag, i.e. the
+    /// caller's.
+    fn tracked() -> DashMap<String, crate::cdr::CdrSession> {
+        let sessions = DashMap::new();
+        sessions.insert(
+            cdr_dialog_key(CALL_ID, CALLER_TAG),
+            crate::cdr::CdrSession::new(
+                CALL_ID.to_string(),
+                "sip:alice@example.com".to_string(),
+                "sip:bob@example.com".to_string(),
+                "sip:bob@192.0.2.1:5060".to_string(),
+                "192.0.2.100".to_string(),
+                "udp".to_string(),
+                None,
+                None,
+            ),
+        );
+        sessions
+    }
+
+    #[test]
+    fn a_bye_from_the_caller_finalizes_the_session() {
+        let sessions = tracked();
+        CdrProxyStop::from_bye(&bye(true))
+            .expect("BYE carries a Call-ID")
+            .finalize(&sessions);
+        assert!(sessions.is_empty(), "the record should have been written");
+    }
+
+    /// The callee's BYE carries the INVITE's From-tag as its *To*-tag, so the
+    /// session has to be resolved through the second candidate.
+    #[test]
+    fn a_bye_from_the_callee_resolves_through_the_to_tag() {
+        let sessions = tracked();
+        CdrProxyStop::from_bye(&bye(false))
+            .expect("BYE carries a Call-ID")
+            .finalize(&sessions);
+        assert!(sessions.is_empty(), "the record should have been written");
+    }
+
+    /// The record is written when the BYE's handling ends — including when the
+    /// script drops the BYE outright, which is the case the guard exists for:
+    /// finalizing before the handler would have made the record unreachable to
+    /// `cdr.write(request, extra=…)` from `@proxy.on_request("BYE")`, and
+    /// finalizing at the end of the happy path only would have lost the record
+    /// entirely for a dropped BYE.
+    #[test]
+    fn the_record_is_written_even_when_the_script_drops_the_bye() {
+        let sessions = Arc::new(tracked());
+        {
+            let _guard = CdrProxyStopGuard {
+                sessions: Arc::clone(&sessions),
+                parts: CdrProxyStop::from_bye(&bye(true)),
+            };
+            // The script returned without relay()/reply() — the request path
+            // takes an early exit and the guard is all that runs.
+            assert_eq!(sessions.len(), 1, "not finalized before the handler ran");
+        }
+        assert!(sessions.is_empty(), "the record should have been written");
+    }
+
+    /// A forwarded INVITE is a call: its record stays open until the BYE, and
+    /// takes the identity the script authenticated on the way through.
+    #[test]
+    fn a_forwarded_invite_keeps_its_record_and_takes_the_authenticated_identity() {
+        let sessions = tracked();
+        cdr_settle_proxy_start(
+            &sessions,
+            &cdr_dialog_key(CALL_ID, CALLER_TAG),
+            ProxyInviteOutcome::Forwarded {
+                auth_user: Some("alice"),
+            },
+        );
+        let session = sessions
+            .get(&cdr_dialog_key(CALL_ID, CALLER_TAG))
+            .expect("the call's record is still open");
+        assert_eq!(
+            session.clone().finalize("caller", None, None).auth_user,
+            Some("alice".to_string())
+        );
+    }
+
+    /// An INVITE the proxy never forwarded is not a call, so the record opened
+    /// for it before the handler ran is discarded rather than left to the
+    /// orphan sweep — a 407 challenge on every REGISTER-less INVITE would
+    /// otherwise pile up records for calls that never happened.
+    #[test]
+    fn a_rejected_invite_discards_its_record() {
+        let sessions = tracked();
+        cdr_settle_proxy_start(
+            &sessions,
+            &cdr_dialog_key(CALL_ID, CALLER_TAG),
+            ProxyInviteOutcome::Rejected { code: 407 },
+        );
+        assert!(sessions.is_empty());
+    }
+
+    /// …unless the script attached fields to it, which is a deliberate ask for
+    /// a record of the attempt. It carries the code the script answered rather
+    /// than the bare `0` a script-built record used to have.
+    #[test]
+    fn a_rejected_invite_the_script_wrote_a_cdr_for_is_emitted() {
+        assert_eq!(
+            cdr_settle_decision(&ProxyInviteOutcome::Rejected { code: 403 }, true),
+            CdrSettle::Emit {
+                disconnect: "callee",
+                code: Some(403),
+            }
+        );
+        assert_eq!(
+            cdr_settle_decision(&ProxyInviteOutcome::Rejected { code: 403 }, false),
+            CdrSettle::Discard
+        );
+        // A silent drop (the rate-limit / scanner pattern) has no code to
+        // report, but the script's record is still emitted when it asked.
+        assert_eq!(
+            cdr_settle_decision(&ProxyInviteOutcome::Dropped, true),
+            CdrSettle::Emit {
+                disconnect: "error",
+                code: None,
+            }
+        );
+        assert_eq!(
+            cdr_settle_decision(&ProxyInviteOutcome::Dropped, false),
+            CdrSettle::Discard
+        );
+        // A forwarded call is never emitted early, whatever is attached.
+        assert_eq!(
+            cdr_settle_decision(&ProxyInviteOutcome::Forwarded { auth_user: None }, true),
+            CdrSettle::Keep
+        );
+    }
+
+    /// A re-INVITE on an established dialog must not re-open (or re-settle)
+    /// the record the call already has — the script rejecting a re-INVITE
+    /// would otherwise throw away the answered call's CDR.
+    #[test]
+    fn a_reinvite_on_a_tracked_dialog_opens_no_second_record() {
+        let sessions = tracked();
+        let invite = SipMessageBuilder::new()
+            .request(
+                Method::Invite,
+                SipUri::new("example.com".to_string()).with_user("bob".to_string()),
+            )
+            .via("SIP/2.0/UDP 192.0.2.1:5060;branch=z9hG4bK-re".to_string())
+            .from(format!("<sip:alice@example.com>;tag={CALLER_TAG}"))
+            .to(format!("<sip:bob@example.com>;tag={CALLEE_TAG}"))
+            .call_id(CALL_ID.to_string())
+            .cseq("2 INVITE".to_string())
+            .content_length(0)
+            .build()
+            .expect("re-INVITE builds");
+
+        // Auto-emit is off in the test binary, so this returns None for that
+        // reason too — what matters is that the tracked record is untouched.
+        assert!(cdr_track_proxy_start(&sessions, &invite, "192.0.2.100", "udp").is_none());
+        assert_eq!(sessions.len(), 1);
+    }
+
+    /// A BYE for a call this proxy never tracked (auto-emit off, or an INVITE
+    /// that predates the process) must not disturb anything.
+    #[test]
+    fn an_untracked_bye_is_a_no_op() {
+        let sessions: DashMap<String, crate::cdr::CdrSession> = DashMap::new();
+        CdrProxyStop::from_bye(&bye(true))
+            .expect("BYE carries a Call-ID")
+            .finalize(&sessions);
+        assert!(sessions.is_empty());
     }
 }
 
@@ -11319,7 +11709,7 @@ fn cdr_finalize_proxy_fail(state: &DispatcherState, invite: &SipMessage, respons
         return;
     };
     cdr_finalize(
-        state,
+        &state.cdr_sessions,
         &cdr_dialog_key(&call_id, &from_tag),
         cdr_disconnect_for_failure(response_code),
         Some(response_code),
@@ -11340,7 +11730,15 @@ fn cdr_track_b2bua_start(
     }
     // Reuse the INVITE field extraction, but key by the internal call UUID so
     // both legs (A/B, different Call-IDs) resolve to one CDR.
-    if let Some((_, session)) = cdr_session_from_invite(invite, source_ip, transport, None) {
+    if let Some((_, mut session)) = cdr_session_from_invite(invite, source_ip, transport, None) {
+        // A B2BUA Rf record is keyed on the internal call UUID, not on either
+        // leg's dialog, so that candidate goes first; the dialog-derived ones
+        // set above stay as the fallback for a record opened on the proxy path.
+        if crate::diameter::rf_service::rf_lookup_installed() {
+            let mut rf_keys = vec![crate::diameter::rf_service::rf_b2bua_key(internal_call_id)];
+            rf_keys.extend(session.rf_keys().iter().cloned());
+            session.set_rf_keys(rf_keys);
+        }
         state
             .cdr_sessions
             .entry(internal_call_id.to_string())
@@ -11384,7 +11782,7 @@ fn cdr_finalize_b2bua_stop(
     }
     let disconnect = if from_a_leg { "caller" } else { "callee" };
     cdr_finalize(
-        state,
+        &state.cdr_sessions,
         internal_call_id,
         disconnect,
         None,
@@ -11400,7 +11798,7 @@ fn cdr_finalize_b2bua_fail(state: &DispatcherState, internal_call_id: &str, resp
         return;
     }
     cdr_finalize(
-        state,
+        &state.cdr_sessions,
         internal_call_id,
         cdr_disconnect_for_failure(response_code),
         Some(response_code),
@@ -12130,7 +12528,7 @@ fn spawn_rf_b2bua_start(
             return;
         }
     };
-    let key = rf_b2bua_key(internal_call_id);
+    let key = crate::diameter::rf_service::rf_b2bua_key(internal_call_id);
     if state.rf_sessions.contains_key(&key) {
         debug!(
             call_id = %internal_call_id,
@@ -12243,7 +12641,7 @@ fn spawn_rf_b2bua_stop(state: &DispatcherState, internal_call_id: &str, cause_co
         Some(c) if c.auto_emit_b2bua() => Arc::clone(c),
         _ => return,
     };
-    let key = rf_b2bua_key(internal_call_id);
+    let key = crate::diameter::rf_service::rf_b2bua_key(internal_call_id);
     if !state.rf_sessions.contains_key(&key) {
         return;
     }
@@ -20593,7 +20991,7 @@ fn b2bua_terminate_call_inner(
     // disconnecting side and the Reason header as sip_reason.
     if crate::cdr::auto_emit_enabled() {
         cdr_finalize(
-            state,
+            &state.cdr_sessions,
             internal_call_id,
             disconnect_initiator,
             None,
@@ -20712,7 +21110,7 @@ fn b2bua_release_transferred_call(internal_call_id: &str, state: &DispatcherStat
     spawn_ro_b2bua_stop(state, internal_call_id, None);
 
     if crate::cdr::auto_emit_enabled() {
-        cdr_finalize(state, internal_call_id, "b2bua", None, None);
+        cdr_finalize(&state.cdr_sessions, internal_call_id, "b2bua", None, None);
     }
 
     // Safety-net RTPEngine cleanup. Keyed on the A-leg Call-ID (the store key);
@@ -28171,24 +28569,62 @@ mod tests {
     /// behaviour test above proves `cdr_session_from_invite` *stores* the
     /// identity, but not that the call site still *passes* it.
     ///
-    /// That is the half that regressed: the parameter existed all along and
-    /// every caller passed `None`. Guard the wiring at the source level, the
-    /// same way the packaging tests guard workflow drift.
+    /// That is the half that regressed once already: the parameter existed all
+    /// along and every caller passed `None`. Guard the wiring at the source
+    /// level, the same way the packaging tests guard workflow drift. The record
+    /// is now opened before the script runs, so the identity is no longer known
+    /// when it is built — it reaches the record through the settle step, and
+    /// that is what has to stay wired.
     #[test]
-    fn the_proxy_cdr_start_is_still_wired_to_the_authenticated_identity() {
+    fn the_proxy_cdr_settle_is_still_wired_to_the_authenticated_identity() {
         let source = include_str!("dispatcher.rs");
 
-        let call = source
-            .split("cdr_track_proxy_start(")
+        // The block in `handle_request` that decides the outcome and settles.
+        let block = source
+            .split("    if let Some(cdr_key) = &cdr_key {")
             .nth(1)
-            .expect("the proxy CDR start is still called");
-        let arguments = call.split(");").next().unwrap_or_default();
+            .expect("the proxy CDR settle is still called");
+        let block = block
+            .split("cdr_settle_proxy_start(")
+            .next()
+            .unwrap_or_default();
 
         assert!(
-            arguments.contains("auth_user"),
-            "cdr_track_proxy_start no longer receives the authenticated \
+            block.contains("auth_user"),
+            "the settled outcome no longer carries the authenticated \
              username — a proxy CDR's auth_user would silently go back to \
-             always being empty. Arguments were:{arguments}"
+             always being empty. The block was:{block}"
+        );
+    }
+
+    /// The record has to exist *while* the script handler runs, or
+    /// `cdr.write(request, extra=…)` from that handler finds nothing to attach
+    /// to and silently falls back to queueing a second, timing-less record —
+    /// the exact behaviour this ordering was changed to fix. Source-level for
+    /// the same reason as the guard above: `handle_request` needs a full
+    /// dispatcher and a live interpreter to drive.
+    #[test]
+    fn the_proxy_cdr_record_is_opened_before_the_script_handler_runs() {
+        let source = include_str!("dispatcher.rs");
+
+        let opened = source
+            .find("    let cdr_key = if method == \"INVITE\" {")
+            .expect("the proxy CDR record is still opened in handle_request");
+        let handlers = source
+            .find("    // Call Python handlers")
+            .expect("the script handlers are still dispatched in handle_request");
+        let settled = source
+            .find("    if let Some(cdr_key) = &cdr_key {")
+            .expect("the proxy CDR record is still settled in handle_request");
+
+        assert!(
+            opened < handlers,
+            "the CDR record is opened after the script handlers run — \
+             cdr.write(request, extra=…) from a handler can no longer reach it"
+        );
+        assert!(
+            handlers < settled,
+            "the CDR record is settled before the script handlers run"
         );
     }
 

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -824,11 +824,25 @@ impl PyCall {
         self.transport_name.clone()
     }
 
+    /// Candidate `cdr_sessions` key for this call's auto-emit CDR.
+    ///
+    /// A B2BUA call is tracked under its internal call UUID (both legs carry
+    /// different Call-IDs and resolve to one record), which is exactly what
+    /// `call.id` exposes.
+    pub fn cdr_session_key_candidates(&self) -> Vec<String> {
+        vec![self.id.clone()]
+    }
+
     /// Candidate Rf-session storage keys for the CDR auto-stamp lookup.
     ///
     /// Mirrors [`PyRequest::cdr_rf_dialog_key_candidates`](super::request::PyRequest)
     /// so a `cdr.write(call)` from a B2BUA handler is annotated with the same
     /// `rf_session_id` / `rf_result_code` the proxy path stamps.
+    ///
+    /// The B2BUA record itself is keyed on the internal call UUID
+    /// (`rf_b2bua_key`), so that is offered first; the dialog-derived
+    /// candidates follow for a call whose Rf record was opened on the proxy
+    /// path (an AS leg, a call that changed mode mid-flight).
     pub fn cdr_rf_dialog_key_candidates(&self) -> Vec<String> {
         let message = match self.message.lock() {
             Ok(guard) => guard,
@@ -855,12 +869,14 @@ impl PyCall {
             .and_then(|v| crate::sip::headers::nameaddr::NameAddr::parse(v).ok())
             .and_then(|na| na.tag);
 
-        crate::diameter::rf_service::rf_lookup_candidates(
+        let mut keys = vec![crate::diameter::rf_service::rf_b2bua_key(&self.id)];
+        keys.extend(crate::diameter::rf_service::rf_lookup_candidates(
             icid.as_deref(),
             call_id.map(|s| s.as_str()),
             from_tag.as_deref(),
             to_tag.as_deref(),
-        )
+        ));
+        keys
     }
 
     /// Whether the script wants to preserve the A-leg Call-ID on the B-leg.
@@ -4089,12 +4105,33 @@ mod tests {
             "udp".to_string(),
         );
         let keys = call.cdr_rf_dialog_key_candidates();
+        // A B2BUA Rf record is keyed on the internal call UUID, not on either
+        // leg's dialog — offering only the dialog keys is why the Rf stamp
+        // never resolved for a B2BUA call.
+        assert_eq!(keys.first().map(String::as_str), Some("b2bua:test-id"));
         // make_invite() has Call-ID "call-test-1" and From-tag "abc"; the
         // dialog-keyed candidate must be present so the Rf auto-stamp can hit.
         assert!(
             keys.iter()
                 .any(|k| k.contains("call-test-1") && k.contains("abc")),
             "expected a dialog key with Call-ID + From-tag, got {keys:?}"
+        );
+    }
+
+    /// A B2BUA call's CDR is tracked under the internal call UUID (one record
+    /// for two dialogs), which is what `cdr.write(call, extra=…)` has to
+    /// resolve to reach it.
+    #[test]
+    fn call_cdr_session_key_is_the_internal_call_id() {
+        let call = PyCall::new(
+            "test-id".to_string(),
+            Arc::new(Mutex::new(make_invite())),
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+        );
+        assert_eq!(
+            call.cdr_session_key_candidates(),
+            vec!["test-id".to_string()]
         );
     }
 }

--- a/src/script/api/cdr.rs
+++ b/src/script/api/cdr.rs
@@ -319,7 +319,10 @@ mod tests {
             dict.set_item(7, "numeric key").unwrap();
 
             let fields = extra_fields(Some(&dict));
-            assert_eq!(fields.get("billing_id").map(String::as_str), Some("B-12345"));
+            assert_eq!(
+                fields.get("billing_id").map(String::as_str),
+                Some("B-12345")
+            );
             assert!(!fields.contains_key("rate"), "non-string value is skipped");
             assert_eq!(fields.len(), 1);
 

--- a/src/script/api/cdr.rs
+++ b/src/script/api/cdr.rs
@@ -26,6 +26,9 @@ struct CdrFields {
     transport: String,
     /// Candidate Rf-session storage keys for the auto-stamp lookup.
     dialog_keys: Vec<String>,
+    /// Candidate `DispatcherState::cdr_sessions` keys — the auto-emit record
+    /// this call is already accumulating, if there is one.
+    session_keys: Vec<String>,
 }
 
 impl CdrFields {
@@ -39,6 +42,7 @@ impl CdrFields {
             source_ip: request.cdr_source_ip(),
             transport: request.cdr_transport(),
             dialog_keys: request.cdr_rf_dialog_key_candidates(),
+            session_keys: request.cdr_session_key_candidates(),
         }
     }
 
@@ -52,13 +56,29 @@ impl CdrFields {
             source_ip: call.cdr_source_ip(),
             transport: call.cdr_transport(),
             dialog_keys: call.cdr_rf_dialog_key_candidates(),
+            session_keys: call.cdr_session_key_candidates(),
         }
     }
 }
 
-/// Build a CDR from resolved fields, apply the Rf auto-stamp and any script
-/// `extra`, and queue it.  Returns whether the CDR was queued.
-fn write_cdr(fields: CdrFields, extra: Option<&Bound<'_, PyDict>>) -> bool {
+/// The script's `extra=` dict as a plain string map.  Non-string keys/values
+/// are skipped (CDR extra fields are a flat `str -> str` map on the wire).
+fn extra_fields(extra: Option<&Bound<'_, PyDict>>) -> std::collections::HashMap<String, String> {
+    let mut fields = std::collections::HashMap::new();
+    let Some(dict) = extra else {
+        return fields;
+    };
+    for (key, value) in dict.iter() {
+        if let (Ok(k), Ok(v)) = (key.extract::<String>(), value.extract::<String>()) {
+            fields.insert(k, v);
+        }
+    }
+    fields
+}
+
+/// Build a standalone CDR from resolved fields, apply the Rf auto-stamp and the
+/// script `extra`, and queue it.  Returns whether the CDR was queued.
+fn write_cdr(fields: CdrFields, extra: &std::collections::HashMap<String, String>) -> bool {
     let mut record = cdr::Cdr::new(
         fields.call_id,
         fields.from_uri,
@@ -86,12 +106,8 @@ fn write_cdr(fields: CdrFields, extra: Option<&Bound<'_, PyDict>>) -> bool {
         }
     }
 
-    if let Some(extra_dict) = extra {
-        for (key, value) in extra_dict.iter() {
-            if let (Ok(k), Ok(v)) = (key.extract::<String>(), value.extract::<String>()) {
-                record = record.with_extra(k, v);
-            }
-        }
+    for (key, value) in extra {
+        record = record.with_extra(key.clone(), value.clone());
     }
 
     cdr::write(record)
@@ -115,7 +131,8 @@ impl PyCdrNamespace {
 
 #[pymethods]
 impl PyCdrNamespace {
-    /// Write a CDR from a Python script.
+    /// Write a CDR from a Python script, or attach fields to the record
+    /// siphon is already keeping for this call.
     ///
     /// Args:
     ///     source: The SIP `Request` (proxy handlers) OR the B2BUA `Call`
@@ -124,16 +141,35 @@ impl PyCdrNamespace {
     ///     extra: Optional dict of extra fields to include in the CDR.
     ///
     /// Returns:
-    ///     True if the CDR was queued, False if CDR system is not enabled or channel is full.
+    ///     True if the fields reached a CDR — merged into the tracked
+    ///     auto-emit record, or queued as a record of their own.  False if
+    ///     the CDR system is disabled or the channel is full.
     ///
     /// Raises:
     ///     TypeError: if `source` is neither a `Request` nor a `Call`.
     ///
+    /// **With `cdr.auto_emit` on, this does NOT write a second record.**
+    /// siphon tracks a CDR for the call from the INVITE onwards, and `extra`
+    /// is merged into it, so the fields are emitted once at teardown on the
+    /// record that also carries `timestamp_start` / `timestamp_answer` /
+    /// `timestamp_end`, `duration_secs`, `response_code` and
+    /// `disconnect_initiator`.  A record built here could carry none of those
+    /// — the call has not ended yet — which is why attaching beats
+    /// duplicating.  Repeat calls merge on top of each other, last write wins
+    /// per key.
+    ///
+    /// A standalone record is still written when there is nothing to merge
+    /// into: `auto_emit` off, a request the auto-emit hooks do not track (a
+    /// MESSAGE, an out-of-dialog request), or a call already finalized —
+    /// notably a proxy-mode `@proxy.on_reply` handler running after the
+    /// upstream final response tore the call down.
+    ///
     /// **Rf auto-stamp:** when an Rf accounting session is currently
     /// tracked for this SIP dialog (proxy or B2BUA auto-emit hooks),
-    /// the resulting CDR is automatically annotated with
-    /// `rf_session_id` and `rf_result_code` so operators can correlate
-    /// billing with the corresponding Diameter accounting record.
+    /// the CDR is automatically annotated with `rf_session_id` and
+    /// `rf_result_code` so operators can correlate billing with the
+    /// corresponding Diameter accounting record; on the merge path the
+    /// auto-emitted record resolves it at teardown.
     /// Manual `extra={"rf_session_id": ...}` values take precedence.
     #[pyo3(signature = (source, extra=None))]
     fn write(
@@ -158,7 +194,16 @@ impl PyCdrNamespace {
             return Ok(false);
         }
 
-        Ok(write_cdr(fields, extra))
+        let extra = extra_fields(extra);
+
+        // Attach to the record this call is already accumulating, when there
+        // is one.  Nothing is queued here — the auto-emit hook writes the one
+        // complete record when the call ends.
+        if cdr::merge_extra_into_session(&fields.session_keys, &extra) {
+            return Ok(true);
+        }
+
+        Ok(write_cdr(fields, &extra))
     }
 
     /// Check if the CDR system is enabled.
@@ -230,6 +275,55 @@ mod tests {
             let bogus = pyo3::types::PyString::new(python, "not a request or call");
             let bogus_result = namespace.write(bogus.as_any(), None);
             assert!(bogus_result.is_err());
+        });
+    }
+
+    /// The keys the merge path resolves the tracked record by: the dialog key
+    /// for a proxy request, the internal call id for a B2BUA call.
+    #[test]
+    fn resolved_fields_carry_the_auto_emit_session_keys() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|python| {
+            let request = PyRequest::new(
+                Arc::new(Mutex::new(make_invite())),
+                "udp".to_string(),
+                "10.0.0.1".to_string(),
+                5060,
+            );
+            let request_obj = pyo3::Py::new(python, request).unwrap();
+            let fields = CdrFields::from_request(&request_obj.borrow(python));
+            assert_eq!(fields.session_keys, vec!["cdr-call-1\0abc".to_string()]);
+
+            let call = PyCall::new(
+                "cdr-test".to_string(),
+                Arc::new(Mutex::new(make_invite())),
+                "10.0.0.1".to_string(),
+                "tcp".to_string(),
+            );
+            let call_obj = pyo3::Py::new(python, call).unwrap();
+            let fields = CdrFields::from_call(&call_obj.borrow(python));
+            assert_eq!(fields.session_keys, vec!["cdr-test".to_string()]);
+        });
+    }
+
+    /// CDR extra fields are a flat `str -> str` map on the wire, so a value the
+    /// script did not stringify is skipped rather than rendered as a Python
+    /// repr — the same rule on the merge path as on the standalone one.
+    #[test]
+    fn extra_fields_takes_strings_only() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|python| {
+            let dict = PyDict::new(python);
+            dict.set_item("billing_id", "B-12345").unwrap();
+            dict.set_item("rate", 0.02_f64).unwrap();
+            dict.set_item(7, "numeric key").unwrap();
+
+            let fields = extra_fields(Some(&dict));
+            assert_eq!(fields.get("billing_id").map(String::as_str), Some("B-12345"));
+            assert!(!fields.contains_key("rate"), "non-string value is skipped");
+            assert_eq!(fields.len(), 1);
+
+            assert!(extra_fields(None).is_empty());
         });
     }
 }

--- a/src/script/api/request.rs
+++ b/src/script/api/request.rs
@@ -544,6 +544,46 @@ impl PyRequest {
         self.transport_name.clone()
     }
 
+    /// Candidate `cdr_sessions` keys for this request's auto-emit CDR.
+    ///
+    /// The dispatcher tracks a proxy call under `<Call-ID>\0<INVITE From-tag>`.
+    /// An in-dialog request from the callee carries that tag as its *To*-tag,
+    /// so both are offered and the first that resolves wins — the same
+    /// caller/callee resolution `CdrProxyStop::finalize` does at teardown.
+    pub fn cdr_session_key_candidates(&self) -> Vec<String> {
+        let message = match self.message.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!("lock poisoned in cdr_session_key_candidates, using poisoned guard");
+                poisoned.into_inner()
+            }
+        };
+        let Some(call_id) = message.headers.call_id() else {
+            return Vec::new();
+        };
+        let from_tag = message
+            .headers
+            .from()
+            .and_then(|v| NameAddr::parse(v).ok())
+            .and_then(|na| na.tag);
+        let to_tag = message
+            .headers
+            .to()
+            .and_then(|v| NameAddr::parse(v).ok())
+            .and_then(|na| na.tag);
+
+        let mut keys = Vec::with_capacity(2);
+        if let Some(tag) = &from_tag {
+            keys.push(format!("{call_id}\0{tag}"));
+        }
+        if let Some(tag) = &to_tag {
+            if from_tag.as_deref() != Some(tag.as_str()) {
+                keys.push(format!("{call_id}\0{tag}"));
+            }
+        }
+        keys
+    }
+
     /// Candidate Rf-session storage keys for the CDR auto-stamp lookup.
     ///
     /// Mirrors the keying scheme used by the dispatcher's auto-emit
@@ -1901,6 +1941,50 @@ mod tests {
     fn make_request() -> PyRequest {
         let message = Arc::new(Mutex::new(invite_request_message()));
         PyRequest::new(message, "udp".to_string(), "10.0.0.1".to_string(), 5060)
+    }
+
+    /// The dispatcher keys a proxy call's CDR on the INVITE's From-tag, so
+    /// that key has to be the first thing `cdr.write(request, extra=…)` tries
+    /// — otherwise the script's fields never reach the auto-emitted record.
+    #[test]
+    fn cdr_session_key_is_the_invite_dialog_key() {
+        let request = make_request();
+        assert_eq!(
+            request.cdr_session_key_candidates(),
+            vec!["a84b4c76e66710@pc33\u{0}1928301774".to_string()],
+        );
+    }
+
+    /// An in-dialog request from the callee (a BYE it sent) carries the
+    /// INVITE's From-tag as its To-tag, so both tags are offered.
+    #[test]
+    fn cdr_session_keys_offer_the_to_tag_for_the_callee_direction() {
+        let message = SipMessageBuilder::new()
+            .request(
+                Method::Bye,
+                SipUri::new("atlanta.com".to_string()).with_user("alice".to_string()),
+            )
+            .via("SIP/2.0/UDP 10.0.0.2:5060;branch=z9hG4bK-bye".to_string())
+            .from("<sip:bob@biloxi.com>;tag=callee-tag".to_string())
+            .to("<sip:alice@atlanta.com>;tag=caller-tag".to_string())
+            .call_id("a84b4c76e66710@pc33".to_string())
+            .cseq("2 BYE".to_string())
+            .content_length(0)
+            .build()
+            .unwrap();
+        let request = PyRequest::new(
+            Arc::new(Mutex::new(message)),
+            "udp".to_string(),
+            "10.0.0.2".to_string(),
+            5060,
+        );
+        assert_eq!(
+            request.cdr_session_key_candidates(),
+            vec![
+                "a84b4c76e66710@pc33\0callee-tag".to_string(),
+                "a84b4c76e66710@pc33\0caller-tag".to_string(),
+            ],
+        );
     }
 
     /// A registered binding with an RFC 3327 Path vector, as `registrar.lookup()`


### PR DESCRIPTION
`cdr.write(request|call, extra=…)` built a whole new record and queued it. With
`cdr.auto_emit: true` that meant two rows per call, describing it from opposite
ends and neither of them complete:

| | timings / duration | response code | disconnect side | script fields |
|---|---|---|---|---|
| auto-emitted record | yes | yes | yes | no |
| script record | none at all | `0` | none | yes |

The script's record is built from the identity headers at the moment the handler
runs, and the call has not ended yet, so it cannot carry any of the first three.
Attaching a `billing_id` to a call therefore produced one row that meant nothing
on its own and forced the collector to join two rows per call on Call-ID — while
the docs sold it as attaching fields "on top of `auto_emit`".

## What changed

`extra` now merges into the record the call is already accumulating, through the
same `CdrSession::merge_extra` the LCR `cdr_fields` stamp already used, and is
emitted once at teardown on the row that carries the timings. A record of its
own is written only when there is nothing to merge into: `auto_emit` off, a
request the auto-emit hooks do not track (a MESSAGE, an out-of-dialog request),
or a call already finalized. Repeat calls merge on top of each other, last write
wins per key.

**Operators counting CDR rows per call will see one row where they saw two.**
The fields are unchanged and now all on the same row.

### The proxy path had to be re-bracketed for that to be true at all

The record was opened *after* the script handler ran and, on the BYE, written
*before* it — so at neither moment could a `cdr.write` from a handler reach one.
Now:

- **INVITE** — the record is opened before the handler and settled once the
  action is known. Forwarded keeps it (and takes the identity the script
  authenticated, which is why the existing source guard moved rather than
  disappeared); rejected or dropped discards it, exactly as before, *unless* the
  script attached fields to it. That case is a deliberate ask for a record of
  the attempt, and it now carries the code the script answered instead of a bare
  `response_code: 0`.
- **BYE** — the finalize became a drop guard, so it fires on every exit path,
  including the one a dropped or rejected BYE takes.
- A **re-INVITE** on a tracked dialog opens no second record and is never
  settled, so a script rejecting one cannot throw away the established call's
  record.

B2BUA already tracked the call before `@b2bua.on_invite`, so it needed no
reordering.

### Rf correlation reaches the record that survives

`rf_session_id` / `rf_result_code` (TS 32.299) were stamped only onto a
script-written record, so an operator running auto-emit never saw them. The
auto-emitted record now resolves them at teardown. That also surfaced the B2BUA
half being broken: a B2BUA accounting record is keyed on the internal call id
(`b2bua:<uuid>`) while the candidate list offered dialog keys only, so the stamp
never resolved for a B2BUA call. The keys are built only when an Rf lookup is
installed — on a deployment without Rf they were eight allocations per call to
search a map that never exists.

## Tests

- `cdr::tests::script_extras_merge_into_the_tracked_session` — the merge is
  taken, the miss is reported so the caller writes its own record, and the one
  emitted record carries both the script's fields and the timings.
- `cdr::tests::finalize_stamps_the_rf_session_it_is_keyed_under`, and a call not
  tracked for Rf is left unstamped rather than carrying another call's id.
- `dispatcher::cdr_proxy_tests` — caller/callee BYE resolution, the record is
  written even when the script drops the BYE, the settle decision table
  (forwarded / rejected / dropped × fields attached), and the re-INVITE case.
- Source guards for the wiring `handle_request` cannot be unit-tested through:
  the settled outcome still carries `auth_user`, and the record is opened before
  the handlers and settled after them.
- Key derivation on both objects, and `extra=` values that are not strings are
  skipped on the merge path exactly as on the standalone one.
- SDK mock mirrors the behaviour (`auto_emit` + `pending` + `finalize`) with
  tests for both keying shapes.

`cargo test` 4528 pass / 0 fail, clippy `-D warnings` clean, SDK 672 pass.

Not run here: the 16-row SIPp baseline and the memory-leak pair. Nothing on the
per-message path changed; the added per-call work is one hash probe per
`cdr.write` plus, with `auto_emit` on, opening the record for an INVITE the
proxy may not forward (built and dropped again in that case).
