### PR TITLE
fix(b2bua): reap a call's B-leg event receiver when the call goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,16 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   under it.
 
 ### Fixed
+- **B2BUA B-leg event receivers are now reaped with their call.** This was the
+  one call-lifetime store in the orphan sweep with no backstop: every teardown
+  path removes it, but a call whose teardown never reached the dispatcher — and
+  which the sweep beside it already reaped — left its receiver behind for the
+  life of the process, holding a whole 64-slot channel of pending call events.
+  It also matters for liveness rather than only memory: the leg actors send on
+  that channel with an unbounded wait, so a full channel parks the actor until
+  something drops the receiver, and dropping it here is what guarantees the
+  actor is released. Reaped by asking whether the call still exists rather than
+  by age, so it catches an orphan from any cause.
 - **A method no script handler claims is no longer answered `500`, and OPTIONS
   is answered by the stack.** Every method without a matching
   `@proxy.on_request` handler got `500 Server Internal Error`, and OPTIONS is

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -2348,6 +2348,15 @@ impl CallActorStore {
         self.calls.get(call_id)
     }
 
+    /// Whether a call is still live, without taking a guard on it.
+    ///
+    /// Deliberately not `get_call(..).is_some()`: this is called from inside a
+    /// `retain` closure on a *different* map, and returning a `Ref` there would
+    /// hold a shard read guard on this map for the body of that closure.
+    pub fn contains_call(&self, call_id: &str) -> bool {
+        self.calls.contains_key(call_id)
+    }
+
     /// Get a mutable reference to a call.
     pub fn get_call_mut(
         &self,
@@ -4618,6 +4627,56 @@ mod tests {
         assert_eq!(store.sweep_stale(std::time::Duration::from_secs(60)), 0);
         assert_eq!(store.sweep_stale(std::time::Duration::ZERO), 1);
         assert_eq!(store.count(), 0);
+    }
+
+    /// The dispatcher parks its B-leg event receivers in a map keyed by call id
+    /// and reaps them by asking whether the call is still live. Two things ride
+    /// on that: a receiver for a reaped call holds a whole 64-slot channel of
+    /// `CallEvent`s forever, and — because the leg actors send on that channel
+    /// with an unbounded await — a full channel parks the actor until something
+    /// drops the receiver.
+    ///
+    /// So this asserts both halves: the reaped call is gone from the store, and
+    /// an actor already parked on a full channel is released once the receiver
+    /// the sweep would drop is dropped.
+    #[tokio::test]
+    async fn a_reaped_call_releases_an_actor_parked_on_its_event_channel() {
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+        assert!(
+            store.contains_call(&call_id),
+            "a fresh call is live, so its receiver must be kept"
+        );
+
+        // One slot, already full: the next send parks, exactly as a leg actor
+        // does when the dispatcher has not drained the channel.
+        let (event_tx, event_rx) = tokio::sync::mpsc::channel::<u8>(1);
+        event_tx.send(1).await.expect("first send fits");
+        let parked = tokio::spawn(async move { event_tx.send(2).await });
+        tokio::task::yield_now().await;
+        assert!(!parked.is_finished(), "the second send must be parked");
+
+        // The sweep's rule: no call, no receiver.
+        store.sweep_stale(std::time::Duration::ZERO);
+        assert!(!store.contains_call(&call_id), "the call was reaped");
+        let receivers = dashmap::DashMap::new();
+        receivers.insert(call_id.clone(), event_rx);
+        receivers.retain(|id: &String, _| store.contains_call(id));
+        assert!(
+            receivers.is_empty(),
+            "a receiver whose call is gone must be reaped — it holds a whole \
+             channel of events, and the actor parked on it, for the life of the \
+             process"
+        );
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), parked)
+            .await
+            .expect("dropping the receiver must release the parked actor")
+            .expect("the sending task did not panic");
+        assert!(
+            outcome.is_err(),
+            "the parked send must complete as Closed once the receiver is gone"
+        );
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2410,6 +2410,34 @@ async fn sweep_stale_entries(state: &DispatcherState) {
     // never refreshed), returns the number reaped.
     let expired_calls = state.call_actors.sweep_stale(ORPHAN_CALL_TTL) as u64;
 
+    // B-leg event receivers — the one call-lifetime store in this function that
+    // had no backstop. Every teardown path removes it, but a call whose teardown
+    // never reached the dispatcher (and which the sweep above just reaped) left
+    // its receiver behind forever, holding up to a full 64-slot channel of
+    // `CallEvent`s.
+    //
+    // It also matters for liveness, not just memory: the leg actors send on that
+    // channel with an unbounded `await`, so a full channel parks the actor until
+    // *something* drops the receiver. Dropping it here is what guarantees the
+    // actor is eventually released (as `Closed`) instead of parking for the life
+    // of the process. Keyed on the call still existing rather than on an age, so
+    // it catches an orphan from any cause, not only from the sweep above.
+    //
+    // The brief window in `recv_b_leg_classification_event`, where the receiver
+    // is extracted and re-inserted around a blocking recv, can re-add an entry
+    // for a call reaped in the same pass; the next sweep collects it.
+    let receivers_before = state.call_event_receivers.len();
+    state
+        .call_event_receivers
+        .retain(|call_id, _| state.call_actors.contains_call(call_id));
+    let expired_call_events = receivers_before.saturating_sub(state.call_event_receivers.len());
+    if expired_call_events > 0 {
+        debug!(
+            expired_call_events,
+            "swept B-leg event receivers whose call is gone"
+        );
+    }
+
     // Proxy Rf charging sessions — one Arc may be filed under several keys
     // (storage_keys aliases), so retain on the value's age to drop every alias
     // of an orphan in one pass.


### PR DESCRIPTION
The last item from the park-forever sweep, and the one where the obvious fix is the wrong one.

## What is wrong

`call_event_receivers` is a `DashMap<call_id, Receiver<CallEvent>>`. Every teardown path removes its entry — there are about twenty of them — but it is the **only** call-lifetime store in `sweep_stale_entries` with no orphan backstop. The sweep immediately above it reaps the `CallActor` itself; the receiver for that same call stays.

That leaks a whole 64-slot channel of pending `CallEvent`s per orphaned call, forever.

The leak is the smaller half. The leg actors send on that channel with an unbounded `await` (seven sites in `LegActor`), so a full channel parks the actor until *something* drops the receiver. With no backstop, nothing did.

## Why not bound the send instead

That is what the rest of this sweep did elsewhere, and here it would be wrong. A shed `CallEvent` means a leg never learns it was answered or torn down — a correctness failure worse than the one being fixed. Dropping the receiver achieves the same liveness result (the parked send completes as `Closed`) without ever discarding an event on a live call.

## The fix

Reap the receiver when its call is gone. Keyed on the call still existing rather than on an age, so it catches an orphan from any cause, not only from the sweep beside it. `contains_call` is added rather than reusing `get_call(..).is_some()` because this runs inside a `retain` closure on a different map and returning a `Ref` would hold a shard guard on `call_actors` for the closure body.

The brief window in `recv_b_leg_classification_event`, where the receiver is extracted and re-inserted around a blocking recv, can re-add an entry for a call reaped in the same pass; the next sweep collects it, and that is noted in the source.

## Tests

`a_reaped_call_releases_an_actor_parked_on_its_event_channel` asserts both halves: the receiver for a reaped call is dropped, and an actor already parked on a full channel is released as `Closed` once it is.

`cargo test` 4656 passed, clippy clean.