### PR TITLE
fix(script): release the interpreter in the three s6a Diameter methods that blocked while attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,21 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   under it.
 
 ### Fixed
+- **Three S6a scripting methods blocked while still attached to the
+  interpreter, risking an engine-wide deadlock.** `diameter.s6a_air()`,
+  `diameter.s6a_ulr()` and `diameter.s6a_purge_ue()` waited for the HSS answer
+  with a bare `block_in_place` + `block_on` instead of the wrapper every one of
+  their eighteen siblings uses, which releases the interpreter for the blocking
+  window. A handler parked in the bare form never reaches a garbage-collection
+  safe point, so the next thread to allocate cyclic garbage — which Python does
+  constantly — blocks behind the stop-the-world pause. That surfaces either as
+  intermittent handler stalls or, when the only thread that could complete the
+  Diameter call is itself caught in the pause, as a permanent deadlock across
+  every handler in the process. All three now release the interpreter while
+  they wait. A source-level test guards the whole scripting-API namespace
+  against the same drift, including files added later, since the two forms
+  compile and behave identically until the collector happens to run at the
+  wrong moment.
 - **A method no script handler claims is no longer answered `500`, and OPTIONS
   is answered by the stack.** Every method without a matching
   `@proxy.on_request` handler got `500 Server Internal Error`, and OPTIONS is

--- a/src/script/api/diameter.rs
+++ b/src/script/api/diameter.rs
@@ -1094,15 +1094,13 @@ impl PyDiameter {
                 return Ok(None);
             }
         };
-        let answer = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(client.send_air(
-                imsi,
-                &visited_plmn_id,
-                num_vectors,
-                immediate_response_preferred,
-                resync_info.as_deref(),
-            ))
-        });
+        let answer = crate::script::detach_block_on(client.send_air(
+            imsi,
+            &visited_plmn_id,
+            num_vectors,
+            immediate_response_preferred,
+            resync_info.as_deref(),
+        ));
         match answer {
             Ok(message) => {
                 let parsed = match crate::diameter::s6a::parse_aia(&message) {
@@ -1159,14 +1157,12 @@ impl PyDiameter {
                 return Ok(None);
             }
         };
-        let answer = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(client.send_ulr(
-                imsi,
-                rat_type,
-                ulr_flags,
-                &visited_plmn_id,
-            ))
-        });
+        let answer = crate::script::detach_block_on(client.send_ulr(
+            imsi,
+            rat_type,
+            ulr_flags,
+            &visited_plmn_id,
+        ));
         match answer {
             Ok(message) => {
                 let parsed = match crate::diameter::s6a::parse_ula(&message) {
@@ -1204,9 +1200,7 @@ impl PyDiameter {
                 return Ok(None);
             }
         };
-        let answer = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(client.send_purge_ue(imsi, pur_flags))
-        });
+        let answer = crate::script::detach_block_on(client.send_purge_ue(imsi, pur_flags));
         match answer {
             Ok(message) => {
                 let dict = PyDict::new(python);

--- a/src/script/blocking.rs
+++ b/src/script/blocking.rs
@@ -41,3 +41,52 @@ where
         })
     })
 }
+
+#[cfg(test)]
+mod tests {
+    /// Every blocking Rust-API call reachable from a script handler must go
+    /// through [`detach_block_on`], never a bare `block_in_place` +
+    /// `block_on`. The two compile identically and behave identically on an
+    /// idle box, which is exactly why the rule cannot be enforced by review:
+    /// the bare form only diverges once the cyclic GC happens to stop the
+    /// world while a handler is parked in it, and then it is an engine-wide
+    /// deadlock rather than a slow call.
+    ///
+    /// This drifted once already — three of the twenty-one Diameter methods
+    /// were written with the bare form while every sibling in the same file
+    /// used the wrapper — so guard it at the source level over the whole
+    /// namespace directory, including files that do not exist yet. Anything
+    /// in `script::api` that genuinely has to stay attached (driving the
+    /// interpreter rather than blocking on Rust) does not belong in a
+    /// handler-reachable method in the first place.
+    #[test]
+    fn no_script_api_method_blocks_while_attached_to_the_interpreter() {
+        let api_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/script/api");
+        let entries = std::fs::read_dir(&api_dir).expect("script api directory is readable");
+
+        let mut offenders = Vec::new();
+        for entry in entries {
+            let path = entry.expect("directory entry is readable").path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                continue;
+            }
+            let source = std::fs::read_to_string(&path).expect("source file is readable");
+            if source.contains("block_in_place") {
+                let name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("<unknown>")
+                    .to_string();
+                offenders.push(name);
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these script::api files call block_in_place directly instead of \
+             going through detach_block_on, so a handler parked in one of them \
+             can never reach a GC safe point and the next thread to allocate \
+             cyclic garbage deadlocks behind the stop-the-world: {offenders:?}"
+        );
+    }
+}


### PR DESCRIPTION
`diameter.s6a_air()`, `diameter.s6a_ulr()` and `diameter.s6a_purge_ue()` wait for the HSS answer with a bare `tokio::task::block_in_place` + `Handle::current().block_on(...)`. Every one of the other eighteen Diameter methods in the same file goes through `script::detach_block_on`, which releases the interpreter for the blocking window.

Why that matters is written out on `src/script/blocking.rs`: a script handler runs attached to the interpreter, and the cyclic GC's stop-the-world pauses every attached thread at a safe point. A handler parked in a blocking Rust call while still attached never reaches one, so the next thread to allocate cyclic garbage blocks behind the collector. Depending on which thread could have released the block, that is either intermittent handler stalls or a permanent deadlock across every handler in the process.

The two forms compile and behave identically until the collector happens to run while a handler is parked, so this is not something review reliably catches. The fix is three call sites; the guard is a source-level test over the whole `src/script/api` directory, including files that do not exist yet.

No behaviour change on the happy path. `cargo test` 4636 passed, clippy clean.