### PR TITLE
perf(b2bua): box the call actor so the store stops retaining its peak footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,27 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   record of the attempt. That record now carries the code the script answered
   (a 403, a 407) instead of the `response_code: 0` a script-built record had.
 
+- **The B2BUA call store no longer retains its peak-concurrency footprint.**
+  Third and largest instance of the same shape as the transaction map and the
+  timer wheel: `CallActorStore` held `DashMap<String, CallActor>` with the actor
+  **inline**, and `CallActor` is ~2.2 KB (an inline `a_leg: Leg`, the `b_legs`
+  vectors, session-timer and transfer state), making the bucket ~2.3 KB —
+  3.8x the transaction bucket and the biggest retained bucket in siphon.
+  `hashbrown` sizes its bucket array for the peak number of live calls and never
+  shrinks it, so a box that once carried N concurrent calls kept
+  `N/0.875` rounded to a power of two, times 2.3 KB, for the rest of its life,
+  with `call_count()` reading 0 the whole time. Boxed, the bucket is 32 bytes.
+
+  No measurable effect on the SIPp bench, and that is expected: the bench tears
+  every call down immediately, so concurrent `CallActor`s number in the tens and
+  the store never grows a bucket array worth retaining. Four interleaved A/B
+  reps of `MODE=b2bua scripts/scale_test.sh 5000 1000 4` on the reference box
+  came out as noise around zero (deltas -2.4, +3.0, -1.0 MB after discarding a
+  cold first run). The saving is proportional to the **peak concurrent call
+  count**, which this workload does not produce: a node that has once held 50k
+  simultaneous calls retains ~151 MB of bucket array for the rest of its life
+  inline, against ~2 MB boxed.
+
 ### Performance
 - **The dispatcher's timer wheel no longer retains its peak-concurrency
   footprint either.** Same shape as the transaction map fixed alongside it:

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -1631,6 +1631,38 @@ const TERMINATED_CALL_TTL: Duration = Duration::from_secs(32);
 /// call rates the TTL evicts long before the cap is in play.
 const TERMINATED_CALL_CAPACITY: usize = 65_536;
 
+#[cfg(test)]
+mod call_actor_footprint {
+    use super::*;
+
+    /// The call store holds a *pointer* to the actor, not the actor.
+    ///
+    /// `CallActor` is ~2.2 KB — an inline `a_leg: Leg`, the `b_legs` vectors,
+    /// session-timer and transfer state — and `hashbrown` sizes its bucket
+    /// array for the peak number of live calls and never shrinks it. Stored
+    /// inline that was the largest retained bucket in siphon, held at the
+    /// busiest moment the process ever saw for the rest of its life, with
+    /// `call_count()` reading 0 the whole time.
+    #[test]
+    fn the_call_store_holds_a_pointer_not_the_actor() {
+        let bucket = std::mem::size_of::<(String, Box<CallActor>)>();
+        let key_only = std::mem::size_of::<String>();
+        assert!(
+            bucket <= key_only + 16,
+            "call bucket is {bucket} B against a {key_only} B key — the actor is \
+             being stored inline again, and the table will retain it at peak \
+             concurrency forever"
+        );
+        // Guard the premise: boxing only pays while the payload is big.
+        let payload = std::mem::size_of::<CallActor>();
+        assert!(
+            payload >= 512,
+            "CallActor is down to {payload} B — re-check whether boxing still earns \
+             its indirection"
+        );
+    }
+}
+
 /// Manages all active B2BUA calls.
 ///
 /// Stores `CallActor` instances in a concurrent map, indexed by internal
@@ -1638,7 +1670,14 @@ const TERMINATED_CALL_CAPACITY: usize = 65_536;
 #[derive(Debug)]
 pub struct CallActorStore {
     /// Internal call ID → CallActor.
-    calls: DashMap<String, CallActor>,
+    /// Boxed: `CallActor` is ~2.2 KB (an inline `a_leg: Leg`, the `b_legs`
+    /// vectors, session-timer and transfer state), and `hashbrown` sizes its
+    /// bucket array for the peak number of live calls and never shrinks it.
+    /// Stored inline that is a ~2.3 KB bucket retained at the busiest moment
+    /// the process ever saw, for the rest of its life, with `calls.len()`
+    /// reading 0 — the same shape fixed for the transaction map and the timer
+    /// wheel. Boxed the bucket is 32 bytes.
+    calls: DashMap<String, Box<CallActor>>,
     /// SIP identifier routing table.
     pub registry: LegRegistry,
     /// Post-teardown re-INVITE ACK absorber, keyed by B-leg SIP Call-ID.
@@ -1774,7 +1813,7 @@ impl CallActorStore {
         let id = call.id.clone();
         self.registry.register_call_id(&sip_call_id, &id);
         self.registry.register_branch(&a_branch, &id);
-        self.calls.insert(id.clone(), call);
+        self.calls.insert(id.clone(), Box::new(call));
         id
     }
 
@@ -2279,7 +2318,7 @@ impl CallActorStore {
     pub fn get_call(
         &self,
         call_id: &str,
-    ) -> Option<dashmap::mapref::one::Ref<'_, String, CallActor>> {
+    ) -> Option<dashmap::mapref::one::Ref<'_, String, Box<CallActor>>> {
         self.calls.get(call_id)
     }
 
@@ -2287,7 +2326,7 @@ impl CallActorStore {
     pub fn get_call_mut(
         &self,
         call_id: &str,
-    ) -> Option<dashmap::mapref::one::RefMut<'_, String, CallActor>> {
+    ) -> Option<dashmap::mapref::one::RefMut<'_, String, Box<CallActor>>> {
         self.calls.get_mut(call_id)
     }
 
@@ -2867,7 +2906,7 @@ impl CallActorStore {
     }
 
     /// Iterate over all active calls (for session timer sweep).
-    pub fn iter_calls(&self) -> dashmap::iter::Iter<'_, String, CallActor> {
+    pub fn iter_calls(&self) -> dashmap::iter::Iter<'_, String, Box<CallActor>> {
         self.calls.iter()
     }
 


### PR DESCRIPTION
Third and largest instance of the shape fixed in #259 (transaction map) and #262
(timer wheel).

## The footprint

```
CallActor              = 2280      (inline a_leg: Leg, b_legs vectors,
Leg                    =  584       session-timer + transfer state)
(String, CallActor)    = 2304      <- the bucket
(String, Box<CallActor>) =  32
```

`CallActorStore` held `DashMap<String, CallActor>` with the actor **inline**, so
the bucket was ~2.3 KB — **3.8× the transaction bucket, the biggest retained
bucket in siphon**. `hashbrown` sizes its bucket array for the peak number of
live entries and never shrinks it, so a box that once carried N concurrent calls
kept `N/0.875` rounded to a power of two, times 2.3 KB, for the rest of the
process's life — with `call_count()` reading 0 the whole time.

Same reason it hides from a store-drains-to-zero check as the other two: the
store does drain. The array it drained out of does not.

## Measured — and it does not show in the bench

`MODE=b2bua scripts/scale_test.sh 5000 1000 4` on the reference box, four
interleaved A/B reps (inline, boxed, inline, boxed — so drift hits both arms
equally):

| rep | inline | boxed | delta |
|---|---|---|---|
| 1 | 120.9 MB | 100.4 MB | -20.5 |
| 2 | 100.8 MB | 98.4 MB | -2.4 |
| 3 | 100.4 MB | 103.4 MB | **+3.0** |
| 4 | 99.2 MB | 98.2 MB | -1.0 |

Discarding rep 1 as a cold first run: inline mean 100.1 MB, boxed mean 100.0 MB.
**No measurable effect.** The sign flips between reps, so this is noise.

I originally reported -17.7 % from a single non-interleaved pair. That was wrong
— it compared a cold inline run against a warm boxed one, which is exactly the
artifact CLAUDE.md's perf log already warns about. Corrected here rather than
left standing.

**The bench cannot show this change**, and that is structural rather than bad
luck: the scenario tears every call down immediately, so concurrent
`CallActor`s number in the tens. The store never grows a bucket array worth
retaining, and peak RSS is measured while the calls are *live*, where boxing
relocates an actor rather than removing it.

The saving is proportional to **peak concurrent calls**, which this workload
does not produce. A node that has once held 50k simultaneous calls keeps
128 shards x 512 buckets x 2304 B = **~151 MB** of array for the rest of its
life; boxed that is **~2 MB**.

So this rests on the same structural argument as #259 and #262 — both of which
*were* measured, because a REGISTER workload does drive concurrency through
`rate x Timer J`. If you want it gated on a number rather than the argument, the
measurement it needs is a long-hold call workload (concurrent calls, not cps),
which no current harness produces.

## Blast radius

`calls` is private to `CallActorStore` and every one of its 56 access sites goes
through the store's own methods; `RefMut` derefs twice, so field access and
method calls are unchanged. Three signatures now hand back a `Ref`/`RefMut`/`Iter`
over the box (`get_call`, `get_call_mut`, `iter_calls`) — callers reach through
them unchanged. Crate `pub` API is out of contract per VERSIONING.md.

## Tests

`the_call_store_holds_a_pointer_not_the_actor` mirrors the guards in #259/#262:
pins the bucket against the key size, and guards the premise that the payload is
still large enough for the indirection to pay.

- `cargo test --all-features` — 4,523 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

## Context: this is not the proxy-vs-B2BUA gap

Measured while chasing why the proxy row has historically used more memory than
B2BUA. It is not this — the same row on the same binary:

| mode | peak RSS |
|---|---|
| proxy | 153.9 MB |
| b2bua (before this change) | 120.6 MB |
| b2bua (after) | 99.3 MB |

Proxy was already higher than the *unfixed* B2BUA, so inline-value retention
runs the wrong way to explain it. That gap wants its own investigation; the
`ProxySession::original_request` deep clone per session is the standing
suspect, and the note in CLAUDE.md that a header-representation change moved
proxy RSS 13–14 % while leaving B2BUA flat points the same way.
