### PR TITLE
ci(control-sdk): build, lint, test and format the control SDK workspace, which CI never compiled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -297,6 +297,80 @@ jobs:
       - name: Clippy (patched to this tree — the released composition)
         run: PYO3_PYTHON=python3.14 cargo clippy -p siphon-bin --features ui -- -D warnings
 
+  # ── External control-plane SDKs (siphon-control-sdk/) ──────────────────
+  # `siphon-control-sdk/` is a SEPARATE, excluded standalone workspace with its
+  # own Cargo.lock (the same arrangement as `siphon-bin/`), so every job above
+  # resolves the siphon-sip graph alone and none of them compiles a line of it.
+  # Before this job it appeared in CI exactly once — as a cargo-deny matrix
+  # entry, which reads its lockfile and never builds the code. A break in the
+  # three crates therefore surfaced for the first time in
+  # release-control-sdk.yaml: at tag time, on the one workflow that publishes to
+  # PyPI and crates.io, with the tag already cut.
+  #
+  # Unlike siphon-bin this is NOT a bit-rot guard. Those crates git-dep a
+  # published siphon-sip, so that job can be green against a lib many commits
+  # behind; these three path-dep each other inside this workspace, so the job
+  # compiles THIS checkout and a break fails on the PR that introduced it.
+  #
+  # The Python leg is why an interpreter is installed at all.
+  # `siphon-control` is a PyO3 extension, and `tests/test_smoke.py` drives the
+  # REAL module against an in-process `websockets` stub that speaks the
+  # `siphon-control.v1` handshake — so it needs the extension built and
+  # installed, not merely compiled. It is the only coverage the pyo3 surface
+  # has: the `sdk-tests` job below is scoped to `sdk/` (the `siphon` script-API
+  # mock) and never sees this package.
+  #
+  # One interpreter is deliberate. This job answers "does the extension build,
+  # and does its surface still behave"; release-control-sdk.yaml owns the
+  # per-interpreter matrix (cp314 + cp314t across manylinux, macOS and Windows)
+  # that answers "does it build for everyone we ship to". Duplicating that here
+  # would cost minutes on every PR to re-prove what only the release needs.
+  control-sdk:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: siphon-control-sdk
+    steps:
+      - uses: actions/checkout@v7
+
+      # Before the Rust steps: the `siphon-control` crate links against this
+      # interpreter, so `cargo test` over the workspace needs it present.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: siphon-control-sdk
+
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      # The wire-format tests on siphon-control-proto and the client's
+      # integration suite. `--all-targets` above type-checks them; this runs
+      # them.
+      - name: Tests (proto + client)
+        run: cargo test
+
+      # `pip install -e .` and not `maturin develop`: the pyproject already
+      # declares the maturin backend, so pip builds the extension through it,
+      # and it needs no virtualenv of its own — the same shape the `sdk-tests`
+      # job uses for the script-API mock.
+      - name: Build and install the extension
+        working-directory: siphon-control-sdk/siphon-control
+        run: pip install -e . pytest websockets
+
+      - name: Python smoke tests
+        working-directory: siphon-control-sdk/siphon-control
+        run: pytest -v
+
   # ── Python SDK tests ──────────────────────────────────────────────────
   sdk-tests:
     runs-on: ubuntu-latest

--- a/siphon-control-sdk/siphon-control-client/src/client.rs
+++ b/siphon-control-sdk/siphon-control-client/src/client.rs
@@ -80,7 +80,9 @@ impl EventStream {
 type EventCallback = Arc<dyn Fn(ClientEvent) + Send + Sync>;
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 pub(crate) struct ClientShared {
@@ -141,7 +143,12 @@ impl ClientShared {
 
     async fn resync_and_reattach(self: &Arc<Self>, core: &Arc<SessionCore>) {
         match core
-            .send_command(None, "resync", serde_json::Value::Null, serde_json::Value::Null)
+            .send_command(
+                None,
+                "resync",
+                serde_json::Value::Null,
+                serde_json::Value::Null,
+            )
             .await
         {
             Ok(value) => match serde_json::from_value::<ResyncResult>(value) {
@@ -223,24 +230,31 @@ impl ControlClient {
         target: serde_json::Value,
         args: serde_json::Value,
     ) -> Result<serde_json::Value, ControlError> {
-        let core = self
-            .shared
-            .current_session()
-            .ok_or(ControlError::Closed)?;
+        let core = self.shared.current_session().ok_or(ControlError::Closed)?;
         core.send_command(module.map(str::to_string), verb, target, args)
             .await
     }
 
     /// Fetch the registered adapters' verb/event schema (`describe`).
     pub async fn describe(&self) -> Result<serde_json::Value, ControlError> {
-        self.command(None, "describe", serde_json::Value::Null, serde_json::Value::Null)
-            .await
+        self.command(
+            None,
+            "describe",
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
+        .await
     }
 
     /// Re-enumerate the channels this connection owns (`resync`).
     pub async fn resync(&self) -> Result<Vec<ChannelSnapshot>, ControlError> {
         let value = self
-            .command(None, "resync", serde_json::Value::Null, serde_json::Value::Null)
+            .command(
+                None,
+                "resync",
+                serde_json::Value::Null,
+                serde_json::Value::Null,
+            )
             .await?;
         let result: ResyncResult = serde_json::from_value(value)?;
         Ok(result.channels)

--- a/siphon-control-sdk/siphon-control-client/src/server.rs
+++ b/siphon-control-sdk/siphon-control-client/src/server.rs
@@ -27,8 +27,7 @@ use crate::session::{spawn_session, CommandTransport, EventSink, SessionCore};
 
 /// A sink the server calls for each event, carrying the [`CommandTransport`] of
 /// the connection that produced it (so a facade commands back on the right one).
-pub(crate) type ConnEventSink =
-    Arc<dyn Fn(EventFrame, Arc<dyn CommandTransport>) + Send + Sync>;
+pub(crate) type ConnEventSink = Arc<dyn Fn(EventFrame, Arc<dyn CommandTransport>) + Send + Sync>;
 
 /// How a [`ControlServer`] listens for siphon's per-call dials.
 #[derive(Debug, Clone)]
@@ -56,7 +55,9 @@ impl ServerConfig {
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// The protocol-agnostic per-call-connect control server.
@@ -157,7 +158,8 @@ async fn drive_accepted(
         let slot = Arc::clone(&core_slot);
         Arc::new(move |frame: EventFrame| {
             if let (Some(core), Some(server_sink)) = (slot.get(), server_sink.as_ref()) {
-                let commander: Arc<dyn CommandTransport> = Arc::clone(core) as Arc<dyn CommandTransport>;
+                let commander: Arc<dyn CommandTransport> =
+                    Arc::clone(core) as Arc<dyn CommandTransport>;
                 server_sink(frame, commander);
             }
         })

--- a/siphon-control-sdk/siphon-control-client/src/session.rs
+++ b/siphon-control-sdk/siphon-control-client/src/session.rs
@@ -44,7 +44,9 @@ pub(crate) trait CommandTransport: Send + Sync {
 
 /// Lock a `Mutex` without ever panicking on poison.
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// The shared, transport-agnostic state of one connection.
@@ -191,7 +193,12 @@ where
     let (sink, stream) = websocket.split();
     let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
     let close_signal = Arc::new(Notify::new());
-    let core = SessionCore::new(next_id, outbound_tx, reply_timeout, Arc::clone(&close_signal));
+    let core = SessionCore::new(
+        next_id,
+        outbound_tx,
+        reply_timeout,
+        Arc::clone(&close_signal),
+    );
     tokio::spawn(write_loop(sink, outbound_rx, close_signal));
     tokio::spawn(read_loop(stream, Arc::clone(&core), event_sink));
     core

--- a/siphon-control-sdk/siphon-control-client/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-client/src/sip.rs
@@ -17,8 +17,10 @@ use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tracing::{debug, warn};
 
 use siphon_control_proto::sip::{
-    BridgeFailedPayload, ChannelBridgedPayload, ChannelDtmfPayload, ChannelUnbridgedPayload, PlayFinishedPayload, PlayStartedPayload, SipEvent, SipVerb, TransferOutcomePayload, TransferRequestedPayload,
-    WsBridgeEndedPayload, WsBridgeStartedPayload, WsTeeEndedPayload, WsTeeStartedPayload,
+    BridgeFailedPayload, ChannelBridgedPayload, ChannelDtmfPayload, ChannelUnbridgedPayload,
+    PlayFinishedPayload, PlayStartedPayload, SipEvent, SipVerb, TransferOutcomePayload,
+    TransferRequestedPayload, WsBridgeEndedPayload, WsBridgeStartedPayload, WsTeeEndedPayload,
+    WsTeeStartedPayload,
 };
 // The `bridge` verb's teardown policy is an argument of this facade, so it is
 // re-exported here rather than reached for through the proto crate.
@@ -32,7 +34,9 @@ use crate::server::{ControlServer, ServerConfig};
 use crate::session::CommandTransport;
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 // ---------------------------------------------------------------------------
@@ -347,10 +351,7 @@ impl CallEvent {
     /// Whether this event ends a bridge this app asked for — exactly one such
     /// event arrives per `bridge`, so this is the signal to stop waiting.
     pub fn is_bridge_final(&self) -> bool {
-        matches!(
-            self.kind,
-            SipEvent::ChannelBridged | SipEvent::BridgeFailed
-        )
+        matches!(self.kind, SipEvent::ChannelBridged | SipEvent::BridgeFailed)
     }
 
     /// The typed [`PlayFinishedPayload`] when this is a
@@ -417,9 +418,7 @@ impl CallEvent {
     pub fn is_unexpected_stream_end(&self) -> bool {
         match self.kind {
             SipEvent::WsTeeEnded => self.ws_tee_ended().is_some_and(|end| end.unexpected),
-            SipEvent::WsBridgeEnded => {
-                self.ws_bridge_ended().is_some_and(|end| end.unexpected)
-            }
+            SipEvent::WsBridgeEnded => self.ws_bridge_ended().is_some_and(|end| end.unexpected),
             _ => false,
         }
     }
@@ -520,10 +519,19 @@ impl Call {
         json!({ "channel": self.inner.channel_id })
     }
 
-    async fn sip(&self, verb: SipVerb, args: serde_json::Value) -> Result<serde_json::Value, ControlError> {
+    async fn sip(
+        &self,
+        verb: SipVerb,
+        args: serde_json::Value,
+    ) -> Result<serde_json::Value, ControlError> {
         self.inner
             .commander
-            .command(Some(MODULE_SIP.to_string()), verb.as_str().to_string(), self.target(), args)
+            .command(
+                Some(MODULE_SIP.to_string()),
+                verb.as_str().to_string(),
+                self.target(),
+                args,
+            )
             .await
     }
 
@@ -542,9 +550,12 @@ impl Call {
         body: Option<&str>,
         content_type: Option<&str>,
     ) -> Result<(), ControlError> {
-        self.sip(SipVerb::Answer, response_args(code, reason, body, content_type))
-            .await
-            .map(drop)
+        self.sip(
+            SipVerb::Answer,
+            response_args(code, reason, body, content_type),
+        )
+        .await
+        .map(drop)
     }
 
     /// Send `180 Ringing`: alerting only, no early media.
@@ -559,7 +570,9 @@ impl Call {
 
     /// [`Call::ring`] with an explicit reason phrase.
     pub async fn ring_with_reason(&self, reason: &str) -> Result<(), ControlError> {
-        self.sip(SipVerb::Ring, json!({ "reason": reason })).await.map(drop)
+        self.sip(SipVerb::Ring, json!({ "reason": reason }))
+            .await
+            .map(drop)
     }
 
     /// Send a UAS 1xx, optionally opening an early-media path (default
@@ -576,9 +589,12 @@ impl Call {
         body: Option<&str>,
         content_type: Option<&str>,
     ) -> Result<(), ControlError> {
-        self.sip(SipVerb::Progress, response_args(code, reason, body, content_type))
-            .await
-            .map(drop)
+        self.sip(
+            SipVerb::Progress,
+            response_args(code, reason, body, content_type),
+        )
+        .await
+        .map(drop)
     }
 
     /// Send a final non-2xx and tear the call down.
@@ -597,7 +613,9 @@ impl Call {
 
     /// Hang up with a `Reason` header value.
     pub async fn hangup_with_reason(&self, reason: &str) -> Result<(), ControlError> {
-        self.sip(SipVerb::Hangup, json!({ "reason": reason })).await.map(drop)
+        self.sip(SipVerb::Hangup, json!({ "reason": reason }))
+            .await
+            .map(drop)
     }
 
     /// Send an in-dialog REFER on the A-leg (blind transfer).
@@ -609,7 +627,9 @@ impl Call {
     /// `TransferFailed`. [`CallEvent::transfer_outcome`] decodes them and
     /// [`CallEvent::is_transfer_final`] says when to stop waiting.
     pub async fn refer(&self, to: &str) -> Result<(), ControlError> {
-        self.sip(SipVerb::Refer, json!({ "to": to })).await.map(drop)
+        self.sip(SipVerb::Refer, json!({ "to": to }))
+            .await
+            .map(drop)
     }
 
     /// Blind-transfer alias for [`Call::refer`].
@@ -792,7 +812,9 @@ impl Call {
 
     /// Read a header from the stored A-leg INVITE (`None` when absent).
     pub async fn get_header(&self, name: &str) -> Result<Option<String>, ControlError> {
-        let result = self.sip(SipVerb::GetHeader, json!({ "name": name })).await?;
+        let result = self
+            .sip(SipVerb::GetHeader, json!({ "name": name }))
+            .await?;
         Ok(string_value(&result))
     }
 
@@ -809,7 +831,12 @@ impl Call {
     pub async fn set_var(&self, key: &str, value: &str) -> Result<(), ControlError> {
         self.inner
             .commander
-            .command(None, "set_var".to_string(), self.target(), json!({ "key": key, "value": value }))
+            .command(
+                None,
+                "set_var".to_string(),
+                self.target(),
+                json!({ "key": key, "value": value }),
+            )
             .await
             .map(drop)
     }
@@ -819,7 +846,12 @@ impl Call {
         let result = self
             .inner
             .commander
-            .command(None, "get_var".to_string(), self.target(), json!({ "key": key }))
+            .command(
+                None,
+                "get_var".to_string(),
+                self.target(),
+                json!({ "key": key }),
+            )
             .await?;
         Ok(string_value(&result))
     }
@@ -834,11 +866,7 @@ impl Call {
     /// shaping. Resolves once the media backend *accepts* the command; the far-end
     /// playback outcome is not the reply. A call with no anchored media session →
     /// [`ControlError`] with `code == "not_found"`.
-    pub async fn play(
-        &self,
-        source: PlaySource,
-        options: PlayOptions,
-    ) -> Result<(), ControlError> {
+    pub async fn play(&self, source: PlaySource, options: PlayOptions) -> Result<(), ControlError> {
         let mut args = serde_json::Map::new();
         source.insert_into(&mut args);
         options.insert_into(&mut args);
@@ -849,7 +877,8 @@ impl Call {
 
     /// Convenience for [`Call::play`] of a server-side file with default options.
     pub async fn play_file(&self, file: &str) -> Result<(), ControlError> {
-        self.play(PlaySource::file(file), PlayOptions::default()).await
+        self.play(PlaySource::file(file), PlayOptions::default())
+            .await
     }
 
     /// Stop the announcement currently playing on the A-leg media.
@@ -916,7 +945,12 @@ impl Call {
     ) -> Result<serde_json::Value, ControlError> {
         self.inner
             .commander
-            .command(Some(MODULE_SIP.to_string()), verb.to_string(), self.target(), args)
+            .command(
+                Some(MODULE_SIP.to_string()),
+                verb.to_string(),
+                self.target(),
+                args,
+            )
             .await
     }
 
@@ -945,7 +979,10 @@ impl std::fmt::Debug for Call {
 }
 
 fn string_value(result: &serde_json::Value) -> Option<String> {
-    result.get("value").and_then(|value| value.as_str()).map(|value| value.to_string())
+    result
+        .get("value")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string())
 }
 
 fn response_args(
@@ -996,7 +1033,8 @@ impl SipFacade {
         F: Fn(Call) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<(), ControlError>> + Send + 'static,
     {
-        let boxed: CallHandler = Arc::new(move |call| Box::pin(handler(call)) as BoxFuture<'static, _>);
+        let boxed: CallHandler =
+            Arc::new(move |call| Box::pin(handler(call)) as BoxFuture<'static, _>);
         *lock(&self.handler) = Some(boxed);
     }
 
@@ -1391,19 +1429,30 @@ mod tests {
         });
         let call = make_call(recorder.clone());
 
-        call.play(PlaySource::file("/prompts/welcome.wav"), PlayOptions::default())
-            .await
-            .expect("play file ok");
+        call.play(
+            PlaySource::file("/prompts/welcome.wav"),
+            PlayOptions::default(),
+        )
+        .await
+        .expect("play file ok");
         call.play(
             PlaySource::blob(b"hi".to_vec()),
-            PlayOptions { repeat: Some(2), duration_ms: Some(10_000), ..Default::default() },
+            PlayOptions {
+                repeat: Some(2),
+                duration_ms: Some(10_000),
+                ..Default::default()
+            },
         )
         .await
         .expect("play blob ok");
         call.stop().await.expect("stop ok");
         call.dtmf(
             "123#",
-            DtmfOptions { duration_ms: Some(100), volume_dbm0: Some(-8), ..Default::default() },
+            DtmfOptions {
+                duration_ms: Some(100),
+                volume_dbm0: Some(-8),
+                ..Default::default()
+            },
         )
         .await
         .expect("dtmf ok");
@@ -1416,23 +1465,37 @@ mod tests {
 
         let recorded = lock(&recorder.calls).clone();
         let by_verb = |verb: &str| -> serde_json::Value {
-            recorded.iter().find(|call| call.verb == verb).expect("verb recorded").args.clone()
+            recorded
+                .iter()
+                .find(|call| call.verb == verb)
+                .expect("verb recorded")
+                .args
+                .clone()
         };
         // Every media verb rides the sip module against this channel.
         for call in &recorded {
             assert_eq!(call.module.as_deref(), Some("sip"));
             assert_eq!(call.target, json!({ "channel": "ch1" }));
         }
-        assert_eq!(by_verb("play").get("file").and_then(|v| v.as_str()), Some("/prompts/welcome.wav"));
+        assert_eq!(
+            by_verb("play").get("file").and_then(|v| v.as_str()),
+            Some("/prompts/welcome.wav")
+        );
         // A blob is base64-encoded on the wire ("hi" → "aGk=").
         let blob_args: Vec<&serde_json::Value> = recorded
             .iter()
             .filter(|call| call.verb == "play")
             .map(|call| &call.args)
             .collect();
-        assert_eq!(blob_args[1], &json!({ "blob": "aGk=", "repeat": 2, "duration_ms": 10_000 }));
+        assert_eq!(
+            blob_args[1],
+            &json!({ "blob": "aGk=", "repeat": 2, "duration_ms": 10_000 })
+        );
         assert_eq!(by_verb("stop"), json!({}));
-        assert_eq!(by_verb("dtmf"), json!({ "digits": "123#", "duration_ms": 100, "volume_dbm0": -8 }));
+        assert_eq!(
+            by_verb("dtmf"),
+            json!({ "digits": "123#", "duration_ms": 100, "volume_dbm0": -8 })
+        );
         assert_eq!(by_verb("hold"), json!({}));
         assert_eq!(by_verb("unhold"), json!({}));
         assert_eq!(
@@ -1459,7 +1522,9 @@ mod tests {
         )
         .await
         .expect("accept_refer ok");
-        call.reject_refer(603, Some("Decline")).await.expect("reject_refer ok");
+        call.reject_refer(603, Some("Decline"))
+            .await
+            .expect("reject_refer ok");
 
         let recorded = lock(&recorder.calls).clone();
         assert_eq!(recorded[0].verb, "remove_header");
@@ -1477,7 +1542,10 @@ mod tests {
             })
         );
         assert_eq!(recorded[2].verb, "reject_refer");
-        assert_eq!(recorded[2].args, json!({ "code": 603, "reason": "Decline" }));
+        assert_eq!(
+            recorded[2].args,
+            json!({ "code": 603, "reason": "Decline" })
+        );
     }
 
     /// An omitted profile is absent from the frame rather than sent as null, so
@@ -1510,10 +1578,17 @@ mod tests {
         let call = make_call(recorder.clone());
 
         call.ring().await.expect("ring ok");
-        call.ring_with_reason("Alerting").await.expect("ring_with_reason ok");
-        call.progress_with(183, Some("Session Progress"), Some("v=0\r\n"), Some("application/sdp"))
+        call.ring_with_reason("Alerting")
             .await
-            .expect("progress ok");
+            .expect("ring_with_reason ok");
+        call.progress_with(
+            183,
+            Some("Session Progress"),
+            Some("v=0\r\n"),
+            Some("application/sdp"),
+        )
+        .await
+        .expect("progress ok");
 
         let recorded = lock(&recorder.calls).clone();
         assert_eq!(recorded[0].verb, "ring");
@@ -1602,7 +1677,10 @@ mod tests {
         );
         assert_eq!(recorded[1].args, json!({ "with": "ch3" }));
         assert_eq!(recorded[2].verb, "unbridge");
-        assert_eq!(recorded[2].args, json!({ "reason": "supervisor took over" }));
+        assert_eq!(
+            recorded[2].args,
+            json!({ "reason": "supervisor took over" })
+        );
         assert_eq!(recorded[3].args, json!({}));
     }
 
@@ -1610,7 +1688,12 @@ mod tests {
     fn bridge_verdicts_parse_from_frames() {
         let frame = |event: &str, payload: serde_json::Value| {
             CallEvent::from_frame(EventFrame::new(
-                event, "ch1", "ivr-app", "call-uuid", "sip@host", payload,
+                event,
+                "ch1",
+                "ivr-app",
+                "call-uuid",
+                "sip@host",
+                payload,
             ))
         };
 
@@ -1709,7 +1792,12 @@ mod tests {
     fn outbound_transfer_verdicts_parse_from_frames() {
         let frame = |event: &str, payload: serde_json::Value| {
             CallEvent::from_frame(EventFrame::new(
-                event, "ch1", "ivr-app", "call-uuid", "sip@host", payload,
+                event,
+                "ch1",
+                "ivr-app",
+                "call-uuid",
+                "sip@host",
+                payload,
             ))
         };
 

--- a/siphon-control-sdk/siphon-control-client/tests/integration.rs
+++ b/siphon-control-sdk/siphon-control-client/tests/integration.rs
@@ -101,7 +101,12 @@ async fn drive_stub(mut socket: WebSocket, stub: Arc<Stub>) {
         match verb.as_str() {
             "resync" => {
                 let channels = stub.resync_channels.lock().unwrap().clone();
-                send_ok(&mut socket, &id, serde_json::json!({ "channels": channels })).await;
+                send_ok(
+                    &mut socket,
+                    &id,
+                    serde_json::json!({ "channels": channels }),
+                )
+                .await;
             }
             "describe" => {
                 send_ok(
@@ -120,7 +125,12 @@ async fn drive_stub(mut socket: WebSocket, stub: Arc<Stub>) {
                 .await;
             }
             "get_header" | "get_var" => {
-                send_ok(&mut socket, &id, serde_json::json!({ "value": "203.0.113.7" })).await;
+                send_ok(
+                    &mut socket,
+                    &id,
+                    serde_json::json!({ "value": "203.0.113.7" }),
+                )
+                .await;
             }
             // A bridge reply reports the LOCAL action only — the media is
             // re-pointed and the first re-INVITE is on the wire. Whether the two
@@ -243,7 +253,12 @@ async fn generic_core_command_routes_any_module() {
     let addr = start_stub(Arc::new(Stub::default())).await;
     let client = ControlClient::connect(client_config(addr)).await.unwrap();
     let value = client
-        .command(Some("smpp"), "submit_sm", serde_json::Value::Null, serde_json::json!({ "short_message": "hi" }))
+        .command(
+            Some("smpp"),
+            "submit_sm",
+            serde_json::Value::Null,
+            serde_json::json!({ "short_message": "hi" }),
+        )
         .await
         .expect("generic command ok");
     assert!(value.is_object());
@@ -255,7 +270,12 @@ async fn error_reply_maps_to_typed_control_error() {
     let client = SipClient::connect(client_config(addr)).await.unwrap();
 
     match client
-        .command(Some("sip"), "boom", serde_json::json!({ "channel": "ch1" }), serde_json::json!({}))
+        .command(
+            Some("sip"),
+            "boom",
+            serde_json::json!({ "channel": "ch1" }),
+            serde_json::json!({}),
+        )
         .await
     {
         Err(ControlError::Command { code, message }) => {
@@ -275,7 +295,12 @@ async fn stasis_start_dispatches_a_call_and_verbs_round_trip() {
     // Trigger the stub to push a StasisStart (deterministic, after the stream is
     // registered so there is no dispatch race).
     client
-        .command(None, "test_push_stasis", serde_json::Value::Null, serde_json::Value::Null)
+        .command(
+            None,
+            "test_push_stasis",
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
         .await
         .unwrap();
 
@@ -290,7 +315,13 @@ async fn stasis_start_dispatches_a_call_and_verbs_round_trip() {
 
     // The high-level verbs each send + await a correlated reply.
     call.answer().await.expect("answer ok");
-    assert_eq!(call.get_header("P-Asserted-Identity").await.unwrap().as_deref(), Some("203.0.113.7"));
+    assert_eq!(
+        call.get_header("P-Asserted-Identity")
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("203.0.113.7")
+    );
     call.transfer("sip:agent@pbx").await.expect("refer ok");
 
     // Bridging this leg to another the app owns: the reply is the local action,
@@ -302,14 +333,20 @@ async fn stasis_start_dispatches_a_call_and_verbs_round_trip() {
     assert_eq!(bridged["with"], "ch2");
     assert_eq!(bridged["on_peer_hangup"], "hold");
     assert_eq!(bridged["state"], "bridging");
-    let unbridged = call.unbridge(Some("agent hung up")).await.expect("unbridge ok");
+    let unbridged = call
+        .unbridge(Some("agent hung up"))
+        .await
+        .expect("unbridge ok");
     assert_eq!(unbridged["state"], "unbridged");
     assert_eq!(unbridged["reason"], "agent hung up");
 
     // A backend-gated verb (ws_tee is siphon-rtp-only) surfaces the server's
     // unsupported_verb as a typed error.
     match call.stream_start("ws://ai:9000/stream", None, None).await {
-        Err(error) => assert!(error.is_unsupported_verb(), "expected unsupported_verb, got {error:?}"),
+        Err(error) => assert!(
+            error.is_unsupported_verb(),
+            "expected unsupported_verb, got {error:?}"
+        ),
         Ok(()) => panic!("stream_start should be unsupported on a non-siphon-rtp backend"),
     }
 }
@@ -333,7 +370,12 @@ async fn on_call_handler_fires_for_stasis_start() {
     });
 
     client
-        .command(None, "test_push_stasis", serde_json::Value::Null, serde_json::Value::Null)
+        .command(
+            None,
+            "test_push_stasis",
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
         .await
         .unwrap();
 
@@ -374,8 +416,14 @@ async fn reconnect_resyncs_and_reattaches_owned_calls() {
         .expect("a reattached call should arrive")
         .expect("call present");
     assert_eq!(call.channel_id(), "ch-live");
-    assert!(call.is_reattached(), "resync-delivered calls are reattached");
-    assert!(stub.conn_count.load(Ordering::SeqCst) >= 2, "the client reconnected");
+    assert!(
+        call.is_reattached(),
+        "resync-delivered calls are reattached"
+    );
+    assert!(
+        stub.conn_count.load(Ordering::SeqCst) >= 2,
+        "the client reconnected"
+    );
 
     client.shutdown();
 }
@@ -391,9 +439,7 @@ async fn dial_as_siphon(
     addr: SocketAddr,
     token: &str,
 ) -> Result<
-    tokio_tungstenite::WebSocketStream<
-        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-    >,
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
     tokio_tungstenite::tungstenite::Error,
 > {
     use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -451,7 +497,9 @@ async fn per_call_connect_owns_the_dialed_call_and_verbs_round_trip() {
         "payload": { "from": "sip:alice@example.com" }
     });
     siphon
-        .send(tokio_tungstenite::tungstenite::Message::Text(stasis.to_string().into()))
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            stasis.to_string().into(),
+        ))
         .await
         .unwrap();
 
@@ -474,7 +522,9 @@ async fn per_call_connect_owns_the_dialed_call_and_verbs_round_trip() {
     let id = command["id"].as_str().unwrap();
     let reply = serde_json::json!({ "id": id, "type": "reply", "status": "ok", "result": { "state": "answered" } });
     siphon
-        .send(tokio_tungstenite::tungstenite::Message::Text(reply.to_string().into()))
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            reply.to_string().into(),
+        ))
         .await
         .unwrap();
 

--- a/siphon-control-sdk/siphon-control-proto/src/lib.rs
+++ b/siphon-control-sdk/siphon-control-proto/src/lib.rs
@@ -391,7 +391,13 @@ mod tests {
     /// bytes stay identical.
     #[test]
     fn substrate_command_serializes_null_target_and_args() {
-        let frame = CommandFrame::new("c-2", None, "resync", serde_json::Value::Null, serde_json::Value::Null);
+        let frame = CommandFrame::new(
+            "c-2",
+            None,
+            "resync",
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        );
         assert_eq!(
             serde_json::to_string(&frame).unwrap(),
             r#"{"id":"c-2","type":"command","verb":"resync","target":null,"args":null}"#
@@ -555,6 +561,9 @@ mod tests {
         let parsed: ResyncResult = serde_json::from_value(value).unwrap();
         assert_eq!(parsed.channels.len(), 1);
         assert_eq!(parsed.channels[0].channel, "ch-live");
-        assert_eq!(parsed.channels[0].vars.get("queue").map(String::as_str), Some("support"));
+        assert_eq!(
+            parsed.channels[0].vars.get("queue").map(String::as_str),
+            Some("support")
+        );
     }
 }

--- a/siphon-control-sdk/siphon-control-proto/src/sip.rs
+++ b/siphon-control-sdk/siphon-control-proto/src/sip.rs
@@ -846,7 +846,10 @@ mod tests {
         for name in ["TransferProgress", "TransferCompleted", "TransferFailed"] {
             let parsed = SipEvent::from(name);
             assert_eq!(parsed.as_str(), name);
-            assert_eq!(serde_json::to_string(&parsed).unwrap(), format!("\"{name}\""));
+            assert_eq!(
+                serde_json::to_string(&parsed).unwrap(),
+                format!("\"{name}\"")
+            );
         }
         assert_eq!(
             SipEvent::from("TransferProgress"),
@@ -860,7 +863,10 @@ mod tests {
         for name in ["ChannelBridged", "BridgeFailed", "ChannelUnbridged"] {
             let parsed = SipEvent::from(name);
             assert_eq!(parsed.as_str(), name);
-            assert_eq!(serde_json::to_string(&parsed).unwrap(), format!("\"{name}\""));
+            assert_eq!(
+                serde_json::to_string(&parsed).unwrap(),
+                format!("\"{name}\"")
+            );
         }
         assert_eq!(SipEvent::from("ChannelBridged"), SipEvent::ChannelBridged);
         assert_eq!(SipEvent::from("BridgeFailed"), SipEvent::BridgeFailed);
@@ -973,7 +979,10 @@ mod tests {
             assert_eq!(TransferStage::from(token), stage);
             assert_eq!(stage.as_str(), token);
             assert_eq!(stage.to_string(), token);
-            assert_eq!(serde_json::to_string(&stage).unwrap(), format!("\"{token}\""));
+            assert_eq!(
+                serde_json::to_string(&stage).unwrap(),
+                format!("\"{token}\"")
+            );
         }
         // A stage a newer server invents must not break decoding.
         let novel: TransferStage = serde_json::from_str("\"something_new\"").unwrap();
@@ -1030,7 +1039,10 @@ mod tests {
             assert_eq!(BridgeRole::from(token), role);
             assert_eq!(role.as_str(), token);
             assert_eq!(role.to_string(), token);
-            assert_eq!(serde_json::to_string(&role).unwrap(), format!("\"{token}\""));
+            assert_eq!(
+                serde_json::to_string(&role).unwrap(),
+                format!("\"{token}\"")
+            );
         }
         let novel: BridgeRole = serde_json::from_str("\"observer\"").unwrap();
         assert_eq!(novel, BridgeRole::Other("observer".to_string()));
@@ -1117,7 +1129,11 @@ mod tests {
         ] {
             let parsed = SipEvent::from(wire);
             assert_eq!(parsed, expected, "{wire} must parse to its own variant");
-            assert_eq!(parsed.as_str(), wire, "{wire} must serialise back unchanged");
+            assert_eq!(
+                parsed.as_str(),
+                wire,
+                "{wire} must serialise back unchanged"
+            );
             assert!(
                 !matches!(parsed, SipEvent::Other(_)),
                 "{wire} fell through to Other"

--- a/siphon-control-sdk/siphon-control/src/lib.rs
+++ b/siphon-control-sdk/siphon-control/src/lib.rs
@@ -222,7 +222,11 @@ fn extract_route_target(item: &Bound<'_, PyAny>) -> PyResult<RouteTarget> {
     })?;
     let uri: String = match dict.get_item("uri")? {
         Some(value) => value.extract()?,
-        None => return Err(PyValueError::new_err("route target dict requires a string 'uri'")),
+        None => {
+            return Err(PyValueError::new_err(
+                "route target dict requires a string 'uri'",
+            ))
+        }
     };
     let next_hop = match dict.get_item("next_hop")? {
         Some(value) if !value.is_none() => Some(value.extract::<String>()?),
@@ -346,9 +350,14 @@ impl Call {
     ) -> PyResult<Bound<'py, PyAny>> {
         let call = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            call.answer_with(code, reason.as_deref(), body.as_deref(), content_type.as_deref())
-                .await
-                .map_err(to_pyerr)
+            call.answer_with(
+                code,
+                reason.as_deref(),
+                body.as_deref(),
+                content_type.as_deref(),
+            )
+            .await
+            .map_err(to_pyerr)
         })
     }
 
@@ -459,7 +468,9 @@ impl Call {
     ) -> PyResult<Bound<'py, PyAny>> {
         let call = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            call.reject_refer(code, reason.as_deref()).await.map_err(to_pyerr)
+            call.reject_refer(code, reason.as_deref())
+                .await
+                .map_err(to_pyerr)
         })
     }
 
@@ -502,10 +513,7 @@ impl Call {
         let policy = parse_peer_hangup(on_peer_hangup)?;
         let call = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let value = call
-                .bridge(&with_channel, policy)
-                .await
-                .map_err(to_pyerr)?;
+            let value = call.bridge(&with_channel, policy).await.map_err(to_pyerr)?;
             attach_if_running(|py| json_to_py(py, &value))
                 .unwrap_or_else(|| Err(interpreter_gone()))
         })
@@ -939,7 +947,9 @@ impl ControlClient {
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Connect the underlying [`SipClient`] once, caching it.
@@ -948,7 +958,11 @@ async fn ensure_client(inner: &Arc<ClientInner>) -> PyResult<Arc<SipClient>> {
     if let Some(client) = guard.as_ref() {
         return Ok(Arc::clone(client));
     }
-    let client = Arc::new(SipClient::connect(inner.config.clone()).await.map_err(to_pyerr)?);
+    let client = Arc::new(
+        SipClient::connect(inner.config.clone())
+            .await
+            .map_err(to_pyerr)?,
+    );
     *guard = Some(Arc::clone(&client));
     Ok(client)
 }
@@ -1064,11 +1078,16 @@ struct ControlServer {
 impl ControlServer {
     #[new]
     #[pyo3(signature = (app, token, bind=None, reply_timeout_ms=10_000))]
-    fn new(app: String, token: String, bind: Option<String>, reply_timeout_ms: u64) -> PyResult<Self> {
+    fn new(
+        app: String,
+        token: String,
+        bind: Option<String>,
+        reply_timeout_ms: u64,
+    ) -> PyResult<Self> {
         let bind = bind.unwrap_or_else(|| "0.0.0.0:8790".to_string());
-        let listen: SocketAddr = bind
-            .parse()
-            .map_err(|error| PyValueError::new_err(format!("invalid bind address {bind:?}: {error}")))?;
+        let listen: SocketAddr = bind.parse().map_err(|error| {
+            PyValueError::new_err(format!("invalid bind address {bind:?}: {error}"))
+        })?;
         let mut config = ServerConfig::new(listen, app, token);
         config.reply_timeout = Duration::from_millis(reply_timeout_ms);
         Ok(Self {
@@ -1168,7 +1187,11 @@ async fn ensure_server(inner: &Arc<ServerInner>) -> PyResult<Arc<SipServer>> {
     if let Some(server) = guard.as_ref() {
         return Ok(Arc::clone(server));
     }
-    let server = Arc::new(SipServer::bind(inner.config.clone()).await.map_err(to_pyerr)?);
+    let server = Arc::new(
+        SipServer::bind(inner.config.clone())
+            .await
+            .map_err(to_pyerr)?,
+    );
     let bound = server.local_addr().map_err(to_pyerr)?;
     *lock(&inner.local_addr) = Some(bound.to_string());
     *guard = Some(Arc::clone(&server));


### PR DESCRIPTION
`siphon-control-sdk/` is an excluded standalone workspace with its own
`Cargo.lock`, the same arrangement as `siphon-bin/`. Every job in `ci.yaml`
therefore resolves the siphon-sip graph alone, and none of them compiles a line
of it. Before this it appeared in CI exactly once — as a `cargo-deny` matrix
entry, which reads the lockfile and never builds the code.

So a break in any of the three crates surfaced for the first time in
`release-control-sdk.yaml`: at tag time, on the one workflow that publishes to
PyPI and crates.io, with the tag already cut.

## The job

Four gates, in the order a failure is cheapest to read:

| gate | what it covers |
|---|---|
| `cargo fmt --all -- --check` | 8 files across the three crates |
| `cargo clippy --all-targets -- -D warnings` | including the test targets |
| `cargo test` | 50 tests: proto wire-format, the client integration suite, doc-tests |
| `pip install -e .` → `pytest` | 12 smoke tests against the real PyO3 extension |

**This is not a bit-rot guard, and that is the difference from `siphon-bin`.**
Those crates git-dep a *published* siphon-sip, so that job can be green against a
lib many commits behind the branch. These three path-dep each other inside the
workspace, so this job compiles *this* checkout and a break fails on the PR that
introduced it.

**The Python leg is why an interpreter is installed at all.**
`tests/test_smoke.py` drives the **real** extension module against an in-process
`websockets` stub that speaks the `siphon-control.v1` handshake — it needs the
extension built and installed, not merely compiled. It is the only coverage the
PyO3 surface has anywhere: the existing `sdk-tests` job is scoped to `sdk/` (the
`siphon` script-API mock) and never sees this package.

Two choices worth stating:

- **`pip install -e .`, not `maturin develop`.** The pyproject already declares
  the maturin backend, so pip drives it and needs no virtualenv of its own —
  the same shape `sdk-tests` uses. `maturin develop` would need a venv step and
  fails on a runner without one.
- **One interpreter, not a matrix.** This job answers "does the extension build
  and does its surface still behave". `release-control-sdk.yaml` already owns
  the cp314 + cp314t matrix across manylinux, macOS and Windows that answers
  "does it build for everyone we ship to". Paying that on every PR would buy
  nothing the release does not already prove.

## The reformat

67 hunks across 8 files. All of it is drift that accumulated precisely because
nothing ever checked it — re-measured against the tree *after* the last merge,
it is the identical 67 hunks, so none of it comes from code that landed
recently.

**It is layout-only in a checkable way rather than an asserted one:** the
character multiset either side of the whole diff is identical once whitespace,
braces and commas are excluded — zero net difference. Nothing was added or
removed, only rearranged and re-braced (rustfmt puts block braces on one
`return Err(...)` match arm in `siphon-control/src/lib.rs`).

Carried in the same commit as the gate, mirroring `1dba476`, which did this for
the main tree. As the note on that commit records, the
`.git-blame-ignore-revs` entry can only be added *afterwards*, against the SHA
the squash actually produces — follow-up.

## Verification

Every leg was run locally before the job was written, rather than pushed and
left to CI:

- `cargo fmt --all -- --check`: clean after the reformat.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 50 passed, 0 failed, across 6 test binaries.
- `pytest`: 12 passed — validated on CPython 3.13, 3.14 and 3.14t.

No `CHANGELOG.md` entry: CI and formatting are internal churn, with nothing
observable to an operator or a script author.
