### PR TITLE
feat(b2bua): accept an inline format= on dial/fork/accept_refer/replace_peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,27 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   the one SDK with no way to read that verdict except by matching the wire
   strings by hand, which rots in silence when the event set grows. TypeScript
   gains `transferOutcome` for the same reason.
+
+- **`format=` on `call.dial()`, `call.fork()`, `call.accept_refer()` and
+  `b2bua.replace_peer()`** — the inline half of number shaping that
+  `rewrite_identities()` always had and the dial family never did. `"e164"`,
+  `"plain"`, `"international"` and `"national"` are *formats*, while
+  `number_policy=` does a registry lookup, so `number_policy="plain"` failed with
+  `unknown number policy "plain"` for a perfectly good format. Two arguments that
+  grew apart rather than a design line, and it bites hardest where it is least
+  expected: a deployment that shapes numbers inline
+  (`rewrite_identities(format="plain")`) has no `number_policies:` block at all,
+  so *every* named lookup fails and `number_policy=` was unusable to it without
+  first inventing config for something it already expresses in one word.
+
+  Resolution order is unchanged and now covers both: the named policy, else the
+  inline format, else `b2bua.default_number_policy`, else no reshaping. Passing
+  both raises, as it does on `rewrite_identities()`. The two are carried as a
+  single selector rather than two `Option`s, so "both at once" is
+  unrepresentable below the constructor that rejects it, and the transfer path
+  now resolves once and hands the send path a resolved policy — the target URI
+  and the identity headers can no longer be shaped by different policies.
+
 ### Fixed
 - **An in-dialog REFER or NOTIFY on a call with no far leg is answered instead
   of dropped.** A call with one leg is not an error state: a UAS-mode answer, a

--- a/docs/cookbook/call-transfer.md
+++ b/docs/cookbook/call-transfer.md
@@ -179,10 +179,20 @@ def on_refer(call):
     )
 ```
 
-Set `b2bua.default_number_policy` in `siphon.yaml` and transfers pick it up with
-no argument at all. An unknown policy name raises `ValueError` in the handler
-rather than silently dialling the target unreshaped. `b2bua.replace_peer()`
-takes the same argument, for the same reason.
+If you shape numbers inline rather than through named policies, `format=` is the
+same thing without the config block, exactly as on `rewrite_identities()`:
+
+```python
+call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
+                  profile="rtp_passthrough", format="plain")
+```
+
+`"e164"`, `"plain"`, `"international"` and `"national"` are *formats*;
+`number_policy=` wants a name from `number_policies:`. Pass one or the other,
+never both. Set `b2bua.default_number_policy` and transfers pick it up with no
+argument at all. An unknown name or format raises `ValueError` in the handler
+rather than silently dialling the target unreshaped. `call.dial()`,
+`call.fork()` and `b2bua.replace_peer()` all take the same pair.
 
 The **routing** half is still the handler's own: a transfer that must leave via
 a particular carrier needs `next_hop=` (or a `target=` naming the right host),

--- a/sdk/siphon_sdk/call.py
+++ b/sdk/siphon_sdk/call.py
@@ -724,6 +724,7 @@ class Call:
         send_socket: Optional[str] = None,
         auth_passthrough: bool = False,
         number_policy: Optional[str] = None,
+        format: Optional[str] = None,
     ) -> None:
         """Dial a single B-leg target.
 
@@ -848,7 +849,7 @@ class Call:
         _validate_send_socket(send_socket)
         if max_duration is not None:
             self._max_duration_secs = max_duration
-        uri = self._normalize_dial_targets([uri], number_policy)[0]
+        uri = self._normalize_dial_targets([uri], number_policy, format)[0]
         self._actions.append(Action(
             kind="dial",
             targets=[uri],
@@ -880,6 +881,7 @@ class Call:
         send_socket: Optional[str] = None,
         auth_passthrough: bool = False,
         number_policy: Optional[str] = None,
+        format: Optional[str] = None,
     ) -> None:
         """Fork to multiple B-leg targets.
 
@@ -930,7 +932,7 @@ class Call:
         if max_duration is not None:
             self._max_duration_secs = max_duration
         uris = [t.uri if isinstance(t, Contact) else str(t) for t in targets]
-        uris = self._normalize_dial_targets(uris, number_policy)
+        uris = self._normalize_dial_targets(uris, number_policy, format)
         self._actions.append(Action(
             kind="fork",
             targets=uris,
@@ -1057,7 +1059,8 @@ class Call:
                      next_hop: Optional[str] = None,
                      mode: Optional[str] = None,
                      profile: Optional[str] = None,
-                     number_policy: Optional[str] = None) -> None:
+                     number_policy: Optional[str] = None,
+                     format: Optional[str] = None) -> None:
         """Accept an incoming REFER and honour the transfer.
 
         Call this from a ``@b2bua.on_refer`` handler to proceed with the
@@ -1124,11 +1127,18 @@ class Call:
                 Terminate mode only: in ``"transparent"`` mode siphon dials
                 nothing — it re-emits the REFER and the far end resolves the
                 target under its own numbering — so this has no effect there.
+            format: The inline form of the same thing, exactly as on
+                :meth:`rewrite_identities`: ``"e164"``, ``"plain"``,
+                ``"international"`` or ``"national"``, applied over the default
+                identity header set on the configured home locale.  Use this
+                when you shape numbers inline and have no ``number_policies:``
+                block to name.  Pass this or ``number_policy``, never both.
 
         Raises:
             ValueError: if ``mode`` is not one of ``None``, ``"terminate"``,
-                or ``"transparent"``, or if ``number_policy`` names a policy
-                that is not configured.
+                or ``"transparent"``; if ``number_policy`` names a policy that
+                is not configured; if ``format`` is not a known format; or if
+                both ``number_policy`` and ``format`` are given.
 
         Example::
 
@@ -1156,18 +1166,27 @@ class Call:
                 call.accept_refer(target=target, next_hop=gw.uri,
                                   mode="terminate", profile="rtp_passthrough",
                                   number_policy="carrier-plain@2026")
+
+            @b2bua.on_refer
+            def handle_refer(call):
+                # Same thing inline, with no number_policies: block to name.
+                call.accept_refer(target=target, next_hop=gw.uri,
+                                  mode="terminate", profile="rtp_passthrough",
+                                  format="plain")
         """
         if mode not in (None, "terminate", "transparent"):
             raise ValueError(
                 f"accept_refer(mode=...) must be None, 'terminate', or "
                 f"'transparent' (got {mode!r})"
             )
+        from siphon_sdk import mock_module
+        mock_module.get_numbers()._resolve_dial(number_policy, format)
         self._actions.append(Action(
             kind="accept_refer",
             targets=[target] if target else None,
             next_hop=next_hop,
             extras={"mode": mode, "profile": profile,
-                    "number_policy": number_policy},
+                    "number_policy": number_policy, "format": format},
         ))
 
     def reject_refer(self, code: int, reason: str) -> None:
@@ -1494,14 +1513,16 @@ class Call:
                         changed += 1
         return changed
 
-    def _normalize_dial_targets(self, targets: list, number_policy: Optional[str]) -> list:
+    def _normalize_dial_targets(
+        self, targets: list, number_policy: Optional[str], format: Optional[str] = None
+    ) -> list:
         """Apply a B2BUA dial/fork number policy: normalize the A-leg header
         identities plus each branch target. Returns the (possibly rewritten)
         targets."""
         from siphon_sdk import mock_module
         from siphon_sdk.numbers import rewrite_nameaddr_userpart
 
-        resolved = mock_module.get_numbers()._resolve_dial(number_policy)
+        resolved = mock_module.get_numbers()._resolve_dial(number_policy, format)
         if resolved is None:
             return targets
         self._apply_number_policy(resolved, include_request_uri=False)

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -890,6 +890,7 @@ class MockB2bua:
         profile: Optional[str] = None,
         timeout: int = 30,
         number_policy: Optional[str] = None,
+        format: Optional[str] = None,
     ) -> bool:
         """Replace one leg of an answered call with a freshly dialed target.
 
@@ -926,6 +927,10 @@ class MockB2bua:
                 else ``b2bua.default_number_policy``, else no reshaping. A
                 replacement leg does not re-enter ``@b2bua.on_invite``, so this
                 is where a carrier's number format gets applied to it.
+            format: the inline form of the same thing, as on
+                ``rewrite_identities(format=...)``: ``"e164"``, ``"plain"``,
+                ``"international"`` or ``"national"``. Pass this or
+                ``number_policy``, never both.
 
         Returns:
             bool: True once the INVITE is on the wire. It does not wait for the
@@ -954,6 +959,7 @@ class MockB2bua:
         """
         if not target or not str(target).strip():
             raise ValueError("bad_request: cannot route to replacement target: ")
+        get_numbers()._resolve_dial(number_policy, format)
         self.replacements.append(
             {
                 "call_id": call_id,
@@ -963,6 +969,7 @@ class MockB2bua:
                 "profile": profile,
                 "timeout": timeout,
                 "number_policy": number_policy,
+                "format": format,
             }
         )
         return True

--- a/sdk/siphon_sdk/numbers.py
+++ b/sdk/siphon_sdk/numbers.py
@@ -330,9 +330,31 @@ class MockNumbersNamespace:
             locale = Locale(**{**self._locale_kwargs(), "country_code": home})
         return _Policy(locale, fmt, {}, walk, "keep", [])
 
-    def _resolve_dial(self, name: Optional[str]) -> Optional[_Policy]:
-        """Resolve the B2BUA dial/fork policy: explicit name, else the
-        configured default, else ``None`` (no normalization)."""
+    def _resolve_dial(
+        self, name: Optional[str], format: Optional[str] = None
+    ) -> Optional[_Policy]:
+        """Resolve the B2BUA dial/fork/transfer policy: a named policy, else an
+        inline format, else the configured default, else ``None`` (no
+        normalization).
+
+        The inline branch is the half ``rewrite_identities`` always had and the
+        dial family never did, which is why ``number_policy="plain"`` used to
+        fail with "unknown number policy" for a perfectly good format."""
+        if name is not None and format is not None:
+            raise ValueError(
+                "pass either number_policy= (a named policy) or format= "
+                "(an inline format), not both"
+            )
+        if format is not None:
+            fmt = format.strip().lower()
+            if fmt not in _FORMATS:
+                raise ValueError(f"unknown number format {format!r}")
+            walk: List[str] = []
+            for token in _DEFAULT_HEADERS:
+                canonical = _IDENTITY_TOKENS.get(token.strip().lower())
+                if canonical is not None and canonical not in walk:
+                    walk.append(canonical)
+            return _Policy(self._locale, fmt, {}, walk, "keep", [])
         resolved_name = name or self._default_b2bua_policy
         if resolved_name is None:
             return None

--- a/sdk/tests/test_b2bua_refer.py
+++ b/sdk/tests/test_b2bua_refer.py
@@ -119,10 +119,13 @@ def on_refer(call):
         assert action.next_hop == "sip:trunk.example.com:5060"
 
     def test_number_policy_recorded_for_the_transferred_leg(self, harness):
-        # A Teams Refer-To names +E.164; a trunk that takes bare digits sees
-        # every ordinary call as 32... and every transferred one as +32...
-        # unless the transfer asks for the same shaping a dial gets. The
-        # replacement leg never re-enters @b2bua.on_invite.
+        # A referrer names its target in +E.164; a trunk that takes bare digits
+        # sees every ordinary call without the plus and every transferred one
+        # with it, unless the transfer asks for the same shaping a dial gets.
+        # The replacement leg never re-enters @b2bua.on_invite.
+        from siphon_sdk import mock_module
+
+        mock_module.get_numbers().register_policy("carrier-plain@2026", default="plain")
         harness.load_source(
             """
 from siphon import b2bua
@@ -141,6 +144,53 @@ def on_refer(call):
         assert action.kind == "accept_refer"
         assert action.extras["number_policy"] == "carrier-plain@2026"
         assert action.extras["profile"] == "rtp_passthrough"
+
+    def test_inline_format_needs_no_configured_policy(self, harness):
+        # The complaint that produced format=: a script that shapes numbers with
+        # rewrite_identities(format="plain") has no number_policies: block at
+        # all, so number_policy="plain" failed as an unknown policy name.
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(target="sip:+15550142@carrier.example",
+                      mode="terminate", format="plain")
+"""
+        )
+
+        action = harness.send_refer().call.last_action
+        assert action.extras["format"] == "plain"
+        assert action.extras["number_policy"] is None
+
+    def test_number_policy_and_format_together_raise(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(number_policy="carrier-plain@2026", format="plain")
+"""
+        )
+
+        with pytest.raises(ValueError):
+            harness.send_refer()
+
+    def test_unknown_format_raises(self, harness):
+        harness.load_source(
+            """
+from siphon import b2bua
+
+@b2bua.on_refer
+def on_refer(call):
+    call.accept_refer(format="e165")
+"""
+        )
+
+        with pytest.raises(ValueError):
+            harness.send_refer()
 
     def test_number_policy_defaults_to_none(self, harness):
         # None means "the configured b2bua.default_number_policy", the same

--- a/sdk/tests/test_b2bua_replace_peer.py
+++ b/sdk/tests/test_b2bua_replace_peer.py
@@ -41,18 +41,39 @@ class TestRecording:
                 "profile": "ims_to_trunk",
                 "timeout": 45,
                 "number_policy": None,
+                "format": None,
             }
         ]
 
     def test_records_the_number_policy_for_the_replacement_leg(self, b2bua):
         # A replacement leg never re-enters @b2bua.on_invite, so the carrier's
         # number format has to be asked for on the verb itself.
+        from siphon_sdk import mock_module
+
+        mock_module.get_numbers().register_policy("carrier-plain@2026", default="plain")
         b2bua.replace_peer(
             "call-1@example.com",
             "sip:+15550142@carrier.example",
             number_policy="carrier-plain@2026",
         )
         assert b2bua.replacements[-1]["number_policy"] == "carrier-plain@2026"
+
+    def test_inline_format_needs_no_configured_policy(self, b2bua):
+        b2bua.replace_peer(
+            "call-1@example.com",
+            "sip:+15550142@carrier.example",
+            format="plain",
+        )
+        assert b2bua.replacements[-1]["format"] == "plain"
+
+    def test_number_policy_and_format_together_raise(self, b2bua):
+        with pytest.raises(ValueError):
+            b2bua.replace_peer(
+                "call-1@example.com",
+                "sip:+15550142@carrier.example",
+                number_policy="carrier-plain@2026",
+                format="plain",
+            )
 
     def test_defaults_replace_the_callee_and_ring_for_thirty(self, b2bua):
         b2bua.replace_peer("call-2@example.com", "sip:bob@example.com")
@@ -123,6 +144,7 @@ def on_digit(call_id, from_tag, digit, duration_ms, volume):
                 "profile": None,
                 "timeout": 45,
                 "number_policy": None,
+                "format": None,
             }
         ]
 

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -62,9 +62,9 @@ impl ControlAdapter for SipControlAdapter {
                 verb("reject", "Send a final non-2xx and tear the call down (args: code, reason)"),
                 verb("hangup", "BYE an answered call, or reject an unanswered one (args: reason)"),
                 verb("refer", "Send an in-dialog REFER on the A-leg; the reply reports only that it was sent, the far end's verdict arrives as TransferProgress then TransferCompleted / TransferFailed (args: to, replaces)"),
-                verb("accept_refer", "Accept a pending inbound REFER (from a TransferRequested event) and run the transfer (args: target, next_hop, mode, profile, number_policy)"),
+                verb("accept_refer", "Accept a pending inbound REFER (from a TransferRequested event) and run the transfer (args: target, next_hop, mode, profile, number_policy, format)"),
                 verb("reject_refer", "Reject a pending inbound REFER with a final non-2xx (args: code, reason)"),
-                verb("replace_peer", "Replace one leg of this answered call with a freshly dialed target, with no REFER involved: the replaced leg stays up while the target rings and is BYE'd only once it answers. The reply says the INVITE is on the wire, PeerReplaced says the new party is bridged and the old one released (args: target, next_hop, replace_a_leg, profile, number_policy, timeout)"),
+                verb("replace_peer", "Replace one leg of this answered call with a freshly dialed target, with no REFER involved: the replaced leg stays up while the target rings and is BYE'd only once it answers. The reply says the INVITE is on the wire, PeerReplaced says the new party is bridged and the old one released (args: target, next_hop, replace_a_leg, profile, number_policy, format, timeout)"),
                 verb("bridge", "Join this channel to another the app owns, so the two parties hear each other; the reply says the media was re-pointed and the first re-INVITE is on the wire, ChannelBridged says the audio meets (args: with, on_peer_hangup)"),
                 verb("unbridge", "Break a bridge — both legs stay answered, owned and held; the reply says the hold offers went out, ChannelUnbridged on each leg says it is parted and safe to bridge again (args: reason)"),
                 verb("route", "Return control to siphon with a routing decision: un-park the call and dial the B-leg via LCR sequential failover (args: targets, strategy, headers)"),
@@ -1527,27 +1527,24 @@ fn refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult {
 /// steers egress, and `mode` (`"terminate"` / `"transparent"`) overrides the
 /// configured `b2bua.default_refer_mode`. No pending REFER (already decided,
 /// timed out, or the call is gone) → `not_found`.
-/// Validate a `number_policy` verb argument against the installed registry.
+/// Validate the mutually-exclusive `number_policy` / `format` verb arguments.
 ///
-/// Resolved by name here so an unknown one is a synchronous `bad_request` to the
+/// Resolved here so an unusable one is a synchronous `bad_request` to the
 /// controller rather than a warn-and-skip deep in the send path — the control
 /// plane can report it, where the script paths raise on the spot for the same
 /// reason.
-fn validate_number_policy(args: &serde_json::Value) -> Result<Option<&str>, ControlResult> {
+fn validate_number_shape(
+    args: &serde_json::Value,
+) -> Result<Option<crate::script::api::numbers::NumberShape>, ControlResult> {
+    use crate::script::api::numbers::{resolve_dial_shape, NumberShape};
+
     let name = args.get("number_policy").and_then(|value| value.as_str());
-    if let Some(name) = name {
-        if crate::script::api::numbers::number_runtime()
-            .registry
-            .get(name)
-            .is_none()
-        {
-            return Err(ControlResult::error(
-                ControlErrorCode::BadRequest,
-                format!("unknown number policy {name:?}"),
-            ));
-        }
-    }
-    Ok(name)
+    let format = args.get("format").and_then(|value| value.as_str());
+    let shape = NumberShape::from_args(name, format)
+        .map_err(|error| ControlResult::error(ControlErrorCode::BadRequest, format!("{error}")))?;
+    resolve_dial_shape(shape.as_ref())
+        .map_err(|error| ControlResult::error(ControlErrorCode::BadRequest, format!("{error}")))?;
+    Ok(shape)
 }
 
 /// Map a `replace_peer` refusal onto its wire code.
@@ -1615,8 +1612,8 @@ fn replace_peer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
     // describes the party that is leaving, so the caller names the one for the
     // pair that remains.
     let media_profile = args.get("profile").and_then(|value| value.as_str());
-    let number_policy = match validate_number_policy(args) {
-        Ok(name) => name,
+    let number_shape = match validate_number_shape(args) {
+        Ok(shape) => shape,
         Err(result) => return result,
     };
     let timeout_secs = match args.get("timeout") {
@@ -1638,7 +1635,7 @@ fn replace_peer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
         next_hop,
         replace_a_leg,
         media_profile,
-        number_policy,
+        number_shape.as_ref(),
         timeout_secs,
     ) {
         Ok(()) => ControlResult::Ok(serde_json::json!({
@@ -1683,8 +1680,8 @@ fn accept_refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
     // A transfer target is named by the referrer, in the referrer's number
     // format; the carrier the new leg is dialled at expects the trunk's. Same
     // knob, same resolution order, as `call.accept_refer(number_policy=…)`.
-    let number_policy = match validate_number_policy(args) {
-        Ok(name) => name,
+    let number_shape = match validate_number_shape(args) {
+        Ok(shape) => shape,
         Err(result) => return result,
     };
 
@@ -1694,7 +1691,7 @@ fn accept_refer(channel: &ChannelRef, args: &serde_json::Value) -> ControlResult
         next_hop.map(|s| s.to_string()),
         mode,
         media_profile.map(|s| s.to_string()),
-        number_policy.map(|s| s.to_string()),
+        number_shape,
     ) {
         ControlResult::Ok(
             serde_json::json!({ "channel": channel.channel_id, "transfer": "accepted" }),

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -14812,6 +14812,25 @@ fn b2bua_advance_route(
             next_hop = ?next_hop,
             "LCR: dialing carrier",
         );
+        // The carrier's identity format, resolved here rather than inside the
+        // send path: that path now takes a policy, not a name, so the two
+        // callers that shape a B-leg (this one and the leg replacement) cannot
+        // disagree about how a selector turns into a policy.
+        let carrier_number_policy = match route.number_policy.as_deref() {
+            None => None,
+            Some(name) => match crate::script::api::numbers::resolve_dial_policy(Some(name)) {
+                Ok(policy) => policy,
+                Err(_) => {
+                    warn!(
+                        call_id = %call_id,
+                        carrier = %route.carrier_id,
+                        policy = %name,
+                        "LCR: unknown number_policy on route, skipping identity reshape"
+                    );
+                    None
+                }
+            },
+        };
         let sent = b2bua_send_b_leg_invite(
             call_id,
             &target,
@@ -14821,7 +14840,7 @@ fn b2bua_advance_route(
             send_socket.as_ref(),
             None,
             original_request,
-            route.number_policy.as_deref(),
+            carrier_number_policy.as_deref(),
             retarget.as_deref(),
             route.caller_id.as_deref(),
             caller_id_presentation,
@@ -16690,7 +16709,7 @@ fn b2bua_send_b_leg_invite(
     // caller pre-generated. `None` → the normal preserve/generate logic.
     forced_call_id: Option<&str>,
     original_request: &SipMessage,
-    number_policy: Option<&str>,
+    number_policy: Option<&crate::numbers::policy::NumberPolicy>,
     // Retargeted destination number (LCR `destination`), when the call was
     // re-aimed. The To userpart follows it so the dialled-in access number
     // never reaches the carrier. Named apart from the local `destination`
@@ -17089,18 +17108,8 @@ fn b2bua_send_b_leg_invite(
     // Per-carrier (LCR) number policy: reshape this B-leg's identity headers
     // (From / To / P-Asserted-Identity / P-Preferred-Identity) to the carrier's
     // format. The R-URI is owned by tech_prefix / ruri, so it is left untouched.
-    if let Some(policy_name) = number_policy {
-        match crate::script::api::numbers::resolve_dial_policy(Some(policy_name)) {
-            Ok(Some(policy)) => {
-                crate::script::api::numbers::apply_identity_headers(&mut b_leg_invite, &policy);
-            }
-            Ok(None) => {}
-            Err(_) => warn!(
-                call_id = %call_id,
-                policy = %policy_name,
-                "unknown number_policy, skipping identity reshape"
-            ),
-        }
+    if let Some(policy) = number_policy {
+        crate::script::api::numbers::apply_identity_headers(&mut b_leg_invite, policy);
     }
 
     // Per-carrier (LCR) CLIR: withhold the calling identity from this carrier
@@ -23339,7 +23348,7 @@ pub fn b2bua_accept_refer_call(
     next_hop: Option<String>,
     mode: Option<crate::script::api::call::ReferMode>,
     media_profile: Option<String>,
-    number_policy: Option<String>,
+    number_shape: Option<crate::script::api::numbers::NumberShape>,
 ) -> bool {
     let Some(control) = B2BUA_CONTROL.get() else {
         return false;
@@ -23372,7 +23381,7 @@ pub fn b2bua_accept_refer_call(
         pending.refer_to.replaces.clone(),
         mode,
         media_profile.as_deref(),
-        number_policy.as_deref(),
+        number_shape.as_ref(),
         state,
     );
     true
@@ -23405,7 +23414,7 @@ pub fn b2bua_replace_peer(
     next_hop: Option<&str>,
     replace_a_leg: bool,
     media_profile: Option<&str>,
-    number_policy: Option<&str>,
+    number_shape: Option<&crate::script::api::numbers::NumberShape>,
     timeout_secs: u32,
 ) -> Result<(), crate::b2bua::transfer::ReplaceError> {
     use crate::b2bua::transfer::{ReplaceError, ReplacementOrigin};
@@ -23481,7 +23490,7 @@ pub fn b2bua_replace_peer(
         None,
         None,
         media_profile,
-        number_policy,
+        number_shape,
         0,
         ReplacementOrigin::SiphonInitiated,
         timeout_secs,
@@ -28121,7 +28130,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
             next_hop,
             mode,
             profile,
-            number_policy,
+            number_shape,
         } => {
             let mode = mode.unwrap_or(state.default_refer_mode);
             let target_uri = target.unwrap_or_else(|| refer_to.uri.clone());
@@ -28135,7 +28144,7 @@ fn handle_b2bua_refer(inbound: InboundMessage, message: SipMessage, state: &Disp
                 refer_to.replaces.clone(),
                 mode,
                 profile.as_deref(),
-                number_policy.as_deref(),
+                number_shape.as_ref(),
                 state,
             );
         }
@@ -28541,7 +28550,7 @@ fn b2bua_refer_accept(
     replaces: Option<crate::sip::headers::refer::Replaces>,
     mode: crate::script::api::call::ReferMode,
     media_profile: Option<&str>,
-    number_policy: Option<&str>,
+    number_shape: Option<&crate::script::api::numbers::NumberShape>,
     state: &DispatcherState,
 ) {
     use crate::script::api::call::ReferMode;
@@ -28730,7 +28739,7 @@ fn b2bua_refer_accept(
                 replaces_header,
                 referred_by,
                 media_profile,
-                number_policy,
+                number_shape,
                 refer_cseq,
                 crate::b2bua::transfer::ReplacementOrigin::Refer,
                 0,
@@ -28779,7 +28788,7 @@ fn b2bua_start_leg_replacement(
     replaces_header: Option<crate::sip::headers::refer::Replaces>,
     referred_by: Option<String>,
     media_profile: Option<&str>,
-    number_policy: Option<&str>,
+    number_shape: Option<&crate::script::api::numbers::NumberShape>,
     event_id: u32,
     origin: crate::b2bua::transfer::ReplacementOrigin,
     timeout_secs: u32,
@@ -28797,17 +28806,31 @@ fn b2bua_start_leg_replacement(
     // arrives with the `+` still attached. `@b2bua.on_invite` does not run again
     // for a replacement leg, so this is the only place the shaping can happen.
     //
-    // Resolution matches `dial()` exactly — the named policy, else
-    // `b2bua.default_number_policy`, else no reshaping. An unknown name is
-    // warned about and skipped rather than failing the transfer: the script path
-    // already rejects a typo eagerly in `accept_refer`, so a name reaching here
-    // unknown came from the control plane, and dropping a transfer over a
-    // formatting policy would be the worse failure.
+    // Resolution matches `dial()` exactly — the named policy or inline format,
+    // else `b2bua.default_number_policy`, else no reshaping. An unresolvable one
+    // is warned about and skipped rather than failing the transfer: every script
+    // path rejects a typo eagerly at the call, so one reaching here came from
+    // the control plane, and dropping a transfer over a formatting policy would
+    // be the worse failure.
+    //
+    // Resolved once, here, and handed to the send path already resolved — the
+    // target and the identity headers must not be able to disagree about which
+    // policy they were shaped by.
+    let number_policy = match crate::script::api::numbers::resolve_dial_shape(number_shape) {
+        Ok(policy) => policy,
+        Err(_) => {
+            warn!(
+                call_id = %call_id,
+                shape = ?number_shape,
+                "leg replacement: unresolvable number policy — dialling the target unreshaped"
+            );
+            None
+        }
+    };
     let reshaped_target;
-    let target_uri = match crate::script::api::numbers::resolve_dial_policy(number_policy) {
-        Ok(Some(policy)) => {
-            reshaped_target =
-                crate::script::api::numbers::reformat_dial_target(target_uri, &policy);
+    let target_uri = match number_policy.as_deref() {
+        Some(policy) => {
+            reshaped_target = crate::script::api::numbers::reformat_dial_target(target_uri, policy);
             if reshaped_target != target_uri {
                 debug!(
                     call_id = %call_id,
@@ -28818,15 +28841,7 @@ fn b2bua_start_leg_replacement(
             }
             reshaped_target.as_str()
         }
-        Ok(None) => target_uri,
-        Err(_) => {
-            warn!(
-                call_id = %call_id,
-                policy = ?number_policy,
-                "leg replacement: unknown number_policy — dialling the target unreshaped"
-            );
-            target_uri
-        }
+        None => target_uri,
     };
 
     // Dial the target as a new leg, then record the replacement tagged with
@@ -28996,7 +29011,7 @@ fn b2bua_start_leg_replacement(
             // target just did — the dial path reshapes both together
             // (`apply_for_dial`), and a From in one shape next to an R-URI in
             // another is what an SBC reads as inconsistent.
-            number_policy,
+            number_policy.as_deref(),
             None,
             None,
             None,

--- a/src/script/api/b2bua.rs
+++ b/src/script/api/b2bua.rs
@@ -305,6 +305,10 @@ impl PyB2buaControl {
     ///         ``b2bua.default_number_policy``, else no reshaping. A replacement
     ///         leg does not re-enter ``@b2bua.on_invite``, so this is where a
     ///         carrier's number format gets applied to it.
+    ///     format: The inline form of the same thing, as on
+    ///         ``rewrite_identities(format=…)``: ``"e164"``, ``"plain"``,
+    ///         ``"international"`` or ``"national"``. Pass one or the other,
+    ///         never both.
     ///
     /// Returns True once the INVITE is on the wire. It does **not** wait for the
     /// target: the replacement completes later, and `@b2bua.on_bye` fires for
@@ -322,7 +326,7 @@ impl PyB2buaControl {
     ///     if digit == "0":
     ///         b2bua.replace_peer(call_id, "sip:operator@pbx.example", timeout=45)
     /// ```
-    #[pyo3(signature = (call_id, target, next_hop=None, replace_a_leg=false, profile=None, timeout=30, number_policy=None))]
+    #[pyo3(signature = (call_id, target, next_hop=None, replace_a_leg=false, profile=None, timeout=30, number_policy=None, format=None))]
     #[allow(clippy::too_many_arguments)]
     fn replace_peer(
         &self,
@@ -333,19 +337,21 @@ impl PyB2buaControl {
         profile: Option<&str>,
         timeout: u32,
         number_policy: Option<&str>,
+        format: Option<&str>,
     ) -> PyResult<bool> {
         use pyo3::exceptions::PyValueError;
-        // Validate the name here so a typo raises on the spot, the way
-        // `dial(number_policy=…)` and `accept_refer(number_policy=…)` do,
-        // instead of silently dialling the target unreshaped.
-        crate::script::api::numbers::resolve_dial_policy(number_policy)?;
+        // Validate here so a typo raises on the spot, the way
+        // `dial(number_policy=…)` and `accept_refer(…)` do, instead of silently
+        // dialling the target unreshaped.
+        let shape = crate::script::api::numbers::NumberShape::from_args(number_policy, format)?;
+        crate::script::api::numbers::resolve_dial_shape(shape.as_ref())?;
         crate::dispatcher::b2bua_replace_peer(
             call_id,
             target,
             next_hop,
             replace_a_leg,
             profile,
-            number_policy,
+            shape.as_ref(),
             timeout,
         )
         .map(|()| true)

--- a/src/script/api/call.rs
+++ b/src/script/api/call.rs
@@ -95,12 +95,12 @@ pub enum CallAction {
         /// correct when that profile is symmetric — see
         /// `ProfileEntry::is_direction_bound`.
         profile: Option<String>,
-        /// Number policy for the leg the transfer dials, resolved the way
-        /// `dial()` resolves it: this name, else `b2bua.default_number_policy`,
-        /// else none. Carried as a name rather than a resolved policy because
+        /// How the leg the transfer dials should have its numbers shaped,
+        /// resolved the way `dial()` resolves it: this selector, else
+        /// `b2bua.default_number_policy`, else none. Carried unresolved because
         /// the reshape happens on the dispatcher side, where the triggered
         /// INVITE is built.
-        number_policy: Option<String>,
+        number_shape: Option<super::numbers::NumberShape>,
     },
     /// Reject a REFER with a status code.
     RejectRefer { code: u16, reason: String },
@@ -1692,7 +1692,7 @@ impl PyCall {
     ///         copy=["X-Operator-Tag"],
     ///         strip=["History-Info"],
     ///     )
-    #[pyo3(signature = (uri, timeout=30, max_duration=None, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None))]
+    #[pyo3(signature = (uri, timeout=30, max_duration=None, next_hop=None, flow=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), route=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None, format=None))]
     #[allow(clippy::too_many_arguments)]
     fn dial(
         &mut self,
@@ -1709,14 +1709,16 @@ impl PyCall {
         send_socket: Option<String>,
         auth_passthrough: bool,
         number_policy: Option<&str>,
+        format: Option<&str>,
     ) -> PyResult<()> {
         super::request::validate_send_socket(send_socket.as_deref())?;
         self.max_duration_secs = max_duration.or(self.max_duration_secs);
-        // Number normalization (explicit `number_policy=`, else the configured
-        // `b2bua.default_number_policy`): reformat the A-leg identity headers
-        // that flow to the B-leg, plus the dial target itself.
+        // Number normalization (a named `number_policy=`, an inline `format=`,
+        // else the configured `b2bua.default_number_policy`): reformat the A-leg
+        // identity headers that flow to the B-leg, plus the dial target itself.
+        let shape = super::numbers::NumberShape::from_args(number_policy, format)?;
         let target = {
-            if let Some(policy) = super::numbers::resolve_dial_policy(number_policy)? {
+            if let Some(policy) = super::numbers::resolve_dial_shape(shape.as_ref())? {
                 let mut message = self.message.lock().map_err(|error| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
                 })?;
@@ -1762,7 +1764,7 @@ impl PyCall {
     /// `strategy="sequential"` carries the same route set per carrier (as an
     /// explicit next-hop plus a `Route` header), so serial failover across an
     /// AoR's bindings reaches each binding's own proxy chain.
-    #[pyo3(signature = (targets, strategy="parallel", timeout=30, max_duration=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None))]
+    #[pyo3(signature = (targets, strategy="parallel", timeout=30, max_duration=None, header_policy=None, copy=Vec::new(), strip=Vec::new(), translate=Vec::new(), send_socket=None, auth_passthrough=false, number_policy=None, format=None))]
     #[allow(clippy::too_many_arguments)]
     fn fork(
         &mut self,
@@ -1777,8 +1779,10 @@ impl PyCall {
         send_socket: Option<String>,
         auth_passthrough: bool,
         number_policy: Option<&str>,
+        format: Option<&str>,
     ) -> PyResult<()> {
         super::request::validate_send_socket(send_socket.as_deref())?;
+        let shape = super::numbers::NumberShape::from_args(number_policy, format)?;
         self.max_duration_secs = max_duration.or(self.max_duration_secs);
         let mut target_uris: Vec<String> = Vec::with_capacity(targets.len());
         let mut flows: Vec<Option<super::registrar::PyFlow>> = Vec::with_capacity(targets.len());
@@ -1796,8 +1800,9 @@ impl PyCall {
             }
         }
         // Number normalization applies to every branch target plus the A-leg
-        // identity headers (explicit `number_policy=`, else the b2bua default).
-        if let Some(policy) = super::numbers::resolve_dial_policy(number_policy)? {
+        // identity headers (a named `number_policy=`, an inline `format=`, else
+        // the b2bua default).
+        if let Some(policy) = super::numbers::resolve_dial_shape(shape.as_ref())? {
             let mut message = self.message.lock().map_err(|error| {
                 pyo3::exceptions::PyRuntimeError::new_err(format!("lock poisoned: {error}"))
             })?;
@@ -2480,14 +2485,24 @@ impl PyCall {
     ///   call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
     ///                     profile="rtp_passthrough",
     ///                     number_policy="carrier-plain@2026")
-    #[pyo3(signature = (target=None, next_hop=None, mode=None, profile=None, number_policy=None))]
+    ///
+    /// `format` is the inline form of the same thing, exactly as on
+    /// `rewrite_identities(format=…)`: `"e164"`, `"plain"`, `"international"` or
+    /// `"national"`, applied over the default identity header set on the
+    /// configured home locale. Pass one or the other, never both.
+    ///
+    ///   call.accept_refer(target=target, next_hop=gw.uri, mode="terminate",
+    ///                     profile="rtp_passthrough", format="plain")
+    #[pyo3(signature = (target=None, next_hop=None, mode=None, profile=None, number_policy=None, format=None))]
+    #[allow(clippy::too_many_arguments)]
     fn accept_refer(
         &mut self,
         target: Option<String>,
         next_hop: Option<String>,
         mode: Option<&str>,
         profile: Option<String>,
-        number_policy: Option<String>,
+        number_policy: Option<&str>,
+        format: Option<&str>,
     ) -> PyResult<()> {
         let mode = match mode {
             None => None,
@@ -2499,18 +2514,19 @@ impl PyCall {
                 )));
             }
         };
-        // Resolve eagerly for the error only: a typo'd policy name has to raise
-        // here, in the handler, the way `dial()` raises — not silently skip the
-        // reshape at dial time where nothing is watching. The resolved policy
-        // itself is discarded; the dispatcher re-resolves by name once it has
-        // the triggered INVITE to apply it to.
-        let _ = super::numbers::resolve_dial_policy(number_policy.as_deref())?;
+        // Resolve eagerly for the error only: a typo'd policy name or an
+        // unknown format has to raise here, in the handler, the way `dial()`
+        // raises — not silently skip the reshape at dial time where nothing is
+        // watching. The resolved policy itself is discarded; the dispatcher
+        // re-resolves once it has the triggered INVITE to apply it to.
+        let number_shape = super::numbers::NumberShape::from_args(number_policy, format)?;
+        let _ = super::numbers::resolve_dial_shape(number_shape.as_ref())?;
         self.action = CallAction::AcceptRefer {
             target,
             next_hop,
             mode,
             profile,
-            number_policy,
+            number_shape,
         };
         Ok(())
     }
@@ -2978,6 +2994,7 @@ mod tests {
             None,
             false,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -3018,6 +3035,7 @@ mod tests {
             None,
             false,
             None,
+            None,
         )
         .unwrap();
         match call.action() {
@@ -3053,6 +3071,7 @@ mod tests {
             vec![],
             None,
             false,
+            None,
             None,
         )
         .unwrap();
@@ -3091,6 +3110,7 @@ mod tests {
             vec![],
             None,
             false,
+            None,
             None,
         )
         .unwrap();
@@ -3131,6 +3151,7 @@ mod tests {
             vec![],
             Some("udp:10.0.0.1:5060".to_string()),
             false,
+            None,
             None,
         )
         .unwrap();
@@ -3174,6 +3195,7 @@ mod tests {
             None,
             false,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(call.max_duration_secs(), Some(3600));
@@ -3197,6 +3219,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .unwrap();
@@ -3223,6 +3246,7 @@ mod tests {
             None,
             false,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(call.max_duration_secs(), Some(0));
@@ -3248,6 +3272,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .unwrap();
@@ -3305,6 +3330,7 @@ mod tests {
             vec![],
             Some("not-a-socket".to_string()),
             false,
+            None,
             None,
         );
         assert!(result.is_err());
@@ -3376,6 +3402,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .unwrap();
 
@@ -3435,6 +3462,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .unwrap();
 
@@ -3489,6 +3517,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .unwrap();
             assert_eq!(
@@ -3535,6 +3564,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .unwrap();
             let input = call
@@ -3567,6 +3597,7 @@ mod tests {
             vec![],
             None,
             true,
+            None,
             None,
         )
         .unwrap();
@@ -3612,6 +3643,7 @@ mod tests {
             None,
             true,
             None,
+            None,
         )
         .unwrap();
         let input = call.header_policy_input().expect("policy input captured");
@@ -3656,6 +3688,7 @@ mod tests {
             vec![],
             None,
             false,
+            None,
             None,
         )
         .unwrap();
@@ -3737,7 +3770,8 @@ mod tests {
             "10.0.0.1".to_string(),
             "udp".to_string(),
         );
-        call.accept_refer(None, None, None, None, None).unwrap();
+        call.accept_refer(None, None, None, None, None, None)
+            .unwrap();
         assert_eq!(
             call.action(),
             &CallAction::AcceptRefer {
@@ -3745,7 +3779,7 @@ mod tests {
                 next_hop: None,
                 mode: None,
                 profile: None,
-                number_policy: None,
+                number_shape: None,
             }
         );
     }
@@ -3765,6 +3799,7 @@ mod tests {
             Some("transparent"),
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -3774,7 +3809,7 @@ mod tests {
                 next_hop: Some("sip:198.51.100.1:5060".to_string()),
                 mode: Some(ReferMode::Transparent),
                 profile: None,
-                number_policy: None,
+                number_shape: None,
             }
         );
     }
@@ -3788,7 +3823,7 @@ mod tests {
             "10.0.0.1".to_string(),
             "udp".to_string(),
         );
-        call.accept_refer(None, None, Some("terminate"), None, None)
+        call.accept_refer(None, None, Some("terminate"), None, None, None)
             .unwrap();
         assert_eq!(
             call.action(),
@@ -3797,7 +3832,7 @@ mod tests {
                 next_hop: None,
                 mode: Some(ReferMode::Terminate),
                 profile: None,
-                number_policy: None,
+                number_shape: None,
             }
         );
     }
@@ -3845,6 +3880,7 @@ mod tests {
             Some("terminate"),
             Some("rtp_passthrough".to_string()),
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -3854,7 +3890,7 @@ mod tests {
                 next_hop: None,
                 mode: Some(ReferMode::Terminate),
                 profile: Some("rtp_passthrough".to_string()),
-                number_policy: None,
+                number_shape: None,
             }
         );
     }
@@ -3868,7 +3904,7 @@ mod tests {
             "10.0.0.1".to_string(),
             "udp".to_string(),
         );
-        let result = call.accept_refer(None, None, Some("bridge"), None, None);
+        let result = call.accept_refer(None, None, Some("bridge"), None, None, None);
         assert!(result.is_err());
         // The invalid call must not have mutated the action.
         assert_eq!(call.action(), &CallAction::None);
@@ -3887,7 +3923,7 @@ mod tests {
             "10.0.0.1".to_string(),
             "udp".to_string(),
         );
-        let result = call.accept_refer(None, None, None, None, Some("nope@2026".to_string()));
+        let result = call.accept_refer(None, None, None, None, Some("nope@2026"), None);
         assert!(result.is_err());
         assert_eq!(call.action(), &CallAction::None);
     }
@@ -3912,6 +3948,7 @@ mod tests {
             Some("terminate"),
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -3921,7 +3958,7 @@ mod tests {
                 next_hop: None,
                 mode: Some(ReferMode::Terminate),
                 profile: None,
-                number_policy: None,
+                number_shape: None,
             }
         );
     }

--- a/src/script/api/numbers.rs
+++ b/src/script/api/numbers.rs
@@ -172,6 +172,59 @@ pub fn reformat_dial_target(target: &str, policy: &NumberPolicy) -> String {
     reformat_target(target, format, policy)
 }
 
+/// How a caller asked for a dialled leg's numbers to be shaped.
+///
+/// `rewrite_identities()` has always taken both forms — `policy=` for a named
+/// registry entry, `format=` for an inline one — while the dial family took only
+/// the named one, so `dial(number_policy="plain")` failed with "unknown number
+/// policy" for a value that is a perfectly good *format*. Two arguments that
+/// grew apart rather than a design line. This is the shared selector that closes
+/// it, and being one enum rather than two `Option`s is what makes "both at once"
+/// unrepresentable below the constructor that rejects it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NumberShape {
+    /// A named entry from `number_policies:`.
+    Named(String),
+    /// An inline format, over the default identity header set.
+    Format(NumberFormat),
+}
+
+impl NumberShape {
+    /// Build from the mutually-exclusive `number_policy=` / `format=` pair a
+    /// caller supplied. `None` for both means "whatever the config defaults to".
+    pub fn from_args(policy: Option<&str>, format: Option<&str>) -> PyResult<Option<Self>> {
+        match (policy, format) {
+            (Some(_), Some(_)) => Err(pyo3::exceptions::PyValueError::new_err(
+                "pass either number_policy= (a named policy) or format= (an inline format), not both",
+            )),
+            (Some(name), None) => Ok(Some(NumberShape::Named(name.to_string()))),
+            (None, Some(format)) => {
+                let parsed: NumberFormat = format.parse().map_err(|error| {
+                    pyo3::exceptions::PyValueError::new_err(format!("{error}"))
+                })?;
+                Ok(Some(NumberShape::Format(parsed)))
+            }
+            (None, None) => Ok(None),
+        }
+    }
+}
+
+/// Resolve a dial/fork/transfer number shape: the named policy, else the inline
+/// format, else the `b2bua.default_number_policy`, else `None`.
+pub fn resolve_dial_shape(shape: Option<&NumberShape>) -> PyResult<Option<Arc<NumberPolicy>>> {
+    match shape {
+        Some(NumberShape::Named(name)) => resolve_dial_policy(Some(name)),
+        // Same construction `rewrite_identities(format=…)` uses: a uniform
+        // policy over the default identity set, on the configured home locale.
+        Some(NumberShape::Format(format)) => Ok(Some(Arc::new(NumberPolicy::uniform(
+            number_runtime().registry.default_locale.clone(),
+            *format,
+            DEFAULT_IDENTITY_HEADERS.to_vec(),
+        )))),
+        None => Ok(default_b2bua_policy()),
+    }
+}
+
 /// Resolve a `number_policy=` argument for the B2BUA dial/fork path: an explicit
 /// named policy, else the `b2bua.default_number_policy`, else `None`.
 pub fn resolve_dial_policy(name: Option<&str>) -> PyResult<Option<Arc<NumberPolicy>>> {
@@ -414,6 +467,54 @@ mod tests {
             reformat_dial_target("sip:pbx.example.com", &policy("plain")),
             "sip:pbx.example.com"
         );
+    }
+
+    #[test]
+    fn shape_from_args_rejects_both_at_once() {
+        // The whole point of one enum instead of two Options: "both" is
+        // rejected at the constructor and unrepresentable after it.
+        assert!(NumberShape::from_args(Some("carrier@2026"), Some("plain")).is_err());
+    }
+
+    #[test]
+    fn shape_from_args_reads_a_named_policy_and_an_inline_format() {
+        assert_eq!(
+            NumberShape::from_args(Some("carrier@2026"), None).unwrap(),
+            Some(NumberShape::Named("carrier@2026".to_string()))
+        );
+        assert_eq!(
+            NumberShape::from_args(None, Some("plain")).unwrap(),
+            Some(NumberShape::Format(NumberFormat::Plain))
+        );
+        // Neither means "whatever b2bua.default_number_policy says".
+        assert_eq!(NumberShape::from_args(None, None).unwrap(), None);
+    }
+
+    #[test]
+    fn shape_from_args_rejects_an_unknown_format() {
+        // The complaint that produced this: `number_policy="plain"` failed with
+        // "unknown number policy" because a format is not a policy name. The
+        // inverse has to fail cleanly too, and say so as a format error.
+        assert!(NumberShape::from_args(None, Some("e165")).is_err());
+    }
+
+    #[test]
+    fn inline_format_resolves_without_any_configured_policy() {
+        // The gap this closes: a deployment that only ever used
+        // `rewrite_identities(format=…)` has no `number_policies:` block at all,
+        // so every named lookup fails. An inline format must not need one.
+        let policy = resolve_dial_shape(Some(&NumberShape::Format(NumberFormat::Plain)))
+            .unwrap()
+            .expect("an inline format always resolves");
+        assert_eq!(
+            reformat_dial_target("sip:+15550142@carrier.example", &policy),
+            "sip:15550142@carrier.example"
+        );
+    }
+
+    #[test]
+    fn unresolvable_named_policy_still_errors_through_the_shape() {
+        assert!(resolve_dial_shape(Some(&NumberShape::Named("nope@2026".to_string()))).is_err());
     }
 
     #[test]

--- a/src/script/engine.rs
+++ b/src/script/engine.rs
@@ -2601,7 +2601,7 @@ def on_invite(call):
         // policy is present whichever of the two runs first.
         use crate::numbers::policy::{NumberPolicyConfig, NumberRegistry, NumberingConfig};
         use crate::script::api::call::{CallAction, PyCall, ReferMode};
-        use crate::script::api::numbers::{set_number_runtime, NumberRuntime};
+        use crate::script::api::numbers::{set_number_runtime, NumberRuntime, NumberShape};
         use crate::sip::builder::SipMessageBuilder;
         use crate::sip::message::Method;
         use crate::sip::uri::SipUri;
@@ -2683,12 +2683,15 @@ def refered(call):
             CallAction::AcceptRefer {
                 target,
                 mode,
-                number_policy,
+                number_shape,
                 ..
             } => {
                 assert_eq!(target.as_deref(), Some("sip:0201234567@carrier.example"));
                 assert_eq!(mode, Some(ReferMode::Terminate));
-                assert_eq!(number_policy.as_deref(), Some("test-e164@2026"));
+                assert_eq!(
+                    number_shape,
+                    Some(NumberShape::Named("test-e164@2026".to_string()))
+                );
             }
             other => panic!("expected AcceptRefer, got {other:?}"),
         }
@@ -2696,6 +2699,104 @@ def refered(call):
         match invoke("sip:+31201234567@bogus.example") {
             CallAction::RejectRefer { code, .. } => assert_eq!(code, 500),
             other => panic!("expected the unknown policy to raise, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn b2bua_accept_refer_takes_an_inline_format_with_no_policy_configured() {
+        // The complaint this exists for, verbatim: a script that shapes numbers
+        // with `rewrite_identities(format="plain")` everywhere has no
+        // `number_policies:` block at all, so `number_policy="plain"` failed
+        // with `unknown number policy "plain"` — a format is not a policy name.
+        // `format=` is the inline half `rewrite_identities` always had and the
+        // dial family never did.
+        use crate::script::api::call::{CallAction, PyCall, ReferMode};
+        use crate::script::api::numbers::NumberShape;
+        use crate::sip::builder::SipMessageBuilder;
+        use crate::sip::message::Method;
+        use crate::sip::uri::SipUri;
+        use std::sync::{Arc, Mutex};
+
+        let source = r#"
+from siphon import b2bua
+
+@b2bua.on_refer
+def refered(call):
+    if call.refer_to.endswith("@both.example"):
+        try:
+            call.accept_refer(number_policy="carrier@2026", format="plain")
+        except ValueError:
+            call.reject_refer(400, "Both")
+        return
+    if call.refer_to.endswith("@bogus.example"):
+        try:
+            call.accept_refer(format="e165")
+        except ValueError:
+            call.reject_refer(400, "Bad Format")
+        return
+    call.accept_refer(target="sip:+15550142@carrier.example",
+                      mode="terminate", format="plain")
+"#;
+        let state = compile_temp_script(source).unwrap();
+
+        let refer = SipMessageBuilder::new()
+            .request(
+                Method::Refer,
+                SipUri::new("siphon.example".to_string()).with_user("alice".to_string()),
+            )
+            .via("SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-reffmt".to_string())
+            .from("<sip:alice@example.com>;tag=ref-fmt".to_string())
+            .to("<sip:bob@example.com>;tag=ref-uas".to_string())
+            .call_id("refer-format@test".to_string())
+            .cseq("2 REFER".to_string())
+            .content_length(0)
+            .build()
+            .unwrap();
+        let message_arc = Arc::new(Mutex::new(refer));
+
+        let invoke = |refer_to: &str| -> CallAction {
+            let mut py_call = PyCall::new(
+                "refer-fmt-001".to_string(),
+                Arc::clone(&message_arc),
+                "10.0.0.1".to_string(),
+                "udp".to_string(),
+            );
+            py_call.set_refer_to(refer_to.to_string(), None);
+            Python::attach(|python| {
+                let call_obj = Py::new(python, py_call).expect("failed to create PyCall");
+                let callable = state.handlers[0].callable.bind(python);
+                callable
+                    .call1((call_obj.bind(python),))
+                    .expect("handler invocation failed");
+                let action = call_obj.borrow(python).action().clone();
+                action
+            })
+        };
+
+        // The inline format resolves with no `number_policies:` configured.
+        match invoke("sip:+15550142@teams.example") {
+            CallAction::AcceptRefer {
+                mode, number_shape, ..
+            } => {
+                assert_eq!(mode, Some(ReferMode::Terminate));
+                assert_eq!(
+                    number_shape,
+                    Some(NumberShape::Format(crate::numbers::NumberFormat::Plain))
+                );
+            }
+            other => panic!("expected AcceptRefer, got {other:?}"),
+        }
+
+        // Both at once is a ValueError, not a silent precedence rule.
+        match invoke("sip:+15550142@both.example") {
+            CallAction::RejectRefer { code, .. } => assert_eq!(code, 400),
+            other => panic!("expected both-at-once to raise, got {other:?}"),
+        }
+
+        // A bad format raises as a format error rather than as a policy lookup.
+        match invoke("sip:+15550142@bogus.example") {
+            CallAction::RejectRefer { code, .. } => assert_eq!(code, 400),
+            other => panic!("expected a bad format to raise, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
`rewrite_identities()` has always taken both forms — `policy=` for a named
registry entry, `format=` for an inline one. The dial family only ever took the
named one, so `number_policy="plain"` came back as:

```
ValueError: unknown number policy "plain"
```

for a value that is a perfectly good *format* and not a policy name at all. Two
arguments that grew apart, not a design line.

It bites hardest where it is least expected. A script that shapes numbers inline
(`call.rewrite_identities(format="plain")` for one direction,
`format="e164"` for the other) has no `number_policies:` block in its config at
all, so *every* named lookup fails and `number_policy=` was unusable to it
without first inventing a named policy for something it already says in one word.

## What changed

`format=` on `call.dial()`, `call.fork()`, `call.accept_refer()` and
`b2bua.replace_peer()` (and both control-plane verbs), taking the same values as
`rewrite_identities(format=…)`: `"e164"`, `"plain"`, `"international"`,
`"national"`.

Resolution order is unchanged and now covers both: the named policy, else the
inline format, else `b2bua.default_number_policy`, else no reshaping. Passing
both raises, as it does on `rewrite_identities()`.

## Two things worth reviewing

**The pair is one selector, not two `Option`s.** `NumberShape::{Named, Format}`
is built by a constructor that rejects "both at once", which makes that state
unrepresentable everywhere below it rather than something each consumer has to
re-check.

**The transfer path now resolves once.** It used to resolve the name for the
target reshape and then hand the *name* to the send path, which looked it up
again for the identity headers. Two lookups of the same name is two chances to
disagree about what shaped the R-URI versus the From. `b2bua_send_b_leg_invite`
now takes a resolved `&NumberPolicy`, and the LCR carrier path resolves at its
own call site — which also keeps its unknown-name warning where the carrier id
is still in scope to log.

## Tests

- `NumberShape::from_args`: named, inline, neither, both-at-once, unknown format.
- An inline format resolves with **no** configured policy at all, which is the
  deployment shape that hit this.
- Engine test driving a real `@b2bua.on_refer` handler: inline format lands on
  the action, both-at-once raises, a bad format raises as a format error rather
  than as a policy lookup.
- SDK: same four cases on `accept_refer` and `replace_peer`. The SDK mock now
  validates the selector too, which is what makes it a faithful mock — it caught
  two of my own tests that had been passing only because nothing checked.

`cargo test` 4744 passed, clippy clean, `cargo fmt --check` exit 0, SDK 707
passed.

Not released — holding for other PRs to land first.
