### PR TITLE
fix(b2bua): Referred-By on the INVITE a terminated transfer triggers, and ACK a target that refuses

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -780,6 +780,31 @@ jobs:
         if: always()
         run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-terminate rm -sf sipp-b2bua-refer-terminate-uac sipp-b2bua-refer-terminate-bob-uas sipp-b2bua-refer-terminate-carol-uas 2>/dev/null || true
 
+      # Graded per leg for the same reason as the referrer-BYE step below: on a
+      # FAILED transfer the referrer and the surviving leg both complete their
+      # scenarios cleanly, and the whole of the damage lands on the transfer
+      # target — a `Referred-By` that never arrived, and a 486 that is never
+      # ACKed. `--exit-code-from` on the UAC alone reports green over both.
+      - name: B2BUA REFER terminate, target refuses (RFC 3892 §3 Referred-By + RFC 3261 §17.1.1.3 ACK)
+        run: |
+          docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-terminate-busy up \
+            sipp-b2bua-refer-terminate-busy-uac \
+            sipp-b2bua-refer-terminate-busy-bob-uas \
+            sipp-b2bua-refer-terminate-busy-carol-uas
+          status=0
+          for service in uac bob-uas carol-uas; do
+            code=$(docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-terminate-busy \
+              ps -a --format '{{.Service}} {{.ExitCode}}' \
+              | awk -v s="sipp-b2bua-refer-terminate-busy-$service" '$1 == s { print $2 }')
+            echo "sipp-b2bua-refer-terminate-busy-$service exit=$code"
+            if [ "$code" != "0" ]; then status=1; fi
+          done
+          exit $status
+
+      - name: Cleanup terminate-busy containers
+        if: always()
+        run: docker compose -f sipp/docker-compose.yaml --profile b2bua-refer-terminate-busy rm -sf sipp-b2bua-refer-terminate-busy-uac sipp-b2bua-refer-terminate-busy-bob-uas sipp-b2bua-refer-terminate-busy-carol-uas 2>/dev/null || true
+
       # Every leg is graded, NOT just the UAC. The referrer completes its own
       # scenario cleanly even when the transfer is broken — the damage lands on
       # the surviving leg (an unexpected BYE) and on the transfer target (a 200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,30 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
   Read-only, no new state, no behaviour change.
 
+### Fixed
+- **The INVITE a siphon-terminated transfer triggers now carries the REFER's
+  `Referred-By` (RFC 3892 §3).** That INVITE is built from the referrer's own
+  INVITE as a dial template, and `Referred-By` lives on the REFER rather than on
+  that template, so it was dropped — the transfer target was never told on whose
+  authority it was being called. It matters most on a REFER that carries no
+  `Replaces`: there it is the only thing tying the triggered INVITE back to the
+  referral, so a referrer that holds the consultation leg itself and expects the
+  triggered INVITE to come back to it has nothing to correlate on and answers it
+  as an unrelated new call. A stale `Referred-By` inherited from the template —
+  a call that itself arrived as a transfer — is now cleared rather than passed
+  on as this referral's, so a chained transfer stops naming the previous
+  referrer.
+- **A transfer target that refuses is now ACKed (RFC 3261 §17.1.1.3).** The
+  transfer-target response interception returns before the ordinary B-leg
+  failure handling, which is where every other B-leg non-2xx is ACKed, so
+  nothing ACKed this one: siphon reported the failure to the referrer on the
+  implicit subscription and moved on while the target retransmitted its final
+  response for the full 32 s of Timer H. The referrer and the surviving leg both
+  complete normally when this happens, which is why nothing upstream noticed —
+  the whole of the damage lands on the target. Covered end to end by a new SIPp
+  acceptance scenario (`b2bua-refer-terminate-busy`) that grades all three legs
+  and pins both fixes.
+
 ## [1.8.1] — 2026-09-04
 
 ### Security

--- a/sipp/b2bua_refer_terminate_busy_bob_uas.xml
+++ b/sipp/b2bua_refer_terminate_busy_bob_uas.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated, target refuses — Bob, the surviving far leg:
+  Receive INVITE → 180 → 200 → ACK → receive BYE → 200.
+
+  The transfer target answers 486, so the transfer never completes: Bob is
+  never re-INVITEd at a new target and the original call is kept intact. It
+  ends the ordinary way, when the referrer hangs up.
+-->
+<scenario name="B2BUA REFER terminate busy Bob UAS">
+
+  <recv request="INVITE" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag01[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv request="ACK" optional="true" timeout="5000" />
+
+  <recv request="BYE" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+</scenario>

--- a/sipp/b2bua_refer_terminate_busy_carol_uas.xml
+++ b/sipp/b2bua_refer_terminate_busy_carol_uas.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated, target REFUSES — Carol, the transfer target:
+  Receive INVITE (siphon dials carol after the terminate REFER) → 180 → 486
+  Busy Here → receive ACK.
+
+  Two regressions live in this one scenario, both on the path that only runs
+  when a siphon-terminated transfer FAILS:
+
+  1. `Referred-By` (RFC 3892 §3) must be on the INVITE the referral triggered.
+     The transfer INVITE is built from the referrer's own INVITE as a template
+     and the referrer's `Referred-By` is on the REFER, not on that template, so
+     it used to be dropped — leaving the target no way to see on whose
+     authority it was called, and leaving a referrer that expects the triggered
+     INVITE back with nothing to correlate it against.
+
+  2. The 486 must be ACKed (RFC 3261 §17.1.1.3). The transfer-target response
+     interception returns before the ordinary B-leg failure handling, which is
+     where every other B-leg non-2xx is ACKed, so nothing ACKed this one and
+     the target retransmitted its final response for the full 32 s of Timer H
+     while siphon had already reported the failure and moved on.
+
+  The 486 is sent with retrans, so a missing ACK fails the call here rather
+  than passing quietly.
+-->
+<scenario name="B2BUA REFER terminate busy Carol UAS">
+
+  <recv request="INVITE" crlf="true">
+    <action>
+      <!-- check_it: the call fails unless the referrer's identity arrived. -->
+      <ereg regexp="sip:alice@"
+            search_in="hdr"
+            header="Referred-By:"
+            check_it="true"
+            assign_to="referred_by" />
+      <log message="Referred-By reached the transfer target: [$referred_by]" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:carol@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <!--
+    retrans: SIPp keeps re-sending this final response until it is ACKed. An
+    un-ACKed 486 therefore times out the recv below and fails the run, which is
+    exactly the regression being pinned.
+  -->
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 486 Busy Here
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTag02[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv request="ACK" timeout="5000" crlf="true" />
+
+</scenario>

--- a/sipp/b2bua_refer_terminate_busy_uac.xml
+++ b/sipp/b2bua_refer_terminate_busy_uac.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA REFER siphon-terminated, target refuses — Alice, the referrer:
+  INVITE → 200 → ACK
+  → REFER (X-Refer-Mode: terminate, Refer-To: carol, Referred-By: alice) → 202
+  → NOTIFY (sipfrag 100 Trying) → 200
+  → NOTIFY (sipfrag 486 Busy Here, subscription terminated) → 200
+  → BYE → 200
+
+  The transfer target answers 486. RFC 3515 §2.4.4: siphon reports the outcome
+  on the implicit subscription and the original call is left intact — so unlike
+  the succeeding terminate scenario there is no BYE from siphon here, and
+  Alice, still talking to Bob, hangs up herself at the end.
+
+  `Referred-By` is on the REFER because RFC 3892 §3 puts it on the request the
+  referral triggers; the Carol scenario asserts it arrived.
+-->
+<scenario name="B2BUA REFER terminate busy UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-terminate-busy-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendrecv
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+REFER sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 REFER
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+Refer-To: <sip:carol@172.20.0.54:5060>
+Referred-By: <sip:alice@[local_ip]>
+X-Refer-Mode: terminate
+User-Agent: SIPp/b2bua-refer-terminate-busy-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="202" crlf="true" />
+
+  <!-- sipfrag NOTIFY 100 Trying (siphon-originated). -->
+  <recv request="NOTIFY" crlf="true" />
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Terminating sipfrag NOTIFY carrying the target's 486. -->
+  <recv request="NOTIFY" crlf="true">
+    <action>
+      <ereg regexp="SIP/2.0 486"
+            search_in="body"
+            check_it="true"
+            assign_to="sipfrag_failure" />
+      <log message="transfer failure reported to the referrer: [$sipfrag_failure]" />
+    </action>
+  </recv>
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!--
+    The failed transfer must NOT have torn the call down: Alice is still
+    talking to Bob and ends the call herself. A siphon that released the
+    referrer on a failed transfer would answer this BYE on a dead dialog.
+  -->
+  <pause milliseconds="500" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 3 BYE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-refer-terminate-busy-test
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" crlf="true" />
+
+</scenario>

--- a/sipp/docker-compose.yaml
+++ b/sipp/docker-compose.yaml
@@ -1552,6 +1552,7 @@ services:
     profiles:
       - b2bua-refer-reject
       - b2bua-refer-terminate
+      - b2bua-refer-terminate-busy
       - b2bua-refer-referrer-bye
       - b2bua-refer-attended
       - b2bua-refer-outbound
@@ -1584,6 +1585,7 @@ services:
     profiles:
       - b2bua-refer-reject
       - b2bua-refer-terminate
+      - b2bua-refer-terminate-busy
       - b2bua-refer-referrer-bye
       - b2bua-refer-attended
       - b2bua-refer-outbound
@@ -1721,6 +1723,94 @@ services:
   # --- REFER terminate, referrer hangs up mid-transfer (RFC 5589 §7) ---
   # The Teams blind-transfer ordering: alice REFERs, then BYEs her own dialog
   # while carol is still ringing. bob must survive and be bridged to carol.
+
+  # Same terminate mode, but the transfer target REFUSES (486). Pins two things
+  # that only happen on the failure path: the triggered INVITE carries the
+  # referrer's Referred-By (RFC 3892 §3), and the target's non-2xx final gets
+  # ACKed (RFC 3261 §17.1.1.3) instead of being left to retransmit for Timer H.
+  sipp-b2bua-refer-terminate-busy-bob-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      sipp-b2bua-refer-modes-register:
+        condition: service_completed_successfully
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.52
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_busy_bob_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-terminate-busy
+
+  sipp-b2bua-refer-terminate-busy-carol-uas:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.54
+    entrypoint:
+      - sipp
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_busy_carol_uas.xml
+      - -p
+      - "5060"
+      - -m
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-terminate-busy
+
+  sipp-b2bua-refer-terminate-busy-uac:
+    image: ctaloi/sipp:latest
+    depends_on:
+      siphon-b2bua-refer-modes:
+        condition: service_healthy
+      sipp-b2bua-refer-terminate-busy-bob-uas:
+        condition: service_started
+      sipp-b2bua-refer-terminate-busy-carol-uas:
+        condition: service_started
+    volumes:
+      - .:/sipp/scenarios:ro
+    networks:
+      sipnet:
+        ipv4_address: 172.20.0.53
+    entrypoint:
+      - sipp
+      - "172.20.0.60:5060"
+      - -sf
+      - /sipp/scenarios/b2bua_refer_terminate_busy_uac.xml
+      # Distinct Call-ID space. SIPp's default `%u-%p@%s` renders to the same
+      # string for every UAC in this file — PID is always 1 in a container and
+      # the referrer always runs at .53 — so back-to-back REFER profiles against
+      # the one long-lived siphon would collide, and the second call would be
+      # absorbed as a retransmission of the first.
+      - -cid_str
+      - "busy-%u-%p@%s"
+      - -m
+      - "1"
+      - -l
+      - "1"
+      - -timeout
+      - "30"
+      - -trace_err
+    profiles:
+      - b2bua-refer-terminate-busy
 
   sipp-b2bua-refer-referrer-bye-bob-uas:
     image: ctaloi/sipp:latest

--- a/src/b2bua/transfer.rs
+++ b/src/b2bua/transfer.rs
@@ -179,6 +179,36 @@ pub fn transfer_result_from_response(status_code: u16) -> TransferState {
     }
 }
 
+/// The `Referred-By` (RFC 3892) that the INVITE triggered by a
+/// siphon-terminated transfer must carry, given the `Referred-By` on the REFER
+/// that asked for it.
+///
+/// RFC 3892 §3: the referee SHOULD place the referrer's `Referred-By` on the
+/// request the referral triggers, so the target can see on whose authority it
+/// is being called. On a REFER without `Replaces` it is also the ONLY thing
+/// tying the triggered INVITE back to the referral — a referrer that keeps the
+/// consultation leg itself and expects the INVITE to come back to it has
+/// nothing else to correlate on, and answers it as an unrelated new call.
+///
+/// `Some(value)` is set on the triggered INVITE; `None` means the triggered
+/// INVITE must carry no `Referred-By` at all. `None` is not the same as "leave
+/// whatever is there": the transfer INVITE is built from the referrer's own
+/// INVITE as a template, so an A-leg that itself arrived as a transfer already
+/// carries a `Referred-By` — the PREVIOUS referrer's. Left alone it would name
+/// the wrong party on every transfer after the first in a chain, which is why
+/// the absent case is explicit rather than a no-op.
+///
+/// Whitespace-only is treated as absent (RFC 3261 §7.3.1 allows the surrounding
+/// LWS, and an empty value names nobody).
+pub fn triggered_referred_by(refer_header: Option<&str>) -> Option<String> {
+    let value = refer_header?.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
 /// Validate that a Replaces header matches an existing call.
 ///
 /// Returns `true` if the given call_id and tags match.
@@ -500,5 +530,44 @@ SIP/2.0 200 OK
         };
         assert!(context.refer_to.replaces.is_some());
         assert_eq!(context.initiated_by, TransferSide::BLeg);
+    }
+
+    // ----- Referred-By on the triggered INVITE (RFC 3892 §3) -----
+
+    #[test]
+    fn triggered_referred_by_carries_the_refers_value_verbatim() {
+        // A referrer's Referred-By is opaque: it can carry URI parameters that
+        // only the referrer understands, and they are exactly what a referrer
+        // correlating the triggered INVITE back to its referral reads. Anything
+        // less than verbatim breaks that.
+        let value = "<sip:proxy.example.net:5061;x-ti=11111111-2222-3333-4444-555555555555>";
+        assert_eq!(
+            triggered_referred_by(Some(value)),
+            Some(value.to_string()),
+            "the referrer's Referred-By must reach the target unmodified"
+        );
+    }
+
+    #[test]
+    fn triggered_referred_by_trims_surrounding_whitespace() {
+        // RFC 3261 §7.3.1 allows LWS around a header value; it is not part of it.
+        assert_eq!(
+            triggered_referred_by(Some("  <sip:alice@example.com>\t")),
+            Some("<sip:alice@example.com>".to_string())
+        );
+    }
+
+    #[test]
+    fn triggered_referred_by_absent_when_the_refer_has_none() {
+        assert_eq!(triggered_referred_by(None), None);
+    }
+
+    #[test]
+    fn triggered_referred_by_treats_an_empty_value_as_absent() {
+        // An empty Referred-By names nobody. Reporting it as present would put a
+        // valueless header on the wire AND, worse, suppress the removal of a
+        // stale one inherited from the dial template.
+        assert_eq!(triggered_referred_by(Some("")), None);
+        assert_eq!(triggered_referred_by(Some("   ")), None);
     }
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -18315,6 +18315,35 @@ fn handle_b2bua_response(
             if (200..300).contains(&status_code) {
                 b2bua_complete_terminated_transfer(call_id, target_idx, message, state);
             } else if status_code >= 300 {
+                // RFC 3261 §17.1.1.3 — the INVITE client transaction MUST ACK a
+                // non-2xx final, on the SAME branch. Nothing else on this path
+                // does it: the interception returns before the ordinary B-leg
+                // failure handling below, which is where every other B-leg
+                // non-2xx is ACKed. Without this the target retransmits its
+                // final response for the full 32 s of Timer H — observed on a
+                // transfer whose target answered `486 Busy Here` (11 copies at
+                // T1-doubling to T2) while siphon had already reported the
+                // failure to the referrer and moved on.
+                if let Some((b_dest, b_transport)) = b_leg_dest {
+                    let (ack_via_host, ack_via_port) =
+                        b_leg_sent_by(b_leg_local_addr, state, &b_transport);
+                    let ack = build_b2bua_ack_for_non2xx(
+                        message,
+                        branch,
+                        b_leg_target.as_deref(),
+                        b_transport,
+                        &ack_via_host,
+                        ack_via_port,
+                    );
+                    send_b2bua_to_bleg(ack, b_transport, b_dest, b_leg_local_addr, state);
+                } else {
+                    warn!(
+                        call_id = %call_id,
+                        status = status_code,
+                        "B2BUA REFER (terminate): transfer target failed but its flow is \
+                         unknown — cannot ACK, the target will retransmit until Timer H"
+                    );
+                }
                 b2bua_fail_terminated_transfer(call_id, target_idx, status_code, state);
             } else {
                 debug!(
@@ -27233,6 +27262,13 @@ fn b2bua_refer_accept(
                 _ => (None, None),
             };
 
+            // RFC 3892 §3: the triggered INVITE carries the REFER's own
+            // `Referred-By`. Read here, off the REFER, because the dial template
+            // below is the A-leg INVITE and never had it.
+            let referred_by = crate::b2bua::transfer::triggered_referred_by(
+                message.headers.get("Referred-By").map(String::as_str),
+            );
+
             // Clone the A-leg INVITE as the dial template, but point its To at
             // the Refer-To target (not the original callee). The generic B-leg
             // builder rewrites only the To host, so without this the dialed
@@ -27244,6 +27280,16 @@ fn b2bua_refer_accept(
                     Ok(invite) => {
                         let mut template = invite.clone();
                         template.headers.set("To", format!("<{target_uri}>"));
+                        // A referrer whose own call arrived as a transfer left
+                        // the PREVIOUS referrer's `Referred-By` on this
+                        // template. When the REFER in hand names someone it is
+                        // overwritten by the injection below; when it names
+                        // nobody the stale value has to go, or the target is
+                        // told it was called on the authority of a party that
+                        // has nothing to do with this referral.
+                        if referred_by.is_none() {
+                            template.headers.remove("Referred-By");
+                        }
                         // Offer the survivor's media (anchored or raw) instead of
                         // the referrer's; leave the referrer's body only when no
                         // survivor SDP was available.
@@ -27267,12 +27313,22 @@ fn b2bua_refer_accept(
                     None
                 }
             };
-            // Injected verbatim onto the triggered INVITE. `Replaces` is not a
-            // dialog-defining header for the dialog this INVITE creates — it
-            // references a *different* dialog — so it is safe in this slot.
-            let replaces_extra_headers: Vec<(String, String)> = replaces_header
+            // Injected verbatim onto the triggered INVITE, after the header
+            // policy. Neither `Replaces` nor `Referred-By` is dialog-defining
+            // for the dialog this INVITE creates — both reference something
+            // outside it — so they are safe in this slot.
+            //
+            // After the policy rather than on the template because neither is a
+            // header of the A-leg dialog that the policy governs the crossing
+            // of: they are properties of the referral, and a default-strip
+            // preset dropping them would break the transfer rather than hide an
+            // identity. No shipped preset strips either.
+            let mut triggered_extra_headers: Vec<(String, String)> = replaces_header
                 .map(|replaces| vec![("Replaces".to_string(), replaces.to_string())])
                 .unwrap_or_default();
+            if let Some(value) = referred_by {
+                triggered_extra_headers.push(("Referred-By".to_string(), value));
+            }
 
             let dialed = if let Some(template) = dial_template {
                 b2bua_send_b_leg_invite(
@@ -27288,7 +27344,7 @@ fn b2bua_refer_accept(
                     None,
                     None,
                     None,
-                    replaces_extra_headers.as_slice(),
+                    triggered_extra_headers.as_slice(),
                     state,
                 );
                 true
@@ -27640,8 +27696,14 @@ fn b2bua_complete_terminated_transfer(
 
 /// The dialed transfer target failed (non-2xx). Notify the referrer that the
 /// transfer failed (terminating sipfrag NOTIFY), drop the failed target leg, and
-/// keep the original call intact. The failed INVITE is ACKed by the client
-/// transaction layer (RFC 3261 §17.1.1.3).
+/// keep the original call intact.
+///
+/// The failed INVITE has already been ACKed by the caller (RFC 3261 §17.1.1.3).
+/// It is done there rather than here because the flow the ACK has to go out on
+/// — the target leg's destination, egress socket and Via sent-by — is only in
+/// scope in the response handler; this function sees the call, not the leg's
+/// transport. Do not assume a transaction layer covers it: B2BUA B-legs ACK
+/// their own non-2xx finals explicitly, everywhere on this path.
 fn b2bua_fail_terminated_transfer(
     call_id: &str,
     target_idx: usize,

--- a/src/script/api/ipsec.rs
+++ b/src/script/api/ipsec.rs
@@ -1523,7 +1523,11 @@ mod tests {
         (PyTransform::HmacSha1_96Null, "hmac-sha-1-96", "null"),
         (PyTransform::HmacMd5_96Null, "hmac-md5-96", "null"),
         (PyTransform::HmacSha256_128Null, "hmac-sha-256-128", "null"),
-        (PyTransform::HmacSha1_96AesCbc128, "hmac-sha-1-96", "aes-cbc"),
+        (
+            PyTransform::HmacSha1_96AesCbc128,
+            "hmac-sha-1-96",
+            "aes-cbc",
+        ),
         (PyTransform::HmacMd5_96AesCbc128, "hmac-md5-96", "aes-cbc"),
         (
             PyTransform::HmacSha256_128AesCbc128,


### PR DESCRIPTION
Two bugs on the siphon-terminated REFER path, both of which only show up when
the transfer target is not a plain new call. They were found together and are
fixed together because one masks the other.

## 1. The triggered INVITE lost the REFER's `Referred-By` (RFC 3892 §3)

`b2bua_refer_accept` builds the transfer INVITE by cloning the **referrer's own
INVITE** as a dial template. `Referred-By` is on the REFER, not on that
template, so it never reached the target: the target was not told on whose
authority it was being called, and the only header that identifies the referral
was silently absent.

It matters most on a REFER that carries **no `Replaces`**. There, `Referred-By`
is the only thing tying the triggered INVITE back to the referral — so a
referrer that keeps the consultation leg itself and expects the triggered INVITE
to come back to it has nothing to correlate on, and answers it as an unrelated
new call. That is a live interop shape, not a hypothetical.

Also fixed: a **stale** `Referred-By` inherited from the template. When the
referrer's own call arrived as a transfer, the template already carries the
*previous* referrer's value; left alone, every transfer after the first in a
chain named the wrong party. It is now cleared when the REFER in hand names
nobody.

`Referred-By` and `Replaces` are injected after the header policy, alongside
each other. Neither is a header of the A-leg dialog whose crossing the policy
governs — both are properties of the referral — and a default-strip preset
dropping them would break the transfer rather than hide an identity. No shipped
preset strips either today, so this changes nothing for existing configs.

## 2. A transfer target that refuses was never ACKed (RFC 3261 §17.1.1.3)

The transfer-target response interception in `handle_b2bua_response` returns
before the ordinary B-leg failure handling — which is exactly where every other
B-leg non-2xx is ACKed. Nothing ACKed this one. siphon reported the failure to
the referrer on the implicit subscription and moved on, while the target
retransmitted its final response for the full 32 s of Timer H (T1-doubling to
T2, ~11 copies for a 486).

The doc comment on `b2bua_fail_terminated_transfer` asserted the client
transaction layer covered it. It does not — B2BUA B-legs ACK their own non-2xx
finals explicitly, everywhere else on this path — so the comment is corrected
rather than left to mislead the next reader. The ACK is sent from the response
handler because that is the only place the target leg's destination, egress
socket and Via sent-by are in scope.

## Why neither was caught before

On a failed transfer the referrer and the surviving leg both complete their
scenarios cleanly. The whole of the damage lands on the transfer target, and
there was no acceptance scenario in which the target refused.

## Tests

- New SIPp acceptance profile **`b2bua-refer-terminate-busy`**: the target rings
  and answers `486 Busy Here`, sent with `retrans` so an un-ACKed final fails the
  run rather than passing quietly. It asserts `Referred-By` arrived (`check_it`),
  asserts the referrer gets the terminating sipfrag NOTIFY carrying the 486, and
  asserts the original call survives the failed transfer. All three legs are
  graded, for the reason above.
- Each fix was reverted **individually** against the harness and reproduces its
  own symptom: without fix 1, `Failed regexp match: header Referred-By: not found
  in message INVITE`; without fix 2, `486` sent once, **3 retransmits**, ACK
  `Timeout 1`, target exits non-zero while the other two legs pass.
- Unit tests for the `Referred-By` rule (verbatim, LWS-trimmed, absent, and
  empty-treated-as-absent — the last is what makes the stale-value removal fire).
- `cargo test` 4192 + 362 + 66 green, clippy `-D warnings` clean.
- Existing REFER profiles re-run green against the new binary: `terminate`,
  `attended`, `referrer-bye`, `reject`.
