### PR TITLE
fix(xml): resolve entity references in element text, and take quick-xml 0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   cannot drift apart. Selection is unchanged (6xx > 5xx > 4xx).
 
 ### Changed
+- **quick-xml 0.41 → 0.42.** `BytesText` is `str`-backed now, so the reader
+  decodes up front and `decode()` is gone; the content accessors
+  (`xml10_content()`) apply XML 1.0 end-of-line normalisation and leave entity
+  resolution to the caller. Element and attribute names are `str` rather than
+  bytes, which removes a set of `from_utf8` conversions at the parse sites.
+
 - **`cdr.write(request|call, extra=…)` now attaches to the auto-emitted CDR
   instead of writing a second record.** With `cdr.auto_emit: true`, siphon
   already tracks a record for the call from the INVITE; a script's `extra`
@@ -126,6 +132,31 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   exactly one BYE and retransmits it correctly per RFC 3261 §17.1.
 
 ### Fixed
+- **XML entity references in element text were silently dropped, since v1.1.1.**
+  quick-xml does not deliver one text node per element: an entity reference
+  terminates the current `Text` event, arrives as its own `GeneralRef`, and the
+  remaining text follows as another `Text`. siphon's three hand-rolled parsers
+  read only `Text`, so every `&amp;`, `&lt;`, `&#38;` and the like vanished from
+  the value — no error, just a shorter string. The 0.37 → 0.41 bump in v1.1.1
+  (RUSTSEC-2026-0194/0195) introduced the split; the compatibility shim written
+  at the time restored `BytesText::unescape()` but never saw the references,
+  because they had already been routed to an event nobody handled.
+
+  This is not cosmetic for SIP. A URI carries `&` as soon as it has two headers
+  (`sip:a@b?X=1&Y=2`), which XML requires be written `&amp;` — so a contact URI
+  in a reg-event NOTIFY (RFC 3680), an Application-Server URI in an iFC
+  (3GPP TS 29.228) and a display name in SIPREC metadata (RFC 7866) all parsed
+  into a *different*, still well-formed value. Affected every release from
+  v1.1.1 through 1.8.0.
+
+  All three parsers now resolve `GeneralRef` through one shared
+  `xml_text::resolve_general_ref` — the five predefined entities plus decimal
+  and hexadecimal numeric references. An unresolvable reference fails the parse
+  rather than being dropped, since siphon reads no DTD and inventing
+  replacement text is how the bug looked in the first place. The SIPREC parser
+  additionally accumulates across fragments instead of assigning, which it had
+  to for a split value to survive at all.
+
 - **A media failure at answer no longer connects the call and starts charging.**
   An exception out of `@b2bua.on_answer` was logged and then ignored: the A-leg
   2xx went out a millisecond later, the ACK followed, and the charging clock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,9 +2357,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ mime_guess = { version = "2", optional = true }
 rasn = "0.28"
 rasn-derive = "0.28"
 chrono = { version = "0.4", default-features = false }
-quick-xml = { version = "0.41", features = ["serialize"] }
+quick-xml = { version = "0.42", features = ["serialize"] }
 # ETSI X1 (TS 103 221-1) schema validation. Pure Rust, zero transitive
 # dependencies, XSD 1.1 — validates every X1 message against the schemas
 # shipped in `schemas/etsi/` on the way in AND on the way out, rather than

--- a/src/ifc/mod.rs
+++ b/src/ifc/mod.rs
@@ -21,9 +21,14 @@ trait BytesTextExt {
 }
 impl BytesTextExt for quick_xml::events::BytesText<'_> {
     fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String> {
-        let decoded = self.decode().map_err(|error| error.to_string())?;
+        // quick-xml 0.42 made `BytesText` `str`-backed, so decoding happens in
+        // the reader and `decode()` is gone. `xml10_content()` is the
+        // replacement for that half — it applies XML 1.0 end-of-line
+        // normalisation (§2.11) and nothing else, so the entity resolution the
+        // old `unescape()` did still has to be layered on top.
+        let content = self.xml10_content();
         Ok(std::borrow::Cow::Owned(
-            quick_xml::escape::unescape(&decoded)
+            quick_xml::escape::unescape(&content)
                 .map_err(|error| error.to_string())?
                 .into_owned(),
         ))
@@ -393,6 +398,20 @@ pub fn parse_service_profile(xml: &str) -> Result<Vec<InitialFilterCriteria>, If
                         .map_err(|error| IfcError::XmlParse(error.to_string()))?,
                 );
             }
+            // An entity reference arrives as its own event between two `Text`
+            // fragments; without this it is dropped and the iFC value silently
+            // loses characters (a ServiceInfo body or an SPT header value can
+            // legitimately contain `&`).
+            Ok(Event::GeneralRef(reference)) => {
+                let resolved =
+                    crate::xml_text::resolve_general_ref(&reference).ok_or_else(|| {
+                        IfcError::XmlParse(format!(
+                            "unresolvable entity reference &{};  (siphon parses no DTD)",
+                            reference.as_ref() as &str
+                        ))
+                    })?;
+                current_text.push_str(&resolved);
+            }
             Ok(Event::Eof) => break,
             Err(error) => return Err(IfcError::XmlParse(error.to_string())),
             _ => {}
@@ -406,7 +425,8 @@ pub fn parse_service_profile(xml: &str) -> Result<Vec<InitialFilterCriteria>, If
 fn local_name(element: &quick_xml::events::BytesStart, _reader: &Reader<&[u8]>) -> String {
     let full = element.name();
     let local = full.local_name();
-    String::from_utf8_lossy(local.as_ref()).to_string()
+    // quick-xml 0.42 yields `str` here, so there is nothing left to decode.
+    local.as_ref().to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -1081,6 +1101,41 @@ mod tests {
             "  </InitialFilterCriteria>\n",
             "</ServiceProfile>\n",
         )
+    }
+
+    /// Entity references in element text survive the parse.
+    ///
+    /// An AS URI carries `&` as soon as it has two URI headers, and XML
+    /// requires that be written `&amp;`. quick-xml delivers the reference as
+    /// its own event between two text fragments, so a parser reading only
+    /// `Event::Text` drops it and silently routes to a *different* AS.
+    #[test]
+    fn parse_resolves_entity_references_in_server_name() {
+        let xml = concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+            "<ServiceProfile>\n",
+            "  <InitialFilterCriteria>\n",
+            "    <Priority>0</Priority>\n",
+            "    <TriggerPoint>\n",
+            "      <ConditionTypeCNF>0</ConditionTypeCNF>\n",
+            "      <SPT>\n",
+            "        <ConditionNegated>0</ConditionNegated>\n",
+            "        <Group>0</Group>\n",
+            "        <Method>INVITE</Method>\n",
+            "      </SPT>\n",
+            "    </TriggerPoint>\n",
+            "    <ApplicationServer>\n",
+            "      <ServerName>sip:as@example.com?P-A=1&amp;P-B=2&#38;P-C=3</ServerName>\n",
+            "      <DefaultHandling>0</DefaultHandling>\n",
+            "    </ApplicationServer>\n",
+            "  </InitialFilterCriteria>\n",
+            "</ServiceProfile>\n",
+        );
+        let ifcs = parse_service_profile(xml).unwrap();
+        assert_eq!(
+            ifcs[0].application_server.server_name, "sip:as@example.com?P-A=1&P-B=2&P-C=3",
+            "named and numeric references must both resolve, and neither be dropped"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod subscribe_state;
 pub mod transaction;
 pub mod transport;
 pub mod uac;
+pub mod xml_text;
 
 pub use server::SiphonServer;
 

--- a/src/registrar/reginfo.rs
+++ b/src/registrar/reginfo.rs
@@ -326,9 +326,14 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
     }
     impl BytesTextExt for quick_xml::events::BytesText<'_> {
         fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String> {
-            let decoded = self.decode().map_err(|error| error.to_string())?;
+            // quick-xml 0.42 made `BytesText` `str`-backed, so decoding happens in
+            // the reader and `decode()` is gone. `xml10_content()` is the
+            // replacement for that half — it applies XML 1.0 end-of-line
+            // normalisation (§2.11) and nothing else, so the entity resolution the
+            // old `unescape()` did still has to be layered on top.
+            let content = self.xml10_content();
             Ok(std::borrow::Cow::Owned(
-                quick_xml::escape::unescape(&decoded)
+                quick_xml::escape::unescape(&content)
                     .map_err(|error| error.to_string())?
                     .into_owned(),
             ))
@@ -362,9 +367,10 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
             Event::Start(element) | Event::Empty(element) => {
                 let _ = is_empty; // captured above; used in branches below
                 let local_name = element.local_name();
-                let name_bytes = local_name.as_ref();
-                match name_bytes {
-                    b"reginfo" => {
+                // `local_name()` yields `str` in quick-xml 0.42, not bytes.
+                let name = local_name.as_ref();
+                match name {
+                    "reginfo" => {
                         let version = attr_required_u32(&element, "version")?;
                         let state = attr_required_str(&element, "state")?;
                         let parsed_state = match state.as_str() {
@@ -383,7 +389,7 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
                             registrations: Vec::new(),
                         });
                     }
-                    b"registration" => {
+                    "registration" => {
                         if body.is_none() {
                             return Err(ReginfoParseError::MissingRoot);
                         }
@@ -416,7 +422,7 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
                             }
                         }
                     }
-                    b"contact" => {
+                    "contact" => {
                         if current_registration.is_none() {
                             // Stray <contact> outside <registration> — skip.
                             continue;
@@ -483,11 +489,11 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
                             }
                         }
                     }
-                    b"uri" => {
+                    "uri" => {
                         in_uri_text = true;
                         uri_text_buffer.clear();
                     }
-                    b"unknown-param" => {
+                    "unknown-param" => {
                         // RFC 3680 §5.3.2.  Flag form is self-closing
                         // (`<unknown-param name="…"/>`); valued form
                         // carries its value as inner text.  We stash the
@@ -509,6 +515,25 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
                     }
                 }
             }
+            // An entity reference splits the text node: quick-xml ends the
+            // current `Text` at the `&`, emits the reference as its own event,
+            // and resumes `Text` after the `;`. Without this arm the reference
+            // is dropped and the value is silently rewritten — a contact URI
+            // with two headers (`sip:a@b?X=1&amp;Y=2`) loses its separator.
+            Event::GeneralRef(reference) => {
+                let resolved =
+                    crate::xml_text::resolve_general_ref(&reference).ok_or_else(|| {
+                        ReginfoParseError::Xml(format!(
+                            "unresolvable entity reference &{};  (siphon parses no DTD)",
+                            reference.as_ref() as &str
+                        ))
+                    })?;
+                if in_uri_text {
+                    uri_text_buffer.push_str(&resolved);
+                } else if pending_unknown_param_name.is_some() {
+                    unknown_param_text_buffer.push_str(&resolved);
+                }
+            }
             Event::Text(text) => {
                 if in_uri_text {
                     let s = text
@@ -526,7 +551,7 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
                 let local_name = element.local_name();
                 let name_bytes = local_name.as_ref();
                 match name_bytes {
-                    b"uri" => {
+                    "uri" => {
                         if let Some(contact) = current_contact.as_mut() {
                             let trimmed = uri_text_buffer.trim();
                             if !trimmed.is_empty() {
@@ -536,7 +561,7 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
                         in_uri_text = false;
                         uri_text_buffer.clear();
                     }
-                    b"unknown-param" => {
+                    "unknown-param" => {
                         if let Some(name) = pending_unknown_param_name.take() {
                             let trimmed = unknown_param_text_buffer.trim();
                             let value = if trimmed.is_empty() {
@@ -550,14 +575,14 @@ pub fn parse_reginfo(xml: &str) -> Result<ReginfoBody, ReginfoParseError> {
                         }
                         unknown_param_text_buffer.clear();
                     }
-                    b"contact" => {
+                    "contact" => {
                         if let Some(contact) = current_contact.take() {
                             if let Some(reg) = current_registration.as_mut() {
                                 reg.contacts.push(contact);
                             }
                         }
                     }
-                    b"registration" => {
+                    "registration" => {
                         if let Some(reg) = current_registration.take() {
                             if let Some(reginfo) = body.as_mut() {
                                 reginfo.registrations.push(reg);
@@ -589,7 +614,7 @@ fn attr_optional_str(
 ) -> Result<Option<String>, ReginfoParseError> {
     for attr in element.attributes().with_checks(false) {
         let attr = attr.map_err(|error| ReginfoParseError::Xml(error.to_string()))?;
-        if attr.key.local_name().as_ref() == name.as_bytes() {
+        if attr.key.local_name().as_ref() == name {
             let value = attr
                 .normalized_value(quick_xml::XmlVersion::Explicit1_0)
                 .map_err(|error| ReginfoParseError::Xml(error.to_string()))?;
@@ -882,6 +907,32 @@ mod tests {
     // -----------------------------------------------------------------
     // Parser tests
     // -----------------------------------------------------------------
+
+    /// Entity references in element text are resolved on parse.
+    ///
+    /// This is the path `BytesTextExt::unescape` exists for, and it had no
+    /// coverage: a SIP URI legitimately carries `&` (a header separator) and
+    /// `=`/`?`, so an escaping regression here silently rewrites the contact a
+    /// terminating request is routed to. quick-xml 0.42 made `BytesText`
+    /// `str`-backed and removed `decode()`, so the shim had to be rebuilt on
+    /// `xml10_content()` + `escape::unescape()`.
+    #[test]
+    fn parse_resolves_entity_references_in_uri_text() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<reginfo xmlns="urn:ietf:params:xml:ns:reginfo" version="1" state="full">
+  <registration aor="sip:alice@ims.example.com" id="reg-1" state="active">
+    <contact id="c-1" state="active" event="registered" expires="1800" q="1.0">
+      <uri>sip:alice@10.0.0.1:5060?X-A=1&amp;X-B=2&lt;3&gt;4&quot;5&apos;6&#38;7</uri>
+    </contact>
+  </registration>
+</reginfo>"#;
+        let body = parse_reginfo(xml).unwrap();
+        let contact = &body.registrations[0].contacts[0];
+        assert_eq!(
+            contact.uri, "sip:alice@10.0.0.1:5060?X-A=1&X-B=2<3>4\"5'6&7",
+            "every entity form (named, numeric) must resolve exactly once"
+        );
+    }
 
     #[test]
     fn parse_full_state_single_registration() {

--- a/src/siprec/metadata.rs
+++ b/src/siprec/metadata.rs
@@ -17,9 +17,14 @@ trait BytesTextExt {
 }
 impl BytesTextExt for quick_xml::events::BytesText<'_> {
     fn unescape(&self) -> Result<std::borrow::Cow<'_, str>, String> {
-        let decoded = self.decode().map_err(|error| error.to_string())?;
+        // quick-xml 0.42 made `BytesText` `str`-backed, so decoding happens in
+        // the reader and `decode()` is gone. `xml10_content()` is the
+        // replacement for that half — it applies XML 1.0 end-of-line
+        // normalisation (§2.11) and nothing else, so the entity resolution the
+        // old `unescape()` did still has to be layered on top.
+        let content = self.xml10_content();
         Ok(std::borrow::Cow::Owned(
-            quick_xml::escape::unescape(&decoded)
+            quick_xml::escape::unescape(&content)
                 .map_err(|error| error.to_string())?
                 .into_owned(),
         ))
@@ -167,6 +172,7 @@ pub fn parse_recording_metadata(xml: &str) -> Result<RecordingMetadata, Metadata
     let mut current_stream_id: Option<String> = None;
     let mut current_stream_session_id: Option<String> = None;
     let mut current_label: Option<String> = None;
+    let mut current_sip_session_id: Option<String> = None;
     let mut inside_label = false;
     let mut inside_name = false;
     let mut inside_sip_session_id = false;
@@ -177,7 +183,7 @@ pub fn parse_recording_metadata(xml: &str) -> Result<RecordingMetadata, Metadata
         match reader.read_event_into(&mut buffer) {
             Ok(Event::Start(ref element)) | Ok(Event::Empty(ref element)) => {
                 let local_name = element.local_name();
-                let name = std::str::from_utf8(local_name.as_ref()).unwrap_or("");
+                let name = local_name.as_ref();
 
                 match name {
                     "session" => {
@@ -212,29 +218,51 @@ pub fn parse_recording_metadata(xml: &str) -> Result<RecordingMetadata, Metadata
                     _ => {}
                 }
             }
+            // An entity reference splits the text node, so a value has to be
+            // accumulated across fragments rather than assigned from one — and
+            // trimmed once at the end, not per fragment, or interior spacing is
+            // eaten. Both `Text` and `GeneralRef` append here.
             Ok(Event::Text(ref text)) => {
-                if inside_label {
-                    if let Ok(value) = text.unescape() {
-                        current_label = Some(value.trim().to_string());
+                if let Ok(value) = text.unescape() {
+                    if inside_label {
+                        current_label
+                            .get_or_insert_with(String::new)
+                            .push_str(&value);
+                    }
+                    if inside_name {
+                        current_participant_name
+                            .get_or_insert_with(String::new)
+                            .push_str(&value);
+                    }
+                    if inside_sip_session_id {
+                        current_sip_session_id
+                            .get_or_insert_with(String::new)
+                            .push_str(&value);
                     }
                 }
-                if inside_name {
-                    if let Ok(value) = text.unescape() {
-                        current_participant_name = Some(value.trim().to_string());
+            }
+            Ok(Event::GeneralRef(ref reference)) => {
+                if let Some(resolved) = crate::xml_text::resolve_general_ref(reference) {
+                    if inside_label {
+                        current_label
+                            .get_or_insert_with(String::new)
+                            .push_str(&resolved);
                     }
-                }
-                if inside_sip_session_id {
-                    if let Ok(value) = text.unescape() {
-                        let trimmed = value.trim().to_string();
-                        if !trimmed.is_empty() {
-                            sip_session_ids.push(trimmed);
-                        }
+                    if inside_name {
+                        current_participant_name
+                            .get_or_insert_with(String::new)
+                            .push_str(&resolved);
+                    }
+                    if inside_sip_session_id {
+                        current_sip_session_id
+                            .get_or_insert_with(String::new)
+                            .push_str(&resolved);
                     }
                 }
             }
             Ok(Event::End(ref element)) => {
                 let local_name = element.local_name();
-                let name = std::str::from_utf8(local_name.as_ref()).unwrap_or("");
+                let name = local_name.as_ref();
 
                 match name {
                     "participant" => {
@@ -245,7 +273,9 @@ pub fn parse_recording_metadata(xml: &str) -> Result<RecordingMetadata, Metadata
                             participants.push(Participant {
                                 participant_id,
                                 aor,
-                                name: current_participant_name.take(),
+                                name: current_participant_name
+                                    .take()
+                                    .map(|value| value.trim().to_string()),
                             });
                         }
                     }
@@ -256,11 +286,21 @@ pub fn parse_recording_metadata(xml: &str) -> Result<RecordingMetadata, Metadata
                             streams.push(StreamInfo {
                                 stream_id,
                                 session_id: stream_session_id,
-                                label: current_label.take().unwrap_or_default(),
+                                label: current_label.take().unwrap_or_default().trim().to_string(),
                             });
                         }
                     }
-                    "sipSessionID" => inside_sip_session_id = false,
+                    "sipSessionID" => {
+                        inside_sip_session_id = false;
+                        // Push once the whole value is in, so an entity split
+                        // across fragments does not become several ids.
+                        if let Some(value) = current_sip_session_id.take() {
+                            let trimmed = value.trim();
+                            if !trimmed.is_empty() {
+                                sip_session_ids.push(trimmed.to_string());
+                            }
+                        }
+                    }
                     "label" => inside_label = false,
                     "name" => inside_name = false,
                     _ => {}
@@ -287,7 +327,8 @@ pub fn parse_recording_metadata(xml: &str) -> Result<RecordingMetadata, Metadata
 /// Extract an attribute value from an XML element.
 fn get_attribute(element: &BytesStart, attribute_name: &str) -> Option<String> {
     for attribute in element.attributes().flatten() {
-        let key = std::str::from_utf8(attribute.key.as_ref()).unwrap_or("");
+        // Attribute keys are `str` in quick-xml 0.42.
+        let key = attribute.key.as_ref();
         if key == attribute_name {
             return attribute
                 .normalized_value(quick_xml::XmlVersion::Explicit1_0)
@@ -372,6 +413,32 @@ mod tests {
     }
 
     // --- Parsing tests ---
+
+    /// A display name carrying entity references parses whole.
+    ///
+    /// The value arrives in fragments — text, reference, text — so the parser
+    /// has to accumulate rather than assign, and trim only once at the end.
+    /// Assigning per fragment silently kept whichever fragment came last.
+    #[test]
+    fn parse_accumulates_entity_references_in_participant_name() {
+        let xml = concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+            "<recording xmlns=\"urn:ietf:params:xml:ns:recording:1\">\n",
+            "  <session session_id=\"s1\"/>\n",
+            "  <participant participant_id=\"p1\">\n",
+            "    <nameID aor=\"sip:alice@example.com\"/>\n",
+            "    <name>Alice &amp; Bob &lt;Support&gt;</name>\n",
+            "  </participant>\n",
+            "</recording>\n",
+        );
+        let metadata = parse_recording_metadata(xml).unwrap();
+        assert_eq!(metadata.participants.len(), 1);
+        assert_eq!(
+            metadata.participants[0].name.as_deref(),
+            Some("Alice & Bob <Support>"),
+            "fragments around each entity must be joined, not overwritten"
+        );
+    }
 
     #[test]
     fn parse_roundtrip_no_original_call_id() {

--- a/src/xml_text.rs
+++ b/src/xml_text.rs
@@ -1,0 +1,75 @@
+//! Shared XML text-content helpers for siphon's hand-rolled quick-xml parsers.
+//!
+//! quick-xml does not hand a parser one text node per element. An entity
+//! reference inside text terminates the current [`Event::Text`] and arrives as
+//! its own [`Event::GeneralRef`], with the text after it following as another
+//! `Text`. A parser that accumulates only `Text` therefore drops every entity
+//! silently — the characters simply vanish from the value, with no error.
+//!
+//! That is not academic for SIP: a contact URI legitimately carries `&` once it
+//! has more than one header (`sip:a@b?X=1&Y=2`), and it must be escaped as
+//! `&amp;` in XML. Dropping it rewrites the URI into a different, still
+//! well-formed one.
+//!
+//! [`Event::Text`]: quick_xml::events::Event::Text
+//! [`Event::GeneralRef`]: quick_xml::events::Event::GeneralRef
+
+/// Resolve a general entity reference to its replacement text.
+///
+/// Takes the reference *body* as quick-xml reports it — no leading `&`, no
+/// trailing `;` — and handles the two forms XML allows in content:
+///
+/// * the five predefined named entities (`amp`, `lt`, `gt`, `quot`, `apos`),
+/// * numeric character references, decimal (`#38`) and hexadecimal (`#x26`).
+///
+/// Returns `None` for anything else, which is the honest answer: siphon parses
+/// no DTD, so a document-defined entity has no replacement text available and
+/// guessing one would invent content. Callers decide whether an unresolvable
+/// reference is worth failing the parse over.
+pub fn resolve_general_ref(reference: &str) -> Option<String> {
+    if let Some(numeric) = reference.strip_prefix('#') {
+        let code = match numeric.strip_prefix(['x', 'X']) {
+            Some(hex) => u32::from_str_radix(hex, 16).ok()?,
+            None => numeric.parse::<u32>().ok()?,
+        };
+        return char::from_u32(code).map(|character| character.to_string());
+    }
+    quick_xml::escape::resolve_xml_entity(reference).map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_the_five_predefined_entities() {
+        for (reference, expected) in [
+            ("amp", "&"),
+            ("lt", "<"),
+            ("gt", ">"),
+            ("quot", "\""),
+            ("apos", "'"),
+        ] {
+            assert_eq!(resolve_general_ref(reference).as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn resolves_numeric_references_in_both_bases() {
+        assert_eq!(resolve_general_ref("#38").as_deref(), Some("&"));
+        assert_eq!(resolve_general_ref("#x26").as_deref(), Some("&"));
+        assert_eq!(resolve_general_ref("#X26").as_deref(), Some("&"));
+        // Beyond the BMP — a decimal reference to an astral plane character.
+        assert_eq!(resolve_general_ref("#128512").as_deref(), Some("\u{1F600}"));
+    }
+
+    #[test]
+    fn refuses_to_invent_replacement_text() {
+        // No DTD is parsed, so a document-defined entity has no expansion.
+        assert_eq!(resolve_general_ref("mycompany"), None);
+        // Not a character at all.
+        assert_eq!(resolve_general_ref("#xD800"), None); // lone surrogate
+        assert_eq!(resolve_general_ref("#99999999"), None);
+        assert_eq!(resolve_general_ref("#xZZ"), None);
+    }
+}


### PR DESCRIPTION
Supersedes #273 (which is the bare bump and does not compile — 0.42 is a
breaking release).

## What the bump exposed

Doing the migration surfaced a **pre-existing bug that has shipped since
v1.1.1**, and it is the larger half of this PR.

quick-xml does not deliver one text node per element. An entity reference
**terminates** the current `Event::Text`, arrives as its own
`Event::GeneralRef`, and the remaining text follows as another `Text`. All three
of siphon's hand-rolled parsers read only `Text`, so every `&amp;`, `&lt;`,
`&#38;` and friend was **silently dropped** — no error, just a shorter string.

The 0.37 → 0.41 bump in v1.1.1 (RUSTSEC-2026-0194/0195) introduced the split.
The shim written at the time restored `BytesText::unescape()` faithfully, but
it never saw the references — they had already been routed to an event nobody
handled.

**Confirmed pre-existing**: the new test fails identically on unmodified `main`
with quick-xml 0.41:

```
left:  "sip:alice@10.0.0.1:5060?X-A=1X-B=234567"
right: "sip:alice@10.0.0.1:5060?X-A=1&X-B=2<3>4\"5'6&7"
```

### Why it matters

A SIP URI carries `&` as soon as it has two headers (`sip:a@b?X=1&Y=2`), and XML
requires that be written `&amp;`. So this silently rewrote:

| parser | value | spec |
|---|---|---|
| `registrar::reginfo` | contact URI in a reg-event NOTIFY | RFC 3680 |
| `ifc` | Application-Server URI | 3GPP TS 29.228 |
| `siprec::metadata` | participant display name | RFC 7866 |

Into a *different, still well-formed* value — which for the first two means
routing somewhere other than intended. Every release v1.1.1 → 1.8.0.

## The fix

One shared `xml_text::resolve_general_ref`, used by all three parsers: the five
predefined entities plus decimal and hexadecimal numeric references. An
unresolvable reference **fails the parse** rather than being dropped — siphon
reads no DTD, and inventing replacement text is precisely how this bug behaved.

`siprec::metadata` additionally had to **accumulate across fragments** and trim
once at the end; it assigned per fragment, so a split value kept only whichever
fragment arrived last.

## The 0.42 migration itself

- `BytesText` is `str`-backed, so the reader decodes up front and `decode()` is
  gone. `xml10_content()` replaces that half — it applies XML 1.0 end-of-line
  normalisation (§2.11) and leaves entity resolution to the caller, so the shim
  layers `escape::unescape()` on top.
- Element and attribute names are `str` rather than bytes, removing a set of
  `from_utf8` conversions and turning nine `b"..."` match arms into `"..."`.

## Tests

Each parser gets a test carrying **both** a named and a numeric reference.
All three fail on the unfixed code — verified by neutering the `GeneralRef`
arms and re-running:

- `registrar::reginfo::tests::parse_resolves_entity_references_in_uri_text`
- `ifc::tests::parse_resolves_entity_references_in_server_name`
- `siprec::metadata::tests::parse_accumulates_entity_references_in_participant_name`
- plus `xml_text` unit tests for both bases, astral-plane characters, lone
  surrogates and unknown entities

Worth stating plainly: **the affected modules had 248 tests between them and
none of them touched an entity reference**, which is why a decade-shaped bug sat
under a green suite. The count was not the coverage.

- `cargo test --all-features` — 4,558 pass, 0 fail
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
