### PR TITLE
feat(b2bua): bound an answered call — max_duration on dial/fork/route plus b2bua.max_call_duration_secs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1923,6 +1923,38 @@ jobs:
       - name: A raised handler and call.terminate() must both fail the call
         run: MODE=both PYO3_PYTHON=python3.14 scripts/b2bua_answer_fail_test.sh
 
+  # An answered call has to be able to end on siphon's own clock. `timeout=`
+  # bounds the ring and stops mattering at the 200 OK, so before max_duration an
+  # answered call was bounded by nothing but a peer BYE or a session timer —
+  # a carrier leg that went quiet with its dialog up held a call actor, a media
+  # anchor and a charging session until the process restarted. Deterministic and
+  # needs no capability: neither SIPp peer ever hangs up in the capped arms, so
+  # the BYE they both wait for can only be the cap, and each asserts it carries
+  # RFC 3326 Q.850;cause=102. The opt-out arm is the one that keeps the other two
+  # honest — a cap applied unconditionally would pass them both.
+  sipp-b2bua-max-duration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Python 3.14 (free-threaded)
+        uses: deadsnakes/action@v3.2.0
+        with:
+          python-version: "3.14-dev"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install SIPp
+        run: sudo apt-get update && sudo apt-get install -y sip-tester
+
+      - name: Build siphon
+        run: PYO3_PYTHON=python3.14 cargo build --bin siphon
+
+      - name: A call must be cut at its maximum duration, and only then
+        run: PYO3_PYTHON=python3.14 scripts/b2bua_max_duration_test.sh
+
   # ── Fuzz testing (nightly) ─────────────────────────────────────────────
   fuzz:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 ## [Unreleased]
 
 ### Added
+- **A maximum call duration — `max_duration=` on `call.dial()` / `call.fork()` /
+  `call.route()`, `call.set_max_duration()`, and `b2bua.max_call_duration_secs`.**
+  A B2BUA call had exactly one bound: `timeout=`, which is how long the B-leg may
+  ring. It stops mattering the moment a `2xx` lands, and after that an answered
+  call was bounded by nothing except a peer BYE, a script `terminate()`, or an
+  RFC 4028 session timer — which is off unless configured, needs the far end to
+  play along, and by design keeps a call up for as long as something keeps
+  refreshing it. So a carrier leg that went silent with its dialog still up, or
+  a call nobody was ever going to hang up, held a call actor, a media anchor, a
+  charging session and an RTP port pair until the process restarted. The new cap
+  measures from the **answer**, not from the dial: the ring is already bounded,
+  and a ceiling that counted ring time would hand a call that rang for 25
+  seconds less talk time than one picked up instantly. On a fork or an LCR
+  sequence it is per call rather than per branch or per carrier — `timeout`
+  bounds each attempt, but whichever one answers hands over a single answered
+  call. On expiry siphon BYEs both legs through the ordinary teardown, so the
+  call leaves the same accounting behind as any other: `Reason:
+  Q.850;cause=102`, a CDR with `disconnect_initiator="timeout"`, Rf/Ro
+  `ACR-STOP`, media released, `StasisEnd` on the control rail. No Python handler
+  fires, matching session-timer expiry and `call.terminate()` —
+  `@b2bua.on_bye` reports which *peer* hung up and here neither did; the CDR's
+  `sip_reason` is what tells a duration cut apart from a session-timer one.
+  `max_call_duration_secs` is the operator backstop for every call that does not
+  ask for its own, including calls answered in UAS mode or handed to a control
+  app; a call overrides it with `max_duration=<seconds>` and opts out entirely
+  with `max_duration=0`.
 - **`b2bua.replace_peer()` and the control plane's `replace_peer` verb** — swap
   one party of an answered call for a freshly dialled target, with no REFER
   anywhere. siphon has always been able to do this: it is what
@@ -194,6 +220,19 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   under it.
 
 ### Fixed
+- **A CDR is on disk when the write returns, and the rotation size check sees
+  the record it just wrote.** The file backend wrote each record with
+  `write_all` and then read `metadata()` to decide whether to rotate, without
+  flushing in between. Tokio buffers the write and runs it on the blocking
+  pool: `write_all` returns once the bytes are in the buffer rather than on
+  disk, and `metadata()` does not wait for an in-flight write either. So on a
+  busy process the size check read the length from *before* the record and the
+  file grew past `rotate_size_mb` before it rotated, while the record itself
+  could still be in flight after the writer had moved on — on a hard exit, a
+  billing record lost. The LI audit log had the same missing flush and holds
+  its handle for the life of the process, so an audit line could sit in the
+  buffer indefinitely instead of being readable the moment the operation it
+  records happened.
 - **A prepaid call that never dialled anything no longer leaves its Ro session
   open.** `call.ro_authorize()` reserves credit *before* the B-leg is connected,
   so from the reservation until the first leg there is a live credit-control

--- a/docs/reference/call.md
+++ b/docs/reference/call.md
@@ -158,6 +158,57 @@ has, which is an operator's decision rather than an upgrade's. (The
 [LCR failover lines](../cookbook/least-cost-routing.md) log at `info`
 unconditionally — they fire only when a carrier fails, not on every call.)
 
+## Bounding a call: `timeout` and `max_duration`
+
+A call has two clocks, and they measure different things.
+
+`timeout=` bounds the **ring**. If nothing answers in that many seconds siphon
+CANCELs the outstanding legs, fires `@b2bua.on_failure`, and answers the caller
+`408`. It stops mattering the moment a `2xx` lands.
+
+`max_duration=` bounds the **talk**. The clock starts at the answer, so a call
+that rang for 25 seconds still gets its full talk time. When it expires siphon
+BYEs both legs.
+
+```python
+@b2bua.on_invite
+def route(call):
+    # 30s to answer, then at most an hour connected.
+    call.dial(call.ruri, timeout=30, max_duration=3600)
+```
+
+Before this existed, an answered call was bounded by nothing but a peer BYE, a
+script `terminate()`, or an RFC 4028 session timer where one is configured *and*
+the far end honours it. A carrier leg that goes silent with its dialog still up
+holds a call actor, a media anchor, a charging session and an RTP port pair for
+as long as the process lives.
+
+The operator backstop is the same cap applied to every call that does not ask
+for its own:
+
+```yaml
+b2bua:
+  max_call_duration_secs: 14400    # 4h; unset means uncapped
+```
+
+A call overrides it with `max_duration=<seconds>` and opts out of it entirely
+with `max_duration=0`. The kwarg is on `call.dial()`, `call.fork()` and
+`call.route()`; on a fork or an LCR sequence it is per *call*, not per branch or
+per carrier — `timeout` bounds each attempt's ring, but whichever one answers
+hands over a single answered call. A call that never dials at all — a UAS-mode
+`call.answer()`, a `call.handover()` — reaches the same knob through
+`call.set_max_duration(seconds)`.
+
+On expiry siphon runs the ordinary teardown: a BYE to each leg carrying
+`Reason: Q.850;cause=102;text="Maximum call duration exceeded"` (RFC 3326), a
+CDR with `disconnect_initiator="timeout"`, Rf/Ro `ACR-STOP`, media released,
+`StasisEnd` on the control rail. **No Python handler fires** — `@b2bua.on_bye`
+reports which *peer* hung up, and here neither did, which is also how a
+session-timer expiry and `call.terminate()` behave. The CDR is the record; its
+`sip_reason` is what distinguishes a duration cut from a session-timer one.
+
+::: siphon_sdk.call.Call.set_max_duration
+
 ## `MediaHandle`
 
 Returned by `call.media` — controls RTP anchoring for the call.

--- a/scripts/b2bua_max_duration.py
+++ b/scripts/b2bua_max_duration.py
@@ -1,0 +1,56 @@
+"""B2BUA script for the maximum-call-duration SIPp test
+(scripts/b2bua_max_duration_test.sh).
+
+The call is dialled with a short ``max_duration``; both parties then sit on the
+answered call doing nothing. Nobody sends a BYE, no session timer is configured,
+and the ring timeout stopped applying at the 200 OK — so if the cap does not
+fire, the call simply stays up and both SIPp peers time out.
+
+``MODE`` selects where the cap comes from, because the two paths reach the call
+actor differently and only one of them goes through the script:
+
+  ``dial``    ``call.dial(max_duration=...)`` — the per-call kwarg.
+  ``config``  no kwarg at all; the cap is ``b2bua.max_call_duration_secs`` in
+              the config, which is what covers calls the dial plan says nothing
+              about.
+  ``optout``  the config cap is set AND the call passes ``max_duration=0``, so
+              the call must survive it. This is the arm that catches a cap
+              applied unconditionally.
+"""
+
+import os
+
+from siphon import b2bua, log, proxy
+
+TARGET = os.environ.get("MAX_DURATION_TARGET", "sip:bob@127.0.0.1:5072")
+MODE = os.environ.get("MODE", "dial")
+MAX_DURATION_SECS = int(os.environ.get("MAX_DURATION_SECS", "5"))
+
+
+@proxy.on_request("OPTIONS")
+def health(request):
+    request.reply(200, "OK")
+
+
+@b2bua.on_invite
+def route(call):
+    if MODE == "dial":
+        call.dial(TARGET, timeout=10, max_duration=MAX_DURATION_SECS)
+    elif MODE == "optout":
+        # Explicitly uncapped, against a configured ceiling this call is well past.
+        call.dial(TARGET, timeout=10, max_duration=0)
+    else:
+        # The cap comes from b2bua.max_call_duration_secs; the dial says nothing.
+        call.dial(TARGET, timeout=10)
+
+
+@b2bua.on_failure
+def failed(call, code, reason):
+    log.info(f"[{call.id}] call failed {code} {reason}")
+
+
+@b2bua.on_bye
+def ended(call, initiator):
+    # A duration cut is a framework teardown, so this must NOT fire for it —
+    # only for a BYE an actual peer sent.
+    log.info(f"[{call.id}] on_bye fired, initiator={initiator.side}")

--- a/scripts/b2bua_max_duration_test.sh
+++ b/scripts/b2bua_max_duration_test.sh
@@ -1,0 +1,122 @@
+set -u
+
+# Maximum-call-duration SIPp test.
+#
+# Three arms, because the cap can arrive by three different routes and only one
+# of them goes through the script:
+#
+#   dial     call.dial(max_duration=5) — the per-call kwarg.
+#   config   b2bua.max_call_duration_secs, with the dial saying nothing. This is
+#            the arm that covers every call the dial plan is silent about.
+#   optout   the config cap is set AND the call passes max_duration=0, so the
+#            call must SURVIVE. Without this arm a cap applied unconditionally
+#            would pass the other two.
+#
+# In the first two arms neither SIPp peer ever sends a BYE, no session timer is
+# configured, and the ring timeout stopped applying at the 200 OK — so the BYE
+# both legs wait for can only be the duration cap, and each leg asserts it
+# carries RFC 3326 Reason: Q.850;cause=102.
+
+cd "$(dirname "$0")/.." || exit 2
+ROOT="$(pwd)"
+SIPHON="${SIPHON_BIN:-$ROOT/target/debug/siphon}"
+PY="${PYO3_PYTHON:-python3}"
+CONFIG="sipp/configs/siphon.max-duration-test.yaml"
+CAP_SECS="${MAX_DURATION_SECS:-5}"
+
+run_mode() {
+  mode="$1"
+  log="$(mktemp -d)"
+  echo "=== mode: $mode (logs in $log) ==="
+
+  # The `dial` arm must prove the kwarg works with NO configured ceiling behind
+  # it; the other two need the ceiling present.
+  if [ "$mode" = "dial" ]; then
+    config_cap=0
+  else
+    config_cap="$CAP_SECS"
+  fi
+
+  if [ "$mode" = "optout" ]; then
+    uac_scenario="sipp/b2bua_max_duration_optout_uac.xml"
+    uas_scenario="sipp/b2bua_session_timer_uas.xml"
+    sipp_timeout="30s"
+  else
+    uac_scenario="sipp/b2bua_max_duration_uac.xml"
+    uas_scenario="sipp/b2bua_max_duration_uas.xml"
+    sipp_timeout="20s"
+  fi
+
+  pids=()
+  cleanup() {
+    for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null; done
+    wait 2>/dev/null
+  }
+
+  MODE="$mode" MAX_DURATION_SECS="$CAP_SECS" MAX_CALL_DURATION_SECS="$config_cap" \
+    PYO3_PYTHON="$PY" "$SIPHON" -c "$CONFIG" > "$log/siphon.log" 2>&1 & pids+=($!)
+  sleep 3
+
+  sipp -sf "$uas_scenario" -i 127.0.0.1 -p 5072 -m 1 -timeout "$sipp_timeout" -timeout_error \
+    -trace_err -error_file "$log/uas.err" -message_file "$log/uas.msg" \
+    > "$log/uas.log" 2>&1 & pids+=($!)
+  sleep 1
+
+  sipp 127.0.0.1:5060 -sf "$uac_scenario" -i 127.0.0.1 -p 5090 -m 1 \
+    -timeout "$sipp_timeout" -timeout_error \
+    -trace_err -error_file "$log/uac.err" -message_file "$log/uac.msg" \
+    > "$log/uac.log" 2>&1
+  uac_rc=$?
+
+  wait "${pids[1]}" 2>/dev/null; uas_rc=$?
+
+  swept=0
+  if grep -q "maximum call duration reached" "$log/siphon.log"; then
+    swept=1
+  fi
+  # A framework teardown is not a peer hangup, so @b2bua.on_bye must stay quiet.
+  handler_fired=0
+  if grep -q "on_bye fired" "$log/siphon.log"; then
+    handler_fired=1
+  fi
+
+  cleanup
+  echo "UAC exit=$uac_rc  UAS exit=$uas_rc  cap-fired=$swept  on_bye=$handler_fired"
+
+  # In the capped arms the cap must fire and @b2bua.on_bye must NOT: a framework
+  # teardown is not a peer hangup. In the opt-out arm it is exactly the other way
+  # round — the caller hangs up for real, so on_bye firing is itself proof the
+  # call was still up when it did.
+  if [ "$mode" = "optout" ]; then
+    expect_swept=0
+    expect_handler=1
+  else
+    expect_swept=1
+    expect_handler=0
+  fi
+
+  if [ "$uac_rc" -eq 0 ] && [ "$uas_rc" -eq 0 ] \
+     && [ "$swept" -eq "$expect_swept" ] && [ "$handler_fired" -eq "$expect_handler" ]; then
+    if [ "$mode" = "optout" ]; then
+      echo "PASS ($mode): max_duration=0 survived a ${CAP_SECS}s configured ceiling; the caller's own BYE ended it"
+    else
+      echo "PASS ($mode): both legs BYEd with Q.850;cause=102 after ${CAP_SECS}s"
+    fi
+    return 0
+  fi
+  echo "FAIL ($mode) — siphon log tail:"; tail -40 "$log/siphon.log"
+  echo "UAC err:"; cat "$log/uac.err" 2>/dev/null
+  echo "UAS err:"; cat "$log/uas.err" 2>/dev/null
+  return 1
+}
+
+MODE="${MODE:-all}"
+rc=0
+if [ "$MODE" = "all" ]; then
+  run_mode dial || rc=1
+  run_mode config || rc=1
+  run_mode optout || rc=1
+else
+  run_mode "$MODE" || rc=1
+fi
+exit "$rc"

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -114,6 +114,11 @@ class Call:
         self._refer_side = refer_side
         self._contact_user_override: Optional[str] = None
         self._contact_override: Optional[str] = None
+        # Cap on how long the call may stay answered, from ``max_duration=`` on
+        # dial/fork/route or from ``set_max_duration()``.  ``None`` inherits
+        # ``b2bua.max_call_duration_secs``; ``0`` opts out of it.  Tests read it
+        # through the ``max_duration`` property.
+        self._max_duration_secs: Optional[int] = None
         # LCR: the carrier that won the sequential failover. In the engine the
         # dispatcher sets this on the on_answer/on_bye Call; in tests pass
         # ``active_route=`` (or set ``call._active_route``) to simulate the winner.
@@ -708,6 +713,7 @@ class Call:
         self,
         uri: str,
         timeout: int = 30,
+        max_duration: Optional[int] = None,
         next_hop: Optional[str] = None,
         flow: Optional["Flow"] = None,
         header_policy: Optional[str] = None,
@@ -723,7 +729,19 @@ class Call:
 
         Args:
             uri: Destination SIP URI — drives the B-leg R-URI.
-            timeout: INVITE timeout in seconds.
+            timeout: How long the B-leg may **ring** before siphon gives up,
+                in seconds.  On expiry siphon CANCELs, fires
+                ``@b2bua.on_failure`` and answers the caller ``408``.
+            max_duration: How long the call may stay **answered**, in seconds.
+                A different clock from ``timeout``: it starts at the answer, so
+                a call that rang for 25 seconds still gets its full talk time.
+                On expiry siphon BYEs both legs through the ordinary teardown
+                (CDR with ``disconnect_initiator="timeout"``, Rf/Ro
+                ``ACR-STOP``, media released) with
+                ``Reason: Q.850;cause=102``; no Python handler fires, the same
+                as for a session-timer expiry.  ``None`` (the default) inherits
+                ``b2bua.max_call_duration_secs``; ``0`` opts this call out of
+                that ceiling.
             next_hop: Optional routing destination.  When set, the new
                 INVITE's R-URI is still built from ``uri`` (so the called
                 party / IMPU shape is preserved), but the message is sent
@@ -801,6 +819,9 @@ class Call:
             # Basic dial (uses configured default policy)
             call.dial("sip:bob@10.0.0.2:5060", timeout=30)
 
+            # 30s to answer, then at most an hour of talk time.
+            call.dial("sip:bob@10.0.0.2:5060", timeout=30, max_duration=3600)
+
             # Device-driven proxy auth: let the extension authenticate to the
             # PBX itself; siphon just relays the challenge and credentials.
             call.dial("sip:bob@pbx.example.com:5060", auth_passthrough=True)
@@ -825,6 +846,8 @@ class Call:
             )
         """
         _validate_send_socket(send_socket)
+        if max_duration is not None:
+            self._max_duration_secs = max_duration
         uri = self._normalize_dial_targets([uri], number_policy)[0]
         self._actions.append(Action(
             kind="dial",
@@ -832,6 +855,7 @@ class Call:
             timeout=timeout,
             next_hop=next_hop,
             extras={
+                "max_duration": max_duration,
                 "flow": flow,
                 "header_policy": header_policy,
                 "copy": copy or [],
@@ -848,6 +872,7 @@ class Call:
         targets: list[Union[str, Contact]],
         strategy: str = "parallel",
         timeout: int = 30,
+        max_duration: Optional[int] = None,
         header_policy: Optional[str] = None,
         copy: Optional[list[str]] = None,
         strip: Optional[list[str]] = None,
@@ -873,7 +898,11 @@ class Call:
                 routing.
             strategy: ``"parallel"`` (ring all, first answer wins) or
                       ``"sequential"`` (try in order).
-            timeout: Per-branch INVITE timeout in seconds.
+            timeout: Per-branch ring timeout in seconds.
+            max_duration: Cap on how long the call may stay answered, in
+                seconds — same semantics as :meth:`dial`.  Unlike ``timeout``
+                this is not per-branch: whichever branch answers hands over one
+                answered call, and the cap is on that call.
             header_policy: Header policy applied to every branch of the fork —
                 same semantics as :meth:`dial`, built-in or operator-defined
                 (per-branch policy is a follow-up).
@@ -898,6 +927,8 @@ class Call:
             call.fork(contacts, strategy="parallel", timeout=30)
         """
         _validate_send_socket(send_socket)
+        if max_duration is not None:
+            self._max_duration_secs = max_duration
         uris = [t.uri if isinstance(t, Contact) else str(t) for t in targets]
         uris = self._normalize_dial_targets(uris, number_policy)
         self._actions.append(Action(
@@ -906,6 +937,7 @@ class Call:
             strategy=strategy,
             timeout=timeout,
             extras={
+                "max_duration": max_duration,
                 "header_policy": header_policy,
                 "copy": copy or [],
                 "strip": strip or [],
@@ -919,6 +951,7 @@ class Call:
         self,
         routes: list["Route"],
         timeout: int = 30,
+        max_duration: Optional[int] = None,
         send_socket: Optional[str] = None,
     ) -> None:
         """Route the call across an ordered list of carrier :class:`~siphon_sdk.lcr.Route`
@@ -935,6 +968,10 @@ class Call:
             routes: Ordered carriers (cheapest first).
             timeout: Default ring timeout (seconds) for a route without its own
                 ``timeout_secs``.
+            max_duration: Cap on how long the call may stay answered, in
+                seconds — same semantics as :meth:`dial`.  Per call, not per
+                attempt: ``timeout`` bounds each carrier's ring, but the
+                carrier that answers hands over one answered call.
             send_socket: Optional egress socket pin applied to every attempt.
 
         Example::
@@ -946,11 +983,17 @@ class Call:
                     call.route(decision.routes)
         """
         _validate_send_socket(send_socket)
+        if max_duration is not None:
+            self._max_duration_secs = max_duration
         self._actions.append(Action(
             kind="route",
             targets=[route.carrier_id for route in routes],
             timeout=timeout,
-            extras={"routes": list(routes), "send_socket": send_socket},
+            extras={
+                "max_duration": max_duration,
+                "routes": list(routes),
+                "send_socket": send_socket,
+            },
         ))
 
     def terminate(self) -> None:
@@ -977,6 +1020,38 @@ class Call:
         """
         self._state = "terminated"
         self._actions.append(Action(kind="terminate"))
+
+    @property
+    def max_duration(self) -> Optional[int]:
+        """The cap this call carries on how long it may stay answered, in
+        seconds, or ``None`` when it inherits ``b2bua.max_call_duration_secs``.
+
+        Read-only view of what ``max_duration=`` / :meth:`set_max_duration`
+        recorded, for test assertions.
+        """
+        return self._max_duration_secs
+
+    def set_max_duration(self, seconds: int) -> None:
+        """Cap how long this call may stay answered, in seconds.
+
+        The same knob as ``max_duration=`` on :meth:`dial` / :meth:`fork` /
+        :meth:`route`, reachable from a call that never dials — a UAS-mode
+        :meth:`answer` (IVR, announcement) or a :meth:`handover` — which would
+        otherwise be stuck on the configured ceiling.
+
+        The clock starts at the answer.  On expiry siphon BYEs both legs
+        through the ordinary teardown (CDR, charging stop, media release) with
+        ``Reason: Q.850;cause=102``; no Python handler fires.  ``0`` means
+        uncapped, overriding a configured ``b2bua.max_call_duration_secs``.
+
+        Example::
+
+            @b2bua.on_invite
+            def ivr(call):
+                call.set_max_duration(600)     # 10 minutes, then hang up
+                call.answer(200, "OK")
+        """
+        self._max_duration_secs = seconds
 
     def accept_refer(self, target: Optional[str] = None,
                      next_hop: Optional[str] = None,

--- a/sdk/tests/test_call_dial.py
+++ b/sdk/tests/test_call_dial.py
@@ -102,3 +102,60 @@ class TestCallDial:
         # A well-formed IPv6 pin is accepted.
         call.dial("sip:bob@10.0.0.2:5060", send_socket="tls:[2001:db8::1]:5061")
         assert call._actions[-1].extras["send_socket"] == "tls:[2001:db8::1]:5061"
+
+
+class TestCallMaxDuration:
+    """``timeout`` bounds the ring, ``max_duration`` bounds the talk.
+
+    Two clocks, deliberately independent: ``timeout`` stops mattering the
+    moment a 2xx lands, and before ``max_duration`` existed nothing bounded an
+    answered call except a peer BYE or an RFC 4028 session timer.
+    """
+
+    def test_dial_records_max_duration_alongside_timeout(self):
+        call = Call()
+        call.dial("sip:bob@10.0.0.2:5060", timeout=30, max_duration=3600)
+        action = call._actions[0]
+        assert action.timeout == 30
+        assert action.extras["max_duration"] == 3600
+        assert call.max_duration == 3600
+
+    def test_dial_without_max_duration_inherits_the_config(self):
+        call = Call()
+        call.dial("sip:bob@10.0.0.2:5060")
+        assert call._actions[0].extras["max_duration"] is None
+        assert call.max_duration is None
+
+    def test_zero_is_an_opt_out_not_an_absent_value(self):
+        # 0 is how a call escapes a configured b2bua.max_call_duration_secs,
+        # so it has to survive as a value rather than collapsing into None.
+        call = Call()
+        call.dial("sip:bob@10.0.0.2:5060", max_duration=0)
+        assert call._actions[0].extras["max_duration"] == 0
+        assert call.max_duration == 0
+
+    def test_fork_and_route_take_max_duration_too(self):
+        forked = Call()
+        forked.fork(["sip:bob@10.0.0.2:5060", "sip:bob@10.0.0.3:5060"],
+                    timeout=20, max_duration=1800)
+        assert forked._actions[0].extras["max_duration"] == 1800
+        assert forked._actions[0].timeout == 20
+        assert forked.max_duration == 1800
+
+        from siphon_sdk.lcr import Route
+
+        routed = Call()
+        routed.route([Route(carrier_id="carrier-a", next_hop="sip:10.0.0.9:5060")],
+                     timeout=12, max_duration=900)
+        assert routed._actions[0].extras["max_duration"] == 900
+        assert routed.max_duration == 900
+
+    def test_set_max_duration_caps_a_call_that_never_dials(self):
+        # A UAS-mode answer or a handover never calls dial/fork/route, so this
+        # is the only per-call cap available to it.
+        call = Call()
+        assert call.max_duration is None
+        call.set_max_duration(600)
+        assert call.max_duration == 600
+        call.set_max_duration(0)
+        assert call.max_duration == 0

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -1753,6 +1753,30 @@ auth:
 # b2bua:
 #   log_dial: true
 
+# Ceiling on how long an ANSWERED call may run, in seconds, for every call that
+# does not set its own call.dial(max_duration=...).
+#
+# UNSET by default — and unset means an answered call is bounded by nothing but
+# a peer BYE, a script terminate(), or the session_timer block above where it is
+# configured AND the far end honours it. This is the backstop for everything
+# else: a carrier leg that goes silent with its dialog still up holds a call
+# actor, a media anchor, a charging session and an RTP port pair until siphon
+# restarts.
+#
+# Measured from the ANSWER, not from the dial — the ring is already bounded by
+# call.dial(timeout=...), and a cap that counted ring time would give a call
+# that rang for 25 seconds less talk time than one picked up instantly.
+#
+# On expiry siphon BYEs both legs through the ordinary teardown: RFC 3326
+# Reason: Q.850;cause=102, a CDR with disconnect_initiator="timeout", Rf/Ro
+# ACR-STOP, media released. No Python handler fires, same as a session-timer
+# expiry — sip_reason on the CDR is what tells the two apart.
+#
+# A single call overrides it with call.dial(max_duration=<seconds>), and opts
+# out entirely with call.dial(max_duration=0).
+# b2bua:
+#   max_call_duration_secs: 14400   # 4h
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------

--- a/sipp/b2bua_max_duration_optout_uac.xml
+++ b/sipp/b2bua_max_duration_optout_uac.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Maximum-call-duration OPT-OUT — the arm that proves the cap is not applied
+  unconditionally.
+
+  siphon runs with b2bua.max_call_duration_secs set to a few seconds, and the
+  script dials with max_duration=0. This scenario then holds the call for
+  noticeably longer than that ceiling and hangs up itself.
+
+  What makes it an assertion rather than a pause: if siphon wrongly cut the
+  call, this leg would receive a BYE it has no <recv> for (an unexpected
+  message, which SIPp fails on) and the BYE it goes on to send would draw a 481
+  for a dialog that no longer exists. A clean 200 to our own BYE is only
+  possible if the call was still up.
+-->
+<scenario name="B2BUA maximum call duration opt-out UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-max-duration-optout-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Well past the configured ceiling this call opted out of. -->
+  <pause milliseconds="9000" />
+
+  <send retrans="500">
+    <![CDATA[
+BYE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 2 BYE
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <recv response="200" rtd="true" />
+
+</scenario>

--- a/sipp/b2bua_max_duration_uac.xml
+++ b/sipp/b2bua_max_duration_uac.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  B2BUA maximum-call-duration UAC:
+  INVITE -> 180 -> 200 OK -> ACK -> (wait) -> receive siphon's BYE -> 200
+
+  The caller never sends a BYE of its own. Once the call is answered nothing in
+  the test config can end it: the ring timeout no longer applies, no session
+  timer is configured, and the callee sits still too. So the BYE this scenario
+  waits for can only be the maximum-duration teardown, and the assertion that
+  it carries Reason: Q.850;cause=102 is what separates it from any other
+  teardown siphon might run.
+-->
+<scenario name="B2BUA maximum call duration UAC">
+
+  <send retrans="500">
+    <![CDATA[
+INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>
+Call-ID: [call_id]
+CSeq: 1 INVITE
+Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+Max-Forwards: 70
+User-Agent: SIPp/b2bua-max-duration-test
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=alice 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+]]>
+  </send>
+
+  <recv response="100" optional="true" />
+
+  <label id="1" />
+  <recv response="180" optional="true" next="1" />
+
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+From: <sip:alice@[local_ip]>;tag=[pid]SIPpTag00[call_number]
+To: <sip:bob@[remote_ip]>[peer_tag_param]
+Call-ID: [call_id]
+CSeq: 1 ACK
+Max-Forwards: 70
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- Sit on the answered call. siphon must hang it up, not us. -->
+  <recv request="BYE" crlf="true">
+    <action>
+      <!-- RFC 3326: the cause is what says WHY the framework hung up, and it
+           is the only thing on the wire that does. A BYE with no Reason would
+           still pass a "did the call end" check. -->
+      <ereg regexp="Q\.850;cause=102" search_in="hdr" header="Reason:"
+            check_it="true" assign_to="1" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- $1 exists only to carry check_it; SIPp refuses a scenario with an
+       assigned variable nothing references. -->
+  <Reference variables="1" />
+
+</scenario>

--- a/sipp/b2bua_max_duration_uas.xml
+++ b/sipp/b2bua_max_duration_uas.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Maximum-call-duration test — the callee (B-leg), which ANSWERS and then sits
+  still.
+
+  Receive INVITE -> 100 -> 180 -> 200 (SDP) -> ACK -> (wait) -> BYE -> 200.
+
+  Both legs have to be released, not just the caller's: the cap tears the whole
+  call down, and a teardown that BYEs only the A-leg would leave this dialog
+  established with the far end still billing it. So this leg waits for its own
+  BYE and would time out rather than pass if it never came.
+-->
+<scenario name="B2BUA maximum call duration UAS">
+
+  <recv request="INVITE" crlf="true" />
+
+  <send>
+    <![CDATA[
+SIP/2.0 100 Trying
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <send>
+    <![CDATA[
+SIP/2.0 180 Ringing
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagB[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Length: 0
+
+]]>
+  </send>
+
+  <pause milliseconds="200" />
+
+  <send retrans="500">
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagB[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Contact: <sip:bob@[local_ip]:[local_port];transport=[transport]>
+Content-Type: application/sdp
+Content-Length: [len]
+
+v=0
+o=bob 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 8
+a=rtpmap:8 PCMA/8000
+]]>
+  </send>
+
+  <recv request="ACK" timeout="5000" />
+
+  <!-- The callee never hangs up either — this BYE is the duration cap. -->
+  <recv request="BYE" crlf="true">
+    <action>
+      <ereg regexp="Q\.850;cause=102" search_in="hdr" header="Reason:"
+            check_it="true" assign_to="1" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+]]>
+  </send>
+
+  <!-- $1 exists only to carry check_it; SIPp refuses a scenario with an
+       assigned variable nothing references. -->
+  <Reference variables="1" />
+
+</scenario>

--- a/sipp/configs/siphon.max-duration-test.yaml
+++ b/sipp/configs/siphon.max-duration-test.yaml
@@ -1,0 +1,27 @@
+# siphon config for the maximum-call-duration SIPp test
+# (scripts/b2bua_max_duration_test.sh). Both parties answer and then sit still;
+# nothing else in this config can end the call, so the BYE the test waits for
+# can only come from the duration cap. `session_timer:` is deliberately absent —
+# it would end the call on its own and hide whether the cap works.
+#
+# MAX_CALL_DURATION_SECS is unset in the `dial` arm (the cap comes from
+# call.dial(max_duration=...)) and set in the `config` and `optout` arms.
+
+listen:
+  udp:
+    - "127.0.0.1:5060"
+
+domain:
+  local:
+    - "127.0.0.1"
+
+advertised_address: "127.0.0.1"
+
+script:
+  path: "scripts/b2bua_max_duration.py"
+
+b2bua:
+  max_call_duration_secs: ${MAX_CALL_DURATION_SECS:-0}
+
+log:
+  level: info

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -1102,6 +1102,26 @@ pub struct CallActor {
     /// the call is still un-answered. `None` = no application timeout (the 24h
     /// orphan backstop still applies).
     pub answer_deadline: Option<std::time::Instant>,
+    /// When this call was answered, stamped by
+    /// [`transition_to`](Self::transition_to) on the first transition to
+    /// [`CallState::Answered`] and never moved afterwards (a re-INVITE or a leg
+    /// replacement re-enters `Answered` but does not restart the call).
+    /// `None` until then. The anchor [`max_duration_secs`] measures
+    /// from — the ring is already bounded by [`answer_deadline`], so a cap on
+    /// the whole call would otherwise vary with how long it rang.
+    ///
+    /// [`max_duration_secs`]: Self::max_duration_secs
+    /// [`answer_deadline`]: Self::answer_deadline
+    pub answered_at: Option<std::time::Instant>,
+    /// Ceiling on how long this call may stay answered, in seconds
+    /// (`call.dial(max_duration=…)` and friends). Once
+    /// `answered_at + max_duration_secs` passes, the framework BYEs both legs
+    /// through the ordinary teardown.
+    ///
+    /// `Some(0)` is an explicit opt-out for this call, which is how a script
+    /// escapes a configured `b2bua.max_call_duration_secs`; `None` inherits
+    /// that configured default (itself usually absent, i.e. uncapped).
+    pub max_duration_secs: Option<u32>,
     /// When true (`call.dial(auth_passthrough=True)`), a B-leg 401/407 with no
     /// siphon-side credentials is relayed to the caller as a non-terminal
     /// challenge: the dispatcher forwards it and keeps the call alive instead of
@@ -1188,6 +1208,8 @@ impl CallActor {
             a_leg_supports_100rel: false,
             auth_retry_count: 0,
             answer_deadline: None,
+            answered_at: None,
+            max_duration_secs: None,
             auth_passthrough: false,
             route_sequence: None,
             control_app: None,
@@ -1465,10 +1487,28 @@ impl CallActor {
             .find(|(_, leg)| leg.branch == branch)
     }
 
+    /// Move this call to `state`, stamping [`answered_at`](Self::answered_at)
+    /// on the **first** transition to [`CallState::Answered`].
+    ///
+    /// Every state change goes through here so the stamp cannot be missed:
+    /// answering is reached from three unrelated directions — a winning B-leg
+    /// 2xx ([`set_winner`](Self::set_winner)), a promoted leg replacement, and
+    /// the store's [`set_state`](CallActorStore::set_state) for the UAS-mode
+    /// `call.answer()` and an originate's 2xx — and a cap that silently never
+    /// fires because one of them wrote the field directly is worse than no cap
+    /// at all. Only the first transition counts, so a re-INVITE or a leg
+    /// replacement re-entering `Answered` cannot push the deadline back out.
+    pub fn transition_to(&mut self, state: CallState) {
+        if state == CallState::Answered && self.answered_at.is_none() {
+            self.answered_at = Some(std::time::Instant::now());
+        }
+        self.state = state;
+    }
+
     /// Set the winner and update call state.
     pub fn set_winner(&mut self, index: usize) {
         self.winner = Some(index);
-        self.state = CallState::Answered;
+        self.transition_to(CallState::Answered);
         if index < self.b_leg_status.len() {
             self.b_leg_status[index] = BLegStatus::Answered;
         }
@@ -2070,7 +2110,7 @@ impl CallActorStore {
             call.b_leg_status.push(BLegStatus::Answered);
             call.b_leg_handles.push(None);
             call.winner = Some(0);
-            call.state = CallState::Answered;
+            call.transition_to(CallState::Answered);
             (replaced, survivor)
         };
 
@@ -2397,9 +2437,14 @@ impl CallActorStore {
     }
 
     /// Set call state.
+    ///
+    /// Delegates to [`CallActor::transition_to`] so a transition to `Answered`
+    /// stamps [`CallActor::answered_at`], the anchor
+    /// [`take_calls_over_max_duration`](Self::take_calls_over_max_duration)
+    /// measures a call's maximum duration from.
     pub fn set_state(&self, call_id: &str, state: CallState) {
         if let Some(mut call) = self.calls.get_mut(call_id) {
-            call.state = state;
+            call.transition_to(state);
         }
     }
 
@@ -2461,7 +2506,7 @@ impl CallActorStore {
             return false;
         }
         if call.state == CallState::Calling {
-            call.state = CallState::Ringing;
+            call.transition_to(CallState::Ringing);
         }
         true
     }
@@ -3095,6 +3140,43 @@ impl CallActorStore {
                     && entry
                         .answer_deadline
                         .is_some_and(|deadline| now >= deadline)
+            })
+            .map(|entry| entry.id.clone())
+            .collect()
+    }
+
+    /// Internal call IDs of answered calls that have been up longer than their
+    /// maximum duration (`call.dial(max_duration=…)`, else `default_secs` from
+    /// `b2bua.max_call_duration_secs`).
+    ///
+    /// The counterpart of [`take_timed_out_calls`](Self::take_timed_out_calls)
+    /// for the other half of a call's life: that one bounds the ring and only
+    /// ever looks at `Calling`/`Ringing`, so nothing bounded an *answered* call
+    /// except the optional RFC 4028 session timer.
+    ///
+    /// A per-call `Some(0)` is an explicit opt-out and wins over `default_secs`
+    /// — that is how a script escapes a configured ceiling. Does NOT remove
+    /// anything: the dispatcher runs the real teardown (BYE both legs, charging
+    /// stop, CDR, media release), which needs to build and send messages.
+    pub fn take_calls_over_max_duration(
+        &self,
+        now: std::time::Instant,
+        default_secs: Option<u32>,
+    ) -> Vec<String> {
+        self.calls
+            .iter()
+            .filter(|entry| {
+                if entry.state != CallState::Answered {
+                    return false;
+                }
+                let Some(seconds) = entry.max_duration_secs.or(default_secs).filter(|s| *s > 0)
+                else {
+                    return false;
+                };
+                entry.answered_at.is_some_and(|answered_at| {
+                    now.duration_since(answered_at)
+                        >= std::time::Duration::from_secs(seconds as u64)
+                })
             })
             .map(|entry| entry.id.clone())
             .collect()
@@ -4781,6 +4863,182 @@ mod tests {
         // Nothing was removed.
         assert_eq!(store.count(), 4);
         let _ = (waiting, answered, no_deadline);
+    }
+
+    /// Answer a call the way the winning-B-leg 2xx does (`try_win` →
+    /// `set_winner`), which is the path that has to stamp `answered_at`.
+    fn answer_call(store: &CallActorStore, call_id: &str) {
+        store.add_b_leg(call_id, make_b_leg(0));
+        store.set_winner(call_id, 0);
+    }
+
+    /// Backdate a call's answer so the maximum-duration sweep sees it as having
+    /// been up for `elapsed`, without sleeping in a unit test.
+    fn backdate_answer(store: &CallActorStore, call_id: &str, elapsed: std::time::Duration) {
+        let mut call = store.get_call_mut(call_id).expect("call exists");
+        let answered_at = call.answered_at.expect("call was answered");
+        call.answered_at = Some(answered_at - elapsed);
+    }
+
+    #[test]
+    fn answering_stamps_answered_at_once_and_never_moves_it() {
+        // The stamp is the anchor the maximum-duration cap measures from, so a
+        // call that re-enters Answered — a re-INVITE, a promoted leg
+        // replacement — must not get a fresh clock, or a call kept busy with
+        // re-INVITEs would never hit its cap.
+        let store = CallActorStore::new();
+
+        let call_id = store.create_call(make_a_leg());
+        assert!(
+            store
+                .get_call(&call_id)
+                .and_then(|c| c.answered_at)
+                .is_none(),
+            "an un-answered call has no answer stamp"
+        );
+
+        answer_call(&store, &call_id);
+        let first = store
+            .get_call(&call_id)
+            .and_then(|c| c.answered_at)
+            .expect("answering stamps answered_at");
+
+        // Re-entering Answered from either direction leaves the stamp alone.
+        store.set_state(&call_id, CallState::Answered);
+        store.set_winner(&call_id, 0);
+        assert_eq!(
+            store.get_call(&call_id).and_then(|c| c.answered_at),
+            Some(first),
+            "the answer stamp must not move once set"
+        );
+    }
+
+    #[test]
+    fn uas_mode_answer_also_stamps_answered_at() {
+        // A call answered by the script itself (`call.answer()`) or by an
+        // originate's 2xx never goes through set_winner — it flips state
+        // through the store. It must be capped like any other answered call.
+        let store = CallActorStore::new();
+        let call_id = store.create_call(make_a_leg());
+
+        store.set_state(&call_id, CallState::Answered);
+
+        assert!(
+            store
+                .get_call(&call_id)
+                .and_then(|c| c.answered_at)
+                .is_some(),
+            "a UAS-mode answer must stamp answered_at too"
+        );
+    }
+
+    #[test]
+    fn take_calls_over_max_duration_only_answered_calls_past_their_cap() {
+        // The answered-call counterpart of the answer-timeout sweep: it must
+        // select only calls that ANSWERED and have been up longer than their
+        // own cap, and must not remove anything (the dispatcher runs the real
+        // teardown: BYE both legs, charging stop, CDR, media release).
+        let store = CallActorStore::new();
+        let now = std::time::Instant::now();
+
+        // Answered 61s ago with a 60s cap → over.
+        let over = store.create_call(make_a_leg());
+        answer_call(&store, &over);
+        backdate_answer(&store, &over, std::time::Duration::from_secs(61));
+        store
+            .get_call_mut(&over)
+            .expect("call exists")
+            .max_duration_secs = Some(60);
+
+        // Answered 61s ago with a 3600s cap → still inside it.
+        let inside = store.create_call(make_a_leg());
+        answer_call(&store, &inside);
+        backdate_answer(&store, &inside, std::time::Duration::from_secs(61));
+        store
+            .get_call_mut(&inside)
+            .expect("call exists")
+            .max_duration_secs = Some(3600);
+
+        // Never answered → the answer-timeout sweep's business, not this one.
+        // A ringing call has no answered_at at all, so a cap on it is inert.
+        let ringing = store.create_call(make_a_leg());
+        store.set_state(&ringing, CallState::Ringing);
+        store
+            .get_call_mut(&ringing)
+            .expect("call exists")
+            .max_duration_secs = Some(1);
+
+        // Answered, no cap and no configured default → uncapped.
+        let uncapped = store.create_call(make_a_leg());
+        answer_call(&store, &uncapped);
+        backdate_answer(&store, &uncapped, std::time::Duration::from_secs(86_400));
+
+        assert_eq!(store.take_calls_over_max_duration(now, None), vec![over]);
+        assert_eq!(store.count(), 4, "the sweep must not remove anything");
+        let _ = (inside, ringing, uncapped);
+    }
+
+    #[test]
+    fn max_duration_falls_back_to_the_configured_default() {
+        // `b2bua.max_call_duration_secs` is the operator's backstop for every
+        // call that didn't ask for its own — including one answered in UAS mode
+        // that never dialled anything.
+        let store = CallActorStore::new();
+        let now = std::time::Instant::now();
+
+        let call_id = store.create_call(make_a_leg());
+        answer_call(&store, &call_id);
+        backdate_answer(&store, &call_id, std::time::Duration::from_secs(120));
+
+        assert!(
+            store.take_calls_over_max_duration(now, None).is_empty(),
+            "no per-call cap and no default means uncapped"
+        );
+        assert!(
+            store
+                .take_calls_over_max_duration(now, Some(300))
+                .is_empty(),
+            "a default the call has not reached yet leaves it alone"
+        );
+        assert_eq!(
+            store.take_calls_over_max_duration(now, Some(60)),
+            vec![call_id],
+            "a call past the configured default is cut"
+        );
+    }
+
+    #[test]
+    fn per_call_max_duration_overrides_the_default_in_both_directions() {
+        // Both directions matter: a script tightening the ceiling for one call,
+        // and `max_duration=0` opting a call out of a configured ceiling
+        // entirely (a supervised conference, a long-running trunk session).
+        let store = CallActorStore::new();
+        let now = std::time::Instant::now();
+
+        // Tighter than the default → cut by its own cap.
+        let tighter = store.create_call(make_a_leg());
+        answer_call(&store, &tighter);
+        backdate_answer(&store, &tighter, std::time::Duration::from_secs(120));
+        store
+            .get_call_mut(&tighter)
+            .expect("call exists")
+            .max_duration_secs = Some(60);
+
+        // Explicitly uncapped → survives a default it is far past.
+        let opted_out = store.create_call(make_a_leg());
+        answer_call(&store, &opted_out);
+        backdate_answer(&store, &opted_out, std::time::Duration::from_secs(86_400));
+        store
+            .get_call_mut(&opted_out)
+            .expect("call exists")
+            .max_duration_secs = Some(0);
+
+        assert_eq!(
+            store.take_calls_over_max_duration(now, Some(3600)),
+            vec![tighter],
+            "max_duration=0 must beat a configured ceiling"
+        );
+        let _ = opted_out;
     }
 
     fn replacement(

--- a/src/cdr/mod.rs
+++ b/src/cdr/mod.rs
@@ -597,6 +597,17 @@ async fn write_file_cdr(cdr: &Cdr, path: &str, rotate_size_mb: u64) {
                 error!("CDR file write error: {error}");
                 return;
             }
+            // Flush before the size check reads the length and before the
+            // handle drops. Tokio buffers the write and runs it on the
+            // blocking pool, so without this a busy pool leaves the check
+            // reading a length that does not include the record just written
+            // — the file then grows past the limit before it rotates — and
+            // leaves the record itself still in flight after this function has
+            // returned, which on a hard exit is a billing record lost.
+            if let Err(error) = file.flush().await {
+                error!("CDR file flush error: {error}");
+                return;
+            }
             // Rotate *after* the write, never mid-record: a CDR split across
             // two files is worse than a file a few hundred bytes over.
             if rotate_size_mb > 0 {
@@ -1366,6 +1377,69 @@ mod tests {
         write_file_cdr(&sample_cdr(), &path_str, 1).await;
         assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 1);
         assert_eq!(rotated_siblings(&path).len(), 1);
+    }
+
+    /// The record has to be on disk by the time the write call returns, and
+    /// the rotation size check has to observe the record it just wrote.
+    ///
+    /// Tokio buffers the write and runs it on the blocking pool; `write_all`
+    /// returns once the bytes are in the buffer, not once they are on disk,
+    /// and `metadata` does not wait for an in-flight write either. So without
+    /// an explicit flush the size check can read the length from before this
+    /// record — the file grows past the limit before it rotates — and the
+    /// record can still be in flight after the call returned, which on a hard
+    /// exit is a billing record lost.
+    ///
+    /// The race needs a busy blocking pool, so each round puts work on it and
+    /// the round is repeated: a single round reproduces roughly a third of the
+    /// time, which is why this loops rather than asserting once.
+    const DURABILITY_ROUNDS: usize = 40;
+
+    fn load_the_blocking_pool() {
+        for _ in 0..64 {
+            tokio::task::spawn_blocking(|| std::thread::sleep(std::time::Duration::from_millis(8)));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn file_backend_record_is_on_disk_when_the_write_returns() {
+        for round in 0..DURABILITY_ROUNDS {
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("cdr.jsonl");
+            let path_str = path.to_string_lossy().into_owned();
+
+            load_the_blocking_pool();
+            // Rotation off, so the size check that would otherwise happen to
+            // force the buffer out is not called at all.
+            write_file_cdr(&sample_cdr(), &path_str, 0).await;
+
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap().lines().count(),
+                1,
+                "round {round}: the record must be readable once the write returned"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn file_backend_flushes_the_record_before_the_size_check() {
+        for round in 0..DURABILITY_ROUNDS {
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("cdr.jsonl");
+            let path_str = path.to_string_lossy().into_owned();
+            // One byte short of 1 MB, so this record is the one that tips the
+            // file over: the check can only rotate if it sees the record.
+            std::fs::write(&path, vec![b'x'; 1024 * 1024 - 1]).unwrap();
+
+            load_the_blocking_pool();
+            write_file_cdr(&sample_cdr(), &path_str, 1).await;
+
+            assert_eq!(
+                rotated_siblings(&path).len(),
+                1,
+                "round {round}: the size check must observe the record it just wrote"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -333,6 +333,34 @@ pub struct B2buaConfig {
     ///   log_dial: true
     /// ```
     pub log_dial: Option<bool>,
+
+    /// Ceiling on how long an answered B2BUA call may run, in seconds, for
+    /// every call that does not set its own `call.dial(max_duration=…)`.
+    ///
+    /// **Unset by default** — an answered call is otherwise bounded by nothing
+    /// except a peer BYE, a script `terminate()`, or the RFC 4028 session timer
+    /// where that is configured *and* the far end honours it. This is the
+    /// backstop for the rest: a carrier leg that goes silent with the dialog
+    /// still up holds a call actor, a media anchor, a charging session and an
+    /// RTP port pair until the process restarts.
+    ///
+    /// Measured from the answer, not from the dial — the ring is already
+    /// bounded by `call.dial(timeout=…)`, and a cap that counted ring time
+    /// would give a call that rang for 25 s less talk time than one that was
+    /// picked up instantly.
+    ///
+    /// On expiry siphon BYEs both legs through the ordinary teardown: RFC 3326
+    /// `Reason: Q.850;cause=102`, a CDR with `disconnect_initiator="timeout"`,
+    /// Rf/Ro `ACR-STOP`, media released. No Python handler fires, the same as
+    /// for a session-timer expiry.
+    ///
+    /// A call opts out with `call.dial(max_duration=0)`.
+    ///
+    /// ```yaml
+    /// b2bua:
+    ///   max_call_duration_secs: 14400    # 4h
+    /// ```
+    pub max_call_duration_secs: Option<u32>,
 }
 
 impl B2buaConfig {
@@ -359,6 +387,16 @@ impl B2buaConfig {
     /// `false` — see [`log_dial`](Self::log_dial).
     pub fn log_dial_enabled(&self) -> bool {
         self.log_dial.unwrap_or(false)
+    }
+
+    /// The default maximum answered call duration, or `None` for uncapped —
+    /// see [`max_call_duration_secs`](Self::max_call_duration_secs).
+    ///
+    /// An explicit `0` normalises to `None` so that writing the knob down as
+    /// "no limit" means the same thing as leaving it out, and matches the
+    /// per-call `max_duration=0` opt-out.
+    pub fn resolved_max_call_duration_secs(&self) -> Option<u32> {
+        self.max_call_duration_secs.filter(|seconds| *seconds > 0)
     }
 
     /// Resolve the configured default REFER mode. `None`, empty, or an
@@ -7363,6 +7401,50 @@ gateway:
         assert_eq!(group2.algorithm, "hash");
         assert_eq!(group2.destinations[0].weight, 1); // default
         assert_eq!(group2.destinations[0].priority, 1); // default
+    }
+
+    #[test]
+    fn parses_b2bua_max_call_duration() {
+        let yaml = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+b2bua:
+  max_call_duration_secs: 14400
+"#;
+        let config = Config::from_str(yaml).unwrap();
+        assert_eq!(config.b2bua.max_call_duration_secs, Some(14400));
+        assert_eq!(config.b2bua.resolved_max_call_duration_secs(), Some(14400));
+    }
+
+    #[test]
+    fn max_call_duration_absent_or_zero_is_uncapped() {
+        // Absent is the historical behaviour (an answered call is bounded only
+        // by a peer BYE or the session timer). An explicit 0 is how an operator
+        // writes "no limit" down, and must mean the same thing as leaving it
+        // out — it is also the per-call `max_duration=0` opt-out's value.
+        let base = r#"
+listen:
+  udp:
+    - "0.0.0.0:5060"
+domain:
+  local:
+    - "example.com"
+script:
+  path: "scripts/proxy_default.py"
+"#;
+        let absent = Config::from_str(base).unwrap();
+        assert_eq!(absent.b2bua.max_call_duration_secs, None);
+        assert_eq!(absent.b2bua.resolved_max_call_duration_secs(), None);
+
+        let zero =
+            Config::from_str(&format!("{base}b2bua:\n  max_call_duration_secs: 0\n")).unwrap();
+        assert_eq!(zero.b2bua.resolved_max_call_duration_secs(), None);
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -178,6 +178,11 @@ struct DispatcherState {
     /// unless the operator turned it on — one line per call on the hottest
     /// path siphon has.
     log_dial: bool,
+    /// Ceiling on how long an answered B2BUA call may run, for calls that do
+    /// not set their own (`call.dial(max_duration=…)`). Resolved from
+    /// `config.b2bua.max_call_duration_secs`; `None` = uncapped, which is the
+    /// default and was the only behaviour before this existed.
+    default_max_call_duration_secs: Option<u32>,
     /// Outbound registration manager (None when registrant is not configured).
     registrant_manager: Option<Arc<crate::registrant::RegistrantManager>>,
     /// SIPREC recording manager (SRC role — sends recordings to external SRS).
@@ -829,6 +834,7 @@ pub async fn run(
         default_refer_mode: config.b2bua.resolved_default_refer_mode(),
         accept_replaces: config.b2bua.replaces_takeover_enabled(),
         log_dial: config.b2bua.log_dial_enabled(),
+        default_max_call_duration_secs: config.b2bua.resolved_max_call_duration_secs(),
         registrant_manager,
         recording_manager: Arc::new(crate::siprec::RecordingManager::new(
             product_name,
@@ -998,6 +1004,7 @@ pub async fn run(
                     }
                     _ = answer_timeout_interval.tick() => {
                         check_b2bua_answer_timeouts(&state);
+                        check_b2bua_max_call_durations(&state);
                         check_b2bua_replacement_timeouts(&state);
                         check_pending_inbound_refer_timeouts(&state);
                         check_orphaned_ro_sessions(&state);
@@ -14291,6 +14298,29 @@ fn check_b2bua_answer_timeouts(state: &DispatcherState) {
     }
 }
 
+/// Tear down every answered B2BUA call that has been up longer than its
+/// maximum duration (`call.dial(max_duration=…)`, else the configured
+/// `b2bua.max_call_duration_secs`).
+///
+/// The answered-call sibling of [`check_b2bua_answer_timeouts`], which bounds
+/// only the ring. Runs on the same fast interval so a short cap — an IVR that
+/// gives a caller 30 seconds — is honoured to within half a second rather than
+/// to within the 30 s cleanup sweep. Returns immediately when no call carries a
+/// cap and none is configured.
+fn check_b2bua_max_call_durations(state: &DispatcherState) {
+    let now = std::time::Instant::now();
+    for call_id in state
+        .call_actors
+        .take_calls_over_max_duration(now, state.default_max_call_duration_secs)
+    {
+        info!(
+            call_id = %call_id,
+            "B2BUA: maximum call duration reached, terminating call"
+        );
+        b2bua_max_duration_terminate(&call_id, state);
+    }
+}
+
 /// Give up on every leg replacement whose dialed target has blown its deadline:
 /// CANCEL that leg and run the ordinary replacement-failure path (`408`).
 ///
@@ -15076,6 +15106,48 @@ fn fail_b2bua_call_on_timeout(call_id: &str, state: &DispatcherState) {
 // B2BUA handlers
 // ---------------------------------------------------------------------------
 
+/// Everything `@b2bua.on_invite` left on the `Call` for the framework to act
+/// on, carried back out across the `Python::attach` boundary in one value.
+///
+/// A named struct rather than the positional tuple this was: the handler can
+/// set a dozen unrelated things, each early-return path had to spell every one
+/// of them out as a bare `None`/`false` in the right order, and adding a
+/// thirteenth meant editing three lists of anonymous placeholders correctly.
+#[derive(Default)]
+struct InviteHandlerOutcome {
+    action: CallAction,
+    timer_override: Option<crate::script::api::call::SessionTimerOverride>,
+    /// Outbound digest credentials for the B-leg 401/407 retry.
+    credentials: Option<(String, String)>,
+    li_record: bool,
+    preserve_call_id: bool,
+    policy_input: Option<crate::script::api::call::HeaderPolicyInput>,
+    from_host_override: Option<String>,
+    to_host_override: Option<String>,
+    contact_user_override: Option<String>,
+    contact_override: Option<String>,
+    auth_passthrough: bool,
+    auth_user: Option<String>,
+    /// `call.dial(max_duration=…)` / `call.set_max_duration()` — the ceiling on
+    /// how long the call may stay answered. `None` inherits
+    /// `b2bua.max_call_duration_secs`.
+    max_duration_secs: Option<u32>,
+}
+
+impl InviteHandlerOutcome {
+    /// The outcome for a handler that raised: reject the call `500`, and take
+    /// nothing else the script may have set on its way to failing.
+    fn script_error() -> Self {
+        Self {
+            action: CallAction::Reject {
+                code: 500,
+                reason: "Script Error".to_string(),
+            },
+            ..Self::default()
+        }
+    }
+}
+
 /// Handle an INVITE in B2BUA mode.
 ///
 /// Creates a Call object, invokes `@b2bua.on_invite`, and processes the
@@ -15450,7 +15522,7 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
     let engine_state = state.engine.state();
     let handlers = engine_state.handlers_for(&HandlerKind::B2buaInvite);
 
-    let (
+    let InviteHandlerOutcome {
         action,
         timer_override,
         credentials,
@@ -15463,25 +15535,13 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
         contact_override,
         auth_passthrough,
         auth_user,
-    ) = Python::attach(|python| {
+        max_duration_secs,
+    } = Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {
             Ok(obj) => obj,
             Err(error) => {
                 error!("failed to create PyCall: {error}");
-                return (
-                    CallAction::None,
-                    None,
-                    None,
-                    false,
-                    false,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                    None,
-                );
+                return InviteHandlerOutcome::default();
             }
         };
 
@@ -15492,78 +15552,35 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                     if handler.is_async {
                         if let Err(error) = run_coroutine(python, &ret) {
                             error!("async B2BUA on_invite handler error: {error}");
-                            return (
-                                CallAction::Reject {
-                                    code: 500,
-                                    reason: "Script Error".to_string(),
-                                },
-                                None,
-                                None,
-                                false,
-                                false,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                false,
-                                None,
-                            );
+                            return InviteHandlerOutcome::script_error();
                         }
                     }
                 }
                 Err(error) => {
                     error!("B2BUA on_invite handler error: {error}");
-                    return (
-                        CallAction::Reject {
-                            code: 500,
-                            reason: "Script Error".to_string(),
-                        },
-                        None,
-                        None,
-                        false,
-                        false,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        false,
-                        None,
-                    );
+                    return InviteHandlerOutcome::script_error();
                 }
             }
         }
 
         let borrowed = call_obj.borrow(python);
-        let action = borrowed.action().clone();
-        let timer_override = borrowed.session_timer_override().cloned();
-        let credentials = borrowed
-            .outbound_credentials()
-            .map(|(u, p)| (u.to_string(), p.to_string()));
-        let li_record = borrowed.li_record();
-        let preserve_cid = borrowed.preserve_call_id();
-        let policy_input = borrowed.header_policy_input().cloned();
-        let from_host_ovr = borrowed.from_host_override().map(String::from);
-        let to_host_ovr = borrowed.to_host_override().map(String::from);
-        let contact_user_ovr = borrowed.contact_user_override().map(String::from);
-        let contact_ovr = borrowed.contact_override().map(String::from);
-        let auth_passthrough = borrowed.auth_passthrough();
-        let auth_user = borrowed.get_auth_user().map(String::from);
-        (
-            action,
-            timer_override,
-            credentials,
-            li_record,
-            preserve_cid,
-            policy_input,
-            from_host_ovr,
-            to_host_ovr,
-            contact_user_ovr,
-            contact_ovr,
-            auth_passthrough,
-            auth_user,
-        )
+        InviteHandlerOutcome {
+            action: borrowed.action().clone(),
+            timer_override: borrowed.session_timer_override().cloned(),
+            credentials: borrowed
+                .outbound_credentials()
+                .map(|(user, password)| (user.to_string(), password.to_string())),
+            li_record: borrowed.li_record(),
+            preserve_call_id: borrowed.preserve_call_id(),
+            policy_input: borrowed.header_policy_input().cloned(),
+            from_host_override: borrowed.from_host_override().map(String::from),
+            to_host_override: borrowed.to_host_override().map(String::from),
+            contact_user_override: borrowed.contact_user_override().map(String::from),
+            contact_override: borrowed.contact_override().map(String::from),
+            auth_passthrough: borrowed.auth_passthrough(),
+            auth_user: borrowed.get_auth_user().map(String::from),
+            max_duration_secs: borrowed.max_duration_secs(),
+        }
     });
 
     // Store the A-leg INVITE for later use by on_answer/on_failure/on_bye handlers
@@ -15644,6 +15661,7 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
         || contact_user_override.is_some()
         || contact_override.is_some()
         || auth_passthrough
+        || max_duration_secs.is_some()
     {
         if let Some(mut call) = state.call_actors.get_call_mut(&call_id) {
             if let Some(override_config) = timer_override {
@@ -15672,6 +15690,13 @@ fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &Dis
                 call.contact_override = contact_override;
             }
             call.auth_passthrough = auth_passthrough;
+            // Stored, not turned into a deadline: the clock starts at the
+            // answer, which has not happened yet. Applies to every action shape
+            // — a dial, a fork, an LCR sequence, a UAS-mode answer, a handover
+            // — because it lives on the `Call`, not inside the action.
+            if max_duration_secs.is_some() {
+                call.max_duration_secs = max_duration_secs;
+            }
         }
     }
 
@@ -22716,6 +22741,27 @@ fn b2bua_session_timer_terminate(call_id: &str, state: &DispatcherState) {
     b2bua_terminate_call_inner(
         call_id,
         Some("Q.850;cause=102;text=\"Session timer expired\""),
+        "timeout",
+        state,
+    );
+}
+
+/// Terminate a call that has hit its maximum answered duration — BYE both legs
+/// through the same framework teardown as the session timer (Rf/Ro ACR-STOP,
+/// CDR, SIPREC, media release, `StasisEnd`).
+///
+/// Deliberately does not fire `@b2bua.on_bye`: no framework-initiated teardown
+/// does (session-timer expiry, `call.terminate()`, `b2bua.terminate()`), and
+/// `ByeInitiator.side` is defined as which *peer* sent the BYE. The CDR is the
+/// record — `disconnect_initiator="timeout"`, with the Reason text below as
+/// `sip_reason`, which is what separates this from a session-timer expiry.
+fn b2bua_max_duration_terminate(call_id: &str, state: &DispatcherState) {
+    // Q.850 cause 102 = "recovery on timer expiry" — the same class as the
+    // session timer, since this too is a local timer ending an established
+    // call rather than anything either peer did.
+    b2bua_terminate_call_inner(
+        call_id,
+        Some("Q.850;cause=102;text=\"Maximum call duration exceeded\""),
         "timeout",
         state,
     );

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -23,9 +23,10 @@ pub struct SessionTimerOverride {
 ///
 /// Not `Eq`: [`CallAction::RouteSequence`] carries `lcr::Route`s whose `rate`
 /// is an `f64`. `PartialEq` is retained for tests.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub enum CallAction {
     /// No action taken yet.
+    #[default]
     None,
     /// Reject the call with a status code and reason.
     Reject { code: u16, reason: String },
@@ -340,6 +341,16 @@ pub struct PyCall {
     /// forward the challenge without firing `@b2bua.on_failure`, deleting media,
     /// or tearing the call down — so the caller can authenticate and re-INVITE.
     auth_passthrough_flag: bool,
+    /// Ceiling on how long this call may stay answered, in seconds — set by
+    /// `max_duration=` on `call.dial()` / `fork()` / `route()`, or directly via
+    /// `call.set_max_duration()`.
+    ///
+    /// Held here rather than inside the [`CallAction`] variants so that one
+    /// read site in the dispatcher covers every shape a call can take,
+    /// including the ones that never dial at all (`call.answer()` in UAS mode,
+    /// `call.handover()`). `Some(0)` opts this call out of a configured
+    /// `b2bua.max_call_duration_secs`; `None` inherits it.
+    max_duration_secs: Option<u32>,
     /// The carrier route that won (LCR) — injected by the dispatcher when it
     /// builds the `@b2bua.on_answer` / `on_bye` `Call` from the call actor's
     /// `route_sequence.active`. Read by scripts via `call.active_route` to stamp
@@ -449,6 +460,7 @@ impl PyCall {
             contact_override: None,
             header_policy_input: None,
             auth_passthrough_flag: false,
+            max_duration_secs: None,
             active_route: None,
             route_attempts: Vec::new(),
             auth_user: None,
@@ -560,6 +572,14 @@ impl PyCall {
     /// handling so a relayed challenge does not tear the call down.
     pub fn auth_passthrough(&self) -> bool {
         self.auth_passthrough_flag
+    }
+
+    /// The maximum answered duration this call asked for, in seconds
+    /// (`max_duration=` on the dial verbs, or `call.set_max_duration()`).
+    /// `None` leaves the call on `b2bua.max_call_duration_secs`. Read by the
+    /// dispatcher after the handler returns and stamped onto the call actor.
+    pub fn max_duration_secs(&self) -> Option<u32> {
+        self.max_duration_secs
     }
 
     /// Append the two auth headers to `copy` for `auth_passthrough`, unless the
@@ -1608,6 +1628,16 @@ impl PyCall {
 
     /// Dial a single target (simple B-leg).
     ///
+    /// A call has two independent bounds, and they measure different things:
+    /// `timeout` is how long the B-leg may **ring** before siphon gives up
+    /// (CANCEL, `@b2bua.on_failure`, `408` upstream), and `max_duration` is how
+    /// long it may stay **answered** before siphon BYEs both legs. The second
+    /// clock starts at the answer, so a call that rang for 25 seconds still
+    /// gets its full talk time.
+    ///
+    /// `max_duration=None` (the default) inherits `b2bua.max_call_duration_secs`;
+    /// `max_duration=0` opts this call out of that ceiling.
+    ///
     /// `next_hop` (optional) decouples R-URI construction from routing:
     /// the new INVITE's R-URI is still built from `uri` (so the IMPU shape
     /// is preserved), but the message is sent to `next_hop`.  Mirrors the
@@ -1634,12 +1664,13 @@ impl PyCall {
     ///         copy=["X-Operator-Tag"],
     ///         strip=["History-Info"],
     ///     )
-    #[pyo3(signature = (uri, timeout=30, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None))]
+    #[pyo3(signature = (uri, timeout=30, max_duration=None, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None))]
     #[allow(clippy::too_many_arguments)]
     fn dial(
         &mut self,
         uri: &str,
         timeout: u32,
+        max_duration: Option<u32>,
         next_hop: Option<&str>,
         flow: Option<super::registrar::PyFlow>,
         header_policy: Option<&str>,
@@ -1652,6 +1683,7 @@ impl PyCall {
         number_policy: Option<&str>,
     ) -> PyResult<()> {
         super::request::validate_send_socket(send_socket.as_deref())?;
+        self.max_duration_secs = max_duration.or(self.max_duration_secs);
         // Number normalization (explicit `number_policy=`, else the configured
         // `b2bua.default_number_policy`): reformat the A-leg identity headers
         // that flow to the B-leg, plus the dial target itself.
@@ -1702,13 +1734,14 @@ impl PyCall {
     /// `strategy="sequential"` carries the same route set per carrier (as an
     /// explicit next-hop plus a `Route` header), so serial failover across an
     /// AoR's bindings reaches each binding's own proxy chain.
-    #[pyo3(signature = (targets, strategy="parallel", timeout=30, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None))]
+    #[pyo3(signature = (targets, strategy="parallel", timeout=30, max_duration=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None))]
     #[allow(clippy::too_many_arguments)]
     fn fork(
         &mut self,
         targets: Vec<Bound<'_, PyAny>>,
         strategy: &str,
         timeout: u32,
+        max_duration: Option<u32>,
         header_policy: Option<&str>,
         mut copy: Vec<String>,
         strip: Vec<String>,
@@ -1718,6 +1751,7 @@ impl PyCall {
         number_policy: Option<&str>,
     ) -> PyResult<()> {
         super::request::validate_send_socket(send_socket.as_deref())?;
+        self.max_duration_secs = max_duration.or(self.max_duration_secs);
         let mut target_uris: Vec<String> = Vec::with_capacity(targets.len());
         let mut flows: Vec<Option<super::registrar::PyFlow>> = Vec::with_capacity(targets.len());
         let mut branch_paths: Vec<Vec<String>> = Vec::with_capacity(targets.len());
@@ -1809,14 +1843,19 @@ impl PyCall {
     ///
     /// Call from `@b2bua.on_invite`. Per-carrier shaping (tech-prefix, injected
     /// headers, R-URI override) and reroute causes are honored per route.
-    #[pyo3(signature = (routes, timeout=30, send_socket=None))]
+    #[pyo3(signature = (routes, timeout=30, max_duration=None, send_socket=None))]
     fn route(
         &mut self,
         routes: Vec<Bound<'_, PyAny>>,
         timeout: u32,
+        max_duration: Option<u32>,
         send_socket: Option<String>,
     ) -> PyResult<()> {
         super::request::validate_send_socket(send_socket.as_deref())?;
+        // The cap is on the call, not the attempt: `timeout` is per-carrier ring
+        // time, but a carrier that answers hands over one answered call whose
+        // clock starts there.
+        self.max_duration_secs = max_duration.or(self.max_duration_secs);
         let mut collected: Vec<crate::lcr::Route> = Vec::with_capacity(routes.len());
         for item in routes {
             let route: PyRef<super::lcr::PyRoute> = item.extract().map_err(|_| {
@@ -1842,6 +1881,26 @@ impl PyCall {
     /// Terminate the call (send BYE to both legs).
     fn terminate(&mut self) {
         self.action = CallAction::Terminate;
+    }
+
+    /// Cap how long this call may stay answered, in seconds.
+    ///
+    /// The same knob as `max_duration=` on `call.dial()` / `fork()` / `route()`,
+    /// reachable from a call that never dials — a UAS-mode `call.answer()`
+    /// (IVR, announcement) or a `call.handover()` to a control app — which
+    /// would otherwise be left on the configured `b2bua.max_call_duration_secs`
+    /// with no way to say anything else.
+    ///
+    /// The clock starts at the answer. On expiry siphon BYEs both legs through
+    /// the ordinary teardown (CDR, charging stop, media release) with
+    /// `Reason: Q.850;cause=102`; no Python handler fires, as for a session-timer
+    /// expiry. `0` means uncapped, overriding a configured ceiling.
+    ///
+    /// Usage in Python:
+    ///   call.set_max_duration(600)     # 10 minutes of talk time
+    ///   call.set_max_duration(0)       # uncapped, ignore the config ceiling
+    fn set_max_duration(&mut self, seconds: u32) {
+        self.max_duration_secs = Some(seconds);
     }
 
     /// Set per-call session timer parameters (overrides global config).
@@ -2855,6 +2914,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             vec![],
             vec![],
             vec![],
@@ -2894,6 +2954,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             vec![],
             vec![],
             vec![],
@@ -2926,6 +2987,7 @@ mod tests {
         call.dial(
             "sip:1000@ims.mnc001.mcc001.3gppnetwork.org",
             30,
+            None,
             Some("sip:192.0.2.178:4060"),
             None,
             None,
@@ -2963,6 +3025,7 @@ mod tests {
         call.dial(
             "sip:bob@10.0.0.2:5060",
             30,
+            None,
             None,
             None,
             Some("ims-trust-domain-boundary@2026"),
@@ -3005,6 +3068,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             vec![],
             vec![],
             vec![],
@@ -3022,6 +3086,147 @@ mod tests {
         }
     }
 
+    /// A `PyCall` for the max-duration tests, which only care about what the
+    /// dial verbs record on the call, not about the message.
+    fn dialing_call() -> PyCall {
+        PyCall::new(
+            "test-id".to_string(),
+            Arc::new(Mutex::new(make_invite())),
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+        )
+    }
+
+    #[test]
+    fn dial_records_max_duration_and_defaults_to_inheriting_the_config() {
+        // `timeout` bounds the ring and `max_duration` bounds the talk; they are
+        // independent, so setting one must not disturb the other. Omitting
+        // max_duration leaves the call on b2bua.max_call_duration_secs, which is
+        // what `None` means to the dispatcher.
+        let mut call = dialing_call();
+        call.dial(
+            "sip:bob@10.0.0.2:5060",
+            30,
+            Some(3600),
+            None,
+            None,
+            None,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(call.max_duration_secs(), Some(3600));
+        match call.action() {
+            CallAction::Dial { timeout, .. } => assert_eq!(*timeout, 30),
+            other => panic!("expected Dial, got {other:?}"),
+        }
+
+        let mut inherits = dialing_call();
+        inherits
+            .dial(
+                "sip:bob@10.0.0.2:5060",
+                30,
+                None,
+                None,
+                None,
+                None,
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .unwrap();
+        assert_eq!(inherits.max_duration_secs(), None);
+    }
+
+    #[test]
+    fn dial_accepts_zero_max_duration_as_an_explicit_opt_out() {
+        // Zero is not "unset": it is how a call escapes a configured
+        // b2bua.max_call_duration_secs, so it has to reach the dispatcher as a
+        // value rather than collapsing into the inherit case.
+        let mut call = dialing_call();
+        call.dial(
+            "sip:bob@10.0.0.2:5060",
+            30,
+            Some(0),
+            None,
+            None,
+            None,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(call.max_duration_secs(), Some(0));
+    }
+
+    #[test]
+    fn fork_and_route_record_max_duration_too() {
+        // The cap is on the call, not on the attempt: a fork branch or an LCR
+        // carrier that answers hands over one answered call.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|python| {
+            let mut call = dialing_call();
+            let targets: Vec<Bound<'_, PyAny>> =
+                vec![pyo3::types::PyString::new(python, "sip:bob@10.0.0.2:5060").into_any()];
+            call.fork(
+                targets,
+                "parallel",
+                30,
+                Some(1800),
+                None,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .unwrap();
+            assert_eq!(call.max_duration_secs(), Some(1800));
+        });
+
+        let mut call = dialing_call();
+        call.route(Vec::new(), 30, Some(900), None)
+            .expect_err("an empty route list is still rejected");
+        assert_eq!(
+            call.max_duration_secs(),
+            Some(900),
+            "the cap is recorded before the route list is validated"
+        );
+    }
+
+    #[test]
+    fn set_max_duration_caps_a_call_that_never_dials() {
+        // A UAS-mode answer (IVR, announcement) or a handover never calls
+        // dial()/fork()/route(), so without this setter the only cap available
+        // to it would be the global config one.
+        let mut call = dialing_call();
+        assert_eq!(call.max_duration_secs(), None);
+
+        call.set_max_duration(600);
+        assert_eq!(call.max_duration_secs(), Some(600));
+
+        call.set_max_duration(0);
+        assert_eq!(
+            call.max_duration_secs(),
+            Some(0),
+            "the setter must be able to opt a call out, not only tighten it"
+        );
+    }
+
     #[test]
     fn call_dial_rejects_malformed_send_socket() {
         let message = Arc::new(Mutex::new(make_invite()));
@@ -3034,6 +3239,7 @@ mod tests {
         let result = call.dial(
             "sip:bob@10.0.0.2:5060",
             30,
+            None,
             None,
             None,
             None,
@@ -3107,6 +3313,7 @@ mod tests {
                 "parallel",
                 30,
                 None,
+                None,
                 vec![],
                 vec![],
                 vec![],
@@ -3165,6 +3372,7 @@ mod tests {
                 "sequential",
                 30,
                 None,
+                None,
                 vec![],
                 vec![],
                 vec![],
@@ -3218,6 +3426,7 @@ mod tests {
                 "parallel",
                 30,
                 None,
+                None,
                 vec![],
                 vec![],
                 vec![],
@@ -3262,6 +3471,7 @@ mod tests {
                 targets,
                 "parallel",
                 30,
+                None,
                 Some("sip-trunk-edge@2026"),
                 vec![],
                 vec!["X-Internal-Tag".to_string()],
@@ -3291,6 +3501,7 @@ mod tests {
         call.dial(
             "sip:bob@pbx.example.com:5060",
             30,
+            None,
             None,
             None,
             None,
@@ -3337,6 +3548,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             vec!["proxy-authenticate".to_string(), "X-Keep".to_string()],
             vec![],
             vec![],
@@ -3378,6 +3590,7 @@ mod tests {
         call.dial(
             "sip:bob@10.0.0.2:5060",
             30,
+            None,
             None,
             None,
             None,

--- a/src/server.rs
+++ b/src/server.rs
@@ -3508,6 +3508,11 @@ async fn spawn_li_tasks(li_state: Option<LiState>, config: &Config) {
                     entry.detail,
                 );
                 let _ = file.write_all(line.as_bytes()).await;
+                // Flush per entry. Tokio buffers the write, and this handle is
+                // held open for the life of the process, so an unflushed audit
+                // record would sit in the buffer indefinitely rather than
+                // being readable the moment the operation it records happened.
+                let _ = file.flush().await;
             }
         }
     });

--- a/tests/integration/b2bua_tests.rs
+++ b/tests/integration/b2bua_tests.rs
@@ -3275,3 +3275,85 @@ fn flow_pinned_bye_retransmits_on_the_non_invite_schedule() {
     assert_eq!(retransmitted.source_local_addr, Some(ue_port_uc()));
     assert!(plain.try_recv().is_err());
 }
+
+// ---------------------------------------------------------------------------
+// Maximum call duration (call.dial(max_duration=…) / b2bua.max_call_duration_secs)
+// ---------------------------------------------------------------------------
+
+/// The ring and the talk are bounded by two different clocks, and only the
+/// first one existed. `call.dial(timeout=…)` arms `answer_deadline`, which the
+/// answer-timeout sweep reads and which stops mattering the moment a 2xx lands;
+/// after that a call was bounded by nothing but a peer BYE. So the two sweeps
+/// have to partition the call population between them: neither may claim a call
+/// the other owns, or an un-answered call gets BYE'd instead of CANCELled and
+/// an answered one gets a 408 instead of a teardown.
+#[test]
+fn answer_timeout_and_max_duration_sweeps_never_claim_the_same_call() {
+    let store = CallActorStore::new();
+    let now = std::time::Instant::now();
+
+    // Still ringing, past its answer deadline, and carrying a max duration
+    // that is nominally exceeded — but it never answered, so the duration
+    // clock has not started and only the answer sweep may have it.
+    let ringing = store.create_call(make_a_leg("ringing@test"));
+    store.set_answer_deadline(&ringing, now - std::time::Duration::from_secs(1));
+    store
+        .get_call_mut(&ringing)
+        .expect("call exists")
+        .max_duration_secs = Some(1);
+
+    // Answered, and up for longer than its cap. Its answer deadline is long
+    // past too — the answer sweep must still leave it alone.
+    let answered = store.create_call(make_a_leg("answered@test"));
+    store.set_answer_deadline(&answered, now - std::time::Duration::from_secs(1));
+    store.add_b_leg(&answered, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&answered, 0);
+    {
+        let mut call = store.get_call_mut(&answered).expect("call exists");
+        call.max_duration_secs = Some(60);
+        let answered_at = call.answered_at.expect("winning 2xx stamps the answer");
+        call.answered_at = Some(answered_at - std::time::Duration::from_secs(61));
+    }
+
+    assert_eq!(store.take_timed_out_calls(now), vec![ringing.clone()]);
+    assert_eq!(
+        store.take_calls_over_max_duration(now, None),
+        vec![answered.clone()]
+    );
+
+    // Neither sweep removes anything: the dispatcher runs the teardown, which
+    // needs the call state to build the CANCEL / BYE it sends.
+    assert_eq!(store.count(), 2);
+}
+
+/// An answered call inside its cap must survive every sweep, whether the cap is
+/// its own or the operator's `b2bua.max_call_duration_secs`. This is the
+/// regression that matters most: the sweep runs twice a second against every
+/// call on the box, so an off-by-one here cuts live calls.
+#[test]
+fn an_answered_call_inside_its_cap_is_left_alone() {
+    let store = CallActorStore::new();
+    let now = std::time::Instant::now();
+
+    let call_id = store.create_call(make_a_leg("talking@test"));
+    store.add_b_leg(&call_id, make_b_leg("10.0.0.2:5060"));
+    store.set_winner(&call_id, 0);
+    {
+        let mut call = store.get_call_mut(&call_id).expect("call exists");
+        let answered_at = call.answered_at.expect("winning 2xx stamps the answer");
+        call.answered_at = Some(answered_at - std::time::Duration::from_secs(600));
+    }
+
+    // No cap anywhere: the behaviour every deployment had before this existed.
+    assert!(store.take_calls_over_max_duration(now, None).is_empty());
+    // Under the operator default.
+    assert!(store
+        .take_calls_over_max_duration(now, Some(3600))
+        .is_empty());
+    // Its own cap, tighter than the default but not yet reached.
+    store
+        .get_call_mut(&call_id)
+        .expect("call exists")
+        .max_duration_secs = Some(900);
+    assert!(store.take_calls_over_max_duration(now, Some(60)).is_empty());
+}


### PR DESCRIPTION
A B2BUA call had exactly one bound, and it was the wrong half.

`call.dial(timeout=…)` bounds the **ring**: it arms the answer deadline, and the
sweep fails the call with a CANCEL, `@b2bua.on_failure` and a `408` if nothing
picks up. It stops mattering the moment a `2xx` lands. After that an answered
call was held up by nothing except a peer BYE, a script `terminate()`, or an
RFC 4028 session timer — which is off unless configured, needs the far end to
play along, and by design keeps a call up for as long as something keeps
refreshing it.

So a carrier leg that went quiet with its dialog still up, or a call nobody was
ever going to hang up, sat there holding a call actor, a media anchor, a
charging session and an RTP port pair until the process restarted.

## The cap

```python
@b2bua.on_invite
def route(call):
    # 30s to answer, then at most an hour connected.
    call.dial(call.ruri, timeout=30, max_duration=3600)
```

```yaml
b2bua:
  max_call_duration_secs: 14400    # operator backstop; unset means uncapped
```

- **Measured from the answer, not from the dial.** The ring is already bounded,
  and a ceiling that counted ring time would hand a call that rang for 25
  seconds less talk time than one picked up instantly.
- **Per call, not per attempt.** On a fork or an LCR sequence `timeout` bounds
  each branch or carrier, but whichever one answers hands over a single
  answered call, and the cap is on that.
- **`max_duration=0` is an opt-out**, not an absent value — it is how a call
  escapes a configured ceiling. `None` inherits it.
- `call.set_max_duration()` reaches the same knob from a call that never dials:
  a UAS-mode `call.answer()`, a `call.handover()`.

Expiry runs the ordinary teardown, so the call leaves the same accounting
behind as any other: RFC 3326 `Reason: Q.850;cause=102`, a CDR with
`disconnect_initiator="timeout"`, Rf/Ro `ACR-STOP`, media released, `StasisEnd`
on the control rail. No Python handler fires, matching session-timer expiry and
`terminate()` — `@b2bua.on_bye` reports which *peer* hung up and here neither
did. The CDR's `sip_reason` is what separates a duration cut from a
session-timer one.

## Two things worth a reviewer's eye

**`CallActor::transition_to` is now the single funnel for state changes.** The
first cut stamped the answer time in the store's `set_state`, which looks like
the one funnel and is not: `try_win` goes through `set_winner`, which wrote
`state = Answered` directly, and that is the ordinary B-leg 2xx path. Left
alone, the cap would have silently never fired for normal calls while passing
every test that answered through `set_state`.

**The `@b2bua.on_invite` handler snapshot is a named struct** instead of a
twelve-wide positional tuple. Each early return had to spell every field out as
a bare `None`/`false` in the right order, and a thirteenth meant editing three
lists of anonymous placeholders correctly.

## Validation

- `cargo test` green (4274 lib + 367 integration + the rest), `cargo clippy
  --all-targets --all-features -D warnings` clean, `cargo fmt --all -- --check`
  clean, SDK 699 pass.
- New SIPp test `scripts/b2bua_max_duration_test.sh`, wired into CI as
  `sipp-b2bua-max-duration`. Three arms: the cap from the kwarg, the cap from
  config, and an opt-out that must survive a configured ceiling. In the capped
  arms neither peer ever hangs up, so the BYE both wait for can only be the cap,
  and each asserts it carries `Q.850;cause=102`. The opt-out arm is what keeps
  the other two honest — a cap applied unconditionally would pass them both.
- CDR checked on a live run: `disconnect_initiator="timeout"`, the Q.850 reason,
  and `duration_secs` measured against `timestamp_answer` rather than the
  INVITE, which is the answer-anchored clock proving itself.

Not yet run: the throughput baseline and memory-leak pair. This adds a second
O(n) sweep at 2 Hz over the call store and 24 bytes per `CallActor`, so it wants
the real numbers on the baseline hardware before merge.

## Also in here: the CDR file backend never flushed

Not part of the cap, but found while chasing a `cdr::tests::file_backend_rotates_once_over_the_limit`
failure this branch surfaced — the extra tests here shift the parallel test
schedule, and that exposed a race that was already on `main`.

`write_file_cdr` wrote each record with `write_all` and then read `metadata()`
to decide whether to rotate, with no flush in between. Tokio buffers the write
and runs it on the blocking pool: `write_all` returns once the bytes are in the
buffer rather than on disk, and `metadata()` does not wait for an in-flight
write either. Reproduced standalone, 200 rounds with the pool busy:

```
File::metadata() saw 0 bytes        = 66/200   <-- the rotate check reads a stale length
file empty after the call returned  =  7/200   <-- the record is not durable yet
```

One `file.flush().await` takes both to 0/200. Two consequences it fixes:

- The size check now observes the record it just wrote, so the file no longer
  grows past `rotate_size_mb` before rotating. The existing comment ("rotate
  *after* the write, never mid-record") had the right intent; the check just
  could not see the write.
- A record is on disk when the writer moves on. Previously a hard exit dropped
  whatever was still buffered, which is billing data.

The LI audit log in `server.rs` had the identical missing flush, and holds its
handle for the life of the process, so an audit line could sit in the buffer
indefinitely rather than being readable when the operation it records happened.

Both regression tests loop instead of asserting once: a single round reproduces
roughly a third of the time, and a probabilistic test that happens to pass on
the run that matters is not a gate. Verified they fail without the flush (rounds
1 and 4) and pass with it; full lib suite then 5/5 clean where it was 1-in-4 red.

## Out of scope

The control plane's `originate` / `route` / `replace_peer` verbs take no
per-call `max_duration` here — they are covered by `max_call_duration_secs`, and
a per-verb argument needs mirroring in three published SDKs. Worth a follow-up.

