### PR TITLE
fix(security): stop banning subscribers for protocol-legal behaviour, refuse non-SIP probes on every message, and bound per-source connection concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Security
+- **Inbound connection ceilings, on by default.** Nothing bounded how many
+  connections or concurrent handshakes a single source could hold: no per-source
+  cap, no global cap, no limit around the TLS handshake. One address opening
+  dozens of connections at once pinned a task each for the full 10-second
+  handshake timeout, and the auto-ban could not help because it needs *completed*
+  failures first. `security.connection_limits` adds four ceilings —
+  `max_handshakes_per_source` (32), `max_handshakes` (1024),
+  `max_connections_per_source` (256), `max_connections` (16384) — with `0`
+  disabling any one of them and `trusted_cidrs` exempt from all of them. Every
+  field defaults, so the ceilings apply with no `security:` block configured.
+
+  In-flight handshakes and established connections are counted separately
+  because they are abused differently: a handshake is CPU held briefly and no
+  legitimate client has many at once, while an established connection is held
+  until the peer leaves or the 300 s idle timeout reaps it and a busy NAT
+  legitimately holds many. Refused connections are dropped silently and are
+  **not** banned — hitting a concurrency ceiling is a capacity fact, not proof of
+  intent. New metrics: `siphon_connections_refused_total{reason}`,
+  `siphon_stream_connections_active`, `siphon_handshakes_in_flight`.
+
+  **`max_connections_per_source` and carrier NAT:** a CGNAT pool or large
+  enterprise NAT can legitimately front more than 256 registrations from one
+  address. The default is a runaway detector, not a policy — raise it or set `0`
+  where that is your topology, and watch
+  `siphon_connections_refused_total{reason="connections_per_source"}`.
+- **A non-SIP probe is now refused on every message, not only a connection's
+  first line.** The accept-time sniff assumes SIP for a peer that sends nothing
+  within its 2-second window — correct for a connection held open for reuse, but
+  also a way past the check: connect, wait, then send. Past the sniff, framing
+  accepted any block ending `\r\n\r\n`, because a missing `Content-Length`
+  defaults to zero, so an HTTP request block framed as a complete "message",
+  reached the dispatcher and was rejected only by the parser — which has no
+  connection to close and no source to record, leaving a scanner free to probe
+  indefinitely over one connection. `frame_sip_message` now checks the start line
+  is a SIP request-line or status-line (RFC 3261 §7.1/§7.2; extension methods
+  still accepted), so the connection is closed and the source counted as a strong
+  `failed_auth_ban` signal wherever the probe arrives. UDP is unchanged — a UDP
+  source is spoofable and does not frame.
+
 ### Added
 - **An LCR failover now leaves a trace, and a record.** A call whose first
   carrier returned `500` and which then answered on the second showed nothing of
@@ -15,70 +55,12 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   burned a carrier on its way recorded that nowhere, so a failing carrier could
   not be alerted on, trended, or taken to the carrier.
 
-  - Each failed attempt is now recorded against the carrier that was in flight
-    (`carrier_id`, `status`, `elapsed_ms`; a ring timeout as `408`) and reported
-    at `info` along with the advance to the next carrier.
-  - `call.route_attempts` exposes that list to scripts wherever the `Call` is —
-    notably in `@b2bua.on_answer`, so a call that *answered* after failing over
-    can still name what it burned. `call.active_route` is unchanged and still
-    names the winner.
-  - `@b2bua.on_route_failure(call, route, code)` fires once per failed attempt,
-    including the last. It fires for every non-2xx a carrier returns — a
-    definitive `486` as much as a `503` — which is the same set
-    `route_attempts` records, so the two can never disagree; filter on `code`
-    for what you treat as a carrier's fault. Purely a notification: the failover
-    decision is already made and raising in it does not change the call.
-  - With `cdr.auto_emit` on, the attempts are stamped onto the CDR as
-    `lcr_attempts` (a compact JSON array), alongside the winning carrier's
-    existing `cdr_fields`.
-
-  `best_error` is now derived from the attempt list rather than accumulated
-  alongside it, so the code the caller receives and the per-attempt record
-  cannot drift apart. Selection is unchanged (6xx > 5xx > 4xx).
-
-- **Header policies can now be defined in `siphon.yaml`.** `header_policies:` is
-  a top-level map of operator-owned policies, in the same namespace as the four
-  built-in presets and selectable the same way — by
-  `b2bua.default_header_policy` and by `call.dial(header_policy=…)` /
-  `call.fork(header_policy=…)`. It completes the set: `number_policies:` and
-  `media.profiles:` were already operator-definable, header policies were the
-  one named-policy surface that was not.
-
-  A policy either extends a built-in with `copy` / `strip` / `rewrite` /
-  `translate` deltas, or declares both directions in full with an explicit
-  `default:`. Under `extends:` the base supplies each direction's default and
-  rules, the policy's own rules are matched first, and a direction left out is
-  inherited verbatim — so an `extends:` with no rules is a stable local alias
-  for a built-in. Header names are exact and case-insensitive, with a trailing
-  `*` for a prefix match; within one direction an exact name beats a prefix and
-  a longer prefix beats a shorter one, so `strip: ["X-*"]` alongside
-  `copy: ["X-Account-Ref"]` is expressible in a single block.
-
-  This is what "that preset, except for these headers" was missing. Before it,
-  the only way to let one header cross was to repeat `copy=[…]` on every
-  `dial()` / `fork()` call site, which puts a trust-boundary decision in N
-  script locations instead of one reviewable config block. Per-call deltas are
-  unchanged and still take precedence (exact names only — patterns are a
-  config-side feature).
-
-  ```yaml
-  header_policies:
-    "trunk-edge-plus@1":
-      extends: "sip-trunk-edge@2026"
-      request:
-        copy: ["X-Account-Ref"]
-
-  b2bua:
-    default_header_policy: "trunk-edge-plus@1"
-  ```
-
 ### Changed
 - **quick-xml 0.41 → 0.42.** `BytesText` is `str`-backed now, so the reader
   decodes up front and `decode()` is gone; the content accessors
   (`xml10_content()`) apply XML 1.0 end-of-line normalisation and leave entity
   resolution to the caller. Element and attribute names are `str` rather than
   bytes, which removes a set of `from_utf8` conversions at the parse sites.
-
 - **`cdr.write(request|call, extra=…)` now attaches to the auto-emitted CDR
   instead of writing a second record.** With `cdr.auto_emit: true`, siphon
   already tracks a record for the call from the INVITE; a script's `extra`
@@ -166,7 +148,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   where the BYE arrives, so an on-time BYE landed before SIPp had armed the
   `recv` and aborted the run as unexpected. Test-side only — siphon sends
   exactly one BYE and retransmits it correctly per RFC 3261 §17.1.
-
 - **`b2bua.default_header_policy` naming an unknown policy now refuses to
   start.** It previously logged a warning and fell back to
   `transparent-b2bua@2026` — the *most* permissive posture — so a typo in the
@@ -182,6 +163,92 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   typo degrades to the operator's chosen posture rather than failing calls.
 
 ### Fixed
+- **A request with no credentials no longer counts toward `failed_auth_ban`, and
+  an auth-backend outage never does.** Both banned real subscribers.
+
+  A challenge issued because the request carried no `Authorization` is the
+  RFC 3261 §22.2 opening leg of challenge-response — every client sends one
+  before it has a nonce — and it scored 1, so five in a window earned an hour-long
+  ban. Behind CGNAT that address is shared, so the ban landed on every subscriber
+  behind it. It is now weighted by the new
+  `failed_auth_ban.missing_credentials_weight`, which defaults to `0`; set it to
+  `1` for the previous behaviour. Volume stays visible in
+  `siphon_auth_failures_total` either way.
+
+  Worse, the HTTP auth backend returned the same "no credential" for *"no such
+  user"* and for *"the request failed"*, so a timeout or a connection refusal was
+  indistinguishable from a wrong password and scored the high-confidence weight of
+  3 — two REGISTER retries during a backend outage banned a subscriber's address
+  for an hour, precisely when every subscriber is retrying. The credential check
+  is now four-way (valid / absent / rejected / backend unavailable) and a backend
+  that could not answer counts nothing. It increments the new
+  `siphon_auth_backend_errors_total`, which is worth alerting on: a non-zero rate
+  means authentication is failing into 401s for everyone.
+
+  `siphon_credential_failures_total` now counts genuine rejections only; it
+  previously included backend errors.
+- **A siphon-originated REFER no longer overtakes the answer it depends on.**
+  A `call.refer()` issued from `@b2bua.on_answer` was emitted at the point the
+  handler ran — which is *before* the A-leg 2xx is forwarded — so the caller
+  received an in-dialog REFER for a dialog it had not yet confirmed (RFC 3261
+  §13.2.2.4: the UAC confirms the dialog on the 2xx). A real UA answers that
+  481. The REFER is now held until the 200 OK is on the wire.
+
+  - Each failed attempt is now recorded against the carrier that was in flight
+    (`carrier_id`, `status`, `elapsed_ms`; a ring timeout as `408`) and reported
+    at `info` along with the advance to the next carrier.
+  - `call.route_attempts` exposes that list to scripts wherever the `Call` is —
+    notably in `@b2bua.on_answer`, so a call that *answered* after failing over
+    can still name what it burned. `call.active_route` is unchanged and still
+    names the winner.
+  - `@b2bua.on_route_failure(call, route, code)` fires once per failed attempt,
+    including the last. It fires for every non-2xx a carrier returns — a
+    definitive `486` as much as a `503` — which is the same set
+    `route_attempts` records, so the two can never disagree; filter on `code`
+    for what you treat as a carrier's fault. Purely a notification: the failover
+    decision is already made and raising in it does not change the call.
+  - With `cdr.auto_emit` on, the attempts are stamped onto the CDR as
+    `lcr_attempts` (a compact JSON array), alongside the winning carrier's
+    existing `cdr_fields`.
+
+  `best_error` is now derived from the attempt list rather than accumulated
+  alongside it, so the code the caller receives and the per-attempt record
+  cannot drift apart. Selection is unchanged (6xx > 5xx > 4xx).
+- **Header policies can now be defined in `siphon.yaml`.** `header_policies:` is
+  a top-level map of operator-owned policies, in the same namespace as the four
+  built-in presets and selectable the same way — by
+  `b2bua.default_header_policy` and by `call.dial(header_policy=…)` /
+  `call.fork(header_policy=…)`. It completes the set: `number_policies:` and
+  `media.profiles:` were already operator-definable, header policies were the
+  one named-policy surface that was not.
+
+  A policy either extends a built-in with `copy` / `strip` / `rewrite` /
+  `translate` deltas, or declares both directions in full with an explicit
+  `default:`. Under `extends:` the base supplies each direction's default and
+  rules, the policy's own rules are matched first, and a direction left out is
+  inherited verbatim — so an `extends:` with no rules is a stable local alias
+  for a built-in. Header names are exact and case-insensitive, with a trailing
+  `*` for a prefix match; within one direction an exact name beats a prefix and
+  a longer prefix beats a shorter one, so `strip: ["X-*"]` alongside
+  `copy: ["X-Account-Ref"]` is expressible in a single block.
+
+  This is what "that preset, except for these headers" was missing. Before it,
+  the only way to let one header cross was to repeat `copy=[…]` on every
+  `dial()` / `fork()` call site, which puts a trust-boundary decision in N
+  script locations instead of one reviewable config block. Per-call deltas are
+  unchanged and still take precedence (exact names only — patterns are a
+  config-side feature).
+
+  ```yaml
+  header_policies:
+    "trunk-edge-plus@1":
+      extends: "sip-trunk-edge@2026"
+      request:
+        copy: ["X-Account-Ref"]
+
+  b2bua:
+    default_header_policy: "trunk-edge-plus@1"
+  ```
 - **XML entity references in element text were silently dropped, since v1.1.1.**
   quick-xml does not deliver one text node per element: an entity reference
   terminates the current `Text` event, arrives as its own `GeneralRef`, and the
@@ -206,7 +273,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   replacement text is how the bug looked in the first place. The SIPREC parser
   additionally accumulates across fragments instead of assigning, which it had
   to for a split value to survive at all.
-
 - **A media failure at answer no longer connects the call and starts charging.**
   An exception out of `@b2bua.on_answer` was logged and then ignored: the A-leg
   2xx went out a millisecond later, the ACK followed, and the charging clock

--- a/benches/sip_hot_path.rs
+++ b/benches/sip_hot_path.rs
@@ -16,6 +16,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use siphon::sip::parse_sip_message;
 use siphon::transaction::TransactionManager;
+use siphon::transport::tcp::{frame_sip_message, FrameVerdict};
 use std::hint::black_box;
 
 /// A realistic offer SDP — the common INVITE body the parser walks on every call.
@@ -236,12 +237,59 @@ fn bench_txn_key(criterion: &mut Criterion) {
     group.finish();
 }
 
+/// Stream framing (RFC 3261 §18.3) — the first thing every message over
+/// TCP/TLS/WS goes through, before the parser sees a byte. It scans for the
+/// end-of-headers marker, reads `Content-Length`, and checks the start line is
+/// SIP (a complete HTTP request block also ends `\r\n\r\n`, so length alone
+/// cannot tell a scanner's probe from a message).
+///
+/// Not benched before this, and it runs per message on every stream transport,
+/// so it belongs in the release-cut gate alongside parse and serialize.
+fn bench_framing(criterion: &mut Criterion) {
+    let invite_sdp = invite_with_sdp();
+    let invite = invite_sdp.as_bytes();
+    let response = RESPONSE_200.as_bytes();
+    // Two messages back to back — the pipelined case a busy TCP connection
+    // actually presents, where framing has to find the first boundary without
+    // being confused by the second message behind it.
+    let mut pipelined = invite_sdp.clone();
+    pipelined.push_str(RESPONSE_200);
+    let pipelined = pipelined.into_bytes();
+
+    let ceiling = 256 * 1024;
+    let mut group = criterion.benchmark_group("framing");
+    group.throughput(Throughput::Bytes(invite.len() as u64));
+    group.bench_function("invite_sdp", |bencher| {
+        bencher.iter(|| black_box(frame_sip_message(black_box(invite), ceiling)));
+    });
+    group.bench_function("response_200", |bencher| {
+        bencher.iter(|| black_box(frame_sip_message(black_box(response), ceiling)));
+    });
+    group.bench_function("pipelined", |bencher| {
+        bencher.iter(|| black_box(frame_sip_message(black_box(&pipelined), ceiling)));
+    });
+    // The rejection path: a scanner's HTTP probe, which must be refused rather
+    // than framed. Cheap by construction — it is decided on the first line.
+    let probe = b"GET / HTTP/1.1\r\nHost: sip.example.com\r\n\r\n";
+    group.bench_function("http_probe_refused", |bencher| {
+        bencher.iter(|| {
+            debug_assert!(matches!(
+                frame_sip_message(black_box(probe), ceiling),
+                FrameVerdict::Garbage
+            ));
+            black_box(frame_sip_message(black_box(probe), ceiling))
+        });
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_parse,
     bench_serialize,
     bench_roundtrip,
     bench_headers,
-    bench_txn_key
+    bench_txn_key,
+    bench_framing
 );
 criterion_main!(benches);

--- a/docs/cookbook/security.md
+++ b/docs/cookbook/security.md
@@ -18,13 +18,22 @@ security:
   scanner_block:
     user_agents: ["sipvicious", "friendly-scanner", "VaxSip", "sipcli"]
 
-  trusted_cidrs: ["10.0.0.0/8"] # own infra: never rate-limited, never banned
+  trusted_cidrs: ["10.0.0.0/8"] # own infra: never rate-limited, never banned,
+                                # never refused by connection_limits
+
+  connection_limits:            # always on — every field defaults
+    max_handshakes_per_source: 32
+    max_handshakes: 1024
+    max_connections_per_source: 256
+    max_connections: 16384
 
   failed_auth_ban:              # auto-ban at accept (UDP/TCP/TLS/WS/SCTP)
     threshold: 10               # weighted failures in window_secs → ban
     window_secs: 600
     ban_duration_secs: 3600
     strong_signal_weight: 3     # weight of a high-confidence abuse signal
+    missing_credentials_weight: 0   # default: a credential-less request is the
+                                    # RFC-mandated first leg, not evidence
 
   apiban:                       # optional: APIBAN community blocklist
     api_key: "your-api-key"
@@ -49,18 +58,65 @@ how hard they are to fake:
 
 | Signal | Score |
 |--------|-------|
-| 401/407 challenge with no follow-up success | 1 |
 | INVITE server-transaction timeout (never ACKed) | 1 |
-| Wrong password, or a forged/stale/replayed digest nonce | `strong_signal_weight` (default 3) |
+| Failed or timed-out TLS/WSS/WS handshake | 1 |
+| Wrong password, a username the auth backend denied, or a forged/stale/replayed digest nonce | `strong_signal_weight` (default 3) |
 | Non-SIP bytes on a TCP/TLS stream | `strong_signal_weight` |
-| Failed TLS/WSS/WS handshake | `strong_signal_weight` |
 | Scanner User-Agent (`scanner_block`) | `strong_signal_weight` |
+| 401/407 challenge because the request carried **no** credentials | `missing_credentials_weight` (default **0** — not counted) |
+| A credential check the auth backend could not answer | **never counted** |
 
-Signals arriving over TCP (handshake, malformed bytes) score high because the source
-IP is validated by the three-way handshake — it can't be spoofed, and a legitimate
-client never trips them. A **successful authentication resets the score to zero**,
-so a subscriber who mistypes a password twice then logs in is never banned, while an
-IP spraying garbage is banned ~3× faster than one just rattling doorknobs.
+Signals carrying present-but-wrong credentials, or garbage over TCP, score high
+because they are unambiguous: the source IP is validated by the three-way handshake
+so it cannot be spoofed, and a legitimate client never trips them. A **successful
+authentication resets the score to zero**, so a subscriber who mistypes a password
+twice then logs in is never banned, while an IP spraying garbage is banned 3× faster
+than one just rattling doorknobs.
+
+The last two rows are the ones worth understanding, because both were once counted
+and both banned real subscribers:
+
+- **A request with no credentials is not evidence.** RFC 3261 §22.2 makes it the
+  opening leg of challenge-response — every client sends one before it has a nonce.
+  Counting it means a handset stuck in a retry loop earns an hour-long ban, and
+  behind CGNAT that address is shared, so the ban lands on every subscriber behind
+  it. Volume still shows in `siphon_auth_failures_total`; set
+  `missing_credentials_weight: 1` if you want the old scoring back.
+- **An auth-backend outage is not an attack.** A `GET` to your credential endpoint
+  that times out tells you nothing about the peer. It used to be indistinguishable
+  from a wrong password, so two REGISTER retries during an outage banned the
+  subscriber — exactly when every subscriber is retrying. Alert on
+  `siphon_auth_backend_errors_total` instead; a non-zero rate means authentication
+  is failing into 401s for everyone.
+
+### Bounding what one source can spend
+
+`connection_limits` is a separate, always-on layer, and it covers what the ban
+counter structurally cannot: a source that opens 50 TLS connections at once and
+completes none of them never produces a *completed* failure to count, while each
+connection burns a real handshake and pins a task for the full 10 s handshake
+timeout.
+
+Two ceilings, because the resources differ. An in-flight handshake is CPU held
+briefly and no legitimate client has many at once, so that one is tight (32 per
+source). An established connection is a socket held until the peer leaves or the
+300 s idle timeout reaps it, and a busy NAT legitimately holds many, so that one is
+loose (256 per source). Each has a global twin for distributed floods. `0` disables
+a ceiling; `trusted_cidrs` are exempt from all of them.
+
+Refused connections are dropped silently and **not** banned — hitting a concurrency
+ceiling is a capacity fact, not proof of intent, and a NAT whose UEs all re-register
+after a network flap looks exactly like a flood.
+
+!!! warning "Carrier NAT and `max_connections_per_source`"
+    A CGNAT pool or a large enterprise NAT can legitimately front more registrations
+    from one address than the 256 default allows, and every one of them is a paying
+    subscriber. The default is a runaway detector, not a policy — raise it, or set
+    `0`, wherever that is your topology. Watch
+    `siphon_connections_refused_total{reason="connections_per_source"}`: it tells you
+    the ceiling is binding on real traffic before the support tickets do.
+    `siphon_stream_connections_active` and `siphon_handshakes_in_flight` are what you
+    size against.
 
 Bans are enforced at `recv()`/`accept()` — before any SIP parsing — and expire on
 their own. `trusted_cidrs` are exempt from scoring entirely, so put your load

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -160,6 +160,20 @@ check still runs, so a captured `Authorization` cannot be replayed (RFC 7616
 `siphon_credential_failures_total` — a path that authenticates without counting
 would be a blind spot for anyone alerting on brute force.
 
+A *rejection* is the case above: credentials were presented and refused. Two
+neighbouring cases score differently, and both used to be conflated with it:
+
+- **No credentials at all.** The RFC 3261 §22.2 opening leg. Counted at
+  `failed_auth_ban.missing_credentials_weight`, which is `0` by default, and
+  visible in `siphon_auth_failures_total`.
+- **The credential source could not answer** — an HTTP auth backend timeout or
+  connection failure, or no usable backend configured. Never counted: it says
+  nothing about the peer. It increments `siphon_auth_backend_errors_total`,
+  which is worth an alert of its own — a non-zero rate means authentication is
+  failing into 401s for every subscriber.
+
+See [Hardening & security](../cookbook/security.md) for the full scoring table.
+
 ::: siphon_sdk.mock_module.MockAuth
 
 ## `ipsec` namespace

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -135,16 +135,38 @@ connection is closed before a byte reaches the SIP framer, and the source is
 counted as a strong `security.failed_auth_ban` signal.
 
 This is what stops a vulnerability scanner walking `/phpinfo.php`, `/info.php`
-and friends against a TLS SIP port. Framing alone cannot: an HTTP header block
-ends in `\r\n\r\n` and carries no `Content-Length`, so it looks like a complete
-message and is rejected only by the parser — after the probe has been queued,
-with the connection still open and nothing recorded against the source. Deciding
-from the first line closes the connection on the first probe and, at the default
-weights, bans the source on the fourth.
+and friends against a TLS SIP port. Framing on length alone cannot: an HTTP
+header block ends in `\r\n\r\n` and carries no `Content-Length`, so it looks like
+a complete message and would be rejected only by the parser — after the probe has
+been queued, with the connection still open and nothing recorded against the
+source. Deciding from the start line closes the connection on the first probe
+and, at the default weights, bans the source on the fourth.
+
+The check runs in **two** places, and both are load-bearing:
+
+- **At accept**, on the connection's first line, before a connection id is even
+  allocated — so a probe never enters the connection map or the accept log.
+- **In the framer, on the start line of every message**, because the accept-time
+  sniff assumes SIP for a peer that sends nothing inside its 2-second window.
+  That assumption is right (a connection held open for reuse must not be
+  dropped) but it is also a way past the first check: connect, wait, then send
+  the probe. Judging every message closes that, and the framer is where the
+  connection can actually be dropped and the source recorded.
 
 The connection is never answered. A SIP port that replies to a probe tells the
 prober what it found, which is also why a blocked request is dropped rather than
 rejected.
+
+### Connection ceilings
+
+Independently of any of the above, `security.connection_limits` bounds how many
+connections and how many concurrent handshakes one source — and the box as a
+whole — can hold. It is always on, and it covers what the ban counter cannot: a
+source that opens dozens of TLS connections and completes none of them never
+produces a *completed* failure to count, while each one costs a real handshake
+and a task held for the whole handshake timeout. See
+[Hardening & security](cookbook/security.md#bounding-what-one-source-can-spend),
+including the note on carrier NAT and `max_connections_per_source`.
 
 ### Per-domain certificates (inbound SNI)
 

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -413,27 +413,79 @@ auth:
 #                               # Default 262144 (256 KB); minimum 4096. Applies
 #                               # even with no security block configured.
 #
+#   connection_limits:          # ALWAYS ON — ceilings on concurrent inbound
+#                               # stream connections. Every field defaults, so
+#                               # these apply with no security block at all.
+#                               # 0 disables an individual ceiling.
+#     max_handshakes_per_source: 32     # concurrent TLS/WS handshakes + first-
+#                               # line sniffs from one source. A legitimate
+#                               # client has one; abuse runs dozens at once,
+#                               # each pinning a task for the whole 10 s
+#                               # handshake timeout. The auto-ban cannot help
+#                               # here — it needs *completed* failures first.
+#     max_handshakes: 1024      # the same, across all sources: what bounds the
+#                               # CPU a distributed flood can spend, since the
+#                               # per-source ceiling says nothing about how many
+#                               # sources there are.
+#     max_connections_per_source: 256   # established stream connections from
+#                               # one source.
+#                               # >>> RAISE THIS (or set 0) IF ONE UPSTREAM
+#                               # ADDRESS LEGITIMATELY FRONTS HUNDREDS OF
+#                               # REGISTRATIONS — a carrier CGNAT pool, a large
+#                               # enterprise NAT, an aggregator. The default is
+#                               # a runaway detector, not a policy. Watch
+#                               # siphon_connections_refused_total
+#                               # {reason="connections_per_source"} to see it
+#                               # binding on real traffic before the tickets
+#                               # arrive.
+#     max_connections: 16384    # established connections across all sources.
+#     # Refused connections are dropped silently and are NOT banned: hitting a
+#     # concurrency ceiling is a capacity fact, not proof of intent (a NAT whose
+#     # UEs all re-register after a network flap looks exactly like a flood), and
+#     # the ceiling has already done the protective work. trusted_cidrs are
+#     # exempt from both ceilings, so a trunk or a probe is never refused.
+#     # Gauges: siphon_stream_connections_active, siphon_handshakes_in_flight.
+#
 #   failed_auth_ban:            # auto-ban scanners at accept (TCP/TLS/UDP/WS/SCTP)
 #     threshold: 10             # weighted failures within window_secs before a ban
 #     window_secs: 600          # sliding window for counting failures (default 600)
 #     ban_duration_secs: 3600   # how long the ban lasts (then auto-expires)
 #     strong_signal_weight: 3   # weight of a high-confidence abuse signal toward
 #                               # threshold (default 3); a plain probe counts as 1
+#     missing_credentials_weight: 0     # weight of a challenge issued because the
+#                               # request carried NO credentials. Default 0 —
+#                               # not counted. That request is the RFC 3261 §22.2
+#                               # opening leg of challenge-response, which every
+#                               # client sends before it has a nonce, so counting
+#                               # it bans clients for behaving correctly; behind
+#                               # CGNAT one handset in a retry loop then takes
+#                               # out every subscriber sharing the address. Set
+#                               # to 1 for the pre-1.8 behaviour. Volume stays
+#                               # visible in siphon_auth_failures_total either way.
 #     # Failures counted toward the ban, by weight:
 #     #   weight 1 (low-confidence — may fire for a benign peer):
-#     #     - an auth challenge (401/407) not followed by a successful auth
 #     #     - a non-ACK INVITE server-transaction timeout (toll-fraud pattern)
 #     #     - a failed/timed-out TLS / WSS / WS handshake
 #     #   weight = strong_signal_weight (high-confidence abuse — bans faster):
-#     #     - present-but-invalid digest credentials (wrong password), or a
-#     #       forged / stale / replayed nonce  [over UDP this stays weight 1,
-#     #       since a UDP source is spoofable and would amplify a reflected ban]
-#     #     - non-SIP bytes on a TCP/TLS stream, decided from the connection's
-#     #       first line before the SIP framer runs (an HTTP probe such as a
-#     #       /phpinfo.php scan, a TLS record on the plaintext port, random
-#     #       bytes); the connection is closed and never answered
+#     #     - present-but-invalid digest credentials (wrong password), a username
+#     #       the auth backend denied, or a forged / stale / replayed nonce
+#     #       [over UDP this stays weight 1, since a UDP source is spoofable and
+#     #       would amplify a reflected ban]
+#     #     - non-SIP bytes on a TCP/TLS stream — decided from the connection's
+#     #       first line at accept AND from the start line of every message
+#     #       thereafter (an HTTP probe such as a /phpinfo.php scan, a TLS record
+#     #       on the plaintext port, random bytes); the connection is closed and
+#     #       never answered
 #     #     - a request whose User-Agent matched scanner_block, over a
 #     #       connection-oriented transport (UDP scanner UAs are dropped, not banned)
+#     #   weight = missing_credentials_weight (default 0 — not counted):
+#     #     - a challenge issued because the request carried no credentials
+#     # NOT counted at all:
+#     #     - a credential check the auth backend could not answer (HTTP timeout
+#     #       or connection failure, no usable backend configured). An outage of
+#     #       your own credential source is not evidence about the peer, and
+#     #       counting it banned real subscribers two REGISTER retries in. Alert
+#     #       on siphon_auth_backend_errors_total instead.
 #     # A successful auth resets the source's counter, so a legit client that
 #     # challenges-then-succeeds (or retries a stale nonce) never accumulates.
 #     # trusted_cidrs are exempt — put load balancers / health-check probes

--- a/src/config.rs
+++ b/src/config.rs
@@ -1531,6 +1531,76 @@ pub struct SecurityConfig {
     /// cannot drive unbounded memory growth. Defaults to
     /// [`crate::security::DEFAULT_MAX_MESSAGE_BYTES`] (256 KB).
     pub max_message_bytes: Option<usize>,
+    /// Ceilings on concurrent inbound stream connections and handshakes.
+    ///
+    /// Unlike the guards above this one is **always on** — every field has a
+    /// default, so omitting the block (or the whole `security:` section) still
+    /// bounds what one source can make siphon spend. See
+    /// [`ConnectionLimitsConfig`].
+    #[serde(default)]
+    pub connection_limits: ConnectionLimitsConfig,
+}
+
+/// `security.connection_limits` — see [`crate::security::ConnectionLimits`] for
+/// what each ceiling bounds and why the two are sized so differently.
+///
+/// Every field defaults; `0` disables that ceiling.
+#[derive(Debug, Deserialize, Clone)]
+pub struct ConnectionLimitsConfig {
+    /// Concurrent in-flight handshakes (TLS/WS) plus first-line sniffs from one
+    /// source. Default 32.
+    #[serde(default = "default_max_handshakes_per_source")]
+    pub max_handshakes_per_source: u32,
+    /// Concurrent in-flight handshakes across all sources. Default 1024.
+    #[serde(default = "default_max_handshakes")]
+    pub max_handshakes: u32,
+    /// Established stream connections from one source. Default 256.
+    ///
+    /// **Raise this (or set 0) where one upstream address legitimately fronts
+    /// hundreds of registrations** — a carrier CGNAT pool, a large enterprise
+    /// NAT, an aggregator. The default is a runaway detector, not a policy, and
+    /// `siphon_connections_refused_total{reason="connections_per_source"}` is
+    /// what tells you it is binding on real traffic.
+    #[serde(default = "default_max_connections_per_source")]
+    pub max_connections_per_source: u32,
+    /// Established stream connections across all sources. Default 16384.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+}
+
+impl Default for ConnectionLimitsConfig {
+    fn default() -> Self {
+        Self {
+            max_handshakes_per_source: default_max_handshakes_per_source(),
+            max_handshakes: default_max_handshakes(),
+            max_connections_per_source: default_max_connections_per_source(),
+            max_connections: default_max_connections(),
+        }
+    }
+}
+
+impl From<&ConnectionLimitsConfig> for crate::security::ConnectionLimits {
+    fn from(config: &ConnectionLimitsConfig) -> Self {
+        Self {
+            max_handshakes_per_source: config.max_handshakes_per_source,
+            max_handshakes: config.max_handshakes,
+            max_connections_per_source: config.max_connections_per_source,
+            max_connections: config.max_connections,
+        }
+    }
+}
+
+fn default_max_handshakes_per_source() -> u32 {
+    crate::security::DEFAULT_MAX_HANDSHAKES_PER_SOURCE
+}
+fn default_max_handshakes() -> u32 {
+    crate::security::DEFAULT_MAX_HANDSHAKES
+}
+fn default_max_connections_per_source() -> u32 {
+    crate::security::DEFAULT_MAX_CONNECTIONS_PER_SOURCE
+}
+fn default_max_connections() -> u32 {
+    crate::security::DEFAULT_MAX_CONNECTIONS
 }
 
 /// Smallest accepted `security.max_message_bytes`. A REGISTER or INVITE with a
@@ -1637,6 +1707,19 @@ pub struct FailedAuthBanConfig {
     /// per-IP window. Clamped to ≥ 1. Default: 3.
     #[serde(default = "default_strong_signal_weight")]
     pub strong_signal_weight: u32,
+    /// Weight applied to a challenge issued because the request carried no
+    /// credentials at all, toward `threshold`.
+    ///
+    /// **Default 0 — not counted.** RFC 3261 §22.2 makes the credential-less
+    /// request the opening leg of challenge-response, so every client sends one
+    /// before it has a nonce and counting it bans clients for behaving
+    /// correctly. Behind CGNAT the blast radius is every subscriber sharing the
+    /// address. The abuse this was reaching for is caught with far fewer false
+    /// positives by `scanner_block`, `rate_limit`, `apiban`, and the
+    /// non-SIP/handshake signals. Set to 1 to restore the pre-1.7 behaviour.
+    /// Clamped to `threshold`.
+    #[serde(default)]
+    pub missing_credentials_weight: u32,
 }
 
 fn default_failed_auth_window_secs() -> u32 {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -192,22 +192,49 @@ pub struct SiphonMetrics {
     /// Source IPs currently auto-banned. Pruned periodically; trusted_cidrs are
     /// never counted. Alert on a sustained rise to spot a scanning campaign.
     pub banned_ips: IntGauge,
-    /// Total failures recorded toward the auto-ban: auth challenges that were not
-    /// followed by a success, plus non-ACK INVITE server-transaction timeouts.
+    /// Total challenges issued because the request carried no credentials — the
+    /// RFC 3261 §22.2 opening leg of challenge-response. Counted for visibility
+    /// whether or not `failed_auth_ban.missing_credentials_weight` acts on it
+    /// (it is 0 by default), so a scanning campaign is still measurable.
     pub auth_failures_total: IntCounter,
     /// Total TLS/WSS/WS handshakes that failed or timed out before completing,
     /// each recorded toward the auto-ban. These are TCP-validated source IPs
     /// (no spoofing), so a sustained rise is an unambiguous scanning campaign.
     pub handshake_failures_total: IntCounter,
     /// Total digest attempts carrying present-but-invalid credentials (wrong
-    /// password) or a forged/stale/replayed nonce, each recorded toward the
-    /// auto-ban as a high-confidence signal. Distinct from `auth_failures_total`
-    /// (which counts credential-less challenge first-legs).
+    /// password), a username the backend denied, or a forged/stale/replayed
+    /// nonce, each recorded toward the auto-ban as a high-confidence signal.
+    /// Distinct from `auth_failures_total` (credential-less first legs) and from
+    /// `auth_backend_errors_total` (the backend never answered).
     pub credential_failures_total: IntCounter,
+    /// Total credential checks that could not be decided because the credential
+    /// source did not answer — HTTP auth backend timeout / connection failure,
+    /// or no usable backend configured. Never counted toward the auto-ban: an
+    /// outage of our own backend is not evidence about the peer, and treating it
+    /// as one banned real subscribers two REGISTER retries into an outage.
+    ///
+    /// **Alert on this.** A non-zero rate means authentication is failing open
+    /// into 401s for everyone, and it is otherwise invisible — it used to be
+    /// indistinguishable from a password brute-force.
+    pub auth_backend_errors_total: IntCounter,
     /// Total non-SIP / unparseable messages received on a stream transport
     /// (TCP/TLS) and dropped, each recorded toward the auto-ban. Excludes
     /// incomplete-but-plausible frames, empty connections, and CRLF keepalives.
     pub malformed_messages_total: IntCounter,
+    /// Inbound stream connections refused by `security.connection_limits`,
+    /// labelled by which ceiling refused them (`handshakes_per_source`,
+    /// `handshakes`, `connections_per_source`, `connections`).
+    ///
+    /// A rising `connections_per_source` is the one to read carefully: it can
+    /// equally mean one source is misbehaving or that a carrier NAT legitimately
+    /// fronts more registrations than the ceiling allows. `handshakes` rising is
+    /// unambiguous — the box is at its concurrent-handshake ceiling.
+    pub connections_refused_total: IntCounterVec,
+    /// Inbound stream connections currently established across all sources.
+    pub stream_connections_active: IntGauge,
+    /// Inbound handshakes (TLS/WS) plus first-line sniffs currently in flight.
+    /// Sits near zero on a healthy edge; a sustained non-zero value is a flood.
+    pub handshakes_in_flight: IntGauge,
     /// Total inbound requests whose topmost Via carried no `branch` parameter,
     /// so no server transaction could be keyed for them (RFC 3261 §8.1.1.7
     /// makes it mandatory). siphon has no RFC 2543 legacy matching, so these
@@ -464,7 +491,7 @@ impl SiphonMetrics {
 
         let auth_failures_total = IntCounter::new(
             "siphon_auth_failures_total",
-            "Total failures recorded toward the auto-ban (auth challenges without a subsequent success + non-ACK INVITE server-transaction timeouts)",
+            "Total challenges issued because the request carried no credentials (the RFC 3261 opening leg of challenge-response); counted for visibility whether or not failed_auth_ban.missing_credentials_weight acts on it",
         )?;
 
         let handshake_failures_total = IntCounter::new(
@@ -474,12 +501,35 @@ impl SiphonMetrics {
 
         let credential_failures_total = IntCounter::new(
             "siphon_credential_failures_total",
-            "Total digest attempts with present-but-invalid credentials or a forged/stale/replayed nonce, each recorded toward the auto-ban as a high-confidence signal",
+            "Total digest attempts with present-but-invalid credentials, a denied username, or a forged/stale/replayed nonce, each recorded toward the auto-ban as a high-confidence signal",
+        )?;
+
+        let auth_backend_errors_total = IntCounter::new(
+            "siphon_auth_backend_errors_total",
+            "Total credential checks the credential source could not answer (HTTP auth backend timeout/connection failure, or no usable backend configured); never counted toward the auto-ban",
         )?;
 
         let malformed_messages_total = IntCounter::new(
             "siphon_malformed_messages_total",
             "Total non-SIP / unparseable messages received on a stream transport (TCP/TLS) and dropped, each recorded toward the auto-ban",
+        )?;
+
+        let connections_refused_total = IntCounterVec::new(
+            Opts::new(
+                "siphon_connections_refused_total",
+                "Inbound stream connections refused by security.connection_limits, by which ceiling refused them",
+            ),
+            &["reason"],
+        )?;
+
+        let stream_connections_active = IntGauge::new(
+            "siphon_stream_connections_active",
+            "Inbound stream connections currently established across all sources",
+        )?;
+
+        let handshakes_in_flight = IntGauge::new(
+            "siphon_handshakes_in_flight",
+            "Inbound handshakes (TLS/WS) and first-line sniffs currently in flight",
         )?;
 
         let requests_without_branch_total = IntCounter::new(
@@ -676,7 +726,11 @@ impl SiphonMetrics {
         registry.register(Box::new(auth_failures_total.clone()))?;
         registry.register(Box::new(handshake_failures_total.clone()))?;
         registry.register(Box::new(credential_failures_total.clone()))?;
+        registry.register(Box::new(auth_backend_errors_total.clone()))?;
         registry.register(Box::new(malformed_messages_total.clone()))?;
+        registry.register(Box::new(connections_refused_total.clone()))?;
+        registry.register(Box::new(stream_connections_active.clone()))?;
+        registry.register(Box::new(handshakes_in_flight.clone()))?;
         registry.register(Box::new(requests_without_branch_total.clone()))?;
         registry.register(Box::new(udp_datagrams_at_buffer_limit_total.clone()))?;
         registry.register(Box::new(scanner_blocked_total.clone()))?;
@@ -736,7 +790,11 @@ impl SiphonMetrics {
             auth_failures_total,
             handshake_failures_total,
             credential_failures_total,
+            auth_backend_errors_total,
             malformed_messages_total,
+            connections_refused_total,
+            stream_connections_active,
+            handshakes_in_flight,
             requests_without_branch_total,
             udp_datagrams_at_buffer_limit_total,
             scanner_blocked_total,

--- a/src/script/api/auth.rs
+++ b/src/script/api/auth.rs
@@ -825,9 +825,9 @@ impl PyAuth {
             .or_else(|| message.headers.get("Proxy-Authorization"));
 
         match auth_header {
-            Some(value) => {
-                Ok(self.validate_credentials_with(value, realm, &method, supplied.as_ref()))
-            }
+            Some(value) => Ok(self
+                .validate_credentials_with(value, realm, &method, supplied.as_ref())
+                .is_valid()),
             None => Ok(false),
         }
     }
@@ -902,7 +902,7 @@ impl PyAuth {
             .get("Authorization")
             .or_else(|| message.headers.get("Proxy-Authorization"));
         match auth_header {
-            Some(value) => Ok(self.validate_credentials(value, realm, &method)),
+            Some(value) => Ok(self.validate_credentials(value, realm, &method).is_valid()),
             None => Ok(false),
         }
     }
@@ -911,6 +911,66 @@ impl PyAuth {
 // ---------------------------------------------------------------------------
 // Internal implementation
 // ---------------------------------------------------------------------------
+
+/// Outcome of checking a request's digest credentials.
+///
+/// A `bool` conflated two failures that are nothing alike: credentials the
+/// credential source actively rejected, and a credential source that could not
+/// answer at all. Both landed on the auto-ban's high-confidence path, so an
+/// outage of *our own* auth backend looked exactly like a password brute-force
+/// and banned real subscribers two REGISTER retries in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CredentialCheck {
+    /// The digest response verified against the credential.
+    Valid,
+    /// The request carried no `Authorization` / `Proxy-Authorization` header.
+    /// The legitimate opening leg of challenge-response (RFC 3261 §22.2) — and
+    /// also what a bare scanner looks like, which is why it is counted by
+    /// policy ([`crate::security::AutoBanStore::record_missing_credentials`])
+    /// rather than treated as abuse outright.
+    Absent,
+    /// Credentials were present and are definitively wrong: a digest mismatch,
+    /// an unparseable or over-long header, a username the backend answered for
+    /// and denied, or a forged/stale/replayed nonce (RFC 7616 §3.3).
+    Rejected,
+    /// The credential source could not answer — a transport error or timeout
+    /// reaching the HTTP backend, or no usable backend configured. Says nothing
+    /// about the peer, so it must never feed the auto-ban.
+    Unavailable,
+}
+
+impl CredentialCheck {
+    /// Lift a backend that answered — and so can only have said yes or no —
+    /// into the four-way outcome.
+    fn from_verified(verified: bool) -> Self {
+        if verified {
+            Self::Valid
+        } else {
+            Self::Rejected
+        }
+    }
+
+    /// Whether the credentials verified. The only outcome that lets a request
+    /// through; every other one arms a challenge.
+    fn is_valid(self) -> bool {
+        matches!(self, Self::Valid)
+    }
+}
+
+/// Result of one credential lookup against the HTTP auth backend.
+///
+/// Split out of `Option<String>` for the same reason as [`CredentialCheck`]:
+/// "the backend said this user does not exist" and "the backend did not answer"
+/// are opposite signals, and collapsing them made an outage indistinguishable
+/// from an attack.
+enum CredentialLookup {
+    /// The backend returned a credential body (HA1 hex or plaintext password).
+    Found(String),
+    /// The backend answered with a non-success status: no such user.
+    NotFound,
+    /// The request failed outright — connection refused, timeout, read error.
+    Unavailable,
+}
 
 impl PyAuth {
     fn require_digest_inner(
@@ -945,14 +1005,21 @@ impl PyAuth {
 
         drop(message_guard);
 
-        // Distinguish a credential-less first leg (the legitimate opening of
-        // challenge-response, or a toll-fraud probe — weight 1) from a present-
-        // but-invalid attempt (wrong password, or a forged/stale/replayed nonce
-        // — a high-confidence abuse signal) handled in the failure arm below.
+        // Four-way, not two-way. A credential-less first leg (the legitimate
+        // opening of challenge-response, or a bare probe), a present-but-invalid
+        // attempt (wrong password or a forged/stale/replayed nonce — the
+        // high-confidence abuse signal) and a credential source that could not
+        // answer all arm the same challenge, but they are worth completely
+        // different things to the auto-ban. The failure arm below is where that
+        // is decided.
+        let outcome = match &auth_header {
+            Some(value) => self.validate_credentials_with(value, realm, &method, supplied),
+            None => CredentialCheck::Absent,
+        };
         let credentials_present = auth_header.is_some();
 
         match auth_header {
-            Some(value) if self.validate_credentials_with(&value, realm, &method, supplied) => {
+            Some(value) if outcome.is_valid() => {
                 // Extract username from the Authorization header
                 if let Some(username) = extract_username(&value) {
                     target.set_auth_user(username);
@@ -982,27 +1049,39 @@ impl PyAuth {
                 Ok(true)
             }
             _ => {
-                // A challenge is being issued. Count it toward the auto-ban:
-                //  * credentials absent → the toll-fraud pattern (REGISTER/INVITE
-                //    without creds, repeatedly) accrues weight 1; a legit client
-                //    is reset by the record_success above.
-                //  * credentials present but invalid → wrong password, or a
-                //    forged/stale/replayed nonce: a high-confidence abuse signal,
-                //    weighted heavier so brute-force bans faster. The heavier
-                //    weight only applies over a connection-oriented transport
-                //    whose handshake validates the source — a bad-nonce attempt
-                //    needs no round-trip, so over UDP its source is spoofable and
-                //    a heavier weight would amplify a reflected ban. Over UDP it
-                //    falls back to weight 1 (today's behaviour, unchanged).
+                // A challenge is being issued. What it is worth to the auto-ban
+                // depends entirely on *why*:
+                //  * `Rejected` — credentials present and definitively wrong
+                //    (bad password, or a forged/stale/replayed nonce): a
+                //    high-confidence abuse signal, weighted heavier so a
+                //    brute-force bans faster. The heavier weight only applies
+                //    over a connection-oriented transport whose handshake
+                //    validates the source — a bad-nonce attempt needs no
+                //    round-trip, so over UDP its source is spoofable and a
+                //    heavier weight would amplify a reflected ban. Over UDP it
+                //    falls back to weight 1.
+                //  * `Absent` — no credentials. This is RFC 3261 §22.2's
+                //    opening leg, which every client sends before it has a
+                //    nonce, and it is also what a bare scanner looks like. It
+                //    is counted at `missing_credentials_weight`, which defaults
+                //    to 0 (not counted): banning on protocol-legal behaviour
+                //    banned real subscribers, and behind CGNAT one handset in a
+                //    retry loop took out every subscriber sharing the address.
+                //  * `Unavailable` — our own credential source could not
+                //    answer. Nothing about the peer, so it counts nothing; an
+                //    auth-backend outage must not read as an attack.
+                //  * `Valid` never reaches here.
                 // trusted_cidrs are exempt inside the store.
                 let source_validated = target.transport_name() != "udp";
-                let strong = credentials_present && source_validated;
                 if let Some(ban) = crate::security::auto_ban() {
                     if let Ok(source) = target.source_ip_str().parse::<std::net::IpAddr>() {
-                        let newly_banned = if strong {
-                            ban.record_strong_failure(source)
-                        } else {
-                            ban.record_failure(source)
+                        let newly_banned = match outcome {
+                            CredentialCheck::Rejected if source_validated => {
+                                ban.record_strong_failure(source)
+                            }
+                            CredentialCheck::Rejected => ban.record_failure(source),
+                            CredentialCheck::Absent => ban.record_missing_credentials(source),
+                            CredentialCheck::Unavailable | CredentialCheck::Valid => false,
                         };
                         if newly_banned {
                             tracing::warn!(
@@ -1013,11 +1092,18 @@ impl PyAuth {
                         }
                     }
                 }
+                // Counted regardless of ban weight, so the volume of every shape
+                // stays visible even where the policy declines to act on it.
                 if let Some(metrics) = crate::metrics::try_metrics() {
-                    if credentials_present {
-                        metrics.credential_failures_total.inc();
-                    } else {
-                        metrics.auth_failures_total.inc();
+                    match outcome {
+                        CredentialCheck::Rejected => metrics.credential_failures_total.inc(),
+                        CredentialCheck::Absent => metrics.auth_failures_total.inc(),
+                        // `auth_backend_errors_total` is incremented where the
+                        // outcome is produced — the only place that knows which
+                        // backend failed and why, and the only one that also
+                        // covers the script-driven `verify_digest` path that
+                        // never reaches this challenge arm.
+                        CredentialCheck::Unavailable | CredentialCheck::Valid => {}
                     }
                 }
 
@@ -1197,7 +1283,7 @@ impl PyAuth {
     }
 
     /// Validate credentials by dispatching to the configured backend.
-    fn validate_credentials(&self, auth_value: &str, realm: &str, method: &str) -> bool {
+    fn validate_credentials(&self, auth_value: &str, realm: &str, method: &str) -> CredentialCheck {
         self.validate_credentials_with(auth_value, realm, method, None)
     }
 
@@ -1213,7 +1299,7 @@ impl PyAuth {
         realm: &str,
         method: &str,
         supplied: Option<&SuppliedSecret<'_>>,
-    ) -> bool {
+    ) -> CredentialCheck {
         // Anti-replay: reject a stale or forged nonce before any backend lookup
         // (RFC 7616 §3.3). Without this, a captured `Authorization` replays
         // forever. Applies to the static + HTTP backends; the IMS/AKA paths use
@@ -1222,22 +1308,32 @@ impl PyAuth {
             Some(nonce) if self.validate_nonce(&nonce) => {}
             _ => {
                 debug!("auth: rejecting digest with missing/stale/invalid nonce");
-                return false;
+                return CredentialCheck::Rejected;
             }
         }
         // A script-supplied secret short-circuits the backend entirely, so a
         // deployment that can derive the credential in-process needs no
         // credential source configured at all.
         if let Some(secret) = supplied {
-            return self.validate_supplied(auth_value, realm, method, secret);
+            return CredentialCheck::from_verified(
+                self.validate_supplied(auth_value, realm, method, secret),
+            );
         }
 
         match self.backend_type {
-            AuthBackendType::Static => self.validate_static(auth_value, realm, method),
+            AuthBackendType::Static => {
+                CredentialCheck::from_verified(self.validate_static(auth_value, realm, method))
+            }
             AuthBackendType::Http => self.validate_http(auth_value, realm, method),
             _ => {
+                // A backend siphon cannot dispatch to is an operator error, not
+                // a peer's: nothing here is evidence about the source, so it
+                // must not count toward a ban.
                 warn!(backend = ?self.backend_type, "unsupported auth backend");
-                false
+                if let Some(metrics) = crate::metrics::try_metrics() {
+                    metrics.auth_backend_errors_total.inc();
+                }
+                CredentialCheck::Unavailable
             }
         }
     }
@@ -1303,10 +1399,10 @@ impl PyAuth {
     }
 
     /// HTTP backend: fetch HA1 (or password) from REST endpoint, then verify digest.
-    fn validate_http(&self, auth_value: &str, realm: &str, method: &str) -> bool {
+    fn validate_http(&self, auth_value: &str, realm: &str, method: &str) -> CredentialCheck {
         let fields = match DigestFields::parse(auth_value) {
             Some(f) => f,
-            None => return false,
+            None => return CredentialCheck::Rejected,
         };
 
         // Bound the attacker-controlled username before it becomes a URL and an
@@ -1317,14 +1413,19 @@ impl PyAuth {
                 username_len = fields.username.len(),
                 "rejecting HTTP auth: username empty or exceeds length limit"
             );
-            return false;
+            return CredentialCheck::Rejected;
         }
 
         let (http_config, client) = match (&self.http_config, &self.http_client) {
             (Some(c), Some(cl)) => (c, cl),
             _ => {
+                // Misconfiguration, not a credential decision — the backend was
+                // never asked, so the peer has told us nothing.
                 warn!("auth backend is http but no http config set");
-                return false;
+                if let Some(metrics) = crate::metrics::try_metrics() {
+                    metrics.auth_backend_errors_total.inc();
+                }
+                return CredentialCheck::Unavailable;
             }
         };
 
@@ -1342,8 +1443,9 @@ impl PyAuth {
             None => {
                 let fetched =
                     match self.fetch_http_credential(http_config, client, &fields.username) {
-                        Some(body) => body,
-                        None => return false,
+                        CredentialLookup::Found(body) => body,
+                        CredentialLookup::NotFound => return CredentialCheck::Rejected,
+                        CredentialLookup::Unavailable => return CredentialCheck::Unavailable,
                     };
                 self.store_credential(&fields.username, &fetched);
                 fetched
@@ -1368,7 +1470,7 @@ impl PyAuth {
 
         let valid = fields.verify(&ha1, method);
         debug!(username = %fields.username, valid, "HTTP auth digest verification");
-        valid
+        CredentialCheck::from_verified(valid)
     }
 
     /// Return a cached credential body for `username` if caching is enabled and
@@ -1412,7 +1514,7 @@ impl PyAuth {
         http_config: &HttpAuthConfig,
         client: &reqwest::Client,
         username: &str,
-    ) -> Option<String> {
+    ) -> CredentialLookup {
         // Percent-encode the attacker-controlled digest username before it lands
         // in the URL path. Substituting it raw lets a crafted `username` break
         // out of the `{username}` segment — `../../admin` (path traversal),
@@ -1437,14 +1539,21 @@ impl PyAuth {
             });
 
         match outcome {
-            Ok(Some(body)) => Some(body),
+            Ok(Some(body)) => CredentialLookup::Found(body),
             Ok(None) => {
                 debug!(username = %username, "HTTP auth: user not found (non-success status)");
-                None
+                CredentialLookup::NotFound
             }
             Err(error) => {
+                // The backend did not answer. Distinct from "no such user":
+                // this says nothing about the peer, and counting it toward the
+                // auto-ban turns an outage of our own credential source into a
+                // wave of hour-long bans on legitimate subscribers.
                 warn!(error = %error, url = %url, "HTTP auth request/read failed");
-                None
+                if let Some(metrics) = crate::metrics::try_metrics() {
+                    metrics.auth_backend_errors_total.inc();
+                }
+                CredentialLookup::Unavailable
             }
         }
     }
@@ -2415,11 +2524,19 @@ mod tests {
             "{:016x}.test",
             now_unix_secs().saturating_sub(DEFAULT_NONCE_TTL_SECS + 100)
         );
-        assert!(!auth.validate_credentials(&build(&stale), "example.com", "REGISTER"));
+        // A stale nonce is a *rejection*, not an inconclusive check: the peer
+        // presented something and it was refused, so it still weighs on the ban.
+        assert_eq!(
+            auth.validate_credentials(&build(&stale), "example.com", "REGISTER"),
+            CredentialCheck::Rejected
+        );
 
         // The identical exchange with a fresh nonce authenticates.
         let fresh = format!("{:016x}.test", now_unix_secs());
-        assert!(auth.validate_credentials(&build(&fresh), "example.com", "REGISTER"));
+        assert_eq!(
+            auth.validate_credentials(&build(&fresh), "example.com", "REGISTER"),
+            CredentialCheck::Valid
+        );
     }
 
     #[test]
@@ -2977,6 +3094,90 @@ mod tests {
         })
         .unwrap();
         auth
+    }
+
+    /// Build an `Authorization` header that is well-formed and carries a fresh
+    /// nonce, so the check reaches the backend instead of being short-circuited
+    /// by the anti-replay guard.
+    fn well_formed_authorization(username: &str) -> String {
+        let nonce = format!("{:016x}.test", now_unix_secs());
+        format!(
+            "Digest username=\"{username}\", realm=\"example.com\", nonce=\"{nonce}\", \
+             uri=\"sip:example.com\", response=\"{}\"",
+            "0".repeat(32)
+        )
+    }
+
+    /// The second half of the ban regression: a credential source that cannot
+    /// answer is not a credential decision.
+    ///
+    /// `fetch_http_credential` used to fold "the backend said no such user" and
+    /// "the backend never answered" into the same `None`, which `validate_http`
+    /// turned into `false`, which the challenge arm read as present-but-invalid
+    /// credentials — the *strong* signal. Two REGISTER retries during an auth
+    /// backend outage therefore banned a real subscriber's address for an hour,
+    /// which is precisely backwards: during an outage every subscriber retries.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unreachable_auth_backend_is_unavailable_not_rejected() {
+        pyo3::Python::initialize();
+        // Port 9 (discard) on loopback: nothing listens, so the connect is
+        // refused promptly rather than waiting out the timeout.
+        let auth = http_auth_with_cache(0);
+
+        assert_eq!(
+            auth.validate_credentials(
+                &well_formed_authorization("alice"),
+                "example.com",
+                "REGISTER"
+            ),
+            CredentialCheck::Unavailable,
+            "a backend that did not answer says nothing about the peer"
+        );
+    }
+
+    /// The distinction that has to survive: an answer of "no" is still a real
+    /// rejection and must keep its high-confidence weight, or turning the
+    /// outage case off would also disarm password brute-force detection.
+    #[test]
+    fn wrong_password_is_rejected_not_unavailable() {
+        let auth = make_auth();
+        let nonce = format!("{:016x}.test", now_unix_secs());
+        let wrong = format!(
+            "Digest username=\"alice\", realm=\"example.com\", nonce=\"{nonce}\", \
+             uri=\"sip:example.com\", response=\"{}\"",
+            "f".repeat(32)
+        );
+        assert_eq!(
+            auth.validate_credentials(&wrong, "example.com", "REGISTER"),
+            CredentialCheck::Rejected
+        );
+    }
+
+    /// An unparseable or absurd `Authorization` is the peer's doing, so it is a
+    /// rejection — the peer sent something and it was refused.
+    #[test]
+    fn malformed_authorization_is_rejected() {
+        let auth = make_auth();
+        assert_eq!(
+            auth.validate_credentials("Digest nonsense", "example.com", "REGISTER"),
+            CredentialCheck::Rejected
+        );
+    }
+
+    /// A backend siphon cannot dispatch to is an operator error. Nothing about
+    /// the request was ever evaluated, so it must not weigh on the source.
+    #[test]
+    fn unsupported_backend_is_unavailable() {
+        let mut auth = PyAuth::empty();
+        auth.set_backend_type(AuthBackendType::Database);
+        assert_eq!(
+            auth.validate_credentials(
+                &well_formed_authorization("alice"),
+                "example.com",
+                "REGISTER"
+            ),
+            CredentialCheck::Unavailable
+        );
     }
 
     #[test]

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,12 +1,25 @@
 //! Auto-ban store — per-source-IP failure tracking with TTL bans.
 //!
 //! Feeds the transport ACL ([`crate::transport::acl::TransportAcl::is_allowed`])
-//! so a banned source is dropped at accept/recv, before any SIP parsing. Two
-//! failure signals increment the same per-IP counter:
-//!   * an auth challenge issued without valid credentials ([`crate::script::api`]
-//!     auth path), and
+//! so a banned source is dropped at accept/recv, before any SIP parsing. Several
+//! failure signals increment the same per-IP counter, at different weights:
+//!   * rejected credentials — a wrong password, a denied username, or a
+//!     forged/stale/replayed nonce ([`crate::script::api`] auth path): weight
+//!     `strong_signal_weight` over a transport whose handshake validates the
+//!     source, weight 1 over UDP where it does not;
+//!   * non-SIP bytes on a stream transport, and a scanner `User-Agent`: weight
+//!     `strong_signal_weight`;
+//!   * a failed or timed-out TLS/WS handshake: weight 1;
 //!   * a non-ACK INVITE **server**-transaction timeout (dispatcher) — the peer
-//!     sent an INVITE, got a final response, and never ACKed it.
+//!     sent an INVITE, got a final response, and never ACKed it: weight 1;
+//!   * a challenge issued because the request carried *no* credentials: weight
+//!     `missing_credentials_weight`, **0 by default**. That leg is required by
+//!     RFC 3261 §22.2, so counting it bans clients for behaving correctly.
+//!
+//! What is deliberately **not** a signal: a credential source that could not
+//! answer. An HTTP auth backend that times out is an outage of ours, not
+//! evidence about the peer, and counting it turned one backend blip into
+//! hour-long bans on real subscribers.
 //!
 //! A successful authentication resets the counter, so a legitimate client that
 //! challenges-then-succeeds never accumulates. Sources matching `trusted_cidrs`
@@ -17,6 +30,7 @@
 //! `security.failed_auth_ban` is configured.
 
 use std::net::IpAddr;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -144,6 +158,395 @@ pub fn record_malformed_message(source: IpAddr, transport: &str) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Inbound connection limits
+// ---------------------------------------------------------------------------
+
+/// Default ceiling on concurrent in-flight handshakes from one source.
+///
+/// A legitimate client opens one connection and completes its handshake; even a
+/// large NAT re-registering after a network flap arrives as a stream of them,
+/// not as a wall of simultaneous half-open ones. Observed abuse ran ~50 at once
+/// from a single address, each pinning a task for the full handshake timeout.
+pub const DEFAULT_MAX_HANDSHAKES_PER_SOURCE: u32 = 32;
+
+/// Default ceiling on concurrent in-flight handshakes across all sources.
+///
+/// What bounds the CPU a *distributed* flood can spend: a TLS handshake is real
+/// asymmetric crypto, and the per-source cap alone does not bound how many
+/// sources there are.
+pub const DEFAULT_MAX_HANDSHAKES: u32 = 1024;
+
+/// Default ceiling on established stream connections from one source.
+///
+/// A runaway detector, not a policy — see the type-level note on
+/// [`ConnectionLimits`] about carrier NAT.
+pub const DEFAULT_MAX_CONNECTIONS_PER_SOURCE: u32 = 256;
+
+/// Default ceiling on established stream connections across all sources.
+pub const DEFAULT_MAX_CONNECTIONS: u32 = 16_384;
+
+/// Ceilings on concurrent inbound stream connections, per source and overall.
+///
+/// Two different resources, because they are abused differently. An *in-flight
+/// handshake* is CPU and a task; it is held for at most the handshake timeout,
+/// and no legitimate peer has many at once, so that cap can be tight. An
+/// *established connection* is a socket, a read buffer and a slot in the
+/// connection map, held until the peer leaves or the 300 s idle timeout reaps
+/// it, and a busy NAT legitimately holds many — so that cap has to be loose.
+///
+/// **The established per-source cap and carrier NAT.** A CGNAT address can front
+/// far more registered UEs than the default allows, and every one of them is a
+/// paying subscriber. The default is sized to catch a runaway, not to express a
+/// policy: raise `max_connections_per_source` (or set it to 0) wherever one
+/// upstream address legitimately carries hundreds of registrations.
+/// `siphon_connections_refused_total{reason="connections_per_source"}` is how
+/// that shows up before the support tickets do.
+///
+/// Every field is a maximum; `0` disables that particular ceiling.
+#[derive(Debug, Clone, Copy)]
+pub struct ConnectionLimits {
+    /// Concurrent handshakes (TLS/WS) plus first-line sniffs from one source.
+    pub max_handshakes_per_source: u32,
+    /// Concurrent handshakes across all sources.
+    pub max_handshakes: u32,
+    /// Established stream connections from one source.
+    pub max_connections_per_source: u32,
+    /// Established stream connections across all sources.
+    pub max_connections: u32,
+}
+
+impl Default for ConnectionLimits {
+    fn default() -> Self {
+        Self {
+            max_handshakes_per_source: DEFAULT_MAX_HANDSHAKES_PER_SOURCE,
+            max_handshakes: DEFAULT_MAX_HANDSHAKES,
+            max_connections_per_source: DEFAULT_MAX_CONNECTIONS_PER_SOURCE,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+        }
+    }
+}
+
+/// Which ceiling refused a connection. Names the `reason` metric label so an
+/// operator can tell "one source is misbehaving" from "the box is full".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefusedReason {
+    HandshakesPerSource,
+    Handshakes,
+    ConnectionsPerSource,
+    Connections,
+}
+
+impl RefusedReason {
+    /// Metric label / log value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HandshakesPerSource => "handshakes_per_source",
+            Self::Handshakes => "handshakes",
+            Self::ConnectionsPerSource => "connections_per_source",
+            Self::Connections => "connections",
+        }
+    }
+}
+
+impl std::fmt::Display for RefusedReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Process-wide inbound connection limiter. Installed unconditionally at
+/// startup (unlike the opt-in guards above) because the ceilings it enforces
+/// have to hold even for a deployment with no `security:` block at all.
+static CONNECTION_LIMITER: OnceLock<Arc<ConnectionLimiter>> = OnceLock::new();
+
+/// Install the process-wide connection limiter (idempotent — a second call is a
+/// no-op). Called once at server startup before any listener binds.
+pub fn set_connection_limiter(limiter: Arc<ConnectionLimiter>) {
+    let _ = CONNECTION_LIMITER.set(limiter);
+}
+
+/// The process-wide connection limiter, if one has been installed.
+pub fn connection_limiter() -> Option<&'static Arc<ConnectionLimiter>> {
+    CONNECTION_LIMITER.get()
+}
+
+/// Take a slot for a newly accepted stream connection from `source`.
+///
+/// Call from an accept loop right after the ACL check and before spawning the
+/// connection task, then move the returned permit into that task: the
+/// established slot is held for as long as the permit lives, so every exit path
+/// — clean close, error, panic — frees it. Release the handshake half with
+/// [`AcceptPermit::handshake_done`] once the connection is confirmed to speak
+/// SIP.
+///
+/// Returns an unmetered permit when no limiter is installed, so a caller never
+/// has to branch on whether the feature is on.
+pub fn try_accept_connection(source: IpAddr) -> Result<AcceptPermit, RefusedReason> {
+    match connection_limiter() {
+        Some(limiter) => limiter.try_accept(source),
+        None => Ok(AcceptPermit::unmetered(source)),
+    }
+}
+
+/// Per-source and global counters behind [`try_accept_connection`].
+pub struct ConnectionLimiter {
+    limits: ConnectionLimits,
+    /// Sources exempt from every ceiling (trunks, monitoring, own infra).
+    trusted: Vec<IpNet>,
+    /// IP → in-flight handshakes. Only populated when the per-source handshake
+    /// ceiling is enabled, so an unlimited policy allocates nothing per source.
+    handshakes: DashMap<IpAddr, u32>,
+    /// IP → established connections. Same conditional-population rule.
+    connections: DashMap<IpAddr, u32>,
+    handshakes_total: AtomicU32,
+    connections_total: AtomicU32,
+}
+
+impl ConnectionLimiter {
+    /// Build a limiter from the configured ceilings and `trusted_cidrs`.
+    /// Invalid CIDRs are ignored (logged by the caller), matching
+    /// [`AutoBanStore::new`].
+    pub fn new(limits: ConnectionLimits, trusted_cidrs: &[String]) -> Self {
+        Self {
+            limits,
+            trusted: trusted_cidrs
+                .iter()
+                .filter_map(|cidr| cidr.parse::<IpNet>().ok())
+                .collect(),
+            handshakes: DashMap::new(),
+            connections: DashMap::new(),
+            handshakes_total: AtomicU32::new(0),
+            connections_total: AtomicU32::new(0),
+        }
+    }
+
+    fn is_trusted(&self, source: IpAddr) -> bool {
+        self.trusted.iter().any(|net| net.contains(&source))
+    }
+
+    /// Take one established-connection slot and one handshake slot, or say
+    /// which ceiling refused.
+    ///
+    /// The connection slot is taken first: it is the longer-lived resource, so
+    /// refusing on it avoids doing handshake bookkeeping for a connection that
+    /// could never be served anyway.
+    pub fn try_accept(self: &Arc<Self>, source: IpAddr) -> Result<AcceptPermit, RefusedReason> {
+        if self.is_trusted(source) {
+            return Ok(AcceptPermit::unmetered(source));
+        }
+
+        if !take_global(&self.connections_total, self.limits.max_connections) {
+            return Err(RefusedReason::Connections);
+        }
+        if !take_per_source(
+            &self.connections,
+            source,
+            self.limits.max_connections_per_source,
+        ) {
+            release_global(&self.connections_total);
+            return Err(RefusedReason::ConnectionsPerSource);
+        }
+        if !take_global(&self.handshakes_total, self.limits.max_handshakes) {
+            release_per_source(&self.connections, source);
+            release_global(&self.connections_total);
+            return Err(RefusedReason::Handshakes);
+        }
+        if !take_per_source(
+            &self.handshakes,
+            source,
+            self.limits.max_handshakes_per_source,
+        ) {
+            release_global(&self.handshakes_total);
+            release_per_source(&self.connections, source);
+            release_global(&self.connections_total);
+            return Err(RefusedReason::HandshakesPerSource);
+        }
+
+        self.publish_gauges();
+        Ok(AcceptPermit {
+            limiter: Some(Arc::clone(self)),
+            source,
+            handshake_held: true,
+            connection_held: true,
+        })
+    }
+
+    fn release_handshake(&self, source: IpAddr) {
+        release_per_source(&self.handshakes, source);
+        release_global(&self.handshakes_total);
+        self.publish_gauges();
+    }
+
+    fn release_connection(&self, source: IpAddr) {
+        release_per_source(&self.connections, source);
+        release_global(&self.connections_total);
+        self.publish_gauges();
+    }
+
+    fn publish_gauges(&self) {
+        if let Some(metrics) = crate::metrics::try_metrics() {
+            metrics
+                .handshakes_in_flight
+                .set(i64::from(self.handshakes_total.load(Ordering::Relaxed)));
+            metrics
+                .stream_connections_active
+                .set(i64::from(self.connections_total.load(Ordering::Relaxed)));
+        }
+    }
+
+    /// Number of sources currently holding at least one slot, as
+    /// `(handshakes, connections)`. Both must return to zero once every permit
+    /// is dropped — these maps are keyed by a live entity, so a row that
+    /// outlives its connection is a per-source leak.
+    #[cfg(test)]
+    fn tracked_sources(&self) -> (usize, usize) {
+        (self.handshakes.len(), self.connections.len())
+    }
+}
+
+/// Take one per-source slot, or report the ceiling was reached.
+///
+/// A zero ceiling means unlimited, and deliberately does not touch the map: an
+/// operator who turned the cap off should not pay a row per source for it.
+fn take_per_source(map: &DashMap<IpAddr, u32>, source: IpAddr, limit: u32) -> bool {
+    if limit == 0 {
+        return true;
+    }
+    let mut entry = map.entry(source).or_insert(0);
+    if *entry >= limit {
+        return false;
+    }
+    *entry += 1;
+    true
+}
+
+/// Give back one per-source slot, removing the row when it reaches zero.
+///
+/// The row must go, not merely decrement: leaving zeroes behind would grow the
+/// map by one entry per source ever seen, which is exactly the shape of leak
+/// this kind of table is prone to.
+fn release_per_source(map: &DashMap<IpAddr, u32>, source: IpAddr) {
+    // Never hold a shard guard across another operation on the same map — take
+    // the decision inside this scope and act on it after the guard is dropped.
+    let now_empty = {
+        match map.get_mut(&source) {
+            Some(mut entry) => {
+                *entry = entry.saturating_sub(1);
+                *entry == 0
+            }
+            // Unmetered (the ceiling is off) or already released.
+            None => false,
+        }
+    };
+    if now_empty {
+        map.remove_if(&source, |_, count| *count == 0);
+    }
+}
+
+/// Take one global slot. A zero ceiling still counts — the total is what the
+/// active-connections gauge reports.
+fn take_global(counter: &AtomicU32, limit: u32) -> bool {
+    if limit == 0 {
+        counter.fetch_add(1, Ordering::Relaxed);
+        return true;
+    }
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            (current < limit).then_some(current + 1)
+        })
+        .is_ok()
+}
+
+fn release_global(counter: &AtomicU32) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(1))
+    });
+}
+
+/// A held pair of connection slots. Dropping it gives back whatever is still
+/// held, so no accept path can leak a slot by returning early.
+pub struct AcceptPermit {
+    /// `None` for a trusted source, or when no limiter is installed — nothing
+    /// was taken, so nothing is given back.
+    limiter: Option<Arc<ConnectionLimiter>>,
+    source: IpAddr,
+    handshake_held: bool,
+    connection_held: bool,
+}
+
+// Hand-written so the permit can be `unwrap_err`'d in tests and logged, without
+// dragging the whole limiter (two `DashMap`s) into a `Debug` impl.
+impl std::fmt::Debug for AcceptPermit {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AcceptPermit")
+            .field("source", &self.source)
+            .field("metered", &self.limiter.is_some())
+            .field("handshake_held", &self.handshake_held)
+            .field("connection_held", &self.connection_held)
+            .finish()
+    }
+}
+
+impl AcceptPermit {
+    /// A permit that counts against nothing.
+    fn unmetered(source: IpAddr) -> Self {
+        Self {
+            limiter: None,
+            source,
+            handshake_held: false,
+            connection_held: false,
+        }
+    }
+
+    /// Give back the handshake slot, keeping the established-connection slot.
+    ///
+    /// Call as soon as the connection is known to speak SIP — after the TLS
+    /// handshake and the first-line sniff. Holding it for the connection's whole
+    /// life would make the tight handshake ceiling behave like a second, much
+    /// stricter connection ceiling. Idempotent.
+    pub fn handshake_done(&mut self) {
+        if !self.handshake_held {
+            return;
+        }
+        self.handshake_held = false;
+        if let Some(limiter) = &self.limiter {
+            limiter.release_handshake(self.source);
+        }
+    }
+}
+
+impl Drop for AcceptPermit {
+    fn drop(&mut self) {
+        let Some(limiter) = &self.limiter else {
+            return;
+        };
+        if self.handshake_held {
+            limiter.release_handshake(self.source);
+        }
+        if self.connection_held {
+            limiter.release_connection(self.source);
+        }
+    }
+}
+
+/// Count one connection refused by [`try_accept_connection`], labelled by the
+/// ceiling that refused it.
+///
+/// Deliberately not an auto-ban signal. Hitting a concurrency ceiling is a
+/// capacity fact, not proof of intent — a NAT whose UEs all re-register after a
+/// network flap arrives exactly like a flood — and the ceiling has already done
+/// the protective work by refusing the connection.
+pub fn record_connection_refused(reason: RefusedReason) {
+    if let Some(metrics) = crate::metrics::try_metrics() {
+        metrics
+            .connections_refused_total
+            .with_label_values(&[reason.as_str()])
+            .inc();
+    }
+}
+
 /// Fixed-window failure counter for one source IP.
 #[derive(Debug, Clone, Copy)]
 struct FailureWindow {
@@ -170,6 +573,20 @@ pub struct AutoBanStore {
     /// these unambiguous signals faster than a bare scanning probe (weight 1)
     /// while reusing the single per-IP window. Always ≥ 1.
     strong_weight: u32,
+    /// Failure weight applied by [`Self::record_missing_credentials`] — a
+    /// challenge issued because the request carried no credentials at all.
+    ///
+    /// **Zero by default, and that is deliberate.** RFC 3261 §22.2 makes the
+    /// credential-less request the opening leg of challenge-response: every
+    /// client sends one before it has a nonce, so counting it bans clients for
+    /// behaving correctly. It fired in production — a subscriber address
+    /// accrued five in one window and lost an hour — and behind CGNAT the blast
+    /// radius is every subscriber sharing the address, none of whom did
+    /// anything. The signal it was reaching for (a scanner that only ever
+    /// probes) is covered better by `scanner_block`, `rate_limit`, apiban and
+    /// the non-SIP/handshake signals, all of which a real client never trips.
+    /// Set it to 1 to restore the old behaviour.
+    missing_credentials_weight: u32,
     /// Optional kernel-firewall handle. When wired, every new ban is also
     /// pushed to the nf_tables set so the source is dropped pre-userspace.
     firewall: OnceLock<crate::firewall::KernelFirewall>,
@@ -184,20 +601,29 @@ impl AutoBanStore {
         ban_duration_secs: u32,
         trusted_cidrs: &[String],
         strong_weight: u32,
+        missing_credentials_weight: u32,
     ) -> Self {
         let trusted = trusted_cidrs
             .iter()
             .filter_map(|cidr| cidr.parse::<IpNet>().ok())
             .collect();
+        let threshold = threshold.max(1);
         Self {
             failures: DashMap::new(),
             bans: DashMap::new(),
             trusted,
             // Guard against a zero policy disabling the feature by accident.
-            threshold: threshold.max(1),
+            threshold,
             window: Duration::from_secs(u64::from(window_secs.max(1))),
             ban_duration: Duration::from_secs(u64::from(ban_duration_secs.max(1))),
             strong_weight: strong_weight.max(1),
+            // Zero is a meaningful value here (do not count it at all) and is
+            // the default, so unlike the others this one is not clamped up.
+            // Clamped down to the threshold only to keep it on the same scale
+            // it is measured against; at exactly the threshold one
+            // credential-less request bans, which is a policy an operator can
+            // legitimately ask for.
+            missing_credentials_weight: missing_credentials_weight.min(threshold),
             firewall: OnceLock::new(),
         }
     }
@@ -213,13 +639,24 @@ impl AutoBanStore {
     }
 
     /// Record one low-confidence failure for `source` (weight 1) — a signal that
-    /// could occasionally fire for a benign peer: an auth challenge without
-    /// credentials (the legitimate first leg of challenge-response), a non-ACK
-    /// INVITE server-transaction timeout, a failed transport handshake. Returns
-    /// `true` if this call newly banned the IP (so the caller can log/metric the
+    /// could occasionally fire for a benign peer: a non-ACK INVITE
+    /// server-transaction timeout, a failed transport handshake, or a rejected
+    /// credential over UDP (where the source is spoofable). Returns `true` if
+    /// this call newly banned the IP (so the caller can log/metric the
     /// transition once).
     pub fn record_failure(&self, source: IpAddr) -> bool {
         self.record_failure_weighted_at(source, 1, Instant::now())
+    }
+
+    /// Record a challenge issued because the request carried no credentials,
+    /// weighted by `missing_credentials_weight` (0 by default — see the field).
+    ///
+    /// At weight 0 this is a total no-op: it does not create a `failures` entry,
+    /// so a scanner sweeping a /16 cannot grow the map one row per source IP
+    /// through a signal that is not being acted on anyway. Returns `true` if
+    /// this call newly banned the IP.
+    pub fn record_missing_credentials(&self, source: IpAddr) -> bool {
+        self.record_failure_weighted_at(source, self.missing_credentials_weight, Instant::now())
     }
 
     /// Record one high-confidence abuse signal for `source`, weighted by
@@ -234,6 +671,12 @@ impl AutoBanStore {
     }
 
     fn record_failure_weighted_at(&self, source: IpAddr, weight: u32, now: Instant) -> bool {
+        // A zero-weight signal is not counted at all — and specifically does not
+        // touch `failures`, so a policy that declines to act on a signal also
+        // declines to allocate a per-source row for it.
+        if weight == 0 {
+            return false;
+        }
         if self.is_trusted(source) {
             return false;
         }
@@ -572,7 +1015,7 @@ mod tests {
 
     #[test]
     fn bans_after_threshold_failures() {
-        let store = AutoBanStore::new(3, 600, 3600, &[], 1);
+        let store = AutoBanStore::new(3, 600, 3600, &[], 1, 0);
         let source = ip("203.0.113.7");
         assert!(!store.record_failure(source)); // 1
         assert!(!store.record_failure(source)); // 2
@@ -584,7 +1027,7 @@ mod tests {
 
     #[test]
     fn success_resets_the_counter() {
-        let store = AutoBanStore::new(3, 600, 3600, &[], 1);
+        let store = AutoBanStore::new(3, 600, 3600, &[], 1, 0);
         let source = ip("203.0.113.8");
         store.record_failure(source);
         store.record_failure(source);
@@ -597,7 +1040,7 @@ mod tests {
 
     #[test]
     fn trusted_cidr_never_banned() {
-        let store = AutoBanStore::new(2, 600, 3600, &["10.0.0.0/8".to_string()], 1);
+        let store = AutoBanStore::new(2, 600, 3600, &["10.0.0.0/8".to_string()], 1, 0);
         let source = ip("10.1.2.3");
         for _ in 0..10 {
             assert!(!store.record_failure(source));
@@ -608,7 +1051,7 @@ mod tests {
 
     #[test]
     fn window_rolls_so_slow_failures_do_not_ban() {
-        let store = AutoBanStore::new(3, 600, 3600, &[], 1);
+        let store = AutoBanStore::new(3, 600, 3600, &[], 1, 0);
         let source = ip("203.0.113.9");
         let t0 = Instant::now();
         assert!(!store.record_failure_at(source, t0));
@@ -620,7 +1063,7 @@ mod tests {
 
     #[test]
     fn ban_expires_after_ttl() {
-        let store = AutoBanStore::new(1, 600, 60, &[], 1);
+        let store = AutoBanStore::new(1, 600, 60, &[], 1, 0);
         let source = ip("203.0.113.10");
         let t0 = Instant::now();
         assert!(store.record_failure_at(source, t0)); // threshold 1 -> immediate ban
@@ -630,7 +1073,7 @@ mod tests {
 
     #[test]
     fn prune_drops_expired_entries() {
-        let store = AutoBanStore::new(1, 600, 60, &[], 1);
+        let store = AutoBanStore::new(1, 600, 60, &[], 1, 0);
         let source = ip("203.0.113.11");
         let t0 = Instant::now();
         store.record_failure_at(source, t0);
@@ -641,7 +1084,7 @@ mod tests {
 
     #[test]
     fn already_banned_failure_is_noop() {
-        let store = AutoBanStore::new(1, 600, 3600, &[], 1);
+        let store = AutoBanStore::new(1, 600, 3600, &[], 1, 0);
         let source = ip("203.0.113.12");
         assert!(store.record_failure(source)); // ban
         assert!(!store.record_failure(source)); // already banned -> not "newly banned"
@@ -650,7 +1093,7 @@ mod tests {
 
     #[test]
     fn unban_lifts_an_active_ban() {
-        let store = AutoBanStore::new(1, 600, 3600, &[], 1);
+        let store = AutoBanStore::new(1, 600, 3600, &[], 1, 0);
         let source = ip("203.0.113.40");
         assert!(store.record_failure(source)); // threshold 1 -> banned
         assert!(store.is_banned(source));
@@ -661,7 +1104,7 @@ mod tests {
 
     #[test]
     fn unban_of_an_unbanned_source_is_false() {
-        let store = AutoBanStore::new(3, 600, 3600, &[], 1);
+        let store = AutoBanStore::new(3, 600, 3600, &[], 1, 0);
         let source = ip("203.0.113.41");
         // Never banned -> nothing to lift.
         assert!(!store.unban(source));
@@ -672,7 +1115,7 @@ mod tests {
 
     #[test]
     fn banned_sources_lists_active_bans_with_remaining() {
-        let store = AutoBanStore::new(1, 600, 3600, &[], 1);
+        let store = AutoBanStore::new(1, 600, 3600, &[], 1, 0);
         let one = ip("203.0.113.42");
         let two = ip("2001:db8::42");
         store.record_failure(one);
@@ -692,7 +1135,7 @@ mod tests {
     fn strong_failures_ban_faster_than_plain_probes() {
         // threshold 6, strong weight 3: two high-confidence signals (3+3=6) ban,
         // while a plain probe (weight 1) needs the full six hits.
-        let store = AutoBanStore::new(6, 600, 3600, &[], 3);
+        let store = AutoBanStore::new(6, 600, 3600, &[], 3, 0);
 
         let abuser = ip("203.0.113.30");
         assert!(!store.record_strong_failure(abuser)); // 3 < 6
@@ -710,10 +1153,68 @@ mod tests {
     #[test]
     fn strong_weight_is_clamped_to_at_least_one() {
         // A misconfigured weight of 0 must not make strong signals free.
-        let store = AutoBanStore::new(2, 600, 3600, &[], 0);
+        let store = AutoBanStore::new(2, 600, 3600, &[], 0, 0);
         let source = ip("203.0.113.32");
         assert!(!store.record_strong_failure(source)); // 1
         assert!(store.record_strong_failure(source)); // 2 -> ban
+    }
+
+    /// The regression this default exists for. A client that keeps sending
+    /// credential-less requests — a handset in a retry loop, a UA that never
+    /// caches a nonce — is doing what RFC 3261 §22.2 tells it to, and it used to
+    /// earn an hour-long ban on the fifth one. Behind CGNAT that address is
+    /// shared, so the ban lands on every subscriber behind it.
+    #[test]
+    fn missing_credentials_do_not_ban_at_the_default_weight() {
+        let store = AutoBanStore::new(5, 600, 3600, &[], 3, 0);
+        let subscriber = ip("203.0.113.40");
+
+        for _ in 0..50 {
+            assert!(!store.record_missing_credentials(subscriber));
+        }
+        assert!(!store.is_banned(subscriber));
+
+        // …and it leaves no per-source row behind, so a scanner sweeping a range
+        // cannot grow the map through a signal nothing acts on.
+        assert_eq!(store.failures.len(), 0);
+
+        // A credential the backend actually rejected still bans, from the same
+        // source, on the same store: switching the default off did not disarm
+        // the signal that matters.
+        assert!(!store.record_strong_failure(subscriber)); // 3 < 5
+        assert!(store.record_strong_failure(subscriber)); // 6 -> ban
+    }
+
+    #[test]
+    fn missing_credentials_weight_is_configurable_back_on() {
+        // weight 1 restores the pre-1.7 behaviour: five in the window, ban.
+        let store = AutoBanStore::new(5, 600, 3600, &[], 3, 1);
+        let prober = ip("203.0.113.41");
+        for _ in 0..4 {
+            assert!(!store.record_missing_credentials(prober));
+        }
+        assert!(store.record_missing_credentials(prober));
+        assert!(store.is_banned(prober));
+    }
+
+    #[test]
+    fn missing_credentials_weight_is_clamped_to_the_threshold() {
+        // An over-large value stays on the scale it is measured against rather
+        // than saturating the counter in ways the window logic cannot reason
+        // about. At exactly the threshold, one request bans — a policy an
+        // operator can legitimately ask for.
+        let store = AutoBanStore::new(3, 600, 3600, &[], 3, 99);
+        let source = ip("203.0.113.42");
+        assert!(store.record_missing_credentials(source));
+        assert!(store.is_banned(source));
+    }
+
+    #[test]
+    fn trusted_sources_are_exempt_from_missing_credential_counting() {
+        let store = AutoBanStore::new(1, 600, 3600, &["203.0.113.0/24".to_string()], 3, 1);
+        let trusted = ip("203.0.113.43");
+        assert!(!store.record_missing_credentials(trusted));
+        assert!(!store.is_banned(trusted));
     }
 
     // --- transport auto-ban signals (handshake failure, non-SIP bytes) -----
@@ -741,7 +1242,7 @@ mod tests {
         // this, one such test bans loopback and every socket test that runs
         // after it is refused at accept.
         let loopback = ["127.0.0.0/8".to_string(), "::1/128".to_string()];
-        let store = Arc::new(AutoBanStore::new(3, 600, 3600, &loopback, 3));
+        let store = Arc::new(AutoBanStore::new(3, 600, 3600, &loopback, 3, 0));
         set_auto_ban(Arc::clone(&store));
 
         // Handshake failures accumulate per-IP across transports and ban at the
@@ -795,6 +1296,7 @@ mod tests {
             failed_auth_ban: None,
             apiban: None,
             firewall: None,
+            connection_limits: Default::default(),
         }
     }
 
@@ -968,5 +1470,245 @@ mod tests {
             rate.prune_at(now + Duration::from_secs(61));
         }
         assert_eq!(filter.rate_limit_bans(), 0);
+    }
+
+    // --- connection limits (ConnectionLimiter) -----------------------------
+
+    fn limits(
+        max_handshakes_per_source: u32,
+        max_handshakes: u32,
+        max_connections_per_source: u32,
+        max_connections: u32,
+    ) -> ConnectionLimits {
+        ConnectionLimits {
+            max_handshakes_per_source,
+            max_handshakes,
+            max_connections_per_source,
+            max_connections,
+        }
+    }
+
+    /// The abuse this exists for: one source opening far more simultaneous
+    /// connections than it could ever be doing legitimately, each one pinning a
+    /// task for the whole handshake timeout. The auto-ban cannot help — it needs
+    /// completed failures first, and these never complete.
+    #[test]
+    fn a_source_cannot_hold_more_handshakes_than_its_ceiling() {
+        let limiter = Arc::new(ConnectionLimiter::new(limits(3, 0, 0, 0), &[]));
+        let flood = ip("203.0.113.50");
+
+        let held: Vec<_> = (0..3)
+            .map(|_| limiter.try_accept(flood).expect("under the ceiling"))
+            .collect();
+        assert_eq!(
+            limiter.try_accept(flood).unwrap_err(),
+            RefusedReason::HandshakesPerSource
+        );
+
+        // A different source is unaffected — the ceiling is per source, so one
+        // abuser cannot deny service to everyone else.
+        let bystander = limiter.try_accept(ip("203.0.113.51"));
+        assert!(bystander.is_ok());
+
+        drop(held);
+        assert!(limiter.try_accept(flood).is_ok(), "slots come back");
+    }
+
+    #[test]
+    fn established_connections_have_their_own_per_source_ceiling() {
+        let limiter = Arc::new(ConnectionLimiter::new(limits(0, 0, 2, 0), &[]));
+        let source = ip("203.0.113.52");
+
+        let mut first = limiter.try_accept(source).unwrap();
+        let mut second = limiter.try_accept(source).unwrap();
+        // Finishing the handshakes must NOT free the connection slots, or the
+        // established ceiling would only ever bound connections mid-handshake.
+        first.handshake_done();
+        second.handshake_done();
+
+        assert_eq!(
+            limiter.try_accept(source).unwrap_err(),
+            RefusedReason::ConnectionsPerSource
+        );
+        drop(first);
+        assert!(limiter.try_accept(source).is_ok());
+    }
+
+    /// The per-source ceilings say nothing about how many sources there are, so
+    /// a distributed flood needs the global ones.
+    #[test]
+    fn global_ceilings_bound_a_distributed_flood() {
+        let limiter = Arc::new(ConnectionLimiter::new(limits(0, 2, 0, 0), &[]));
+        let _one = limiter.try_accept(ip("203.0.113.60")).unwrap();
+        let _two = limiter.try_accept(ip("203.0.113.61")).unwrap();
+        assert_eq!(
+            limiter.try_accept(ip("203.0.113.62")).unwrap_err(),
+            RefusedReason::Handshakes
+        );
+
+        let limiter = Arc::new(ConnectionLimiter::new(limits(0, 0, 0, 1), &[]));
+        let _held = limiter.try_accept(ip("203.0.113.63")).unwrap();
+        assert_eq!(
+            limiter.try_accept(ip("203.0.113.64")).unwrap_err(),
+            RefusedReason::Connections
+        );
+    }
+
+    /// `handshake_done` releases the tight ceiling and keeps the loose one.
+    /// Without that split, a 32-handshake ceiling would silently behave as a
+    /// 32-connection ceiling and cut off any busy NAT.
+    #[test]
+    fn handshake_done_releases_only_the_handshake_half() {
+        let limiter = Arc::new(ConnectionLimiter::new(limits(1, 0, 4, 0), &[]));
+        let source = ip("203.0.113.70");
+
+        let mut first = limiter.try_accept(source).unwrap();
+        assert_eq!(
+            limiter.try_accept(source).unwrap_err(),
+            RefusedReason::HandshakesPerSource
+        );
+
+        first.handshake_done();
+        let _second = limiter
+            .try_accept(source)
+            .expect("the handshake slot was returned");
+
+        // Idempotent: a second call must not double-release into an underflow
+        // that hands out free slots forever.
+        first.handshake_done();
+        first.handshake_done();
+        assert_eq!(
+            limiter.try_accept(source).unwrap_err(),
+            RefusedReason::HandshakesPerSource,
+            "the second connection still holds the only handshake slot"
+        );
+    }
+
+    /// Trunks and monitoring must never be refused: an outage caused by our own
+    /// ceiling on a carrier interconnect is worse than anything it prevents.
+    #[test]
+    fn trusted_sources_are_never_refused() {
+        let limiter = Arc::new(ConnectionLimiter::new(
+            limits(1, 1, 1, 1),
+            &["198.51.100.0/24".to_string()],
+        ));
+        let trunk = ip("198.51.100.7");
+        let held: Vec<_> = (0..64)
+            .map(|_| limiter.try_accept(trunk).expect("trusted is exempt"))
+            .collect();
+        assert_eq!(held.len(), 64);
+        // And an exempt source consumes none of the global budget that protects
+        // everyone else.
+        assert!(limiter.try_accept(ip("203.0.113.80")).is_ok());
+    }
+
+    /// A disabled ceiling must cost nothing — in particular it must not keep a
+    /// row per source that has ever connected.
+    #[test]
+    fn zero_means_unlimited_and_tracks_no_per_source_state() {
+        let limiter = Arc::new(ConnectionLimiter::new(limits(0, 0, 0, 0), &[]));
+        let held: Vec<_> = (0..1000)
+            .map(|index| {
+                limiter
+                    .try_accept(ip(&format!("203.0.113.{}", index % 250)))
+                    .expect("unlimited")
+            })
+            .collect();
+        assert_eq!(limiter.tracked_sources(), (0, 0));
+        drop(held);
+    }
+
+    /// Steady-state allocation check for the two per-source maps: they are
+    /// keyed by a live entity, so a row that outlives its connection is a leak
+    /// that grows with every source ever seen. Drives complete accept/release
+    /// cycles and asserts both maps return to their starting size.
+    #[test]
+    fn per_source_maps_drain_to_baseline_after_complete_cycles() {
+        let limiter = Arc::new(ConnectionLimiter::new(limits(8, 0, 8, 0), &[]));
+        assert_eq!(limiter.tracked_sources(), (0, 0));
+
+        for round in 0..200u32 {
+            // A fresh source each round is the shape that leaks: a scanner
+            // sweeping a range, or ordinary churn across a subscriber base.
+            let source = ip(&format!("198.51.100.{}", round % 250));
+            let mut permit = limiter.try_accept(source).unwrap();
+            permit.handshake_done();
+            drop(permit);
+        }
+
+        assert_eq!(
+            limiter.tracked_sources(),
+            (0, 0),
+            "every source that finished must leave no row behind"
+        );
+    }
+
+    #[test]
+    fn concurrent_accepts_never_exceed_the_ceiling() {
+        use std::sync::atomic::AtomicUsize;
+        use std::thread;
+
+        const CEILING: u32 = 16;
+        let limiter = Arc::new(ConnectionLimiter::new(limits(0, 0, CEILING, 0), &[]));
+        let source = ip("203.0.113.90");
+        let granted = Arc::new(AtomicUsize::new(0));
+
+        // Every thread takes a slot and holds it, so the ceiling has to be
+        // enforced across threads, not merely within one.
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let limiter = Arc::clone(&limiter);
+                let granted = Arc::clone(&granted);
+                thread::spawn(move || {
+                    let mut held = Vec::new();
+                    for _ in 0..32 {
+                        if let Ok(permit) = limiter.try_accept(source) {
+                            granted.fetch_add(1, Ordering::Relaxed);
+                            held.push(permit);
+                        }
+                    }
+                    held
+                })
+            })
+            .collect();
+
+        let held: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+        assert_eq!(
+            granted.load(Ordering::Relaxed),
+            CEILING as usize,
+            "the ceiling must hold under contention, with no lost or double counts"
+        );
+
+        drop(held);
+        assert_eq!(limiter.tracked_sources(), (0, 0));
+        assert!(limiter.try_accept(source).is_ok());
+    }
+
+    #[test]
+    fn refused_reason_labels_are_stable() {
+        // These are metric label values; renaming one silently breaks a
+        // dashboard or an alert rule.
+        assert_eq!(
+            RefusedReason::HandshakesPerSource.as_str(),
+            "handshakes_per_source"
+        );
+        assert_eq!(RefusedReason::Handshakes.as_str(), "handshakes");
+        assert_eq!(
+            RefusedReason::ConnectionsPerSource.as_str(),
+            "connections_per_source"
+        );
+        assert_eq!(RefusedReason::Connections.as_str(), "connections");
+    }
+
+    #[test]
+    fn default_ceilings_are_the_documented_ones() {
+        let defaults = ConnectionLimits::default();
+        assert_eq!(defaults.max_handshakes_per_source, 32);
+        assert_eq!(defaults.max_handshakes, 1024);
+        assert_eq!(defaults.max_connections_per_source, 256);
+        assert_eq!(defaults.max_connections, 16_384);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1136,6 +1136,36 @@ impl SiphonServer {
         crate::security::set_max_message_bytes(max_message_bytes);
         debug!(max_message_bytes, "stream message-size ceiling installed");
 
+        // --- Inbound connection ceilings ---
+        // Also always installed, and for the same reason: nothing else bounds
+        // how many connections or concurrent handshakes one source can make
+        // siphon carry, and a TLS handshake is real CPU held for the whole
+        // handshake timeout. `trusted_cidrs` are exempt so a trunk or a
+        // monitoring probe is never refused.
+        let connection_limits_config = config
+            .security
+            .as_ref()
+            .map(|sec| sec.connection_limits.clone())
+            .unwrap_or_default();
+        let trusted_cidrs = config
+            .security
+            .as_ref()
+            .map(|sec| sec.trusted_cidrs.clone())
+            .unwrap_or_default();
+        let connection_limits = crate::security::ConnectionLimits::from(&connection_limits_config);
+        crate::security::set_connection_limiter(Arc::new(crate::security::ConnectionLimiter::new(
+            connection_limits,
+            &trusted_cidrs,
+        )));
+        info!(
+            max_handshakes_per_source = connection_limits.max_handshakes_per_source,
+            max_handshakes = connection_limits.max_handshakes,
+            max_connections_per_source = connection_limits.max_connections_per_source,
+            max_connections = connection_limits.max_connections,
+            trusted_cidrs = trusted_cidrs.len(),
+            "inbound connection ceilings installed (0 = unlimited)"
+        );
+
         // --- Auto-ban (failed_auth_ban scanner protection) ---
         // Opt-in: only installed when configured. Once installed, the auth path
         // (challenge/success), the dispatcher (non-ACK INVITE Timer H), and the
@@ -1148,6 +1178,7 @@ impl SiphonServer {
                     fab.ban_duration_secs,
                     &sec.trusted_cidrs,
                     fab.strong_signal_weight,
+                    fab.missing_credentials_weight,
                 ));
                 crate::security::set_auto_ban(Arc::clone(&store));
                 if let Some(ref firewall) = kernel_firewall {
@@ -1158,6 +1189,7 @@ impl SiphonServer {
                     window_secs = fab.window_secs,
                     ban_duration_secs = fab.ban_duration_secs,
                     strong_signal_weight = fab.strong_signal_weight,
+                    missing_credentials_weight = fab.missing_credentials_weight,
                     trusted_cidrs = sec.trusted_cidrs.len(),
                     "failed_auth_ban scanner protection enabled"
                 );

--- a/src/transport/mux.rs
+++ b/src/transport/mux.rs
@@ -136,6 +136,19 @@ pub async fn listen(
                 debug!("{sip_transport}+{websocket_transport} mux rejected {remote_addr} by ACL");
                 continue;
             }
+            // See the TLS listener for why this is taken here, before the spawn,
+            // and dropped silently rather than banned.
+            let permit = match crate::security::try_accept_connection(remote_addr.ip()) {
+                Ok(permit) => permit,
+                Err(reason) => {
+                    debug!(
+                        "{sip_transport}+{websocket_transport} mux refused {remote_addr} by \
+                         connection limit: {reason}"
+                    );
+                    crate::security::record_connection_refused(reason);
+                    continue;
+                }
+            };
             configure_tcp_socket(&tcp_stream, tos);
 
             // Read the *current* acceptor — it may have been swapped by the
@@ -177,6 +190,7 @@ pub async fn listen(
                             (Transport::Tls, Transport::WebSocketSecure),
                             local_addr,
                             remote_addr,
+                            permit,
                             inbound_tx,
                             sip_connection_map,
                             websocket_connection_map,
@@ -193,6 +207,7 @@ pub async fn listen(
                             (Transport::Tcp, Transport::WebSocket),
                             local_addr,
                             remote_addr,
+                            permit,
                             inbound_tx,
                             sip_connection_map,
                             websocket_connection_map,
@@ -216,6 +231,10 @@ async fn dispatch<S>(
     transports: (Transport, Transport),
     local_addr: SocketAddr,
     remote_addr: SocketAddr,
+    // Connection slot taken at accept. Released when this function returns,
+    // so it covers the sniff and then the whole connection, whichever protocol
+    // won.
+    mut permit: crate::security::AcceptPermit,
     inbound_tx: flume::Sender<InboundMessage>,
     sip_connection_map: Arc<DashMap<ConnectionId, mpsc::Sender<Bytes>>>,
     websocket_connection_map: Arc<DashMap<ConnectionId, mpsc::Sender<Bytes>>>,
@@ -238,6 +257,9 @@ async fn dispatch<S>(
             return;
         }
     };
+    // Protocol decided: the handshake slot goes back, the connection slot stays
+    // held by `permit` until this function returns.
+    permit.handshake_done();
 
     let connection_id = next_connection_id();
     match protocol {
@@ -274,6 +296,9 @@ async fn dispatch<S>(
                 connection_id,
                 local_addr,
                 remote_addr,
+                // Hands the connection slot on; its handshake half was already
+                // released above, and `handshake_done` is idempotent.
+                permit,
                 inbound_tx,
                 websocket_connection_map,
                 stream_connections,

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -71,6 +71,17 @@ pub async fn listen(
                         debug!("TCP rejected {} by ACL", remote_addr);
                         continue;
                     }
+                    // See the TLS listener for why this is taken here, before
+                    // the spawn, and dropped silently rather than banned.
+                    let mut permit = match crate::security::try_accept_connection(remote_addr.ip())
+                    {
+                        Ok(permit) => permit,
+                        Err(reason) => {
+                            debug!("TCP refused {} by connection limit: {reason}", remote_addr);
+                            crate::security::record_connection_refused(reason);
+                            continue;
+                        }
+                    };
                     let inbound_tx = inbound_tx.clone();
                     let connection_map = connection_map.clone();
 
@@ -92,6 +103,9 @@ pub async fn listen(
                         else {
                             return;
                         };
+                        // Confirmed SIP: the handshake slot goes back, the
+                        // connection slot stays with `permit` below.
+                        permit.handshake_done();
 
                         let connection_id = next_connection_id();
                         debug!("TCP accepted {} as {:?}", remote_addr, connection_id);
@@ -213,8 +227,7 @@ pub(crate) fn classify_incomplete_stream(buffer: &[u8]) -> StreamVerdict {
     // Wait for the first line to complete before judging its request/status shape.
     match buffer.windows(2).position(|window| window == b"\r\n") {
         Some(line_end) => {
-            let line = &buffer[..line_end];
-            if line.starts_with(b"SIP/2.0 ") || line.ends_with(b" SIP/2.0") {
+            if is_sip_start_line(&buffer[..line_end]) {
                 StreamVerdict::MaybeSip
             } else {
                 StreamVerdict::Garbage
@@ -224,6 +237,17 @@ pub(crate) fn classify_incomplete_stream(buffer: &[u8]) -> StreamVerdict {
         // (bounded by the size cap above and the connection idle timeout).
         None => StreamVerdict::MaybeSip,
     }
+}
+
+/// Whether `line` is a SIP start-line — a request-line (RFC 3261 §7.1) or a
+/// status-line (§7.2).
+///
+/// RFC 3261 permits extension methods, so the method token is deliberately not
+/// checked against a list: a request-line qualifies while it ends with
+/// ` SIP/2.0`, and a status-line while it starts with `SIP/2.0 `. Anything else
+/// with a complete first line is not SIP.
+pub(crate) fn is_sip_start_line(line: &[u8]) -> bool {
+    line.starts_with(b"SIP/2.0 ") || line.ends_with(b" SIP/2.0")
 }
 
 /// Verdict for one framing attempt over a stream accumulator.
@@ -261,11 +285,33 @@ pub fn frame_sip_message(buffer: &[u8], max_message_bytes: usize) -> FrameVerdic
             StreamVerdict::Garbage => FrameVerdict::Garbage,
         };
     };
+    // A complete header block is not the same thing as a SIP message. An HTTP
+    // request block also ends `\r\n\r\n`, and `extract_sip_message_length`
+    // defaults a missing `Content-Length` to zero, so a scanner's `GET /` frames
+    // as a complete "message" and reaches the parser — which has no connection
+    // to close and no source to count. The start line has to be judged here, on
+    // every message, because the sniff at accept
+    // ([`super::stream::sniff_stream`]) judges only the connection's *first*
+    // line and assumes SIP for a peer that stays silent past its window, so a
+    // probe that waits before speaking skips it entirely.
+    //
+    // Before the size check below: a non-SIP block that declares a huge
+    // `Content-Length` is garbage, not an oversized SIP message owed a 513.
+    let prefix = crate::sip::parser::leading_crlf_len(buffer);
+    let first_line_end = buffer[prefix..]
+        .windows(2)
+        .position(|window| window == b"\r\n")
+        .map(|end| prefix + end)
+        // Unreachable: `extract_sip_message_length` returned `Some`, so a
+        // `\r\n\r\n` exists past the prefix. Refuse rather than index blindly.
+        .unwrap_or(buffer.len());
+    if !is_sip_start_line(&buffer[prefix..first_line_end]) {
+        return FrameVerdict::Garbage;
+    }
     if len > max_message_bytes {
         // Safe: `extract_sip_message_length` returned `Some`, so `\r\n\r\n`
         // is present and the header block is fully buffered. Measured past any
         // leading CRLF keepalives, exactly as the length above was.
-        let prefix = crate::sip::parser::leading_crlf_len(buffer);
         let header_len = buffer[prefix..]
             .windows(4)
             .position(|window| window == b"\r\n\r\n")
@@ -603,9 +649,9 @@ mod tests {
     }
 
     /// The pre-existing `classify_incomplete_stream` guards still fire through
-    /// the new entry point, unchanged: they apply only while the header block
-    /// is incomplete (a buffer that already holds `\r\n\r\n` frames as a
-    /// message and is judged further up the stack).
+    /// this entry point, unchanged, while the header block is incomplete. A
+    /// buffer that already holds `\r\n\r\n` is judged by the start-line check
+    /// instead — see [`http_request_block_is_garbage_not_a_message`].
     #[test]
     fn frame_sip_message_preserves_garbage_classification() {
         // A complete non-SIP first line, still mid-header-block.
@@ -627,6 +673,104 @@ mod tests {
         let mut flood = b"INVITE sip:bob@example.com SIP/2.0\r\n".to_vec();
         flood.resize(MAX_INCOMPLETE_HEADER_BYTES + 1, b'x');
         assert_eq!(frame_sip_message(&flood, CEILING), FrameVerdict::Garbage);
+    }
+
+    /// The probe this check exists to stop. A *complete* HTTP request block
+    /// satisfies `extract_sip_message_length` — it ends `\r\n\r\n` and carries
+    /// no `Content-Length`, which defaults to zero — so before the start-line
+    /// check it framed as a complete "message", reached the dispatcher, and was
+    /// rejected only by the parser, which has no connection to close and no
+    /// source to record. A scanner could probe indefinitely over one connection.
+    ///
+    /// It is not caught by the accept-time sniff either: that judges only the
+    /// connection's first line and assumes SIP for a peer that sends nothing
+    /// inside its window, so a probe that connects, waits, then speaks skips it.
+    #[test]
+    fn http_request_block_is_garbage_not_a_message() {
+        for probe in [
+            &b"GET / HTTP/1.1\r\nHost: sip.example.com:443\r\n\r\n"[..],
+            &b"GET / HTTP/1.0\r\n\r\n"[..],
+            &b"POST /phpinfo.php HTTP/1.1\r\nContent-Length: 0\r\n\r\n"[..],
+            // No recognisable protocol at all, but a well-formed header block.
+            &b"hello world\r\n\r\n"[..],
+        ] {
+            assert_eq!(
+                frame_sip_message(probe, CEILING),
+                FrameVerdict::Garbage,
+                "expected Garbage for {:?}",
+                String::from_utf8_lossy(probe)
+            );
+        }
+    }
+
+    /// Leading CRLF keepalives (RFC 5626 §4.4.1) must not hide the start line
+    /// from the check. The inbound readers drain them first, but the outbound
+    /// pool frames straight off its accumulator, so the start line is measured
+    /// past the same prefix the length is.
+    #[test]
+    fn http_request_block_behind_crlf_keepalives_is_garbage() {
+        assert_eq!(
+            frame_sip_message(b"\r\n\r\nGET / HTTP/1.1\r\nHost: x\r\n\r\n", CEILING),
+            FrameVerdict::Garbage
+        );
+    }
+
+    /// A non-SIP block declaring a huge body is garbage, not an oversized SIP
+    /// message: the start-line check runs before the ceiling, so the peer is
+    /// disconnected rather than answered 513 (which would need a Via it has not
+    /// got, and would fingerprint the port to a scanner).
+    #[test]
+    fn non_sip_block_declaring_a_huge_body_is_garbage_not_oversized() {
+        assert_eq!(
+            frame_sip_message(
+                b"GET / HTTP/1.1\r\nContent-Length: 4000000000\r\n\r\n",
+                CEILING
+            ),
+            FrameVerdict::Garbage
+        );
+    }
+
+    /// Every legitimate start-line shape still frames. RFC 3261 §7.1 permits
+    /// extension methods, so the method token is never checked against a list —
+    /// only the ` SIP/2.0` tail (request) or `SIP/2.0 ` head (status).
+    #[test]
+    fn every_sip_start_line_shape_still_frames() {
+        let requests: [&[u8]; 4] = [
+            b"INVITE sip:bob@example.com SIP/2.0\r\nContent-Length: 0\r\n\r\n",
+            b"REGISTER sip:example.com SIP/2.0\r\n\r\n",
+            // Extension method (RFC 6086 INFO is registered; an unregistered
+            // token must frame just the same).
+            b"FROBNICATE sip:bob@example.com SIP/2.0\r\n\r\n",
+            b"SIP/2.0 200 OK\r\nContent-Length: 0\r\n\r\n",
+        ];
+        for message in requests {
+            assert_eq!(
+                frame_sip_message(message, CEILING),
+                FrameVerdict::Complete { len: message.len() },
+                "expected Complete for {:?}",
+                String::from_utf8_lossy(message)
+            );
+        }
+
+        // With a body, and behind keepalive CRLFs.
+        let with_body = b"\r\nSIP/2.0 200 OK\r\nContent-Length: 4\r\n\r\nAAAA";
+        assert_eq!(
+            frame_sip_message(with_body, CEILING),
+            FrameVerdict::Complete {
+                len: with_body.len()
+            }
+        );
+    }
+
+    #[test]
+    fn is_sip_start_line_accepts_requests_and_status_lines_only() {
+        assert!(is_sip_start_line(b"INVITE sip:bob@example.com SIP/2.0"));
+        assert!(is_sip_start_line(b"SIP/2.0 486 Busy Here"));
+        assert!(!is_sip_start_line(b"GET / HTTP/1.1"));
+        assert!(!is_sip_start_line(b"SIP/2.0"));
+        assert!(!is_sip_start_line(b""));
+        // A URI that merely mentions the token is not a start line.
+        assert!(!is_sip_start_line(b"Via: SIP/2.0/TCP host"));
     }
 
     /// The ceiling counts headers *and* body, so a message whose header block

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -544,6 +544,21 @@ pub async fn listen(
                         debug!("TLS rejected {} by ACL", remote_addr);
                         continue;
                     }
+                    // Take the connection + handshake slots before spawning, so
+                    // a refusal costs one accept() and nothing else — no task,
+                    // no TLS handshake, no CPU. Dropped silently: a port that
+                    // answers a probe fingerprints itself, and this is not a ban
+                    // signal (a NAT whose UEs all re-register after a flap is
+                    // bursty, not abusive).
+                    let mut permit = match crate::security::try_accept_connection(remote_addr.ip())
+                    {
+                        Ok(permit) => permit,
+                        Err(reason) => {
+                            debug!("TLS refused {} by connection limit: {reason}", remote_addr);
+                            crate::security::record_connection_refused(reason);
+                            continue;
+                        }
+                    };
                     // Read the *current* acceptor — it may have been swapped
                     // by the hot-reload watcher since the previous accept().
                     let acceptor = (**acceptor.load()).clone();
@@ -591,6 +606,10 @@ pub async fn listen(
                         else {
                             return;
                         };
+                        // Confirmed SIP: give the handshake slot back. The
+                        // connection slot stays with `permit` for the life of
+                        // the connection below.
+                        permit.handshake_done();
 
                         let connection_id = next_connection_id();
                         debug!("TLS accepted {} as {:?}", remote_addr, connection_id);

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -15,7 +15,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::config::TlsServerConfig;
 use crate::transport::acl::TransportAcl;
@@ -38,6 +38,9 @@ pub(crate) async fn handle_connection<S: AsyncRead + AsyncWrite + Unpin + Send +
     connection_id: ConnectionId,
     local_addr: SocketAddr,
     remote_addr: SocketAddr,
+    // Connection slot taken at accept. Released when this function returns,
+    // so it covers the upgrade and then the whole connection.
+    mut permit: crate::security::AcceptPermit,
     inbound_tx: flume::Sender<InboundMessage>,
     connection_map: Arc<DashMap<ConnectionId, mpsc::Sender<Bytes>>>,
     stream_connections: StreamConnections,
@@ -84,6 +87,9 @@ pub(crate) async fn handle_connection<S: AsyncRead + AsyncWrite + Unpin + Send +
             return;
         }
     };
+    // Upgrade complete: give the handshake slot back, keep the connection slot
+    // for the life of this function.
+    permit.handshake_done();
 
     let (mut ws_sink, mut ws_source) = ws_stream.split();
 
@@ -217,6 +223,16 @@ pub async fn listen(
                     if !acl.is_allowed(remote_addr.ip()) {
                         continue;
                     }
+                    // See the TLS listener for why this is taken here, before
+                    // the spawn, and dropped silently rather than banned.
+                    let permit = match crate::security::try_accept_connection(remote_addr.ip()) {
+                        Ok(permit) => permit,
+                        Err(reason) => {
+                            debug!("WS refused {remote_addr} by connection limit: {reason}");
+                            crate::security::record_connection_refused(reason);
+                            continue;
+                        }
+                    };
                     let connection_id = next_connection_id();
                     let inbound_tx = inbound_tx.clone();
                     let connection_map = connection_map.clone();
@@ -234,6 +250,7 @@ pub async fn listen(
                             connection_id,
                             local,
                             remote_addr,
+                            permit,
                             inbound_tx,
                             connection_map,
                             stream_connections,
@@ -292,6 +309,16 @@ pub async fn listen_secure(
                     if !acl.is_allowed(remote_addr.ip()) {
                         continue;
                     }
+                    // See the TLS listener for why this is taken here, before
+                    // the spawn, and dropped silently rather than banned.
+                    let permit = match crate::security::try_accept_connection(remote_addr.ip()) {
+                        Ok(permit) => permit,
+                        Err(reason) => {
+                            debug!("WSS refused {remote_addr} by connection limit: {reason}");
+                            crate::security::record_connection_refused(reason);
+                            continue;
+                        }
+                    };
                     // Hot-reloadable acceptor — read the live one each accept.
                     let acceptor = (**acceptor.load()).clone();
                     let inbound_tx = inbound_tx.clone();
@@ -322,6 +349,7 @@ pub async fn listen_secure(
                             connection_id,
                             local,
                             remote_addr,
+                            permit,
                             inbound_tx,
                             connection_map,
                             stream_connections,


### PR DESCRIPTION
Three defects found reading 24 hours of logs from a public-facing edge (TLS on 443, UDP restricted to trunks). All three are in siphon, not in that deployment's config, and all three had already fired.

## 1. A live subscriber address was auto-banned for an hour

```
auto-ban: source banned (repeated auth failures) source=<subscriber> credentials_present=false
```

That address registers and dials all day. A challenge issued because the request carried no `Authorization` is the RFC 3261 §22.2 opening leg of challenge-response — every client sends one before it has a nonce — and it scored 1, so five inside `window_secs` earned an hour-long ban. Behind CGNAT that address is shared, so the ban lands on every subscriber behind it, none of whom did anything.

Now weighted by a new `failed_auth_ban.missing_credentials_weight`, **default 0**. Set it to `1` for the previous behaviour. Volume stays visible in `siphon_auth_failures_total` either way, so a scanning campaign is still measurable.

The abuse this was reaching for is caught with far fewer false positives by `scanner_block`, `rate_limit`, apiban, and the non-SIP/handshake signals — none of which a real client trips.

### The worse half of the same defect

`fetch_http_credential` returned the same `None` for *"the backend answered, no such user"* and for *"the backend never answered"*. Both collapsed to `validate_http -> false`, which the challenge arm read as present-but-invalid credentials — the **strong** signal, weight 3. So two REGISTER retries during an auth-backend outage banned a subscriber's address for an hour, which is exactly backwards: during an outage every subscriber retries.

The credential check is now four-way:

| Outcome | Meaning | Ban weight |
|---|---|---|
| `Valid` | verified | resets the counter |
| `Absent` | no credentials — the RFC-mandated first leg | `missing_credentials_weight` (0) |
| `Rejected` | wrong password, denied username, forged/stale/replayed nonce | `strong_signal_weight` (3), or 1 over UDP |
| `Unavailable` | backend timeout / connection failure / no backend configured | **nothing** |

`Unavailable` increments the new `siphon_auth_backend_errors_total`, which is worth an alert of its own — a non-zero rate means authentication is failing into 401s for everyone, and it used to be indistinguishable from a brute-force. `siphon_credential_failures_total` goes back to meaning genuine rejections only.

## 2. An HTTP probe that waits two seconds bypassed the non-SIP detection entirely

`sniff_stream` assumes SIP for a peer that sends nothing within `SNIFF_TIMEOUT` (2 s). That is correct — a connection held open for reuse must not be dropped — but the sniff was the only place a start line was ever judged. Past it, `frame_sip_message` accepted any block ending `\r\n\r\n`, because `extract_sip_message_length` finds the marker and defaults a missing `Content-Length` to zero. So an HTTP request block framed as a complete "message", reached the dispatcher, and died at `SIP parse error` — where there is no connection to close and no source to record.

Connect, wait 3 s, send `GET /`, repeat forever, entirely free. Four such probes reached the dispatcher in the sample, from a rotating /16.

`frame_sip_message` now checks the start line is a SIP request-line or status-line (RFC 3261 §7.1/§7.2 — extension methods still accepted), before the size check so a non-SIP block declaring a huge `Content-Length` is refused as garbage rather than answered 513. Everything downstream was already wired: the existing `FrameVerdict::Garbage` arm closes the connection and records the strong signal.

UDP is untouched — a UDP source is spoofable, and UDP does not frame.

**Behaviour change worth calling out:** a peer that sends a well-formed-looking block with a non-SIP start line now loses its connection instead of having one message dropped by the parser. That includes the outbound pool, which closes (as it already did for other garbage) without recording anything against a trunk.

## 3. Nothing bounded concurrent connections or handshakes

No per-source cap, no global cap, no limit around the TLS handshake. One address ran ~50 simultaneous connections, each pinning a task for the full 10 s `TLS_HANDSHAKE_TIMEOUT`. The auto-ban cannot help: it needs *completed* failures, and these never complete.

`security.connection_limits`, always on, every field defaulting, `0` disables any one:

```yaml
security:
  connection_limits:
    max_handshakes_per_source: 32
    max_handshakes: 1024
    max_connections_per_source: 256
    max_connections: 16384
```

In-flight handshakes and established connections are counted separately because they are abused differently. A handshake is CPU held briefly and no legitimate client has many at once, so that ceiling is tight. An established connection is a socket held until the peer leaves or the 300 s idle timeout reaps it, and a busy NAT legitimately holds many, so that one is loose. `AcceptPermit::handshake_done()` releases the tight half as soon as the connection is confirmed to speak SIP; `Drop` releases the rest, so no accept path can leak a slot by returning early.

Refused connections are dropped silently and are **not** banned. Hitting a concurrency ceiling is a capacity fact, not proof of intent — a NAT whose UEs all re-register after a network flap looks exactly like a flood — and the ceiling has already done the protective work. `trusted_cidrs` are exempt from both ceilings, so a trunk or a monitoring probe is never refused.

> ### `max_connections_per_source` and carrier NAT
> A CGNAT pool or large enterprise NAT can legitimately front more than 256 registrations from one address. The default is a runaway detector, not a policy — raise it or set `0` where that is the topology. `siphon_connections_refused_total{reason="connections_per_source"}` is what says it is binding on real traffic before the support tickets do. Documented in `siphon.yaml`, the cookbook and the config rustdoc rather than left for someone to discover.

New metrics: `siphon_connections_refused_total{reason}`, `siphon_stream_connections_active`, `siphon_handshakes_in_flight`.

## Tests

- **`security.rs`** — both ceilings per-source and global, `handshake_done` releasing only the handshake half (and being idempotent), trusted exempt, `0` meaning unlimited *without* allocating a per-source row, and a `Arc` + `thread::spawn` contention test asserting the ceiling holds exactly under 8 threads racing.
- **Steady-state leak test for the limiter's two `DashMap`s**, per project policy: 200 accept/release cycles across changing sources must return both maps to their starting `len()`. `record_missing_credentials` at weight 0 likewise creates no `failures` row, so a scanner sweeping a range cannot grow the map through a signal nothing acts on.
- **`transport/tcp.rs`** — an HTTP request block is `Garbage`, so is one behind leading CRLF keepalives, and so is a non-SIP block declaring a huge body (`Garbage`, not `Oversized`); request-lines, status-lines, extension methods and bodies all still frame `Complete`.
- **`script/api/auth.rs`** — an unreachable backend is `Unavailable`, a wrong password and a malformed header stay `Rejected`, an undispatchable backend is `Unavailable`.
- New `framing` criterion group in `benches/sip_hot_path.rs`: `frame_sip_message` is per-message on every stream transport and this change adds work to it, and nothing benched it before. **Its `benches/baseline.json` entry still needs recording on the reference machine** — not committed from here, since a baseline measured on the wrong hardware is worse than none.

`cargo test` 4515 passed, `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Verified live

Against a local instance, because the listener wiring is four near-identical accept-loop call sites and a unit test for it would have to own the process-global limiter and would go flaky against the other listener tests:

- **Delayed HTTP probe** — connect, sleep past the 2 s sniff, send `GET /`. Connection closed both times, `non-SIP bytes ... dropping connection`, `malformed_messages_total 2`, and the second probe crossed the threshold: `auto-ban: source banned (non-SIP bytes on stream)`. Nothing reached the dispatcher.
- **Both ceilings** — 5 silent connections against `max_handshakes_per_source: 2` left 2 open and refused 3 with `reason="handshakes_per_source"`; 5 SIP-speaking connections against `max_connections_per_source: 3` served 3 and refused 2 with `reason="connections_per_source"`, confirming a connection that speaks SIP gives its handshake slot back. Both gauges returned to 0.
- **Auth-backend outage** — four credentialed REGISTERs against a dead backend port: ban list empty, `banned_ips 0`, `credential_failures_total 0`, `auth_backend_errors_total 4`. Under the previous behaviour the second one banned the source for an hour.

## Not done here

The 16-row SIPp baseline and `mem_leak_test.sh`. `frame_sip_message` is on the per-message path so the pair is owed before this merges, and it wants the reference machine and a quiet box.
