### PR TITLE
feat(script): call.local_tag and call.set_body, for calls whose media is negotiated outside siphon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **`call.local_tag` and `call.set_body()`** — the two things a B2BUA script
+  needed when the media for a call is negotiated by something outside siphon.
+  `call.local_tag` exposes the UAS To-tag siphon minted for the A-leg dialog: it
+  is generated with the dialog, so it reads from the first handler onwards,
+  before any response goes out, and it is the tag stamped on every response the
+  framework sends. It was reachable from nowhere in the script API — the To-tag
+  is a header *parameter*, so `call.to_uri` cannot carry it, and it never
+  appears in the inbound INVITE the script API holds because siphon generates
+  it — which left a controller keying an offer/answer on
+  `(call-id, from-tag, to-tag)` no way to agree with siphon about the dialog it
+  was answering for, and minting its own there desynchronises the media answer
+  from the dialog. `call.set_body(body, content_type=None)` replaces the body of
+  the captured A-leg INVITE, restating `Content-Length` (and `Content-Type` when
+  given), which is the `dial()`-time counterpart of `set_ruri_user()` /
+  `set_from_user()`: the B-leg INVITE is built from that message, so it is the
+  only place to put a rewritten offer. `request.set_body()` has always existed;
+  its `Call` twin did not, so a script that anchored media and then needed to
+  strip or rewrite an attribute before the offer went out had nowhere to put the
+  result. Omitting `content_type` leaves the existing one alone — the body
+  changed, the type did not — and an empty body clears it with
+  `Content-Length: 0` rather than being refused, since a delayed-offer INVITE is
+  a legitimate thing to build.
 - **`siphon_memory_metadata_bytes`** — jemalloc's `stats.metadata`, the last of
   the allocator's own numbers that siphon read but did not export. Without it
   `resident - allocated - retained` is unattributed, and it is the term that

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 
 import ipaddress
 import uuid
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from siphon_sdk.types import Action, Contact, Flow, MediaHandle, SipUri
 from siphon_sdk.request import _parse_uri, _validate_send_socket
 from siphon_sdk.lcr import Route
+
+# Distinguishes "caller said nothing about local_tag" (generate one, like the
+# engine does when it creates the dialog) from an explicit ``local_tag=None``
+# (simulate a call that is no longer live).
+_UNSET_LOCAL_TAG: Any = object()
 
 
 def _validate_replaces(replaces: Optional[dict]) -> None:
@@ -73,6 +78,7 @@ class Call:
         active_route: Optional[Route] = None,
         route_attempts: Optional[list[dict]] = None,
         flow: Optional[Flow] = None,
+        local_tag: Optional[str] = _UNSET_LOCAL_TAG,
     ) -> None:
         self._id = call_id or str(uuid.uuid4())
         self._from_uri = _parse_uri(from_uri)
@@ -86,6 +92,15 @@ class Call:
         # produces a record carrying the A-leg transport, like the engine does.
         self._transport = transport
         self._body = body
+        # siphon mints the A-leg To-tag with the dialog, so a live call always
+        # has one — default to a generated tag rather than None, or every mock
+        # call would look like a torn-down one. ``local_tag=None`` opts into
+        # exactly that case.
+        self._local_tag = (
+            f"sb-{uuid.uuid4().hex[:12]}"
+            if local_tag is _UNSET_LOCAL_TAG
+            else local_tag
+        )
         self._call_id = call_id or self._id
         self._headers: dict[str, str] = dict(headers) if headers else {}
         self._actions: list[Action] = []
@@ -341,6 +356,39 @@ class Call:
     def body(self) -> Optional[bytes]:
         """SDP body content, or ``None``."""
         return self._body
+
+    @property
+    def local_tag(self) -> Optional[str]:
+        """The UAS To-tag siphon minted for this call's A-leg.
+
+        siphon owns this tag: it is generated with the A-leg dialog, so it is
+        readable from the first handler onwards — before any response goes
+        out — and it is the tag stamped on every response the framework sends,
+        from the ``progress()`` 18x through the ``answer()`` 2xx and on into
+        in-dialog requests.  It does not change for the life of the dialog.
+        ``None`` only when the call is no longer live.
+
+        Read it when something outside siphon has to agree with siphon about
+        the dialog's identity — an external media controller keying an
+        offer/answer on ``(call-id, from-tag, to-tag)`` needs the same to-tag
+        siphon put on the wire, and minting its own there desynchronises the
+        media answer from the dialog.
+
+        Example::
+
+            @b2bua.on_invite
+            def new_call(call):
+                answer_sdp = media_control.answer(
+                    call_id=call.call_id,
+                    to_tag=call.local_tag,
+                    offer=call.body,
+                )
+                call.answer(200, "OK", answer_sdp, "application/sdp")
+
+        In tests, pass ``local_tag=`` to pin it, or ``local_tag=None`` to
+        simulate reading it on a call that has already gone away.
+        """
+        return self._local_tag
 
     @property
     def media(self) -> MediaHandle:
@@ -1511,6 +1559,45 @@ class Call:
     def set_header(self, name: str, value: str) -> None:
         """Set (replace) a header value."""
         self._headers[name] = value
+
+    def set_body(
+        self,
+        body: Union[str, bytes],
+        content_type: Optional[str] = None,
+    ) -> None:
+        """Replace the body of the captured A-leg INVITE.
+
+        Updates ``Content-Type`` and ``Content-Length`` to match.  ``body``
+        accepts ``str`` or ``bytes``.
+
+        The B-leg INVITE is built from this message, so a body set here is the
+        body the callee receives — this is the ``dial()``-time counterpart of
+        :meth:`set_ruri_user` / :meth:`set_from_user` and must be called
+        *before* :meth:`dial` / :meth:`fork`.  The typical use is sanitising
+        the SDP an anchoring step left behind: ``rtpengine.offer(call)``
+        rewrites the captured INVITE in place, and a script that needs to strip
+        or rewrite attributes before the offer goes out has nowhere else to put
+        the result.
+
+        Args:
+            body: Replacement body, ``str`` or ``bytes``.
+            content_type: Content-Type to set.  Omit to leave the existing one
+                in place — the body changed, the type did not.
+
+        Example::
+
+            @b2bua.on_invite
+            async def new_call(call):
+                await rtpengine.offer(call, profile="trunk_to_ims")
+                cleaned = strip_unwanted_attributes(call.body)
+                call.set_body(cleaned, "application/sdp")
+                call.dial("sip:bob@example.com")
+        """
+        payload = body.encode() if isinstance(body, str) else bytes(body)
+        self._body = payload or None
+        if content_type is not None:
+            self.set_header("Content-Type", content_type)
+        self.set_header("Content-Length", str(len(payload)))
 
     def set_charging_param(self, name: str, value: str) -> None:
         """Stash a charging-param for the Rf B2BUA auto-emit hook.

--- a/sdk/tests/test_call_body_and_local_tag.py
+++ b/sdk/tests/test_call_body_and_local_tag.py
@@ -1,0 +1,115 @@
+"""Tests for ``call.set_body()`` and ``call.local_tag``.
+
+Both exist for scripts that hand the A-leg's media off to something outside
+siphon.  ``set_body()`` rewrites the captured INVITE the B-leg is built from,
+which is the only place to put the result of a post-anchor SDP rewrite.
+``local_tag`` exposes the UAS To-tag siphon minted, so an external media
+controller keys its answer on the same dialog identity siphon put on the wire
+instead of inventing one.
+"""
+
+import pytest
+
+from siphon_sdk.call import Call
+from siphon_sdk.testing import SipTestHarness
+
+
+SDP = (
+    "v=0\r\n"
+    "o=- 1 1 IN IP4 192.0.2.1\r\n"
+    "s=-\r\n"
+    "c=IN IP4 192.0.2.1\r\n"
+    "t=0 0\r\n"
+    "m=audio 40000 RTP/AVP 0\r\n"
+)
+
+
+class TestSetBody:
+    def test_replaces_the_body_and_restates_content_length(self):
+        call = Call()
+        call.set_body(SDP, "application/sdp")
+        # The B-leg INVITE is built from this message, so a stale
+        # Content-Length here is a malformed INVITE on the wire.
+        assert call.body == SDP.encode()
+        assert call.get_header("Content-Type") == "application/sdp"
+        assert call.get_header("Content-Length") == str(len(SDP))
+
+    def test_accepts_bytes_so_a_read_modify_write_needs_no_decode(self):
+        call = Call(body=SDP.encode())
+        rewritten = call.body.replace(b"40000", b"40002")
+        call.set_body(rewritten)
+        assert call.body == rewritten
+        assert call.get_header("Content-Length") == str(len(rewritten))
+
+    def test_omitting_content_type_keeps_the_one_already_set(self):
+        call = Call()
+        call.set_body(SDP, "application/sdp")
+        call.set_body(SDP.replace("40000", "40002"))
+        # The body changed, the type did not — clearing it here would strip
+        # Content-Type off an INVITE that still carries SDP.
+        assert call.get_header("Content-Type") == "application/sdp"
+
+    def test_empty_body_clears_it_and_says_zero(self):
+        call = Call(body=SDP.encode())
+        call.set_body("")
+        # A bodiless INVITE is a legitimate state (delayed offer), so this is
+        # a clear, not a refusal.
+        assert call.body is None
+        assert call.get_header("Content-Length") == "0"
+
+
+class TestLocalTag:
+    def test_a_live_call_always_has_one(self):
+        # siphon mints the tag with the dialog, so it is readable from the
+        # first handler onwards — before any response has gone out.
+        assert Call().local_tag
+
+    def test_is_stable_across_reads(self):
+        call = Call()
+        assert call.local_tag == call.local_tag
+
+    def test_distinct_calls_get_distinct_tags(self):
+        assert Call().local_tag != Call().local_tag
+
+    def test_can_be_pinned_for_assertions(self):
+        assert Call(local_tag="sb-deadbeef").local_tag == "sb-deadbeef"
+
+    def test_none_models_a_call_that_is_no_longer_live(self):
+        # The engine returns None once the call actor is gone; a script reading
+        # it from a late async handler must get None, not a stale tag.
+        assert Call(local_tag=None).local_tag is None
+
+
+@pytest.fixture
+def harness():
+    h = SipTestHarness(local_domains=["example.com"])
+    yield h
+    h.reset()
+    h.close()
+
+
+class TestExternalMediaControlShape:
+    def test_script_answers_with_a_body_keyed_on_the_dialog_tag(self, harness):
+        # The shape both APIs exist for: anchor, rewrite the offer the anchor
+        # produced, and answer with media negotiated against siphon's own
+        # dialog identity.
+        harness.load_source(
+            """
+from siphon import b2bua, rtpengine
+
+@b2bua.on_invite
+async def on_invite(call):
+    await rtpengine.offer(call, profile="ivr")
+    call.set_body((call.body or b"").replace(b"sendrecv", b"sendonly"),
+                  "application/sdp")
+    call.set_header("X-Dialog-Tag", call.local_tag or "none")
+    call.answer(200, "OK", body=call.body, content_type="application/sdp")
+"""
+        )
+        result = harness.send_invite(
+            ruri="sip:echo@example.com", from_uri="sip:alice@example.com"
+        )
+        assert result.action == "answer"
+        # The tag the script read is the one the call carries — not a fresh one.
+        assert result.call.get_header("X-Dialog-Tag") == result.call.local_tag
+        assert result.call.get_header("Content-Type") == "application/sdp"

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -23324,6 +23324,24 @@ pub fn b2bua_answer_call(
     )
 }
 
+/// The A-leg's local (UAS) To-tag for a live B2BUA call (`call.local_tag`).
+///
+/// siphon mints this tag with the A-leg dialog (`Dialog::from_inbound`), so it
+/// exists before any response is sent, and stamps it on everything
+/// `b2bua_send_uas_response` puts on the wire — it is the tag the far end sees.
+/// It lives on the actor and never appears in the inbound INVITE the script API
+/// holds, which is why reading it needs a door through the control handle
+/// rather than a lookup on `PyCall`'s own message. Keyed on the internal call
+/// id, like the other UAS-side entry points (`b2bua_answer_call`,
+/// `b2bua_progress_call`).
+///
+/// `None` when the dispatcher is down or the call is gone.
+pub fn b2bua_local_tag(internal_call_id: &str) -> Option<String> {
+    let control = B2BUA_CONTROL.get()?;
+    let call = control.state.call_actors.get_call(internal_call_id)?;
+    Some(call.a_leg.dialog.local_tag.clone())
+}
+
 /// Imperatively send a provisional (1xx) for a UAS-mode B2BUA call
 /// (`call.progress()`) — e.g. a 183 with early-media SDP. Does not answer the
 /// call. Returns `false` if the call is gone / dispatcher down.
@@ -30753,6 +30771,16 @@ mod tests {
             None,
             None
         ));
+    }
+
+    #[test]
+    fn b2bua_local_tag_unknown_id_is_none_no_panic() {
+        // `call.local_tag` is read from script threads, including after the
+        // call it names has been torn down (an async handler resuming late, a
+        // timer firing on a hung-up call). Unknown id — and no running
+        // dispatcher in the test binary — must be None, never a panic.
+        assert!(b2bua_local_tag("nope").is_none());
+        assert!(b2bua_local_tag("").is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -1343,6 +1343,63 @@ impl PyCall {
         }
     }
 
+    /// Replace the body of the captured A-leg INVITE.
+    ///
+    /// Updates ``Content-Type`` and ``Content-Length`` to match.  ``body``
+    /// accepts ``str`` or ``bytes``.
+    ///
+    /// The B-leg INVITE is built from this message, so a body set here is the
+    /// body the callee receives — this is the ``dial()``-time counterpart of
+    /// ``set_ruri_user()`` / ``set_from_user()`` and must be called *before*
+    /// ``dial()`` / ``fork()``.  The typical use is sanitising the SDP an
+    /// anchoring step left behind: ``rtpengine.offer(call)`` rewrites the
+    /// captured INVITE in place, and a script that needs to strip or rewrite
+    /// attributes before the offer goes out has nowhere else to put the result.
+    ///
+    /// ```python
+    /// await rtpengine.offer(call, profile="trunk_to_ims")
+    /// cleaned = strip_unwanted_attributes(call.body)
+    /// call.set_body(cleaned, "application/sdp")
+    /// call.dial("sip:bob@example.com")
+    /// ```
+    #[pyo3(signature = (body, content_type=None))]
+    fn set_body(&self, body: &Bound<'_, PyAny>, content_type: Option<&str>) -> PyResult<()> {
+        let bytes = super::request::extract_body_bytes(body)?;
+        let mut message = self.message.lock().map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
+        })?;
+        if let Some(content_type) = content_type {
+            message
+                .headers
+                .set("Content-Type", content_type.to_string());
+        }
+        message
+            .headers
+            .set("Content-Length", bytes.len().to_string());
+        message.body = bytes;
+        Ok(())
+    }
+
+    /// The UAS To-tag siphon minted for this call's A-leg.
+    ///
+    /// siphon owns this tag: it is generated with the A-leg dialog, so it is
+    /// readable from the first handler onwards — before any response goes out —
+    /// and it is the tag stamped on every response the framework sends, from
+    /// the ``progress()`` 18x through the ``answer()`` 2xx and on into the
+    /// in-dialog requests.  It does not change for the life of the dialog.
+    /// ``None`` only when the call is no longer live (or the B2BUA is not
+    /// running).
+    ///
+    /// Read it when something outside siphon has to agree with siphon about
+    /// the dialog's identity — an external media controller keying an
+    /// offer/answer on ``(call-id, from-tag, to-tag)`` needs the same to-tag
+    /// siphon put on the wire, and minting its own there desynchronises the
+    /// media answer from the dialog.
+    #[getter]
+    fn local_tag(&self) -> Option<String> {
+        crate::dispatcher::b2bua_local_tag(&self.id)
+    }
+
     /// Reject the call with a status code.
     fn reject(&mut self, code: u16, reason: &str) {
         self.action = CallAction::Reject {
@@ -4189,5 +4246,101 @@ mod tests {
             call.cdr_session_key_candidates(),
             vec!["test-id".to_string()]
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // call.set_body / call.local_tag
+    // -----------------------------------------------------------------------
+
+    const SDP: &str = "v=0\r\no=- 1 1 IN IP4 192.0.2.1\r\ns=-\r\nc=IN IP4 192.0.2.1\r\nt=0 0\r\nm=audio 40000 RTP/AVP 0\r\n";
+
+    fn plain_call() -> PyCall {
+        PyCall::new(
+            "test-id".to_string(),
+            Arc::new(Mutex::new(make_invite())),
+            "192.0.2.10".to_string(),
+            "udp".to_string(),
+        )
+    }
+
+    /// The B-leg INVITE is built from this message, so a wrong Content-Length
+    /// here is a malformed INVITE on the wire, not a local inconsistency.
+    #[test]
+    fn set_body_replaces_the_body_and_restates_content_length() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let call = plain_call();
+            let body = pyo3::types::PyString::new(py, SDP).into_any();
+
+            call.set_body(&body, Some("application/sdp")).unwrap();
+
+            assert_eq!(call.body().unwrap().as_deref(), Some(SDP.as_bytes()));
+            let message = call.message.lock().unwrap();
+            assert_eq!(
+                message.headers.get("Content-Length").map(String::as_str),
+                Some(SDP.len().to_string().as_str())
+            );
+            assert_eq!(
+                message.headers.get("Content-Type").map(String::as_str),
+                Some("application/sdp")
+            );
+        });
+    }
+
+    /// `bytes` is the shape `call.body` hands back, so a read-modify-write
+    /// round trip must not have to decode to `str` first.
+    #[test]
+    fn set_body_accepts_bytes_and_keeps_the_content_type_when_omitted() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let call = plain_call();
+            let first = pyo3::types::PyString::new(py, SDP).into_any();
+            call.set_body(&first, Some("application/sdp")).unwrap();
+
+            let rewritten = SDP.replace("40000", "40002");
+            let second = pyo3::types::PyBytes::new(py, rewritten.as_bytes()).into_any();
+            call.set_body(&second, None).unwrap();
+
+            assert_eq!(call.body().unwrap().as_deref(), Some(rewritten.as_bytes()));
+            let message = call.message.lock().unwrap();
+            // Omitting content_type leaves the one already negotiated in place
+            // rather than clearing it — the body changed, the type did not.
+            assert_eq!(
+                message.headers.get("Content-Type").map(String::as_str),
+                Some("application/sdp")
+            );
+            assert_eq!(
+                message.headers.get("Content-Length").map(String::as_str),
+                Some(rewritten.len().to_string().as_str())
+            );
+        });
+    }
+
+    /// An empty body is a legitimate state (a delayed-offer INVITE), so it must
+    /// clear the body and say `Content-Length: 0` rather than being refused.
+    #[test]
+    fn set_body_empty_clears_the_body() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let call = plain_call();
+            let body = pyo3::types::PyString::new(py, "").into_any();
+
+            call.set_body(&body, None).unwrap();
+
+            assert!(call.body().unwrap().is_none());
+            let message = call.message.lock().unwrap();
+            assert_eq!(
+                message.headers.get("Content-Length").map(String::as_str),
+                Some("0")
+            );
+        });
+    }
+
+    /// No B2BUA is running in the test binary, so this exercises the
+    /// dispatcher-down arm: a script reading the tag on a call that has gone
+    /// away gets `None`, never a panic on a script thread.
+    #[test]
+    fn local_tag_is_none_when_the_call_is_not_live() {
+        assert!(plain_call().local_tag().is_none());
     }
 }


### PR DESCRIPTION
Two gaps in the B2BUA script API that only show up when the media for a call is negotiated by something outside siphon, and the script has to hand that thing siphon's own view of the dialog.

## `call.local_tag`

The UAS To-tag siphon minted for the A-leg dialog. It was reachable from nowhere in the script API: the To-tag is a header *parameter*, so `call.to_uri` cannot carry it, and it never appears in the inbound INVITE the script API holds because siphon generates it in `Dialog::from_inbound`.

That left an external media controller keying an offer/answer on `(call-id, from-tag, to-tag)` with no way to agree with siphon about the dialog it was answering for. Minting its own to-tag there desynchronises the media answer from the dialog.

Because the tag is created with the dialog rather than at the first response, it reads from the first handler onwards, before anything goes on the wire, and it does not change for the life of the dialog. `None` only once the call is no longer live, which is the case a late async handler or a timer firing on a hung-up call lands in.

Reading it needs a door through the B2BUA control handle rather than a lookup on `PyCall`'s own message, so this adds `b2bua_local_tag`, keyed on the internal call id like the other UAS-side entry points (`b2bua_answer_call`, `b2bua_progress_call`).

## `call.set_body(body, content_type=None)`

Replaces the body of the captured A-leg INVITE, restating `Content-Length`, and `Content-Type` when one is given.

`request.set_body()` has always existed; the `Call` twin did not. The B-leg INVITE is built from that captured message, so this is the `dial()`-time counterpart of `set_ruri_user()` / `set_from_user()` and it is the only place to put a rewritten offer. A script that anchored media and then needed to strip or rewrite an attribute before the offer went out had nowhere to put the result.

Two deliberate behaviours: omitting `content_type` leaves the existing one alone, since the body changed and the type did not, and clearing it would strip `Content-Type` off an INVITE that still carries SDP; and an empty body clears the body with `Content-Length: 0` rather than being refused, because a delayed-offer INVITE is a legitimate thing to build.

## Tests

- `b2bua_local_tag` with an unknown id and no running dispatcher is `None`, never a panic (it is read from script threads, including after the call it names is gone).
- `set_body` round trip: replaces the body and restates `Content-Length`; accepts `bytes` so a read-modify-write off `call.body` needs no decode; keeps the existing `Content-Type` when omitted; empty clears.
- SDK mock mirrors both, with a `local_tag=` kwarg to pin a tag or pass `None` to model a call that is no longer live. Ten SDK tests including the end-to-end shape both APIs exist for: anchor, rewrite the offer the anchor produced, answer keyed on the dialog tag.

`docs/reference/call.md` renders the class, so the docstrings carry into the site.

Clippy clean, `cargo fmt` clean, full Rust suite (4660) and SDK suite (687) green.
