### PR TITLE
fix(b2bua): apply the dial path's number policy to a transferred leg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+## [1.8.5] — 2026-09-08
+
+### Fixed
+- **A transferred leg is dialled in the carrier's number format, not the
+  referrer's — `number_policy=` on `call.accept_refer()` and
+  `b2bua.replace_peer()`.** A siphon-terminated REFER dials its target directly:
+  `@b2bua.on_invite` does not run again for the replacement leg, so nothing that
+  handler does to shape a call was repeated for it, and the number policy every
+  dialled leg gets (`call.dial(number_policy=…)`, or
+  `b2bua.default_number_policy`) was skipped outright. The two ends disagree
+  about number format by default — a referrer names its target in its own
+  (a Microsoft Teams `Refer-To` names `+E.164`), the carrier the leg is dialled
+  at expects the trunk's — so on a bare-digit trunk every ordinary call went out
+  as `15550142` and every transferred one arrived as `+15550142`, from the
+  same node, on the same trunk, in the same call. Whether that is a rejection or
+  a silently different route is the carrier's business, and either way it looks
+  like the transfer is broken rather than the numbering.
+
+  `number_policy=` resolves the way `dial()` resolves it — the named policy,
+  else `b2bua.default_number_policy`, else no reshaping — and applies to the
+  target URI (and so to the R-URI and To of the triggered INVITE) and to that
+  INVITE's identity headers, which the dial path already reshapes together. A
+  deployment that already sets `b2bua.default_number_policy` gets its transfers
+  fixed with no script change. An unknown policy name raises in the handler
+  rather than dialling unreshaped; from the control plane it is a synchronous
+  `bad_request`, and from the send path a warning that keeps the transfer rather
+  than dropping a call over a formatting policy.
+
+  The **routing** half of the dial plan is still the handler's own — a transfer
+  that must leave via a particular carrier needs `next_hop=` — and the docs now
+  say so. `accept_refer`'s own documentation had claimed terminate mode
+  "re-resolves the Refer-To through the dial plan as a new leg", which is
+  exactly the expectation that made the gap invisible.
+
+- **`@b2bua.on_refer` now warns when a B-leg shaping setter is called in it and
+  silently ignored.** `set_contact_uri()`, `set_contact_user()`,
+  `set_from_host()` and `set_to_host()` are read off the `PyCall` the
+  `on_invite` path builds, on its way into `call.dial()`. The one a REFER
+  handler gets is a throwaway whose only surviving output is the accept/reject
+  decision, so those calls did nothing at all — and did it quietly, which is the
+  expensive way: the script reads as though it steered the transferred leg and
+  the wire says otherwise. Message mutations (`set_header()`,
+  `rewrite_identities()`) are the same shape and harder to spot, because they
+  land on that handler's own clone of the REFER while the new leg is built from
+  a clone of the stored A-leg INVITE. `accept_refer()`'s arguments — `target`,
+  `next_hop`, `profile`, `number_policy` — are what reach the dialled leg.
+
 ## [1.8.4] — 2026-09-08
 
 ### Added

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -9,7 +9,7 @@ decides to swap a party with no `REFER` on the wire at all:
 
 | Mode | What siphon does | Use it for |
 |---|---|---|
-| **siphon-terminated** *(default)* | Answers `202` + sends the sipfrag `NOTIFY`s itself, re-resolves `Refer-To` through the dial plan as a **new** leg, re-bridges the surviving party, and BYEs the referred-away leg. | Trunk-facing SBCs and media-anchored calls — the endpoints never see the transfer, media stays anchored on siphon. |
+| **siphon-terminated** *(default)* | Answers `202` + sends the sipfrag `NOTIFY`s itself, dials `Refer-To` (or `target=`) as a **new** leg, re-bridges the surviving party, and BYEs the referred-away leg. | Trunk-facing SBCs and media-anchored calls — the endpoints never see the transfer, media stays anchored on siphon. |
 | **transparent** | Re-emits the `REFER` on the far leg's own dialog and relays the far end's `202` + `message/sipfrag` `NOTIFY`s back to the referrer. | UA-to-UA / PBX transfers where you want the endpoints to run the transfer themselves. |
 | **siphon-originated** | siphon *sends* a `REFER` to a leg — `call.refer(target)` (deferred, from a handler) or `b2bua.refer(call_id, target)` (imperative, from an event callback). | IVR / TAS offload — answer, play a prompt, then hand the caller off. |
 
@@ -148,6 +148,49 @@ def on_refer(call):
     call.accept_refer(target="sip:+15550142@example.com",
                       next_hop="sip:trunk.example.com:5060")
 ```
+
+### Number shape across a transfer — read this before deploying on a trunk
+
+A siphon-terminated transfer dials the target **directly**. `@b2bua.on_invite`
+does not run again for the replacement leg, so nothing that handler does to
+shape a call is repeated: not the number formatting, not the route selection.
+
+That matters because the two ends disagree about number format by default. The
+*referrer* names the target in its own format — a Microsoft Teams `Refer-To`
+names `+E.164` — while the carrier the new leg is dialled at expects whatever
+the trunk speaks. Left alone, every ordinary call on that trunk goes out as
+`15550142` and every transferred one arrives as `+15550142`, from the same
+siphon, on the same trunk, in the same call.
+
+`number_policy=` closes it, resolving exactly as `call.dial(number_policy=…)`
+does — the named policy, else `b2bua.default_number_policy`, else no reshaping —
+and applying to the target URI (so to the triggered INVITE's R-URI and To) and
+to that INVITE's identity headers:
+
+```python
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(
+        target=f"sip:{user}@{carrier_domain}",
+        next_hop=gateway.select("carriers").uri,
+        mode="terminate",
+        profile="rtp_passthrough",
+        number_policy="carrier-plain@2026",   # same shape every dialled leg gets
+    )
+```
+
+Set `b2bua.default_number_policy` in `siphon.yaml` and transfers pick it up with
+no argument at all. An unknown policy name raises `ValueError` in the handler
+rather than silently dialling the target unreshaped. `b2bua.replace_peer()`
+takes the same argument, for the same reason.
+
+The **routing** half is still the handler's own: a transfer that must leave via
+a particular carrier needs `next_hop=` (or a `target=` naming the right host),
+because no gateway selection runs for it either.
+
+All of this is terminate mode. In `"transparent"` mode siphon dials nothing —
+it re-emits the `REFER` and the far end resolves the target under its own
+numbering — so `number_policy` has no effect there.
 
 ### Media profiles across a transfer — read this before deploying an SRTP edge
 

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -1056,7 +1056,8 @@ class Call:
     def accept_refer(self, target: Optional[str] = None,
                      next_hop: Optional[str] = None,
                      mode: Optional[str] = None,
-                     profile: Optional[str] = None) -> None:
+                     profile: Optional[str] = None,
+                     number_policy: Optional[str] = None) -> None:
         """Accept an incoming REFER and honour the transfer.
 
         Call this from a ``@b2bua.on_refer`` handler to proceed with the
@@ -1073,11 +1074,16 @@ class Call:
             mode: How siphon honours the REFER:
 
                 - ``"terminate"`` — siphon **terminates** the transfer: it
-                  answers ``202 Accepted`` locally, re-resolves ``target``
-                  (the Refer-To) through the dial plan as a brand-new leg,
-                  re-bridges the surviving leg to it, and sends BYE to the
-                  referred-away leg.  The transferor drops out; siphon owns
-                  both new legs.  The transferee never sees the REFER.
+                  answers ``202 Accepted`` locally, dials ``target`` (the
+                  Refer-To) as a brand-new leg, re-bridges the surviving leg to
+                  it, and sends BYE to the referred-away leg.  The transferor
+                  drops out; siphon owns both new legs.  The transferee never
+                  sees the REFER.
+
+                  The new leg is dialled **directly**: ``@b2bua.on_invite``
+                  does not run again for it, so any routing that handler does
+                  is this handler's to repeat.  ``number_policy`` below covers
+                  the number-shaping half of that.
                 - ``"transparent"`` — siphon **re-emits** the REFER on the far
                   leg and relays the far leg's ``202 Accepted`` plus the
                   sipfrag ``NOTIFY`` progress reports back to the transferor,
@@ -1102,10 +1108,27 @@ class Call:
                 symmetric and re-pairs safely.  ``None`` inherits the call's
                 profile, which is correct only when it is symmetric; siphon
                 logs a WARN when it is not.
+            number_policy: Reshape the transferred leg's number, exactly as
+                ``dial(number_policy=...)`` reshapes a dialled one: this named
+                policy, else ``b2bua.default_number_policy``, else no
+                reshaping.  It applies to ``target`` (and so to the R-URI and
+                To of the triggered INVITE) and to that INVITE's identity
+                headers.
+
+                Without it the target goes out in whatever shape the
+                *referrer* named it in.  A Teams ``Refer-To`` names
+                ``+E.164``, so a trunk that takes bare digits sees every
+                ordinary call arrive as ``32...`` and every transferred one as
+                ``+32...``.
+
+                Terminate mode only: in ``"transparent"`` mode siphon dials
+                nothing — it re-emits the REFER and the far end resolves the
+                target under its own numbering — so this has no effect there.
 
         Raises:
             ValueError: if ``mode`` is not one of ``None``, ``"terminate"``,
-                or ``"transparent"``.
+                or ``"transparent"``, or if ``number_policy`` names a policy
+                that is not configured.
 
         Example::
 
@@ -1126,6 +1149,13 @@ class Call:
                 # that remains is plain RTP on both sides.
                 call.accept_refer(target=call.refer_to, mode="terminate",
                                   profile="rtp_passthrough")
+
+            @b2bua.on_refer
+            def handle_refer(call):
+                # Trunk takes bare digits; the Refer-To names +E.164.
+                call.accept_refer(target=target, next_hop=gw.uri,
+                                  mode="terminate", profile="rtp_passthrough",
+                                  number_policy="carrier-plain@2026")
         """
         if mode not in (None, "terminate", "transparent"):
             raise ValueError(
@@ -1136,7 +1166,8 @@ class Call:
             kind="accept_refer",
             targets=[target] if target else None,
             next_hop=next_hop,
-            extras={"mode": mode, "profile": profile},
+            extras={"mode": mode, "profile": profile,
+                    "number_policy": number_policy},
         ))
 
     def reject_refer(self, code: int, reason: str) -> None:

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -889,6 +889,7 @@ class MockB2bua:
         replace_a_leg: bool = False,
         profile: Optional[str] = None,
         timeout: int = 30,
+        number_policy: Optional[str] = None,
     ) -> bool:
         """Replace one leg of an answered call with a freshly dialed target.
 
@@ -919,6 +920,12 @@ class MockB2bua:
                 one describes the party that is leaving.
             timeout: seconds to wait for the target to answer. 0 means no ring
                 policy, only siphon's guard against a target that never answers.
+            number_policy: reshape the target's number (and the triggered
+                INVITE's identity headers) the way
+                :meth:`siphon_sdk.call.Call.dial` does — this named policy,
+                else ``b2bua.default_number_policy``, else no reshaping. A
+                replacement leg does not re-enter ``@b2bua.on_invite``, so this
+                is where a carrier's number format gets applied to it.
 
         Returns:
             bool: True once the INVITE is on the wire. It does not wait for the
@@ -955,6 +962,7 @@ class MockB2bua:
                 "replace_a_leg": replace_a_leg,
                 "profile": profile,
                 "timeout": timeout,
+                "number_policy": number_policy,
             }
         )
         return True

--- a/sdk/tests/test_b2bua_refer.py
+++ b/sdk/tests/test_b2bua_refer.py
@@ -118,6 +118,45 @@ def on_refer(call):
         assert action.targets == ["sip:+15550142@example.com"]
         assert action.next_hop == "sip:trunk.example.com:5060"
 
+    def test_number_policy_recorded_for_the_transferred_leg(self, harness):
+        # A Teams Refer-To names +E.164; a trunk that takes bare digits sees
+        # every ordinary call as 32... and every transferred one as +32...
+        # unless the transfer asks for the same shaping a dial gets. The
+        # replacement leg never re-enters @b2bua.on_invite.
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(target="sip:+15550142@carrier.example",
+                      mode="terminate",
+                      profile="rtp_passthrough",
+                      number_policy="carrier-plain@2026")
+"""
+        )
+
+        result = harness.send_refer()
+        action = result.call.last_action
+        assert action.kind == "accept_refer"
+        assert action.extras["number_policy"] == "carrier-plain@2026"
+        assert action.extras["profile"] == "rtp_passthrough"
+
+    def test_number_policy_defaults_to_none(self, harness):
+        # None means "the configured b2bua.default_number_policy", the same
+        # thing it means on dial() — not "never reshape".
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer()
+"""
+        )
+
+        assert harness.send_refer().call.last_action.extras["number_policy"] is None
+
     def test_invalid_mode_raises_value_error(self, harness):
         harness.load_source(
             """

--- a/sdk/tests/test_b2bua_replace_peer.py
+++ b/sdk/tests/test_b2bua_replace_peer.py
@@ -40,8 +40,19 @@ class TestRecording:
                 "replace_a_leg": True,
                 "profile": "ims_to_trunk",
                 "timeout": 45,
+                "number_policy": None,
             }
         ]
+
+    def test_records_the_number_policy_for_the_replacement_leg(self, b2bua):
+        # A replacement leg never re-enters @b2bua.on_invite, so the carrier's
+        # number format has to be asked for on the verb itself.
+        b2bua.replace_peer(
+            "call-1@example.com",
+            "sip:+15550142@carrier.example",
+            number_policy="carrier-plain@2026",
+        )
+        assert b2bua.replacements[-1]["number_policy"] == "carrier-plain@2026"
 
     def test_defaults_replace_the_callee_and_ring_for_thirty(self, b2bua):
         b2bua.replace_peer("call-2@example.com", "sip:bob@example.com")
@@ -111,6 +122,7 @@ def on_digit(call_id, from_tag, digit, duration_ms, volume):
                 "replace_a_leg": False,
                 "profile": None,
                 "timeout": 45,
+                "number_policy": None,
             }
         ]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,10 +266,12 @@ pub struct B2buaConfig {
     /// calls `accept_refer()` without an explicit `mode=`.
     ///
     /// - `"terminate"` (default) — siphon terminates the transfer: answer 202
-    ///   locally, re-resolve the Refer-To through the dial plan as a new leg,
+    ///   locally, dial the Refer-To (or the handler's `target=`) as a new leg,
     ///   re-bridge the media, and BYE the referred-away leg. Correct for
     ///   trunk-facing SBCs (the far end need not support REFER) and keeps media
-    ///   anchored.
+    ///   anchored. The new leg is dialled directly — `@b2bua.on_invite` does not
+    ///   run again for it — so `accept_refer(number_policy=…, next_hop=…)` is
+    ///   where the dial plan's shaping and steering are reapplied.
     /// - `"transparent"` — siphon re-emits the REFER on the far leg's own dialog
     ///   and relays the far end's 202 + `message/sipfrag` NOTIFYs back. Correct
     ///   for UA-to-UA (PBX / softphone) topologies.

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -62,9 +62,9 @@ impl ControlAdapter for SipControlAdapter {
                 verb("reject", "Send a final non-2xx and tear the call down (args: code, reason)"),
                 verb("hangup", "BYE an answered call, or reject an unanswered one (args: reason)"),
                 verb("refer", "Send an in-dialog REFER on the A-leg; the reply reports only that it was sent, the far end's verdict arrives as TransferProgress then TransferCompleted / TransferFailed (args: to, replaces)"),
-                verb("accept_refer", "Accept a pending inbound REFER (from a TransferRequested event) and run the transfer (args: target, next_hop, mode)"),
+                verb("accept_refer", "Accept a pending inbound REFER (from a TransferRequested event) and run the transfer (args: target, next_hop, mode, profile, number_policy)"),
                 verb("reject_refer", "Reject a pending inbound REFER with a final non-2xx (args: code, reason)"),
-                verb("replace_peer", "Replace one leg of this answered call with a freshly dialed target, with no REFER involved: the replaced leg stays up while the target rings and is BYE'd only once it answers. The reply says the INVITE is on the wire, PeerReplaced says the new party is bridged and the old one released (args: target, next_hop, replace_a_leg, profile, timeout)"),
+                verb("replace_peer", "Replace one leg of this answered call with a freshly dialed target, with no REFER involved: the replaced leg stays up while the target rings and is BYE'd only once it answers. The reply says the INVITE is on the wire, PeerReplaced says the new party is bridged and the old one released (args: target, next_hop, replace_a_leg, profile, number_policy, timeout)"),
                 verb("bridge", "Join this channel to another the app owns, so the two parties hear each other; the reply says the media was re-pointed and the first re-INVITE is on the wire, ChannelBridged says the audio meets (args: with, on_peer_hangup)"),
                 verb("unbridge", "Break a bridge — both legs stay answered, owned and held; the reply says the hold offers went out, ChannelUnbridged on each leg says it is parted and safe to bridge again (args: reason)"),
                 verb("route", "Return control to siphon with a routing decision: un-park the call and dial the B-leg via LCR sequential failover (args: targets, strategy, headers)"),
@@ -1459,6 +1459,29 @@ fn refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
 /// steers egress, and `mode` (`"terminate"` / `"transparent"`) overrides the
 /// configured `b2bua.default_refer_mode`. No pending REFER (already decided,
 /// timed out, or the call is gone) → `not_found`.
+/// Validate a `number_policy` verb argument against the installed registry.
+///
+/// Resolved by name here so an unknown one is a synchronous `bad_request` to the
+/// controller rather than a warn-and-skip deep in the send path — the control
+/// plane can report it, where the script paths raise on the spot for the same
+/// reason.
+fn validate_number_policy(args: &serde_json::Value) -> Result<Option<&str>, ControlResult> {
+    let name = args.get("number_policy").and_then(|value| value.as_str());
+    if let Some(name) = name {
+        if crate::script::api::numbers::number_runtime()
+            .registry
+            .get(name)
+            .is_none()
+        {
+            return Err(ControlResult::error(
+                ControlErrorCode::BadRequest,
+                format!("unknown number policy {name:?}"),
+            ));
+        }
+    }
+    Ok(name)
+}
+
 /// Map a `replace_peer` refusal onto its wire code.
 ///
 /// Same discipline as [`bridge_error`]: one code per cause, so a controller can
@@ -1524,6 +1547,10 @@ fn replace_peer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
     // describes the party that is leaving, so the caller names the one for the
     // pair that remains.
     let media_profile = args.get("profile").and_then(|value| value.as_str());
+    let number_policy = match validate_number_policy(args) {
+        Ok(name) => name,
+        Err(result) => return result,
+    };
     let timeout_secs = match args.get("timeout") {
         None => 30,
         Some(value) => match value.as_u64() {
@@ -1543,6 +1570,7 @@ fn replace_peer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
         next_hop,
         replace_a_leg,
         media_profile,
+        number_policy,
         timeout_secs,
     ) {
         Ok(()) => ControlResult::Ok(serde_json::json!({
@@ -1584,12 +1612,21 @@ fn accept_refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
     // written for the party being transferred away.
     let media_profile = args.get("profile").and_then(|v| v.as_str());
 
+    // A transfer target is named by the referrer, in the referrer's number
+    // format; the carrier the new leg is dialled at expects the trunk's. Same
+    // knob, same resolution order, as `call.accept_refer(number_policy=…)`.
+    let number_policy = match validate_number_policy(args) {
+        Ok(name) => name,
+        Err(result) => return result,
+    };
+
     if crate::dispatcher::b2bua_accept_refer_call(
         &channel.sip_call_id,
         target.map(|s| s.to_string()),
         next_hop.map(|s| s.to_string()),
         mode,
         media_profile.map(|s| s.to_string()),
+        number_policy.map(|s| s.to_string()),
     ) {
         ControlResult::Ok(
             serde_json::json!({ "channel": channel.channel_id, "transfer": "accepted" }),

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -17017,7 +17017,7 @@ fn b2bua_send_b_leg_invite(
             Err(_) => warn!(
                 call_id = %call_id,
                 policy = %policy_name,
-                "LCR: unknown number_policy on route, skipping identity reshape"
+                "unknown number_policy, skipping identity reshape"
             ),
         }
     }
@@ -23247,6 +23247,7 @@ pub fn b2bua_accept_refer_call(
     next_hop: Option<String>,
     mode: Option<crate::script::api::call::ReferMode>,
     media_profile: Option<String>,
+    number_policy: Option<String>,
 ) -> bool {
     let Some(control) = B2BUA_CONTROL.get() else {
         return false;
@@ -23279,6 +23280,7 @@ pub fn b2bua_accept_refer_call(
         pending.refer_to.replaces.clone(),
         mode,
         media_profile.as_deref(),
+        number_policy.as_deref(),
         state,
     );
     true
@@ -23311,6 +23313,7 @@ pub fn b2bua_replace_peer(
     next_hop: Option<&str>,
     replace_a_leg: bool,
     media_profile: Option<&str>,
+    number_policy: Option<&str>,
     timeout_secs: u32,
 ) -> Result<(), crate::b2bua::transfer::ReplaceError> {
     use crate::b2bua::transfer::{ReplaceError, ReplacementOrigin};
@@ -23386,6 +23389,7 @@ pub fn b2bua_replace_peer(
         None,
         None,
         media_profile,
+        number_policy,
         0,
         ReplacementOrigin::SiphonInitiated,
         timeout_secs,
@@ -27877,15 +27881,18 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
     // surviving pair's media profile has to be (see `accept_refer(profile=…)`).
     py_call.set_refer_from_a_leg(from_a_leg);
 
-    let action = Python::attach(|python| {
+    let (action, ignored_overrides) = Python::attach(|python| {
         let call_obj = match Py::new(python, py_call) {
             Ok(obj) => obj,
             Err(error) => {
                 error!("failed to create PyCall for on_refer: {error}");
-                return CallAction::RejectRefer {
-                    code: 500,
-                    reason: "Script Error".to_string(),
-                };
+                return (
+                    CallAction::RejectRefer {
+                        code: 500,
+                        reason: "Script Error".to_string(),
+                    },
+                    false,
+                );
             }
         };
         for handler in &handlers {
@@ -27895,25 +27902,52 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
                     if handler.is_async {
                         if let Err(error) = run_coroutine(python, &ret) {
                             error!("async B2BUA on_refer handler error: {error}");
-                            return CallAction::RejectRefer {
-                                code: 500,
-                                reason: "Script Error".to_string(),
-                            };
+                            return (
+                                CallAction::RejectRefer {
+                                    code: 500,
+                                    reason: "Script Error".to_string(),
+                                },
+                                false,
+                            );
                         }
                     }
                 }
                 Err(error) => {
                     error!("B2BUA on_refer handler error: {error}");
-                    return CallAction::RejectRefer {
-                        code: 500,
-                        reason: "Script Error".to_string(),
-                    };
+                    return (
+                        CallAction::RejectRefer {
+                            code: 500,
+                            reason: "Script Error".to_string(),
+                        },
+                        false,
+                    );
                 }
             }
         }
         let borrowed = call_obj.borrow(python);
-        borrowed.action().clone()
+        // The B-leg shaping setters belong to the `on_invite` → `dial()` path:
+        // they are read off the PyCall built there, and this one is a throwaway
+        // whose only surviving output is the action below. Silently doing
+        // nothing is the expensive failure — the script looks like it steered
+        // the transferred leg and the wire says otherwise — so say so.
+        //
+        // Message mutations (`set_header`, `rewrite_identities`) are the same
+        // shape and worse to detect: they land on this call's own clone of the
+        // REFER, while the leg is dialled from a clone of the *stored* A-leg
+        // INVITE. `accept_refer`'s own arguments are what reach the new leg.
+        let ignored_overrides = borrowed.contact_override().is_some()
+            || borrowed.contact_user_override().is_some()
+            || borrowed.from_host_override().is_some()
+            || borrowed.to_host_override().is_some();
+        (borrowed.action().clone(), ignored_overrides)
     });
+
+    if ignored_overrides {
+        warn!(
+            call_id = %call_id,
+            "B2BUA on_refer: set_contact_uri / set_contact_user / set_from_host / set_to_host have no effect in this handler — they shape a leg dialled by call.dial(), and a transfer leg is dialled from the stored A-leg INVITE. Use accept_refer(target=…, next_hop=…, number_policy=…) instead"
+        );
+    }
 
     match action {
         CallAction::RejectRefer { code, reason } => {
@@ -27925,6 +27959,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
             next_hop,
             mode,
             profile,
+            number_policy,
         } => {
             let mode = mode.unwrap_or(state.default_refer_mode);
             let target_uri = target.unwrap_or_else(|| refer_to.uri.clone());
@@ -27938,6 +27973,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
                 refer_to.replaces.clone(),
                 mode,
                 profile.as_deref(),
+                number_policy.as_deref(),
                 state,
             );
         }
@@ -28319,9 +28355,15 @@ fn b2bua_transfer_rtpengine_delete(state: &DispatcherState, cid_old: &str, from_
 
 /// Siphon-terminated (default): answer `202 Accepted` to the referrer, open the
 /// implicit REFER subscription, and start feeding it `message/sipfrag` NOTIFY
-/// progress (RFC 3515 §2.4.4). Siphon re-resolves the Refer-To through the dial
-/// plan as a new leg, re-bridges the surviving party to it, then BYEs the
+/// progress (RFC 3515 §2.4.4). Siphon dials the Refer-To (or the script's
+/// `target=`) as a new leg, re-bridges the surviving party to it, then BYEs the
 /// referred-away leg and sends the terminating `NOTIFY 200`.
+///
+/// The new leg is dialled *directly* — `@b2bua.on_invite` does not run again for
+/// it, so nothing the dial plan does there is repeated here. `number_policy` is
+/// the one piece of that shaping the transfer path applies itself, because a
+/// referrer names its target in its own number format and the carrier the leg is
+/// dialled at expects the trunk's.
 ///
 /// The `202 + NOTIFY 100 Trying + subscription` opening is done here; the
 /// new-leg dial and the transfer-aware bridge/BYE completion are driven off the
@@ -28337,6 +28379,7 @@ fn b2bua_refer_accept(
     replaces: Option<crate::sip::headers::refer::Replaces>,
     mode: crate::script::api::call::ReferMode,
     media_profile: Option<&str>,
+    number_policy: Option<&str>,
     state: &DispatcherState,
 ) {
     use crate::script::api::call::ReferMode;
@@ -28525,6 +28568,7 @@ fn b2bua_refer_accept(
                 replaces_header,
                 referred_by,
                 media_profile,
+                number_policy,
                 refer_cseq,
                 crate::b2bua::transfer::ReplacementOrigin::Refer,
                 0,
@@ -28573,11 +28617,56 @@ fn b2bua_start_leg_replacement(
     replaces_header: Option<crate::sip::headers::refer::Replaces>,
     referred_by: Option<String>,
     media_profile: Option<&str>,
+    number_policy: Option<&str>,
     event_id: u32,
     origin: crate::b2bua::transfer::ReplacementOrigin,
     timeout_secs: u32,
     state: &DispatcherState,
 ) -> bool {
+    // Reshape the target to the carrier's number format before anything reads
+    // it — the R-URI, the To, and the wire destination all derive from this one
+    // string.
+    //
+    // A transfer target is named by the *referrer*, in whatever shape the
+    // referrer speaks (a Teams `Refer-To` names `+E.164`), while a dialled leg
+    // is shaped by `dial(number_policy=…)` / `b2bua.default_number_policy` on
+    // the way out. Without this the two disagree on the same trunk: every
+    // normal call reaches the carrier as bare digits and every transferred one
+    // arrives with the `+` still attached. `@b2bua.on_invite` does not run again
+    // for a replacement leg, so this is the only place the shaping can happen.
+    //
+    // Resolution matches `dial()` exactly — the named policy, else
+    // `b2bua.default_number_policy`, else no reshaping. An unknown name is
+    // warned about and skipped rather than failing the transfer: the script path
+    // already rejects a typo eagerly in `accept_refer`, so a name reaching here
+    // unknown came from the control plane, and dropping a transfer over a
+    // formatting policy would be the worse failure.
+    let reshaped_target;
+    let target_uri = match crate::script::api::numbers::resolve_dial_policy(number_policy) {
+        Ok(Some(policy)) => {
+            reshaped_target =
+                crate::script::api::numbers::reformat_dial_target(target_uri, &policy);
+            if reshaped_target != target_uri {
+                debug!(
+                    call_id = %call_id,
+                    from = %target_uri,
+                    to = %reshaped_target,
+                    "leg replacement: number policy reshaped the transfer target"
+                );
+            }
+            reshaped_target.as_str()
+        }
+        Ok(None) => target_uri,
+        Err(_) => {
+            warn!(
+                call_id = %call_id,
+                policy = ?number_policy,
+                "leg replacement: unknown number_policy — dialling the target unreshaped"
+            );
+            target_uri
+        }
+    };
+
     // Dial the target as a new leg, then record the replacement tagged with
     // that leg's Call-ID. The leg's 2xx is intercepted in the response path
     // (b2bua_complete_terminated_transfer) to promote it into the surviving
@@ -28741,7 +28830,11 @@ fn b2bua_start_leg_replacement(
             None,
             forced_cid,
             &template,
-            None,
+            // Identity headers of the triggered INVITE get the same policy the
+            // target just did — the dial path reshapes both together
+            // (`apply_for_dial`), and a From in one shape next to an R-URI in
+            // another is what an SBC reads as inconsistent.
+            number_policy,
             None,
             None,
             None,

--- a/src/script/api/b2bua.rs
+++ b/src/script/api/b2bua.rs
@@ -299,6 +299,12 @@ impl PyB2buaControl {
     ///         call is anchored with a direction-bound profile — the inherited
     ///         one describes the party that is leaving.
     ///     timeout: Seconds to wait for the target to answer.
+    ///     number_policy: Reshape the target's number (and the triggered
+    ///         INVITE's identity headers) the way ``call.dial(number_policy=…)``
+    ///         does — an explicit named policy, else
+    ///         ``b2bua.default_number_policy``, else no reshaping. A replacement
+    ///         leg does not re-enter ``@b2bua.on_invite``, so this is where a
+    ///         carrier's number format gets applied to it.
     ///
     /// Returns True once the INVITE is on the wire. It does **not** wait for the
     /// target: the replacement completes later, and `@b2bua.on_bye` fires for
@@ -316,7 +322,8 @@ impl PyB2buaControl {
     ///     if digit == "0":
     ///         b2bua.replace_peer(call_id, "sip:operator@pbx.example", timeout=45)
     /// ```
-    #[pyo3(signature = (call_id, target, next_hop=None, replace_a_leg=false, profile=None, timeout=30))]
+    #[pyo3(signature = (call_id, target, next_hop=None, replace_a_leg=false, profile=None, timeout=30, number_policy=None))]
+    #[allow(clippy::too_many_arguments)]
     fn replace_peer(
         &self,
         call_id: &str,
@@ -325,14 +332,20 @@ impl PyB2buaControl {
         replace_a_leg: bool,
         profile: Option<&str>,
         timeout: u32,
+        number_policy: Option<&str>,
     ) -> PyResult<bool> {
         use pyo3::exceptions::PyValueError;
+        // Validate the name here so a typo raises on the spot, the way
+        // `dial(number_policy=…)` and `accept_refer(number_policy=…)` do,
+        // instead of silently dialling the target unreshaped.
+        crate::script::api::numbers::resolve_dial_policy(number_policy)?;
         crate::dispatcher::b2bua_replace_peer(
             call_id,
             target,
             next_hop,
             replace_a_leg,
             profile,
+            number_policy,
             timeout,
         )
         .map(|()| true)

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -95,6 +95,12 @@ pub enum CallAction {
         /// correct when that profile is symmetric — see
         /// `ProfileEntry::is_direction_bound`.
         profile: Option<String>,
+        /// Number policy for the leg the transfer dials, resolved the way
+        /// `dial()` resolves it: this name, else `b2bua.default_number_policy`,
+        /// else none. Carried as a name rather than a resolved policy because
+        /// the reshape happens on the dispatcher side, where the triggered
+        /// INVITE is built.
+        number_policy: Option<String>,
     },
     /// Reject a REFER with a status code.
     RejectRefer { code: u16, reason: String },
@@ -161,10 +167,11 @@ pub enum CallAction {
 /// configured `b2bua.default_refer_mode` fallback).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReferMode {
-    /// siphon terminates the transfer: answer 202 locally, re-resolve the
-    /// Refer-To through the dial plan as a new leg, re-bridge the media, and BYE
+    /// siphon terminates the transfer: answer 202 locally, dial the Refer-To
+    /// (or the handler's `target=`) as a new leg, re-bridge the media, and BYE
     /// the referred-away leg. Correct for trunk-facing SBCs (the far end need not
-    /// support REFER) and keeps media anchored.
+    /// support REFER) and keeps media anchored. The new leg is dialled directly:
+    /// `@b2bua.on_invite` does not run again for it.
     Terminate,
     /// siphon forwards the REFER transparently on the far leg's own dialog and
     /// relays the far end's 202 + `message/sipfrag` NOTIFYs back to the referrer.
@@ -2403,9 +2410,12 @@ impl PyCall {
     ///
     /// `mode` selects how siphon honors the transfer:
     ///   - `"terminate"`   — siphon terminates the transfer: answer 202 locally,
-    ///     re-resolve the Refer-To through the dial plan as a new leg, re-bridge
-    ///     the media, and BYE the referred-away leg. Works even when the far end
-    ///     cannot handle REFER; keeps media anchored.
+    ///     dial the Refer-To (or `target`) as a new leg, re-bridge the media,
+    ///     and BYE the referred-away leg. Works even when the far end cannot
+    ///     handle REFER; keeps media anchored. Note this dials the target
+    ///     directly — `@b2bua.on_invite` does NOT run again for the new leg, so
+    ///     any routing the dial plan does there is this handler's to repeat
+    ///     (`number_policy` below covers the number shaping half of it).
     ///   - `"transparent"` — siphon re-emits the REFER on the far leg's own
     ///     dialog and relays the far end's 202 + sipfrag NOTIFYs back.
     ///   - `None` (default) — use the configured `b2bua.default_refer_mode`.
@@ -2432,13 +2442,31 @@ impl PyCall {
     ///   # both remaining parties are on the carrier side
     ///   call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
     ///                     profile="rtp_passthrough")
-    #[pyo3(signature = (target=None, next_hop=None, mode=None, profile=None))]
+    ///
+    /// `number_policy` reshapes the transferred leg's number the way
+    /// `call.dial(number_policy=…)` reshapes a dialled one: an explicit named
+    /// policy, else `b2bua.default_number_policy`, else no reshaping. It applies
+    /// to the target URI (and so to the R-URI and To of the triggered INVITE)
+    /// and to that INVITE's identity headers. Without it the target goes out in
+    /// whatever shape the referrer named it in — a `Refer-To` naming `+E.164`
+    /// reaches a bare-digit carrier with the `+` still on, while every dialled
+    /// leg on the same trunk gets the carrier's shape.
+    ///
+    /// Terminate mode only: in `"transparent"` mode siphon dials nothing, it
+    /// re-emits the REFER and the far end resolves the target under its own
+    /// numbering. Setting it there has no effect.
+    ///
+    ///   call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
+    ///                     profile="rtp_passthrough",
+    ///                     number_policy="carrier-plain@2026")
+    #[pyo3(signature = (target=None, next_hop=None, mode=None, profile=None, number_policy=None))]
     fn accept_refer(
         &mut self,
         target: Option<String>,
         next_hop: Option<String>,
         mode: Option<&str>,
         profile: Option<String>,
+        number_policy: Option<String>,
     ) -> PyResult<()> {
         let mode = match mode {
             None => None,
@@ -2450,11 +2478,18 @@ impl PyCall {
                 )));
             }
         };
+        // Resolve eagerly for the error only: a typo'd policy name has to raise
+        // here, in the handler, the way `dial()` raises — not silently skip the
+        // reshape at dial time where nothing is watching. The resolved policy
+        // itself is discarded; the dispatcher re-resolves by name once it has
+        // the triggered INVITE to apply it to.
+        let _ = super::numbers::resolve_dial_policy(number_policy.as_deref())?;
         self.action = CallAction::AcceptRefer {
             target,
             next_hop,
             mode,
             profile,
+            number_policy,
         };
         Ok(())
     }
@@ -3681,7 +3716,7 @@ mod tests {
             "10.0.0.1".to_string(),
             "udp".to_string(),
         );
-        call.accept_refer(None, None, None, None).unwrap();
+        call.accept_refer(None, None, None, None, None).unwrap();
         assert_eq!(
             call.action(),
             &CallAction::AcceptRefer {
@@ -3689,6 +3724,7 @@ mod tests {
                 next_hop: None,
                 mode: None,
                 profile: None,
+                number_policy: None,
             }
         );
     }
@@ -3707,6 +3743,7 @@ mod tests {
             Some("sip:198.51.100.1:5060".to_string()),
             Some("transparent"),
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -3716,6 +3753,7 @@ mod tests {
                 next_hop: Some("sip:198.51.100.1:5060".to_string()),
                 mode: Some(ReferMode::Transparent),
                 profile: None,
+                number_policy: None,
             }
         );
     }
@@ -3729,7 +3767,7 @@ mod tests {
             "10.0.0.1".to_string(),
             "udp".to_string(),
         );
-        call.accept_refer(None, None, Some("terminate"), None)
+        call.accept_refer(None, None, Some("terminate"), None, None)
             .unwrap();
         assert_eq!(
             call.action(),
@@ -3738,6 +3776,7 @@ mod tests {
                 next_hop: None,
                 mode: Some(ReferMode::Terminate),
                 profile: None,
+                number_policy: None,
             }
         );
     }
@@ -3784,6 +3823,7 @@ mod tests {
             None,
             Some("terminate"),
             Some("rtp_passthrough".to_string()),
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -3793,6 +3833,7 @@ mod tests {
                 next_hop: None,
                 mode: Some(ReferMode::Terminate),
                 profile: Some("rtp_passthrough".to_string()),
+                number_policy: None,
             }
         );
     }
@@ -3806,10 +3847,62 @@ mod tests {
             "10.0.0.1".to_string(),
             "udp".to_string(),
         );
-        let result = call.accept_refer(None, None, Some("bridge"), None);
+        let result = call.accept_refer(None, None, Some("bridge"), None, None);
         assert!(result.is_err());
         // The invalid call must not have mutated the action.
         assert_eq!(call.action(), &CallAction::None);
+    }
+
+    #[test]
+    fn call_accept_refer_rejects_an_unknown_number_policy() {
+        // Same contract as `dial(number_policy=…)`: a typo raises in the
+        // handler rather than silently skipping the reshape at dial time, where
+        // the only symptom would be a transferred leg going out in the wrong
+        // shape. No registry is installed here, so every name is unknown.
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new(
+            "test-id".to_string(),
+            message,
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+        );
+        let result = call.accept_refer(None, None, None, None, Some("nope@2026".to_string()));
+        assert!(result.is_err());
+        assert_eq!(call.action(), &CallAction::None);
+    }
+
+    #[test]
+    fn call_accept_refer_carries_the_number_policy_name() {
+        // The name rides on the action; the dispatcher re-resolves it once it
+        // has the triggered INVITE to apply it to.
+        let message = Arc::new(Mutex::new(make_invite()));
+        let mut call = PyCall::new(
+            "test-id".to_string(),
+            message,
+            "10.0.0.1".to_string(),
+            "udp".to_string(),
+        );
+        // `None` resolves to `b2bua.default_number_policy`, which is unset in
+        // this binary — so it validates, and stays `None` for the dispatcher to
+        // resolve the same way.
+        call.accept_refer(
+            Some("sip:+15550142@carrier.example".to_string()),
+            None,
+            Some("terminate"),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            call.action(),
+            &CallAction::AcceptRefer {
+                target: Some("sip:+15550142@carrier.example".to_string()),
+                next_hop: None,
+                mode: Some(ReferMode::Terminate),
+                profile: None,
+                number_policy: None,
+            }
+        );
     }
 
     #[test]

--- a/src/script/api/numbers.rs
+++ b/src/script/api/numbers.rs
@@ -158,6 +158,20 @@ pub fn apply_for_fork(message: &mut SipMessage, policy: &NumberPolicy, targets: 
     }
 }
 
+/// B2BUA transfer path: reshape a REFER / leg-replacement target URI to the
+/// policy's Request-URI format.
+///
+/// Split out from [`apply_for_dial`] because a transfer decides its target
+/// without an A-leg message in hand: the triggered INVITE is built later, from
+/// a clone of the stored A-leg INVITE, and its identity headers are reshaped
+/// there by [`apply_identity_headers`]. Only the target needs doing here — but
+/// it does need doing, or the transferred leg goes out in whatever shape the
+/// referrer named while every dialled leg gets the carrier's.
+pub fn reformat_dial_target(target: &str, policy: &NumberPolicy) -> String {
+    let format = policy.format_for(IdentityHeader::RequestUri);
+    reformat_target(target, format, policy)
+}
+
 /// Resolve a `number_policy=` argument for the B2BUA dial/fork path: an explicit
 /// named policy, else the `b2bua.default_number_policy`, else `None`.
 pub fn resolve_dial_policy(name: Option<&str>) -> PyResult<Option<Arc<NumberPolicy>>> {
@@ -325,5 +339,91 @@ mod tests {
     fn resolve_unknown_named_policy_errors() {
         // With no runtime installed the registry is empty.
         assert!(resolve_rewrite_policy(Some("nope@2026"), None, None, None).is_err());
+    }
+
+    /// A uniform policy over the default identity set, built without touching
+    /// the process-wide runtime (a `OnceLock` — the first installer in the test
+    /// binary wins, so these stay independent of it).
+    ///
+    /// The locale mirrors a real trunk's `numbering:` block: an
+    /// `assume: international` plan, where bare digits are already
+    /// country-code-first. Under the `National` default the same input would
+    /// pick up a second country code, which is correct for that plan and not
+    /// what a transfer target off a Refer-To looks like.
+    fn policy(format: &str) -> NumberPolicy {
+        use crate::numbers::{AssumeForm, Locale};
+        let locale = Locale {
+            country_code: "1".to_string(),
+            assume: AssumeForm::International,
+            ..Locale::default()
+        };
+        NumberPolicy::uniform(
+            locale,
+            format.parse().unwrap(),
+            DEFAULT_IDENTITY_HEADERS.to_vec(),
+        )
+    }
+
+    #[test]
+    fn transfer_target_loses_the_plus_for_a_plain_carrier() {
+        // The bug this exists for: a REFER names its target in +E.164 and the
+        // carrier the transferred leg is dialled at takes bare digits, exactly
+        // as every dialled leg on that trunk already does.
+        assert_eq!(
+            reformat_dial_target("sip:+15550142@carrier.example", &policy("plain")),
+            "sip:15550142@carrier.example"
+        );
+    }
+
+    #[test]
+    fn transfer_target_gains_the_plus_for_an_e164_carrier() {
+        // The other direction of the same trunk pair — a transfer back out
+        // towards a peer that wants +E.164.
+        assert_eq!(
+            reformat_dial_target("sip:15550142@peer.example", &policy("e164")),
+            "sip:+15550142@peer.example"
+        );
+    }
+
+    #[test]
+    fn transfer_target_keeps_uri_parameters_and_port() {
+        // Only the userpart is the policy's business — the host, port and
+        // params of a Refer-To carry routing meaning.
+        assert_eq!(
+            reformat_dial_target(
+                "sip:+15550142@carrier.example:5060;transport=tls",
+                &policy("plain")
+            ),
+            "sip:15550142@carrier.example:5060;transport=tls"
+        );
+    }
+
+    #[test]
+    fn transfer_target_with_a_non_numeric_user_is_left_alone() {
+        // A transfer to a SIP AoR is not a number and must not be mangled into
+        // one.
+        assert_eq!(
+            reformat_dial_target("sip:alice@example.com", &policy("plain")),
+            "sip:alice@example.com"
+        );
+    }
+
+    #[test]
+    fn transfer_target_without_a_userpart_is_left_alone() {
+        assert_eq!(
+            reformat_dial_target("sip:pbx.example.com", &policy("plain")),
+            "sip:pbx.example.com"
+        );
+    }
+
+    #[test]
+    fn unparseable_transfer_target_is_returned_verbatim() {
+        // Never swallow a target: an unroutable one has to reach the send path
+        // and fail there, where the transfer is refused, rather than be turned
+        // into something else here.
+        assert_eq!(
+            reformat_dial_target("not a uri", &policy("plain")),
+            "not a uri"
+        );
     }
 }

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -2588,6 +2588,118 @@ def on_invite(call):
     }
 
     #[test]
+    fn b2bua_accept_refer_carries_a_number_policy_for_the_transferred_leg() {
+        // A transfer target is named by the referrer, in the referrer's format
+        // (a Teams `Refer-To` names `+E.164`), and dialled at a carrier that
+        // wants the trunk's. `@b2bua.on_invite` does not run again for the
+        // replacement leg, so `accept_refer(number_policy=…)` is where that
+        // shaping has to be asked for — this proves the name survives onto the
+        // action the dispatcher acts on, and that a typo raises instead.
+        //
+        // The runtime install below is idempotent (`OnceLock`, first writer
+        // wins) and deliberately identical to the sibling dial test's, so the
+        // policy is present whichever of the two runs first.
+        use crate::numbers::policy::{NumberPolicyConfig, NumberRegistry, NumberingConfig};
+        use crate::script::api::call::{CallAction, PyCall, ReferMode};
+        use crate::script::api::numbers::{set_number_runtime, NumberRuntime};
+        use crate::sip::builder::SipMessageBuilder;
+        use crate::sip::message::Method;
+        use crate::sip::uri::SipUri;
+        use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
+
+        let numbering = NumberingConfig {
+            country_code: "31".to_string(),
+            ..Default::default()
+        };
+        let mut policies = HashMap::new();
+        policies.insert(
+            "test-e164@2026".to_string(),
+            serde_yaml_ng::from_str::<NumberPolicyConfig>("default: e164\n").unwrap(),
+        );
+        let (registry, warnings) = NumberRegistry::build(&numbering, &policies);
+        assert!(warnings.is_empty(), "policy warnings: {warnings:?}");
+        set_number_runtime(Arc::new(NumberRuntime {
+            registry,
+            default_b2bua_policy: None,
+        }));
+
+        let source = r#"
+from siphon import b2bua
+
+@b2bua.on_refer
+def refered(call):
+    if call.refer_to.endswith("@bogus.example"):
+        # A typo'd policy name must raise in the handler, not silently skip the
+        # reshape at dial time.
+        try:
+            call.accept_refer(number_policy="nope@2026")
+        except ValueError:
+            call.reject_refer(500, "Bad Policy")
+        return
+    call.accept_refer(
+        target="sip:0201234567@carrier.example",
+        mode="terminate",
+        number_policy="test-e164@2026",
+    )
+"#;
+        let state = compile_temp_script(source).unwrap();
+
+        let refer = SipMessageBuilder::new()
+            .request(
+                Method::Refer,
+                SipUri::new("siphon.example".to_string()).with_user("alice".to_string()),
+            )
+            .via("SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-refnp".to_string())
+            .from("<sip:0612345678@example.com>;tag=ref-np".to_string())
+            .to("<sip:0201234567@example.com>;tag=ref-uas".to_string())
+            .call_id("refer-policy@test".to_string())
+            .cseq("2 REFER".to_string())
+            .content_length(0)
+            .build()
+            .unwrap();
+        let message_arc = Arc::new(Mutex::new(refer));
+
+        let invoke = |refer_to: &str| -> CallAction {
+            let mut py_call = PyCall::new(
+                "refer-np-001".to_string(),
+                Arc::clone(&message_arc),
+                "10.0.0.1".to_string(),
+                "udp".to_string(),
+            );
+            py_call.set_refer_to(refer_to.to_string(), None);
+            Python::attach(|python| {
+                let call_obj = Py::new(python, py_call).expect("failed to create PyCall");
+                let callable = state.handlers[0].callable.bind(python);
+                callable
+                    .call1((call_obj.bind(python),))
+                    .expect("handler invocation failed");
+                let action = call_obj.borrow(python).action().clone();
+                action
+            })
+        };
+
+        match invoke("sip:+31201234567@teams.example") {
+            CallAction::AcceptRefer {
+                target,
+                mode,
+                number_policy,
+                ..
+            } => {
+                assert_eq!(target.as_deref(), Some("sip:0201234567@carrier.example"));
+                assert_eq!(mode, Some(ReferMode::Terminate));
+                assert_eq!(number_policy.as_deref(), Some("test-e164@2026"));
+            }
+            other => panic!("expected AcceptRefer, got {other:?}"),
+        }
+
+        match invoke("sip:+31201234567@bogus.example") {
+            CallAction::RejectRefer { code, .. } => assert_eq!(code, 500),
+            other => panic!("expected the unknown policy to raise, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn b2bua_dial_next_hop_decouples_ruri_from_routing() {
         // IMS BGCF use case: stamp the canonical home-domain IMPU on the
         // R-URI of the B-leg INVITE (so the receiving S-CSCF's alias-chain


### PR DESCRIPTION
A siphon-terminated REFER dials its target **directly**: `@b2bua.on_invite` does
not run again for the replacement leg, so nothing that handler does to shape a
call was repeated for it, and the number policy every dialled leg gets
(`call.dial(number_policy=…)`, or `b2bua.default_number_policy`) was skipped
outright — `b2bua_start_leg_replacement` passed a hardcoded `None` into
`b2bua_send_b_leg_invite`, and `accept_refer()` had no such argument to pass.

The two ends disagree about number format by default. The *referrer* names its
target in its own format (an E.164 one, `+` included); the carrier the new leg
is dialled at expects whatever the trunk speaks. So on a bare-digit trunk every
ordinary call went out without the `+` and every transferred one arrived with
it — same node, same trunk, same call. Whether that is a rejection or a silently
different route is the carrier's business, and either way it presents as a
broken transfer rather than a numbering one.

## What changed

`number_policy=` on `call.accept_refer()` and `b2bua.replace_peer()` (and on
both control-plane verbs), resolving exactly the way `dial()` resolves it — the
named policy, else `b2bua.default_number_policy`, else no reshaping. It applies
to the target URI (and so to the R-URI and To of the triggered INVITE) and to
that INVITE's identity headers, which the dial path already reshapes together.

A deployment that already sets `b2bua.default_number_policy` gets its transfers
fixed with no script change.

Failure handling follows where the name came from: the script paths raise on an
unknown policy, the control plane returns a synchronous `bad_request`, and the
send path warns and keeps the transfer — dropping a call over a formatting
policy is the worse failure.

Terminate mode only: in transparent mode siphon dials nothing, so there is no
leg for a policy to shape.

The **routing** half of the dial plan stays the handler's own; `next_hop=` is
still how a transfer picks a carrier. The docs now say that, in place of
`accept_refer`'s claim that terminate mode "re-resolves the Refer-To through the
dial plan as a new leg" — the exact expectation that made the gap invisible.
Corrected in the rustdoc, the config doc, the SDK and the cookbook.

## Also

`@b2bua.on_refer` now warns when `set_contact_uri()` / `set_contact_user()` /
`set_from_host()` / `set_to_host()` are called in it. Those are read off the
`PyCall` the `on_invite` path builds on its way into `dial()`; the one a REFER
handler gets is a throwaway whose only surviving output is the accept/reject
decision, so they did nothing — quietly, which is the expensive way. Message
mutations (`set_header`, `rewrite_identities`) are the same shape and harder to
spot: they land on that handler's own clone of the REFER, while the new leg is
built from a clone of the stored A-leg INVITE.

## Tests

- `reformat_dial_target` unit tests: the `+` in both directions, URI params and
  port preserved, and non-numeric / userless / unparseable targets returned
  verbatim (a target is never swallowed — an unroutable one has to fail at the
  send path, where the transfer is refused).
- Engine test: the policy name survives onto the `AcceptRefer` action the
  dispatcher acts on, and a typo raises in the handler.
- `call.rs`: eager validation, and the name carried on the action.
- SDK: `accept_refer(number_policy=…)` and `replace_peer(number_policy=…)`
  recorded, defaulting to `None` (which means "the configured default", not
  "never reshape").

`cargo test` 4724 passed, clippy clean, `cargo fmt --check` exit 0, SDK 702
passed.
