### PR TITLE
perf(proxy): retire a dialog-key entry on Timer I once its 2xx ACK has been routed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Performance
+- **A proxy no longer pins a whole INVITE per answered call for the full
+  transaction timeout.** The `by_dialog_key` entry exists for one purpose:
+  routing the end-to-end 2xx ACK, which is a new request and so does not match
+  the INVITE server transaction (RFC 3261 §13.2.2.4). It was aged only by
+  64*T1 (32 s) from creation, so every *answered* call held its
+  `ProxySession` — including a full cloned `original_request` — for 32 s after
+  the call had otherwise finished. At 10k cps that is ~320k pinned INVITEs at
+  steady state, and it is the bulk of why a proxy row outweighs the equivalent
+  B2BUA row, which drops its call state at teardown.
+
+  Once that ACK has been routed the only thing still owed is absorbing a
+  *retransmitted* ACK, which the UAS sends in response to a retransmitted 2xx —
+  bounded by Timer I (T4, 5 s), not by the transaction timeout. Dialogs that
+  have seen their ACK now retire on that shorter window; dialogs still waiting
+  for one keep the full timeout unchanged, so a late ACK is never left
+  unroutable.
+
+  Measured on the reference box, `scripts/scale_test.sh 1200000 10000 8` (120 s
+  of sustained load, long enough for both arms to reach steady state), two
+  interleaved reps on jemalloc live bytes:
+
+  | | live bytes | peak CPS | peak CPU |
+  |---|---|---|---|
+  | before | 4147 / 4165 MB | 9952 / 9960 | 541 / 565 % |
+  | after | **2600 / 2628 MB** | 9928 / 9944 | 550 / 553 % |
+
+  **-1.54 GB (-37 %)**, with CPU a wash and CPS at parity.
+
 ### Changed
 - **`cdr.write(request|call, extra=…)` now attaches to the auto-emitted CDR
   instead of writing a second record.** With `cdr.auto_emit: true`, siphon

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2344,7 +2344,12 @@ const ORPHAN_CALL_TTL: std::time::Duration = std::time::Duration::from_secs(24 *
 async fn sweep_stale_entries(state: &DispatcherState) {
     let now = std::time::Instant::now();
     let ttl = state.transaction_timeout;
-    let expired_sessions = state.session_store.sweep_stale(ttl) as u64;
+    // Timer I (T4) is the ACK-absorption window (RFC 3261 §17.2.1), which is
+    // all a dialog owes once its 2xx ACK has been routed.
+    let expired_sessions = state
+        .session_store
+        .sweep_stale_with_ack_grace(ttl, crate::transaction::timer::DEFAULT_T4)
+        as u64;
 
     // Expire UAC pending requests whose response never arrived. Callers
     // (NAT keepalive, gateway health probe, proxy.send_request) apply a short
@@ -4027,6 +4032,16 @@ fn handle_request(
                 let from_tag = message.typed_from().ok().flatten().and_then(|na| na.tag);
                 if let (Some(cid), Some(ftag)) = (call_id, from_tag.as_deref()) {
                     if let Some(session_arc) = state.session_store.get_by_dialog_key(cid, ftag) {
+                        // Stamp before forwarding: the entry existed only to
+                        // route this ACK, and what is still owed afterwards is
+                        // absorbing a *retransmitted* ACK (the UAS sends one per
+                        // retransmitted 2xx), which Timer I bounds. Retiring on
+                        // that window instead of 64*T1 is what stops a proxy
+                        // pinning a whole `original_request` per answered call.
+                        // Stamped here rather than after the call because
+                        // `handle_ack_via_session` consumes `message`, which
+                        // `cid` borrows from; the ACK is routed either way.
+                        ProxySessionStore::mark_dialog_acked(&session_arc);
                         handle_ack_via_session(inbound, message, session_arc, state);
                         return;
                     }

--- a/src/proxy/session.rs
+++ b/src/proxy/session.rs
@@ -97,6 +97,22 @@ pub struct ProxySession {
     pub record_routed: bool,
     /// When this session was created (for TTL-based cleanup).
     pub created_at: Instant,
+    /// When the end-to-end 2xx ACK was routed through this session, if it has
+    /// been.
+    ///
+    /// The `by_dialog_key` entry exists for exactly one purpose: routing that
+    /// ACK (RFC 3261 §13.2.2.4 — a 2xx ACK is a new request, so it does not
+    /// match the INVITE server transaction). Once it has been routed, the only
+    /// thing still owed is absorbing a *retransmitted* ACK, which the UAS sends
+    /// in response to a retransmitted 2xx — bounded by Timer I (T4, 5 s), not by
+    /// the full transaction timeout.
+    ///
+    /// Ageing post-ACK entries by that shorter window rather than 64*T1 is what
+    /// keeps a proxy from pinning one whole `original_request` per *answered*
+    /// call for 32 s. At 10k cps that is 320k pinned INVITEs at steady state,
+    /// ~1.6 KB each — the bulk of why a proxy row outweighs the equivalent
+    /// B2BUA row, which drops its call state at teardown.
+    pub acked_at: Option<Instant>,
     /// Per-relay on_reply Python callback (called with `(request, reply)`).
     pub on_reply_callback: Option<Py<PyAny>>,
     /// Per-relay on_failure Python callback (called with `(request, code, reason)`).
@@ -148,6 +164,7 @@ impl ProxySession {
             original_request,
             record_routed,
             created_at: Instant::now(),
+            acked_at: None,
             on_reply_callback: None,
             on_failure_callback: None,
             final_response_sent: false,
@@ -526,8 +543,42 @@ impl ProxySessionStore {
         true
     }
 
+    /// Mark that the end-to-end 2xx ACK has been routed for this dialog, so the
+    /// sweep can retire the `by_dialog_key` entry on the short Timer I window
+    /// instead of the full transaction timeout.
+    ///
+    /// Takes the session the caller already resolved rather than re-keying the
+    /// map: the ACK path has just done that lookup, and repeating it costs a
+    /// hash plus a shard lock on every answered call.
+    ///
+    /// Idempotent: a retransmitted ACK keeps the first stamp, so the grace is
+    /// measured from the first ACK rather than being extended by each repeat.
+    pub fn mark_dialog_acked(session: &Arc<RwLock<ProxySession>>) {
+        if let Ok(mut guard) = session.write() {
+            if guard.acked_at.is_none() {
+                guard.acked_at = Some(Instant::now());
+            }
+        }
+    }
+
+    /// Sweep sessions older than `ttl`, returning the number removed.
+    ///
+    /// `ack_grace` is the shorter window applied to `by_dialog_key` entries
+    /// whose 2xx ACK has already been routed — see [`ProxySession::acked_at`].
+    pub fn sweep_stale_with_ack_grace(
+        &self,
+        ttl: std::time::Duration,
+        ack_grace: std::time::Duration,
+    ) -> usize {
+        self.sweep_inner(ttl, ack_grace)
+    }
+
     /// Sweep sessions older than `ttl`, returning the number removed.
     pub fn sweep_stale(&self, ttl: std::time::Duration) -> usize {
+        self.sweep_inner(ttl, ttl)
+    }
+
+    fn sweep_inner(&self, ttl: std::time::Duration, ack_grace: std::time::Duration) -> usize {
         let now = Instant::now();
         let mut stale_server_keys = Vec::new();
 
@@ -565,7 +616,14 @@ impl ProxySessionStore {
         let mut stale_dialog_keys = Vec::new();
         for entry in self.by_dialog_key.iter() {
             if let Ok(session) = entry.value().read() {
-                if now.duration_since(session.created_at) > ttl {
+                // A dialog whose ACK has been routed only owes the Timer I
+                // absorption window; one still waiting for it keeps the full
+                // transaction timeout.
+                let (since, limit) = match session.acked_at {
+                    Some(acked) => (acked, ack_grace),
+                    None => (session.created_at, ttl),
+                };
+                if now.duration_since(since) > limit {
                     stale_dialog_keys.push(entry.key().clone());
                 }
             }
@@ -975,6 +1033,89 @@ mod tests {
         assert_eq!(swept, 1);
         assert_eq!(store.session_count(), 0);
         assert_eq!(store.client_key_count(), 0);
+    }
+
+    /// Once the 2xx ACK has been routed, the dialog entry retires on the short
+    /// Timer I window instead of the full transaction timeout.
+    ///
+    /// This is the whole point of the change: the entry exists only to route
+    /// that ACK, so holding a full `original_request` for 64*T1 after it has
+    /// been routed pins one INVITE per *answered* call for 32 s — at 10k cps,
+    /// 320k of them at steady state.
+    #[test]
+    fn an_acked_dialog_retires_on_the_timer_i_window() {
+        let store = ProxySessionStore::new();
+        store.insert(make_session());
+        assert_eq!(store.dialog_key_count(), 1);
+
+        let sess = store
+            .get_by_dialog_key("session-test", "abc")
+            .expect("dialog entry present");
+        ProxySessionStore::mark_dialog_acked(&sess);
+
+        // Full transaction timeout has NOT elapsed, but the ACK grace has.
+        let swept = store.sweep_stale_with_ack_grace(
+            std::time::Duration::from_secs(32),
+            std::time::Duration::ZERO,
+        );
+        assert_eq!(
+            store.dialog_key_count(),
+            0,
+            "an acked dialog should retire on the ack grace, not the full ttl"
+        );
+        let _ = swept;
+    }
+
+    /// A dialog still waiting for its ACK keeps the full transaction timeout.
+    ///
+    /// The guard that matters: shortening the window must not retire an entry
+    /// whose ACK has not arrived, or the 2xx ACK becomes unroutable and the
+    /// call is left hanging at the UAS.
+    #[test]
+    fn an_unacked_dialog_keeps_the_full_timeout() {
+        let store = ProxySessionStore::new();
+        store.insert(make_session());
+
+        // Zero ack-grace, but no ACK seen — the full ttl still governs.
+        let swept = store.sweep_stale_with_ack_grace(
+            std::time::Duration::from_secs(3600),
+            std::time::Duration::ZERO,
+        );
+        assert_eq!(swept, 0);
+        assert_eq!(
+            store.dialog_key_count(),
+            1,
+            "a dialog with no ACK yet must survive the ack grace"
+        );
+    }
+
+    /// A retransmitted ACK must not extend the grace indefinitely.
+    #[test]
+    fn a_retransmitted_ack_does_not_extend_the_grace() {
+        let store = ProxySessionStore::new();
+        store.insert(make_session());
+
+        let sess = store
+            .get_by_dialog_key("session-test", "abc")
+            .expect("dialog entry present");
+        ProxySessionStore::mark_dialog_acked(&sess);
+        let first = store
+            .get_by_dialog_key("session-test", "abc")
+            .and_then(|s| s.read().ok().map(|g| g.acked_at));
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let sess = store
+            .get_by_dialog_key("session-test", "abc")
+            .expect("dialog entry present");
+        ProxySessionStore::mark_dialog_acked(&sess);
+        let second = store
+            .get_by_dialog_key("session-test", "abc")
+            .and_then(|s| s.read().ok().map(|g| g.acked_at));
+
+        assert_eq!(
+            first, second,
+            "the stamp must stay at the first ACK, so repeats cannot hold the \
+             entry open forever"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Answers the proxy-vs-B2BUA memory gap measured while investigating #267.

## Why a proxy row outweighs the equivalent B2BUA row

The `by_dialog_key` entry exists for exactly one purpose: routing the
end-to-end 2xx ACK, which per RFC 3261 §13.2.2.4 is a *new request* and so does
not match the INVITE server transaction. It was aged only by the transaction
timeout (64·T1 = 32 s) from `created_at`.

So every **answered** call kept its `ProxySession` — including a full cloned
`original_request` — for 32 s after the call had otherwise finished. B2BUA drops
its `CallActor` at teardown instead, on the BYE.

Measured from the 16-row baseline, this is the whole gap:

| row | proxy | b2bua | gap | pinned (`rate x 32s`) | per clone |
|---|---|---|---|---|---|
| `20000 5000 4` | 381.7 MB | 126.2 MB | 255.5 MB | 160,000 | 1.60 KB |
| `40000 10000 8` | 683.3 MB | 151.2 MB | 532.1 MB | 320,000 | 1.66 KB |

Constant per-clone cost across a 2x rate change, scaling linearly with rate —
the signature of a `rate x timeout` pinned-clone model, and nothing else in the
two modes has that shape.

## The change

Once the ACK has been routed, the only thing still owed is absorbing a
*retransmitted* ACK — the UAS sends one per retransmitted 2xx — which **Timer I
(T4, 5 s)** bounds, not the transaction timeout. Dialogs that have seen their
ACK retire on that shorter window.

Dialogs **still waiting** for an ACK keep the full timeout, untouched. That is
the case that matters for correctness: shortening it would leave a late 2xx ACK
unroutable and hang the call at the UAS. It has its own test.

The stamp is taken once (a retransmitted ACK does not extend it, or a repeating
peer could hold the entry open indefinitely), and it is taken through the
session the ACK path **already resolved** rather than re-keying the map — that
lookup would cost a hash and a shard lock on every answered call.

## Measured

`scripts/scale_test.sh 1200000 10000 8` — 120 s of sustained load, long enough
for **both** arms to reach steady state. Two interleaved reps, on jemalloc live
bytes:

| | live bytes | peak CPS | peak CPU |
|---|---|---|---|
| before | 4147 / 4165 MB | 9952 / 9960 | 541 / 565 % |
| after | **2600 / 2628 MB** | 9928 / 9944 | 550 / 553 % |

**−1.54 GB (−37 %). CPU a wash. CPS at parity.**

### On the instrument, because it changed the answer twice

- **RSS is not usable here.** It is THP-sensitive, and the same unchanged
  binary read 4388 MB and 3226 MB on the same row as the box's memory got
  fragmented under repeated runs — a 26 % swing, the same magnitude as the
  effect. `siphon_memory_allocated_bytes` reproduces inside 1 %.
- **A short row cannot see this at all.** Over the 40 s row the saving looked
  like −20 MB, because the steady state (`rate x 32 s`) needs longer than 32 s
  to even form.
- **The 40 s row also invented a +22 % CPU cost** that is not real: the unfixed
  arm accumulates for 32 s and the run ends before it pays the deallocation,
  while the fixed arm frees throughout. Over 120 s both arms do the same work
  and the gap disappears.

## Tests

- `an_acked_dialog_retires_on_the_timer_i_window`
- `an_unacked_dialog_keeps_the_full_timeout` — the correctness guard
- `a_retransmitted_ack_does_not_extend_the_grace`

- `cargo test --all-features` — 4,530 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Full 16-row baseline + `mem_leak_test.sh` not yet re-run against this branch;
it touches the proxy ACK path and wants both before merge.
