### PR TITLE
fix(b2bua): fail an undialled b-leg immediately instead of at the ring timeout, and stop blaming carriers for calls they never received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,35 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
   Read-only, no new state, no behaviour change.
 
+- **An LCR failover now leaves a trace, and a record.** A call whose first
+  carrier returned `500` and which then answered on the second showed nothing of
+  it at `log.level: info` — the four lines describing the failover were `debug`,
+  and the only thing kept was `best_error`, a single code that exists to pick
+  what the A-leg gets once every carrier is exhausted. A completed call that
+  burned a carrier on its way recorded that nowhere, so a failing carrier could
+  not be alerted on, trended, or taken to the carrier.
+
+  - Each failed attempt is now recorded against the carrier that was in flight
+    (`carrier_id`, `status`, `elapsed_ms`; a ring timeout as `408`) and reported
+    at `info` along with the advance to the next carrier.
+  - `call.route_attempts` exposes that list to scripts wherever the `Call` is —
+    notably in `@b2bua.on_answer`, so a call that *answered* after failing over
+    can still name what it burned. `call.active_route` is unchanged and still
+    names the winner.
+  - `@b2bua.on_route_failure(call, route, code)` fires once per failed attempt,
+    including the last. It fires for every non-2xx a carrier returns — a
+    definitive `486` as much as a `503` — which is the same set
+    `route_attempts` records, so the two can never disagree; filter on `code`
+    for what you treat as a carrier's fault. Purely a notification: the failover
+    decision is already made and raising in it does not change the call.
+  - With `cdr.auto_emit` on, the attempts are stamped onto the CDR as
+    `lcr_attempts` (a compact JSON array), alongside the winning carrier's
+    existing `cdr_fields`.
+
+  `best_error` is now derived from the attempt list rather than accumulated
+  alongside it, so the code the caller receives and the per-attempt record
+  cannot drift apart. Selection is unchanged (6xx > 5xx > 4xx).
+
 ### Fixed
 - **The INVITE a siphon-terminated transfer triggers now carries the REFER's
   `Referred-By` (RFC 3892 §3).** That INVITE is built from the referrer's own
@@ -52,6 +81,7 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the whole of the damage lands on the target. Covered end to end by a new SIPp
   acceptance scenario (`b2bua-refer-terminate-busy`) that grades all three legs
   and pins both fixes.
+
 
 ## [1.8.1] — 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,40 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
   Read-only, no new state, no behaviour change.
 
+- **`b2bua.log_dial` — report every outbound B-leg INVITE at `info`.** A B2BUA
+  call at `log.level: info` said nothing about where it was dialling. The line
+  existed but was `debug`, which in siphon is a firehose, so the practical
+  options were "no record of the outbound leg" or "everything".
+
+  ```yaml
+  b2bua:
+    log_dial: true      # default false
+  ```
+
+  ```
+  B2BUA: dialling B-leg  call_id=… b_leg_call_id=… ruri=sip:…@carrier
+                         next_hop=Some("sip:198.51.100.7:5060")
+                         destination=198.51.100.7:5060 transport=udp source=…
+  ```
+
+  Off by default: this is one line per call on the busiest path siphon has, and
+  that is an operator's decision rather than an upgrade's. (The LCR failover
+  lines log at `info` unconditionally because they fire only when a carrier
+  fails.)
+
+  It is emitted from the send itself rather than from `call.dial()`, and that is
+  the point. `call.dial()` only records an action the framework executes after
+  the handler returns, so a line written beside it in the script — the workaround
+  this replaces — precedes the dial and still claims it when the destination
+  fails to resolve. By the time this line is emitted, routing, the header
+  policy, the number policy and the LCR tech-prefix / retarget / CLIR steps have
+  all run, so the logged R-URI is the one on the wire rather than the string the
+  script passed, and `b_leg_call_id` is the Call-ID the far end will quote back.
+
+  Covers every B-leg INVITE — `call.dial()`, each `call.fork()` branch, each
+  `call.route()` carrier attempt, and a REFER-terminate re-dial — so it needs no
+  per-call-site opt-in and cannot be missed on one dial path out of three.
+
 - **An LCR failover now leaves a trace, and a record.** A call whose first
   carrier returned `500` and which then answered on the second showed nothing of
   it at `log.level: info` — the four lines describing the failover were `debug`,
@@ -82,6 +116,62 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   acceptance scenario (`b2bua-refer-terminate-busy`) that grades all three legs
   and pins both fixes.
 
+- **A B2BUA call whose B-leg INVITE was never sent no longer costs the caller
+  the full ring timeout.** `b2bua_send_b_leg_invite` returned nothing, so every
+  caller was blind to whether the INVITE had actually reached the transport.
+  When the destination would not resolve it logged a warning and returned, and
+  the answer deadline — already armed — ran its course.
+
+  Measured with a `call.dial()` at a host that does not resolve: siphon knew in
+  0.4 ms, and the caller got ringback for **30.1 s** followed by a misleading
+  `408 Request Timeout`. It now receives `503 Destination Unreachable` in
+  **115 ms**, and `@b2bua.on_failure` fires with it so a script can release
+  whatever the call was holding (Rx / N5 QoS, an anchored media session, an
+  external reservation).
+
+  The proxy already answered `502` the instant a relay target would not resolve;
+  this is the B2BUA half that was missing. Per path:
+
+  - **`call.dial()`** — the A-leg is answered `503` immediately.
+  - **`call.fork()`** — a branch that cannot be sent is simply not a branch, and
+    the others ring as before. Only *all* of them failing fails the call, now at
+    once rather than at the ring timeout.
+  - **`call.route()` / `fork(strategy="sequential")`** — see below.
+  - **REFER-terminate** — the transfer's `dialed` flag was hardcoded `true` next
+    to a discarded result, so a target that would not resolve was treated as
+    dialled and the referrer was BYE'd for a leg that never existed.
+
+  The return value is now `#[must_use]`, so a future caller cannot silently
+  reintroduce this.
+
+- **An LCR sequence now fails over past an unreachable carrier immediately, and
+  stops blaming it.** A carrier whose INVITE never left the box was marked
+  in-flight anyway; the sequence then sat on that carrier's ring timeout before
+  advancing, and recorded the result as a `408` ring timeout against a carrier
+  that never received a packet. With a stale DNS name and a realistic 30 s
+  per-carrier timeout that is 30 s of dead air on every call.
+
+  Measured with an unresolvable first carrier on a 20 s timeout: **5.07 s → 0 s**
+  to reach the second carrier (the whole failover now completes in under a
+  millisecond).
+
+  That false `408` also reached `call.route_attempts`, the CDR's `lcr_attempts`
+  and `@b2bua.on_route_failure` — the figures an operator trends a carrier on,
+  and takes to that carrier. Attempts therefore gained a **`dialed`** field:
+
+  - `dialed: False` means siphon never put an INVITE on the wire for that
+    carrier, so its `status` (`503`) is siphon's verdict on the route rather
+    than the carrier's answer. Filter on it before counting a carrier fault.
+  - A carrier skipped as unroutable (gateway group unknown or entirely down, no
+    explicit next-hop) is now **recorded** as well, instead of being dropped
+    silently — `route_attempts` was meant to name every carrier a sequence
+    burned, and it did not.
+  - `@b2bua.on_route_failure` fires for these too, keeping the hook and the
+    attempt list describing the same set of carriers.
+
+  Existing fields (`carrier_id`, `status`, `elapsed_ms`) are unchanged, and
+  `best_error` selection is unchanged.
+
 
 ## [1.8.1] — 2026-09-04
 
@@ -124,15 +214,6 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   still accepted), so the connection is closed and the source counted as a strong
   `failed_auth_ban` signal wherever the probe arrives. UDP is unchanged — a UDP
   source is spoofable and does not frame.
-
-### Added
-- **An LCR failover now leaves a trace, and a record.** A call whose first
-  carrier returned `500` and which then answered on the second showed nothing of
-  it at `log.level: info` — the four lines describing the failover were `debug`,
-  and the only thing kept was `best_error`, a single code that exists to pick
-  what the A-leg gets once every carrier is exhausted. A completed call that
-  burned a carrier on its way recorded that nowhere, so a failing carrier could
-  not be alerted on, trended, or taken to the carrier.
 
 ### Changed
 - **quick-xml 0.41 → 0.42.** `BytesText` is `str`-backed now, so the reader

--- a/docs/cookbook/least-cost-routing.md
+++ b/docs/cookbook/least-cost-routing.md
@@ -95,8 +95,12 @@ Full example: [`examples/lcr_b2bua.py`](https://github.com/siphon-project/siphon
   `@b2bua.on_failure` fires once, with the last carrier's response.
 - On answer, `call.active_route` is the carrier that won.
 - `call.route_attempts` lists the carriers it **burned** to get there — one
-  entry per failed attempt (`carrier_id`, `status`, `elapsed_ms`), oldest
-  first. Empty when the first carrier answered.
+  entry per failed attempt (`carrier_id`, `status`, `elapsed_ms`, `dialed`),
+  oldest first. Empty when the first carrier answered.
+- A carrier siphon could not **reach** (its gateway group unknown or entirely
+  down, or its destination would not resolve) is skipped **immediately** — the
+  sequence does not wait out that carrier's ring timeout for an INVITE it never
+  sent. It is still recorded, with `dialed: False`.
 
 ## Seeing a failover happen
 
@@ -126,6 +130,33 @@ the same set `call.route_attempts` records, so the two never disagree; filter on
 `code` for what you actually treat as a carrier health signal. It is purely a
 notification: the failover decision is already made, and raising in it does not
 change the call.
+
+### Not every burned carrier is the carrier's fault
+
+An attempt's `dialed` says whether siphon actually put an INVITE on the wire for
+that carrier. `False` means it did not — the gateway group was unknown or
+entirely down, or the next-hop would not resolve — so `status` (`503`) is
+siphon's own verdict on the route, not something the carrier said. The carrier
+never saw the call.
+
+**Filter on it before counting a failure against a carrier.** A stale DNS name
+or a down gateway group is a local configuration problem, and trending it as
+carrier quality sends you to the carrier with figures they cannot reconcile:
+
+```python
+@b2bua.on_route_failure
+def carrier_failed(call, route, code):
+    attempt = call.route_attempts[-1]
+    if not attempt["dialed"]:
+        # siphon never reached this carrier — alert your own config, not them.
+        unroutable_carriers.labels(carrier=route.carrier_id).inc()
+        return
+    if code in (408, 503):
+        carrier_failures.labels(carrier=route.carrier_id).inc()
+```
+
+siphon logs an undialled carrier at `info` too (`LCR: carrier burned without
+dialling`), so it is visible without a handler.
 
 When `cdr.auto_emit` is on, the same list is stamped onto the CDR as
 `lcr_attempts` (a compact JSON array), alongside the winning carrier's

--- a/docs/reference/call.md
+++ b/docs/reference/call.md
@@ -83,6 +83,41 @@ than returning a hollow success. The out-of-process twin is the control plane's
 
 ::: siphon_sdk.mock_module.MockB2bua.unbridge
 
+## Logging the outbound leg: `b2bua.log_dial`
+
+A B2BUA call says nothing at `log.level: info` about where it dialled. The
+obvious workaround is a `log.info()` next to the `call.dial()`, and it has a real
+flaw: `call.dial()` does not dial. It records an action that the framework
+executes once the handler returns, so the line is written before the dial exists
+and still claims it when the destination fails to resolve. It also logs the
+string the script passed, which is not necessarily what goes on the wire — the
+header policy, the number policy, and LCR's tech-prefix / retarget / CLIR steps
+all still get a turn.
+
+Turn the framework's own line on instead:
+
+```yaml
+b2bua:
+  log_dial: true      # default false
+```
+
+```
+B2BUA: dialling B-leg  call_id=… b_leg_call_id=… ruri=sip:…@carrier.example
+                       next_hop=Some("sip:198.51.100.7:5060")
+                       destination=198.51.100.7:5060 transport=udp source=…
+```
+
+It is emitted from the send itself, so the R-URI is the one on the wire and
+`b_leg_call_id` is the Call-ID the far end will quote back at you. It covers
+every outbound INVITE — `call.dial()`, each `call.fork()` branch, each
+`call.route()` carrier attempt, and a REFER-terminate re-dial — so there is no
+per-call-site flag to forget on one of three dial paths.
+
+It is off by default because it is one line per call on the busiest path siphon
+has, which is an operator's decision rather than an upgrade's. (The
+[LCR failover lines](../cookbook/least-cost-routing.md) log at `info`
+unconditionally — they fire only when a carrier fails, not on every call.)
+
 ## `MediaHandle`
 
 Returned by `call.media` — controls RTP anchoring for the call.

--- a/scripts/lcr_sipp_test.sh
+++ b/scripts/lcr_sipp_test.sh
@@ -28,10 +28,24 @@ trap cleanup EXIT
 # MODE=timeout: carrier A is SILENT; siphon rings it for the route's timeout_secs
 #   then CANCELs and re-routes ("try carrier X for N seconds, then re-route").
 MODE="${MODE:-reject}"
+# Carrier A's UAS is skipped entirely in `unroutable` mode — the whole point is
+# that no INVITE is ever sent to it, so there is nothing for a UAS to receive.
+RUN_CARRIER_A_UAS=1
 if [ "$MODE" = "timeout" ]; then
   CARRIER_A_SCENARIO="sipp/b2bua_lcr_carrier_a_silent_uas.xml"
   export LCR_CARRIER_A_TIMEOUT=3
   echo "mode: timeout (carrier A silent, ring timeout 3s)"
+elif [ "$MODE" = "unroutable" ]; then
+  # Carrier A's next-hop does not resolve. siphon knows that the instant it
+  # tries, so the sequence must advance to carrier B immediately instead of
+  # arming carrier A's ring timeout and charging it a 408 for a call it never
+  # saw. The 20 s timeout is the assertion: if the advance waits for it, the
+  # elapsed check below fails.
+  CARRIER_A_SCENARIO=""
+  RUN_CARRIER_A_UAS=0
+  export LCR_CARRIER_A="sip:carrier-a.invalid:5071"
+  export LCR_CARRIER_A_TIMEOUT=20
+  echo "mode: unroutable (carrier A next-hop does not resolve, ring timeout 20s)"
 else
   CARRIER_A_SCENARIO="sipp/b2bua_lcr_carrier_a_uas.xml"
   echo "mode: reject (carrier A 503)"
@@ -57,29 +71,40 @@ PYO3_PYTHON="$PY" "$SIPHON" -c "$CONFIG" > "$LOG/siphon.log" 2>&1 & pids+=($!)
 sleep 3
 
 # 3. carrier A UAS — rejects 503 (reject mode) or stays silent (timeout mode)
-sipp -sf "$CARRIER_A_SCENARIO" -i 127.0.0.1 -p 5071 -m 1 -timeout 25s -timeout_error \
-  -trace_err -error_file "$LOG/carrierA.err" -message_file "$LOG/carrierA.msg" \
-  > "$LOG/carrierA.log" 2>&1 & pids+=($!)
+carriera_pid=""
+if [ "$RUN_CARRIER_A_UAS" = "1" ]; then
+  sipp -sf "$CARRIER_A_SCENARIO" -i 127.0.0.1 -p 5071 -m 1 -timeout 25s -timeout_error \
+    -trace_err -error_file "$LOG/carrierA.err" -message_file "$LOG/carrierA.msg" \
+    > "$LOG/carrierA.log" 2>&1 & carriera_pid=$!; pids+=($carriera_pid)
+fi
 
 # 4. carrier B UAS — answers 200
 sipp -sf sipp/b2bua_lcr_carrier_b_uas.xml -i 127.0.0.1 -p 5072 -m 1 -timeout 20s -timeout_error \
   -trace_err -error_file "$LOG/carrierB.err" -message_file "$LOG/carrierB.msg" \
-  > "$LOG/carrierB.log" 2>&1 & pids+=($!)
+  > "$LOG/carrierB.log" 2>&1 & carrierb_pid=$!; pids+=($carrierb_pid)
 sleep 1
 
 # 5. UAC — expects a single 200 (failover is transparent)
-sipp 127.0.0.1:5060 -sf sipp/b2bua_lcr_uac.xml -i 127.0.0.1 -p 5090 -m 1 -timeout 20s -timeout_error \
+call_start=$(date +%s)
+sipp 127.0.0.1:5060 -sf sipp/b2bua_lcr_uac.xml -i 127.0.0.1 -p 5090 -m 1 -timeout 30s -timeout_error \
   -trace_err -error_file "$LOG/uac.err" -message_file "$LOG/uac.msg" \
   > "$LOG/uac.log" 2>&1
 uac_rc=$?
+call_secs=$(( $(date +%s) - call_start ))
 
 # Assert BOTH carriers completed their scenarios — this is the failover proof:
 #   - carrier A (pids[2]) exits 0 only if it received the INVITE AND ACKed its
 #     503, i.e. siphon actually TRIED carrier A first (not just carrier B).
 #   - carrier B (pids[3]) exits 0 only if it answered AND received the BYE.
 # Without checking carrier A, a "caller got 200" could hide a skipped-failover bug.
-wait "${pids[2]}" 2>/dev/null; carriera_rc=$?
-wait "${pids[3]}" 2>/dev/null; carrierb_rc=$?
+# In `unroutable` mode carrier A has no UAS at all — not being contacted IS the
+# expected behaviour there — so it is scored as passed.
+if [ -n "$carriera_pid" ]; then
+  wait "$carriera_pid" 2>/dev/null; carriera_rc=$?
+else
+  carriera_rc=0
+fi
+wait "$carrierb_pid" 2>/dev/null; carrierb_rc=$?
 
 # Flush the pcap (SIGTERM makes hep_to_pcap.py write it), after giving siphon a
 # moment to HEP-trace the last messages.
@@ -90,11 +115,55 @@ if [ -n "$HEP_PID" ]; then
   echo "pcap written: $PCAP_OUT"
 fi
 
-echo "UAC exit=$uac_rc  carrierA exit=$carriera_rc  carrierB exit=$carrierb_rc"
-if [ "$uac_rc" -eq 0 ] && [ "$carriera_rc" -eq 0 ] && [ "$carrierb_rc" -eq 0 ]; then
-  echo "PASS: carrier A rejected 503, siphon failed over to carrier B (200); caller saw one 200"
+# b2bua.log_dial is on in the test config: every carrier siphon actually dialled
+# must have left an info line naming it. Two carriers are dialled in reject /
+# timeout mode; in unroutable mode carrier A is never dialled, so exactly one.
+dialled=$(grep -c "B2BUA: dialling B-leg" "$LOG/siphon.log")
+expect_dialled=2
+extra_ok=1
+extra_note=""
+
+if [ "$MODE" = "unroutable" ]; then
+  expect_dialled=1
+  # The defect this mode exists for: siphon knows carrier A is unroutable the
+  # instant it tries, but used to arm carrier A's ring timeout anyway and only
+  # advance when it fired. Carrier A's timeout is 20 s, so anything near it
+  # means the failover is waiting on a timer rather than on the known failure.
+  if [ "$call_secs" -ge 10 ]; then
+    extra_ok=0
+    extra_note="FAIL: took ${call_secs}s — the sequence waited for carrier A's ring timeout instead of advancing on the send failure"
+  fi
+  # ...and the burned carrier must be recorded as never dialled, so nothing
+  # downstream (route_attempts / lcr_attempts / on_route_failure) reads a local
+  # routing failure as something the carrier answered.
+  if ! grep -q "burned carrier-a 503 .* dialed=False" "$LOG/siphon.log"; then
+    extra_ok=0
+    extra_note="$extra_note
+FAIL: carrier-a was not recorded on route_attempts as dialed=False"
+  fi
+  if ! grep -q "carrier burned without dialling" "$LOG/siphon.log"; then
+    extra_ok=0
+    extra_note="$extra_note
+FAIL: no info line reporting the undialled carrier"
+  fi
+fi
+
+echo "UAC exit=$uac_rc  carrierA exit=$carriera_rc  carrierB exit=$carrierb_rc  dial lines=$dialled  call=${call_secs}s"
+if [ "$uac_rc" -eq 0 ] && [ "$carriera_rc" -eq 0 ] && [ "$carrierb_rc" -eq 0 ] \
+   && [ "$dialled" -eq "$expect_dialled" ] && [ "$extra_ok" -eq 1 ]; then
+  if [ "$MODE" = "unroutable" ]; then
+    echo "PASS: carrier A was unroutable, siphon advanced to carrier B at once (${call_secs}s, not its 20s ring timeout)"
+    echo "      carrier A recorded on route_attempts as dialed=False — never blamed for a call it did not see"
+  else
+    echo "PASS: carrier A rejected 503, siphon failed over to carrier B (200); caller saw one 200"
+    echo "      both carrier attempts reported at info (b2bua.log_dial)"
+  fi
   exit 0
 fi
+if [ "$dialled" -ne "$expect_dialled" ]; then
+  echo "FAIL: expected $expect_dialled 'B2BUA: dialling B-leg' info lines, got $dialled"
+fi
+[ -n "$extra_note" ] && echo "$extra_note"
 echo "FAIL — siphon log tail:"; tail -30 "$LOG/siphon.log"
 echo "UAC err:"; cat "$LOG/uac.err" 2>/dev/null
 exit 1

--- a/scripts/lcr_test.py
+++ b/scripts/lcr_test.py
@@ -40,7 +40,8 @@ def answered(call, reply):
     for attempt in call.route_attempts:
         log.info(
             f"[{call.id}] burned {attempt['carrier_id']} "
-            f"{attempt['status']} after {attempt['elapsed_ms']}ms"
+            f"{attempt['status']} after {attempt['elapsed_ms']}ms "
+            f"dialed={attempt['dialed']}"
         )
 
 

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -130,17 +130,26 @@ class Call:
         first — the counterpart to :attr:`active_route`, which names only the
         winner.
 
-        Each entry is a dict with ``carrier_id``, ``status`` and
-        ``elapsed_ms``. Empty for a non-LCR call, and for an LCR call whose
+        Each entry is a dict with ``carrier_id``, ``status``, ``elapsed_ms``
+        and ``dialed``. Empty for a non-LCR call, and for an LCR call whose
         first carrier answered. Available wherever the ``Call`` is, so a call
         that answered *after* burning a carrier can still record which one it
         burned — siphon stamps the same list onto the CDR as ``lcr_attempts``.
+
+        ``dialed`` is ``False`` when siphon never put an INVITE on the wire for
+        that carrier — its gateway group was unknown or entirely down, or its
+        destination would not resolve. ``status`` is then siphon's own verdict
+        on the route, not the carrier's answer, so filter on it before counting
+        a failure against a carrier: a local DNS or gateway problem is not the
+        carrier's fault and does not belong in their quality figures.
 
         Example::
 
             @b2bua.on_answer
             def answered(call, reply):
                 for attempt in call.route_attempts:
+                    if not attempt["dialed"]:
+                        continue        # siphon never reached this carrier
                     log.warn(f"carrier {attempt['carrier_id']} failed "
                              f"{attempt['status']} after {attempt['elapsed_ms']}ms")
         """

--- a/sdk/tests/test_lcr.py
+++ b/sdk/tests/test_lcr.py
@@ -87,13 +87,40 @@ class TestCallRoute:
         call = Call(
             active_route=Route(carrier_id="carrier-b"),
             route_attempts=[
-                {"carrier_id": "carrier-a", "status": 503, "elapsed_ms": 1204},
+                {
+                    "carrier_id": "carrier-a",
+                    "status": 503,
+                    "elapsed_ms": 1204,
+                    "dialed": True,
+                },
             ],
         )
         assert call.active_route.carrier_id == "carrier-b"
         assert [a["carrier_id"] for a in call.route_attempts] == ["carrier-a"]
         assert call.route_attempts[0]["status"] == 503
         assert call.route_attempts[0]["elapsed_ms"] == 1204
+        assert call.route_attempts[0]["dialed"] is True
+
+    def test_an_undialled_carrier_is_recorded_but_marked_not_dialled(self):
+        # siphon never reached this carrier (group down, or the destination
+        # would not resolve), so the status is siphon's verdict on the route and
+        # not something the carrier answered. A script counting carrier faults
+        # filters on `dialed` — otherwise a local DNS problem is trended against
+        # the carrier and taken to them.
+        call = Call(
+            active_route=Route(carrier_id="carrier-b"),
+            route_attempts=[
+                {
+                    "carrier_id": "carrier-a",
+                    "status": 503,
+                    "elapsed_ms": 0,
+                    "dialed": False,
+                },
+            ],
+        )
+        assert call.route_attempts[0]["dialed"] is False
+        blameable = [a for a in call.route_attempts if a["dialed"]]
+        assert blameable == []
 
 
 class TestOnRouteFailure:

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -1681,6 +1681,30 @@ auth:
 # b2bua:
 #   accept_replaces: true
 
+# Report every outbound B-leg INVITE at info, as it is handed to the transport:
+#
+#   B2BUA: dialling B-leg  call_id=... b_leg_call_id=... ruri=sip:31612345678@carrier
+#                          next_hop=Some("sip:198.51.100.7:5060")
+#                          destination=198.51.100.7:5060 transport=udp source=...
+#
+# OFF by default — one line per call on the busiest path siphon has. (The LCR
+# failover lines already log at info without a knob because they fire only when
+# a carrier fails, not on every call.)
+#
+# Worth preferring over a log.info() next to your call.dial(): call.dial() only
+# records an action the framework executes after the handler returns, so a line
+# written in the script precedes the dial and still claims it when the
+# destination fails to resolve. This one is emitted from the send itself, after
+# routing, the header policy, the number policy and the LCR tech-prefix /
+# retarget / CLIR steps have run — so the R-URI is what actually went on the
+# wire, not the string the script passed, and b_leg_call_id is the Call-ID the
+# far end will quote back at you.
+#
+# Covers every B-leg INVITE: call.dial(), each call.fork() branch, each
+# call.route() carrier attempt, and a REFER-terminate re-dial.
+# b2bua:
+#   log_dial: true
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------

--- a/sipp/configs/siphon.lcr-test-hep.yaml
+++ b/sipp/configs/siphon.lcr-test-hep.yaml
@@ -30,3 +30,6 @@ tracing:
 
 log:
   level: info
+
+b2bua:
+  log_dial: true

--- a/sipp/configs/siphon.lcr-test.yaml
+++ b/sipp/configs/siphon.lcr-test.yaml
@@ -23,3 +23,6 @@ lcr:
 
 log:
   level: info
+
+b2bua:
+  log_dial: true

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -948,6 +948,16 @@ pub struct RouteAttempt {
     pub status: u16,
     /// How long the attempt was in flight, in milliseconds.
     pub elapsed_ms: u64,
+    /// Whether this carrier's INVITE actually reached the transport.
+    ///
+    /// `false` means siphon never sent it — the carrier's gateway group was
+    /// unknown or entirely down, or its destination would not resolve — so
+    /// `status` is siphon's own verdict on the route and **not** something the
+    /// carrier said. Without this the two are indistinguishable, and a local
+    /// DNS or gateway problem reads as a carrier fault in `route_attempts`, in
+    /// the CDR's `lcr_attempts`, and in `@b2bua.on_route_failure` — the data an
+    /// operator trends a carrier on, and takes to that carrier.
+    pub dialed: bool,
 }
 
 #[derive(Debug)]
@@ -1182,6 +1192,21 @@ impl CallActor {
     /// Returns the attempt, so the caller can log it and hand it to
     /// `@b2bua.on_route_failure` without re-reading the actor.
     pub fn record_route_failure(&mut self, status_code: u16) -> Option<RouteAttempt> {
+        self.record_route_attempt(status_code, true)
+    }
+
+    /// Record a carrier that was burned **without ever being dialled** — its
+    /// gateway group was unknown or entirely down, or its destination would not
+    /// resolve, so no INVITE left the box.
+    ///
+    /// It still belongs on the attempt list: the sequence consumed that carrier
+    /// and the caller's call took the consequences. `dialed: false` is what
+    /// keeps it from reading as the carrier's own answer.
+    pub fn record_route_undialed(&mut self, status_code: u16) -> Option<RouteAttempt> {
+        self.record_route_attempt(status_code, false)
+    }
+
+    fn record_route_attempt(&mut self, status_code: u16, dialed: bool) -> Option<RouteAttempt> {
         let sequence = self.route_sequence.as_mut()?;
         let attempt = RouteAttempt {
             carrier_id: sequence
@@ -1194,6 +1219,7 @@ impl CallActor {
                 .active_since
                 .map(|since| since.elapsed().as_millis() as u64)
                 .unwrap_or_default(),
+            dialed,
         };
         sequence.attempts.push(attempt.clone());
         Some(attempt)
@@ -2420,6 +2446,14 @@ impl CallActorStore {
             .record_route_failure(status_code)
     }
 
+    /// Record a carrier burned without ever being dialled — see
+    /// [`CallActor::record_route_undialed`].
+    pub fn record_route_undialed(&self, call_id: &str, status_code: u16) -> Option<RouteAttempt> {
+        self.calls
+            .get_mut(call_id)?
+            .record_route_undialed(status_code)
+    }
+
     /// Every failed attempt of a call's failover sequence, in order tried.
     pub fn route_attempts(&self, call_id: &str) -> Vec<RouteAttempt> {
         self.calls
@@ -3502,6 +3536,44 @@ mod tests {
         assert_eq!(actor.best_route_error(), Some(503));
     }
 
+    /// A carrier siphon never reached is still an attempt — the sequence
+    /// consumed it and the caller took the consequence — but it must not read
+    /// as the carrier's own answer. Without the distinction a local DNS or
+    /// gateway problem is indistinguishable from a carrier rejecting the call,
+    /// in `route_attempts`, in the CDR's `lcr_attempts` and in
+    /// `@b2bua.on_route_failure` alike: the figures an operator trends a
+    /// carrier on, and takes to that carrier.
+    #[test]
+    fn a_carrier_that_was_never_dialled_is_recorded_but_not_blamed() {
+        let mut actor = CallActor::new(make_a_leg());
+        actor.route_sequence = Some(RouteSequenceState {
+            pending: [lcr_route("a"), lcr_route("b")].into_iter().collect(),
+            ..Default::default()
+        });
+
+        actor.take_next_route().expect("carrier a");
+        let undialed = actor.record_route_undialed(503).expect("attempt recorded");
+        assert_eq!(undialed.carrier_id, "a");
+        assert_eq!(undialed.status, 503);
+        assert!(
+            !undialed.dialed,
+            "no INVITE reached the transport for this carrier"
+        );
+
+        actor.take_next_route().expect("carrier b");
+        let answered_badly = actor.record_route_failure(486).expect("attempt recorded");
+        assert!(
+            answered_badly.dialed,
+            "the carrier was dialled and answered 486 itself"
+        );
+
+        // Both are on the list — the sequence burned both — and the list is
+        // still what best_route_error derives from, so an exhausted sequence of
+        // unroutable carriers still hands the caller a code.
+        assert_eq!(actor.route_attempts().len(), 2);
+        assert_eq!(actor.best_route_error(), Some(503));
+    }
+
     /// A call with no failover sequence has nothing to report, and asking must
     /// not be an error — every `Call` handed to a script reads this property,
     /// LCR or not.
@@ -3510,6 +3582,7 @@ mod tests {
         let mut actor = CallActor::new(make_a_leg());
         assert!(actor.route_attempts().is_empty());
         assert!(actor.record_route_failure(503).is_none());
+        assert!(actor.record_route_undialed(503).is_none());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -306,6 +306,33 @@ pub struct B2buaConfig {
     ///   accept_replaces: true
     /// ```
     pub accept_replaces: Option<bool>,
+
+    /// Report every outbound B-leg INVITE at `info`, at the moment it is
+    /// handed to the transport.
+    ///
+    /// **Off by default** — this is one line per call on the busiest path
+    /// siphon has, so it is an operator's decision, not an upgrade's. The
+    /// LCR lines that already log at `info` fire only on failover, which is
+    /// why they need no knob.
+    ///
+    /// What it buys over logging the dial from the script: `call.dial()` only
+    /// *records* an action that the framework executes after the handler
+    /// returns, so a script-side line is written before the dial exists and
+    /// still claims it when the destination fails to resolve. This line is
+    /// emitted from the send itself, after routing, the header policy, the
+    /// number policy, LCR tech-prefix/retarget and CLIR have all had their
+    /// turn — so it reports the Request-URI that actually went on the wire,
+    /// not the string the script passed in, and it carries the B-leg Call-ID
+    /// the far end will quote back.
+    ///
+    /// Covers every B-leg INVITE — `call.dial()`, each `call.fork()` branch,
+    /// each `call.route()` carrier attempt, and a REFER-terminate re-dial.
+    ///
+    /// ```yaml
+    /// b2bua:
+    ///   log_dial: true
+    /// ```
+    pub log_dial: Option<bool>,
 }
 
 impl B2buaConfig {
@@ -326,6 +353,12 @@ impl B2buaConfig {
     /// `false` — see [`accept_replaces`](Self::accept_replaces).
     pub fn replaces_takeover_enabled(&self) -> bool {
         self.accept_replaces.unwrap_or(false)
+    }
+
+    /// Whether outbound B-leg INVITEs are reported at `info`. Defaults to
+    /// `false` — see [`log_dial`](Self::log_dial).
+    pub fn log_dial_enabled(&self) -> bool {
+        self.log_dial.unwrap_or(false)
     }
 
     /// Resolve the configured default REFER mode. `None`, empty, or an
@@ -4813,6 +4846,37 @@ codec:
             ..Default::default()
         }
         .replaces_takeover_enabled());
+    }
+
+    /// One `info` line per call on the busiest path siphon has is an
+    /// operator's decision, not an upgrade's — the LCR lines that already log
+    /// at `info` fire only on failover, which is why they carry no knob.
+    #[test]
+    fn dial_logging_is_off_unless_enabled() {
+        assert!(
+            !B2buaConfig::default().log_dial_enabled(),
+            "per-call dial logging is opt-in"
+        );
+        assert!(!B2buaConfig {
+            log_dial: Some(false),
+            ..Default::default()
+        }
+        .log_dial_enabled());
+        assert!(B2buaConfig {
+            log_dial: Some(true),
+            ..Default::default()
+        }
+        .log_dial_enabled());
+    }
+
+    #[test]
+    fn dial_logging_parses_from_yaml() {
+        let config: B2buaConfig =
+            serde_yaml_ng::from_str("log_dial: true").expect("b2bua block must parse");
+        assert!(config.log_dial_enabled());
+        let empty: B2buaConfig =
+            serde_yaml_ng::from_str("default_refer_mode: terminate").expect("must parse");
+        assert!(!empty.log_dial_enabled());
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -14176,10 +14176,12 @@ fn b2bua_advance_route(
     loop {
         let route = match state.call_actors.take_next_route(call_id) {
             Some(route) => route,
-            None => return RouteAdvance {
-                dialed: false,
-                burned,
-            },
+            None => {
+                return RouteAdvance {
+                    dialed: false,
+                    burned,
+                }
+            }
         };
         // Prefer a healthy gateway-group member; fall back to an explicit
         // next-hop. Warn (not silent) when the API named a group that siphon
@@ -14327,7 +14329,14 @@ fn b2bua_dispatch_burned_routes(
         return;
     };
     for (route, status) in burned {
-        b2bua_dispatch_route_failure(call_id, route, *status, &a_leg, a_leg_invite.as_ref(), state);
+        b2bua_dispatch_route_failure(
+            call_id,
+            route,
+            *status,
+            &a_leg,
+            a_leg_invite.as_ref(),
+            state,
+        );
     }
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -170,6 +170,11 @@ struct DispatcherState {
     /// unless the operator turned it on, because possession of a dialog's
     /// identifiers is not authority to end that dialog (RFC 3891 §5).
     accept_replaces: bool,
+    /// Whether every outbound B-leg INVITE is reported at `info` as it is
+    /// handed to the transport. Resolved from `config.b2bua.log_dial`; **off**
+    /// unless the operator turned it on — one line per call on the hottest
+    /// path siphon has.
+    log_dial: bool,
     /// Outbound registration manager (None when registrant is not configured).
     registrant_manager: Option<Arc<crate::registrant::RegistrantManager>>,
     /// SIPREC recording manager (SRC role — sends recordings to external SRS).
@@ -757,6 +762,7 @@ pub async fn run(
         default_header_policy,
         default_refer_mode: config.b2bua.resolved_default_refer_mode(),
         accept_replaces: config.b2bua.replaces_takeover_enabled(),
+        log_dial: config.b2bua.log_dial_enabled(),
         registrant_manager,
         recording_manager: Arc::new(crate::siprec::RecordingManager::new(
             product_name,
@@ -11814,10 +11820,11 @@ fn cdr_stamp_route_attempts(state: &DispatcherState, internal_call_id: &str) {
         .iter()
         .map(|attempt| {
             format!(
-                r#"{{"carrier_id":{},"status":{},"elapsed_ms":{}}}"#,
+                r#"{{"carrier_id":{},"status":{},"elapsed_ms":{},"dialed":{}}}"#,
                 serde_json::Value::String(attempt.carrier_id.clone()),
                 attempt.status,
-                attempt.elapsed_ms
+                attempt.elapsed_ms,
+                attempt.dialed
             )
         })
         .collect::<Vec<_>>()
@@ -14119,21 +14126,60 @@ fn lcr_destination_userpart(destination: &str) -> String {
 /// once the queue is exhausted. `original_request` is the stored A-leg INVITE
 /// (its R-URI is the default dial target when a route omits its own `ruri`);
 /// the caller passes the locked message so this never re-locks it.
+/// Outcome of one [`b2bua_advance_route`] pass.
+struct RouteAdvance {
+    /// Whether a carrier's INVITE actually reached the transport.
+    dialed: bool,
+    /// Carriers this pass burned **without dialling** — an unroutable one
+    /// (gateway group unknown or entirely down, no explicit next-hop) or one
+    /// whose INVITE could not be sent. Each is already on the call's attempt
+    /// list; the caller fires `@b2bua.on_route_failure` for them.
+    ///
+    /// Returned rather than dispatched here because the hook re-locks the A-leg
+    /// INVITE that every caller of this function is holding a guard on — the
+    /// same reason the reject and ring-timeout paths already fire it *before*
+    /// taking that guard. Firing it inline would deadlock the dispatcher.
+    burned: Vec<(crate::lcr::Route, u16)>,
+}
+
+impl RouteAdvance {
+    /// No carrier dialled and nothing burned — the queue was already empty, or
+    /// the A-leg INVITE could not be locked.
+    fn none() -> Self {
+        Self {
+            dialed: false,
+            burned: Vec::new(),
+        }
+    }
+}
+
+/// Status recorded against a carrier the sequence burned without dialling it.
+///
+/// `503` is what the A-leg already receives when no carrier at all is routable
+/// (`503 No Route`), so an exhausted sequence hands the caller the same code
+/// however it got there. The attempt's `dialed: false` is what says the carrier
+/// never answered this — it is siphon's verdict on the route.
+const LCR_UNDIALED_STATUS: u16 = 503;
+
 fn b2bua_advance_route(
     call_id: &str,
     original_request: &SipMessage,
     state: &DispatcherState,
-) -> bool {
+) -> RouteAdvance {
     let send_socket_str = state.call_actors.route_send_socket(call_id);
     let send_socket = state.resolve_send_socket(send_socket_str.as_deref());
     let a_leg_ruri = match &original_request.start_line {
         StartLine::Request(request_line) => request_line.request_uri.to_string(),
         _ => String::new(),
     };
+    let mut burned: Vec<(crate::lcr::Route, u16)> = Vec::new();
     loop {
         let route = match state.call_actors.take_next_route(call_id) {
             Some(route) => route,
-            None => return false,
+            None => return RouteAdvance {
+                dialed: false,
+                burned,
+            },
         };
         // Prefer a healthy gateway-group member; fall back to an explicit
         // next-hop. Warn (not silent) when the API named a group that siphon
@@ -14158,6 +14204,11 @@ fn b2bua_advance_route(
                 carrier = %route.carrier_id,
                 "LCR: carrier unroutable (group unknown/down, no next-hop), skipping",
             );
+            // Burned, so it belongs on the attempt list: the sequence consumed
+            // this carrier and the call took the consequence. Skipping it
+            // silently left `route_attempts` unable to name every carrier the
+            // call went through, which is the one thing that list is for.
+            b2bua_record_undialed_carrier(call_id, &route, &mut burned, state);
             continue;
         }
         let target = b2bua_carrier_ruri(&route, &a_leg_ruri, next_hop.as_deref());
@@ -14197,7 +14248,7 @@ fn b2bua_advance_route(
             next_hop = ?next_hop,
             "LCR: dialing carrier",
         );
-        b2bua_send_b_leg_invite(
+        let sent = b2bua_send_b_leg_invite(
             call_id,
             &target,
             next_hop.as_deref(),
@@ -14213,8 +14264,70 @@ fn b2bua_advance_route(
             &extra_headers,
             state,
         );
+        if !sent {
+            // The INVITE never left the box (unresolvable destination, dead
+            // egress). Arming the answer deadline here would sit on the caller
+            // for this carrier's whole ring timeout and then charge the carrier
+            // a 408 for a packet it never received. Burn it and take the next
+            // one now — the failure is already known.
+            b2bua_record_undialed_carrier(call_id, &route, &mut burned, state);
+            continue;
+        }
         set_b2bua_answer_deadline(call_id, timeout, state);
-        return true;
+        return RouteAdvance {
+            dialed: true,
+            burned,
+        };
+    }
+}
+
+/// Record a carrier burned without ever being dialled, and queue it for the
+/// `@b2bua.on_route_failure` notification its caller will fire.
+///
+/// Both halves matter: the attempt list is what `call.route_attempts`, the CDR's
+/// `lcr_attempts` and the hook all read, and the commitment is that the three
+/// never disagree about which carriers a sequence went through.
+fn b2bua_record_undialed_carrier(
+    call_id: &str,
+    route: &crate::lcr::Route,
+    burned: &mut Vec<(crate::lcr::Route, u16)>,
+    state: &DispatcherState,
+) {
+    if let Some(attempt) = state
+        .call_actors
+        .record_route_undialed(call_id, LCR_UNDIALED_STATUS)
+    {
+        info!(
+            call_id = %call_id,
+            carrier = %attempt.carrier_id,
+            status = attempt.status,
+            "LCR: carrier burned without dialling — advancing immediately (the carrier never saw this call)"
+        );
+    }
+    burned.push((route.clone(), LCR_UNDIALED_STATUS));
+}
+
+/// Fire `@b2bua.on_route_failure` for every carrier a [`RouteAdvance`] burned.
+///
+/// **Call this only once the A-leg INVITE guard is released** — the handler
+/// re-locks it (see [`RouteAdvance::burned`]).
+fn b2bua_dispatch_burned_routes(
+    call_id: &str,
+    burned: &[(crate::lcr::Route, u16)],
+    state: &DispatcherState,
+) {
+    if burned.is_empty() {
+        return;
+    }
+    let Some((a_leg, a_leg_invite)) = state
+        .call_actors
+        .get_call(call_id)
+        .map(|call| (call.a_leg.clone(), call.a_leg_invite.clone()))
+    else {
+        return;
+    };
+    for (route, status) in burned {
+        b2bua_dispatch_route_failure(call_id, route, *status, &a_leg, a_leg_invite.as_ref(), state);
     }
 }
 
@@ -14345,9 +14458,11 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
         state.call_actors.mark_active_b_legs_cancelled(call_id);
         let advanced = match a_leg_invite.as_ref().map(|arc| arc.lock()) {
             Some(Ok(guard)) => b2bua_advance_route(call_id, &guard, state),
-            _ => false,
+            _ => RouteAdvance::none(),
         };
-        if advanced {
+        // The guard above is out of scope now, so the hook may lock the INVITE.
+        b2bua_dispatch_burned_routes(call_id, &advanced.burned, state);
+        if advanced.dialed {
             info!(call_id = %call_id, "LCR: advanced to next carrier after ring-timeout");
             return;
         }
@@ -15074,6 +15189,13 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
         }
     }
 
+    // Filled by the LCR arm below and acted on after the match, once
+    // `message_guard` is released — `@b2bua.on_route_failure` re-locks the A-leg
+    // INVITE, and the teardown would take the call out from under it.
+    let mut burned_routes: Vec<(crate::lcr::Route, u16)> = Vec::new();
+    let mut teardown_after_hooks = false;
+    let mut fail_undialed = false;
+
     match action {
         CallAction::None => {
             debug!(call_id = %call_id, "B2BUA: silent drop (no action from script)");
@@ -15127,10 +15249,15 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                 next_hop = ?next_hop,
                 flow = flow.is_some(),
                 routes = route.len(),
-                "B2BUA: dialling B-leg",
+                // The script's intent, as passed to `call.dial()` — before
+                // resolution, the header policy or any number reshaping. The
+                // dial that actually leaves the socket is the `b2bua.log_dial`
+                // line in `b2bua_send_b_leg_invite`; this one can still be
+                // followed by a resolve failure.
+                "B2BUA: dial requested by script",
             );
             let send_socket = state.resolve_send_socket(send_socket.as_deref());
-            b2bua_send_b_leg_invite(
+            let sent = b2bua_send_b_leg_invite(
                 &call_id,
                 &target,
                 next_hop.as_deref(),
@@ -15146,7 +15273,23 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                 &[],
                 state,
             );
-            set_b2bua_answer_deadline(&call_id, timeout, state);
+            if sent {
+                set_b2bua_answer_deadline(&call_id, timeout, state);
+            } else {
+                // Nothing was put on the wire, so nothing will ever answer.
+                // Arming the deadline instead would leave the caller in ringback
+                // for its full length (30 s by default) before a 408 — for a
+                // failure siphon already logged. The proxy answers 502 the
+                // moment a relay target will not resolve; this is that, for a
+                // B2BUA, as the 503 the LCR path already uses for a route it
+                // cannot take.
+                warn!(
+                    call_id = %call_id,
+                    target = %target,
+                    "B2BUA: B-leg INVITE was never sent — failing the call now",
+                );
+                fail_undialed = true;
+            }
         }
         CallAction::Fork {
             targets,
@@ -15158,6 +15301,7 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
         } => {
             debug!(call_id = %call_id, targets = ?targets, "B2BUA: forking B-legs");
             let send_socket = state.resolve_send_socket(send_socket.as_deref());
+            let mut branches_sent = 0usize;
             for (index, target) in targets.iter().enumerate() {
                 // Each branch gets the route set of *its own* binding (RFC 3327
                 // §5.3), which also decides where the branch is sent.  A shared
@@ -15168,7 +15312,7 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                 let branch_route = crate::proxy::core::route_set_from_path(branch_path)
                     .map(|value| vec![value])
                     .unwrap_or_default();
-                b2bua_send_b_leg_invite(
+                if b2bua_send_b_leg_invite(
                     &call_id,
                     target,
                     None,
@@ -15183,9 +15327,25 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                     None,
                     &[],
                     state,
-                );
+                ) {
+                    branches_sent += 1;
+                }
             }
-            set_b2bua_answer_deadline(&call_id, timeout, state);
+            // A branch that could not be sent is simply not a branch (RFC 3261
+            // §16.7 aggregates over the branches that exist), so one bad
+            // contact among several does not fail the call. All of them failing
+            // does: there is no branch left to answer, and waiting for the ring
+            // timeout would only turn a known failure into 30 s of ringback.
+            if branches_sent > 0 {
+                set_b2bua_answer_deadline(&call_id, timeout, state);
+            } else {
+                warn!(
+                    call_id = %call_id,
+                    branches = targets.len(),
+                    "B2BUA: no fork branch could be sent — failing the call now",
+                );
+                fail_undialed = true;
+            }
         }
         CallAction::RouteSequence {
             mut routes,
@@ -15214,7 +15374,9 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                     default_timeout,
                 },
             );
-            if !b2bua_advance_route(&call_id, &message_guard, state) {
+            let advanced = b2bua_advance_route(&call_id, &message_guard, state);
+            burned_routes = advanced.burned;
+            if !advanced.dialed {
                 // No carrier was routable (e.g. every gateway group down and no
                 // explicit next-hop) — answer the A-leg 503 instead of stalling.
                 debug!(call_id = %call_id, "B2BUA: LCR — no routable carrier");
@@ -15233,8 +15395,11 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                     Some(inbound.local_addr),
                     state,
                 );
-                state.call_actors.remove_call(&call_id);
-                state.call_event_receivers.remove(&call_id);
+                // Teardown is deferred to after the burned-carrier hooks below:
+                // they read the call's A-leg, and an exhausted sequence is
+                // exactly the case where a script most needs to hear which
+                // carriers it went through.
+                teardown_after_hooks = true;
             }
         }
         CallAction::Terminate => {
@@ -15285,6 +15450,91 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
             );
         }
     }
+
+    // Release the A-leg INVITE before anything that re-locks it. The hook does,
+    // via the `Call` it is handed, and it runs inline on this thread — holding
+    // the guard across it would deadlock the dispatcher on a non-reentrant
+    // mutex, which is why the reject and ring-timeout paths already fire it
+    // outside their own guards.
+    drop(message_guard);
+    b2bua_dispatch_burned_routes(&call_id, &burned_routes, state);
+    if fail_undialed {
+        b2bua_fail_undialed_call(&call_id, &message_arc, &inbound, state);
+    }
+    if teardown_after_hooks {
+        state.call_actors.remove_call(&call_id);
+        state.call_event_receivers.remove(&call_id);
+    }
+}
+
+/// Answer the A-leg and tear the call down when its B-leg INVITE never reached
+/// the transport.
+///
+/// The alternative — the behaviour this replaces — is to arm the answer deadline
+/// anyway and let the caller sit in ringback for its full length before a `408
+/// Request Timeout`, for a failure siphon logged milliseconds earlier. `503` is
+/// the code the LCR path already answers when it cannot take a route, and it is
+/// honest about whose problem this is: no callee ever saw the call.
+/// Called with **no lock held on `invite_arc`** — it locks to build the
+/// response, and `@b2bua.on_failure` locks again through the `Call` it is given.
+fn b2bua_fail_undialed_call(
+    call_id: &str,
+    invite_arc: &Arc<Mutex<SipMessage>>,
+    inbound: &InboundMessage,
+    state: &DispatcherState,
+) {
+    const REASON: &str = "Destination Unreachable";
+
+    let response = match invite_arc.lock() {
+        Ok(invite) => {
+            let mut response =
+                build_response(&invite, 503, REASON, state.server_header.as_deref(), &[]);
+            // siphon is the UAS on the A-leg, so this locally-generated final
+            // response carries the dialog's UAS To-tag (RFC 3261 §8.2.6.2) —
+            // same as the reject and answer-timeout paths.
+            if let Some(local_tag) = state
+                .call_actors
+                .get_call(call_id)
+                .map(|call| call.a_leg.dialog.local_tag.clone())
+            {
+                stamp_uas_to_tag(&mut response, &local_tag);
+            }
+            Some(response)
+        }
+        Err(_) => {
+            error!(call_id = %call_id, "B2BUA: A-leg INVITE lock poisoned — cannot answer an undialled call");
+            None
+        }
+    };
+    if let Some(response) = response {
+        send_message_from(
+            response,
+            inbound.transport,
+            inbound.remote_addr,
+            inbound.connection_id,
+            Some(inbound.local_addr),
+            state,
+        );
+    }
+
+    // The script asked for a dial and did not get one, so it hears about it the
+    // same way it would have if the callee had answered 503 — this is not the
+    // script's own `call.reject()`, and it may be holding per-call state (Rx /
+    // N5 QoS, an anchored media session, an external reservation) that only a
+    // failure notification releases.
+    if let Some(a_leg) = state
+        .call_actors
+        .get_call(call_id)
+        .map(|call| call.a_leg.clone())
+    {
+        b2bua_fire_failure_handlers(call_id, &a_leg, 503, REASON, state);
+    }
+
+    if crate::cdr::auto_emit_enabled() {
+        cdr_finalize_b2bua_fail(state, call_id, 503);
+    }
+    state.call_actors.remove_call(call_id);
+    state.call_event_receivers.remove(call_id);
 }
 
 /// Parameters for [`control_handover`], grouped to keep the arity sane.
@@ -15742,6 +15992,16 @@ fn advertise_option_tag(headers: &mut crate::sip::headers::SipHeaders, tag: &str
 /// R-URI must carry the canonical home-domain IMPU but the message has to
 /// be routed via a fixed next-hop (BGCF, I-CSCF, outbound proxy, …).
 #[allow(clippy::too_many_arguments)]
+/// Build and send a B-leg INVITE. Returns whether it actually reached the
+/// transport.
+///
+/// **The return value is load-bearing** — every caller has already armed an
+/// answer deadline by the time this returns, so a caller that ignores a `false`
+/// leaves the A-leg ringing for the full ring timeout on a failure siphon knew
+/// about instantly (and, on the LCR path, blames the carrier for a `408` it
+/// never saw a packet for). The proxy's own relay answers `502` the moment a
+/// target will not resolve; this is the B2BUA half of that.
+#[must_use = "an unsent B-leg INVITE must fail the call now, not at the ring timeout"]
 fn b2bua_send_b_leg_invite(
     call_id: &str,
     target_uri: &str,
@@ -15773,7 +16033,7 @@ fn b2bua_send_b_leg_invite(
     caller_id_presentation: Option<crate::sip::privacy::CallerIdPresentation>,
     extra_headers: &[(String, String)],
     state: &DispatcherState,
-) {
+) -> bool {
     // Shadowed rather than branched so every flow-derived decision below — MTU
     // bias, egress pin, Via sent-by, Contact, leg connection id — treats a
     // Path-routed B-leg as the freshly-resolved leg it now is.
@@ -15812,7 +16072,7 @@ fn b2bua_send_b_leg_invite(
             "wss" => Transport::WebSocketSecure,
             other => {
                 warn!(call_id = %call_id, transport = %other, "B2BUA: unknown flow transport");
-                return;
+                return false;
             }
         };
         (flow.source_addr, transport)
@@ -15827,7 +16087,7 @@ fn b2bua_send_b_leg_invite(
                     route_next_hop = ?route_next_hop,
                     "B2BUA: cannot resolve destination",
                 );
-                return;
+                return false;
             }
         };
         (
@@ -16292,6 +16552,34 @@ fn b2bua_send_b_leg_invite(
 
     let data = Bytes::from(b_leg_invite.to_bytes());
 
+    // `b2bua.log_dial` — report the outbound leg at info, from the send itself.
+    // Deliberately here and not in `call.dial()`: that binding only records a
+    // `CallAction` the dispatcher executes after the handler returns, so a line
+    // written there (by siphon or by the script) precedes the dial and still
+    // claims it when the destination fails to resolve — the paths above this
+    // one that `warn!` and return. By this point routing, the header policy,
+    // the number policy and the LCR tech-prefix / retarget / CLIR steps have
+    // all run, so the R-URI logged is the one on the wire rather than the
+    // string the script passed, and `b_leg_call_id` is what the far end quotes
+    // back. Every B-leg INVITE funnels through here — dial, each fork branch,
+    // each LCR carrier attempt, a REFER-terminate re-dial.
+    if state.log_dial {
+        let ruri = match &b_leg_invite.start_line {
+            StartLine::Request(request_line) => request_line.request_uri.to_string(),
+            StartLine::Response(_) => String::new(),
+        };
+        info!(
+            call_id = %call_id,
+            b_leg_call_id = %b_leg.dialog.call_id,
+            ruri = %ruri,
+            next_hop = ?next_hop,
+            destination = %destination,
+            transport = %outbound_transport,
+            source = ?flow.map(|flow| flow.local_addr).or(send_socket.map(|pin| pin.addr)),
+            "B2BUA: dialling B-leg",
+        );
+    }
+
     // Send: over the captured flow (direct OutboundMessage, bypassing DNS/pool —
     // mirrors the proxy relay(flow=...) path) when one is attached, else via the
     // resolver/pool path.
@@ -16344,6 +16632,11 @@ fn b2bua_send_b_leg_invite(
         };
         if let Err(error) = state.outbound.send(outbound_message) {
             error!(call_id = %call_id, destination = %destination, transport = %outbound_transport, "B2BUA: flow send failed: {error}");
+            // The leg is registered and its actor spawned by this point, but the
+            // INVITE is not on the wire and nothing will ever answer it. Report
+            // the failure so the caller fails the call now instead of leaving it
+            // to the ring timeout; the leg goes with the call's teardown.
+            return false;
         }
     } else {
         let relay_target = RelayTarget {
@@ -16409,6 +16702,8 @@ fn b2bua_send_b_leg_invite(
         // the flow's socket.
         send_b2bua_to_bleg(cancel_msg, b_transport, b_dest, flow_local_addr, state);
     }
+
+    true
 }
 
 /// Apply 401/407 digest-retry edits to a previously sent B-leg INVITE.
@@ -19967,9 +20262,11 @@ fn handle_b2bua_response(
                         }
                         let advanced = match a_leg_invite.as_ref().map(|arc| arc.lock()) {
                             Some(Ok(guard)) => b2bua_advance_route(call_id, &guard, state),
-                            _ => false,
+                            _ => RouteAdvance::none(),
                         };
-                        if advanced {
+                        // Guard released — safe to run the hook (it re-locks).
+                        b2bua_dispatch_burned_routes(call_id, &advanced.burned, state);
+                        if advanced.dialed {
                             info!(call_id = %call_id, status = status_code,
                         "LCR: advanced to next carrier");
                             return;
@@ -22454,7 +22751,12 @@ pub fn b2bua_route_call(
         carriers = carrier_count,
         "control plane: route — un-parked, dialing B-leg via LCR sequential failover"
     );
-    if !b2bua_advance_route(&internal_call_id, &template, state) {
+    let advanced = b2bua_advance_route(&internal_call_id, &template, state);
+    // `template` is an owned clone, not a guard, so the hook is free to lock the
+    // stored INVITE. Fired before the teardown below, which would take the call
+    // out from under it.
+    b2bua_dispatch_burned_routes(&internal_call_id, &advanced.burned, state);
+    if !advanced.dialed {
         // No carrier was routable — answer the A-leg 503 and tear down, mirroring
         // the CallAction::RouteSequence "no routable carrier" arm.
         warn!(call_id = %internal_call_id, "control plane: route — no routable carrier, 503 to A-leg");
@@ -23437,7 +23739,7 @@ fn handle_originated_call_response(
     if crate::cdr::auto_emit_enabled() {
         cdr_finalize_b2bua_fail(state, internal_call_id, status_code);
     }
-    originate_fire_failure_handlers(internal_call_id, &leg, status_code, &reason_phrase, state);
+    b2bua_fire_failure_handlers(internal_call_id, &leg, status_code, &reason_phrase, state);
     control_notify_terminated_with_cause(
         &sip_call_id,
         "rejected",
@@ -23660,9 +23962,13 @@ fn originate_fire_answer_handlers(
     });
 }
 
-/// Fire `@b2bua.on_failure(call, code, reason)` for an originated call the
-/// callee rejected.
-fn originate_fire_failure_handlers(
+/// Fire `@b2bua.on_failure(call, code, reason)` for a call that failed before it
+/// was ever answered — an originated call the callee rejected, or one whose
+/// B-leg INVITE never reached the transport at all.
+///
+/// The caller must hold no lock on the A-leg INVITE: the `Call` handed to the
+/// handler locks it, and handlers run inline on this thread.
+fn b2bua_fire_failure_handlers(
     internal_call_id: &str,
     leg: &crate::b2bua::actor::Leg,
     status_code: u16,
@@ -27330,6 +27636,11 @@ fn b2bua_refer_accept(
                 triggered_extra_headers.push(("Referred-By".to_string(), value));
             }
 
+            // `dialed` decides whether the transfer proceeds, so it has to be
+            // what actually happened. It used to be hardcoded `true` next to a
+            // send whose result was discarded, so a target that would not
+            // resolve was treated as dialled and the referrer was BYE'd for a
+            // leg that never existed.
             let dialed = if let Some(template) = dial_template {
                 b2bua_send_b_leg_invite(
                     call_id,
@@ -27346,8 +27657,7 @@ fn b2bua_refer_accept(
                     None,
                     triggered_extra_headers.as_slice(),
                     state,
-                );
-                true
+                )
             } else {
                 false
             };

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -1822,8 +1822,16 @@ impl PyCall {
     /// Every carrier attempt that FAILED before this call settled, oldest first
     /// — the counterpart to `active_route`, which names only the winner.
     ///
-    /// Each entry is a dict with `carrier_id`, `status` and `elapsed_ms`. Empty
-    /// for a non-LCR call, and for an LCR call whose first carrier answered.
+    /// Each entry is a dict with `carrier_id`, `status`, `elapsed_ms` and
+    /// `dialed`. Empty for a non-LCR call, and for an LCR call whose first
+    /// carrier answered.
+    ///
+    /// `dialed` is `False` when siphon never put an INVITE on the wire for that
+    /// carrier — its gateway group was unknown or entirely down, or its
+    /// destination would not resolve. `status` is then siphon's own verdict on
+    /// the route, not the carrier's answer, so filter on it before counting a
+    /// failure against a carrier: a local DNS or gateway problem is not the
+    /// carrier's fault and does not belong in their quality figures.
     /// Available wherever the `Call` is (`@b2bua.on_answer`, `on_failure`,
     /// `on_bye`, `on_route_failure`), so a call that answered *after* burning a
     /// carrier can still record which one it burned — siphon stamps the same
@@ -1833,6 +1841,8 @@ impl PyCall {
     /// @b2bua.on_answer
     /// def answered(call, reply):
     ///     for attempt in call.route_attempts:
+    ///         if not attempt["dialed"]:
+    ///             continue        # siphon never reached this carrier
     ///         log.warn(f"carrier {attempt['carrier_id']} failed "
     ///                  f"{attempt['status']} after {attempt['elapsed_ms']}ms")
     /// ```
@@ -1845,6 +1855,7 @@ impl PyCall {
                 entry.set_item("carrier_id", &attempt.carrier_id)?;
                 entry.set_item("status", attempt.status)?;
                 entry.set_item("elapsed_ms", attempt.elapsed_ms)?;
+                entry.set_item("dialed", attempt.dialed)?;
                 Ok(entry)
             })
             .collect()


### PR DESCRIPTION
Two commits on the B2BUA's outbound leg: what it records about a failover, and what it does when the INVITE never leaves the box.

## `b2bua_send_b_leg_invite` returned nothing, so no caller knew whether it sent

Every caller had already armed the answer deadline by the time it returned, so a destination that would not resolve logged a warning, returned, and let the deadline run its course.

Measured with `call.dial()` at a host that does not resolve — siphon knew in 0.4 ms:

```
11:24:32.099  WARN  B2BUA: cannot resolve destination  target=sip:bob@…
11:25:02.129  WARN  B2BUA: answer timeout — no final response from B-leg, failing call with 408
```

**30.1 s of ringback, then a misleading `408`.** It is now `503 Destination Unreachable` in **115 ms**, and `@b2bua.on_failure` fires with it so a script can release whatever the call was holding (Rx / N5 QoS, an anchored media session, an external reservation). The proxy has always answered `502` the instant a relay target would not resolve; this is the B2BUA half that was missing.

Per path:

| | before | after |
|---|---|---|
| `call.dial()` | 30.1 s → `408` | 115 ms → `503`, `on_failure` fires |
| `call.fork()`, all branches bad | 30 s → `408` | 114 ms → `503` |
| `call.fork()`, one bad branch | — | unchanged, the others ring and the call answers |
| `call.route()`, bad first carrier | 5.07 s to reach carrier B | **0 s** |
| REFER-terminate | treated an unresolvable target as dialled, BYE'd the referrer | uses the real result |

The return value is `#[must_use]`, which is how the REFER site was caught: it hardcoded `dialed = true` next to a discarded result.

## An LCR sequence blamed carriers for calls they never received

A carrier whose INVITE never left was marked in flight anyway, so the sequence sat on its ring timeout before advancing — and then recorded a `408` ring timeout against a carrier that never saw a packet. With a stale DNS name and a realistic 30 s per-carrier timeout that is 30 s of dead air on every call.

```
11:25:56.508  WARN  B2BUA: cannot resolve destination   next_hop=…
11:26:01.579  INFO  LCR: carrier ring-timeout           carrier=carrier-a elapsed_ms=5072
```

That false `408` reached `call.route_attempts`, the CDR's `lcr_attempts` and `@b2bua.on_route_failure` alike — the figures an operator trends a carrier on, and takes to that carrier. Attempts therefore gain **`dialed`**:

- `dialed: false` means siphon never put an INVITE on the wire, so `status` (`503`) is siphon's verdict on the route rather than the carrier's answer. Filter on it before counting a carrier fault.
- A carrier skipped as unroutable (gateway group unknown or entirely down) is now **recorded** too, instead of dropped silently — `route_attempts` is meant to name every carrier a sequence burned.
- `@b2bua.on_route_failure` fires for these, so the hook and the list keep describing the same set of carriers.

Existing fields (`carrier_id`, `status`, `elapsed_ms`) and `best_error` selection are unchanged.

Burned carriers are returned from `b2bua_advance_route` and dispatched by its caller, because the hook re-locks the A-leg INVITE its callers hold a guard on and runs inline — the ordering the reject and ring-timeout paths already used.

## `b2bua.log_dial`

Off by default. Reports every outbound B-leg INVITE at `info`, from the send itself:

```yaml
b2bua:
  log_dial: true
```

```
B2BUA: dialling B-leg  call_id=… b_leg_call_id=… ruri=sip:…@carrier
                       next_hop=Some("sip:198.51.100.7:5060")
                       destination=198.51.100.7:5060 transport=udp source=…
```

The alternative — a `log.info()` beside the `call.dial()` — has a real flaw: `call.dial()` does not dial, it records an action the framework executes after the handler returns, so a script-side line precedes the dial and still claims it when the destination fails to resolve. This one cannot, and the R-URI it logs is the one on the wire, after the header policy, the number policy and LCR's tech-prefix / retarget / CLIR have had their turn. `b_leg_call_id` is the Call-ID the far end quotes back.

It covers every outbound INVITE — dial, each fork branch, each carrier attempt, a REFER-terminate re-dial — so there is no per-call-site flag to forget on one of three dial paths. Off by default because it is one line per call on the busiest path there is, which is an operator's decision rather than an upgrade's.

## Also in here

The first commit is the LCR failover trace and record (`route_attempts`, `@b2bua.on_route_failure`, `lcr_attempts` on the CDR, `best_error` derived from the attempt list). It was written before `1.8.1` was cut and has been rebased onto current `main`, with its CHANGELOG entry re-filed under `[Unreleased]`.

## Verified

- 4622 tests, clippy clean, 677 SDK tests.
- All three LCR e2e modes green, including a new `MODE=unroutable` in `scripts/lcr_sipp_test.sh` that reproduces the defect: it asserts the failover completes well inside carrier A's 20 s timeout and that the attempt is recorded `dialed=False`.
- The dial, all-branches-fail and partial-fork cases measured directly against a running binary.
- **Not verified:** the REFER-terminate path end to end (the compose network was occupied), and the 16-row throughput baseline.
