### PR TITLE
release: control sdk 0.2.0

### DIFF
--- a/siphon-control-sdk/Cargo.lock
+++ b/siphon-control-sdk/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control-client"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "siphon-control-proto"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/siphon-control-sdk/Cargo.toml
+++ b/siphon-control-sdk/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/siphon-control-sdk/siphon-control-client/Cargo.toml
+++ b/siphon-control-sdk/siphon-control-client/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 readme = "README.md"
 
 [dependencies]
-siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.3" }
+siphon-control-proto = { path = "../siphon-control-proto", version = "0.2.0" }
 base64 = "0.23"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/siphon-control-sdk/siphon-control/Cargo.toml
+++ b/siphon-control-sdk/siphon-control/Cargo.toml
@@ -20,8 +20,8 @@ name = "siphon_control"
 crate-type = ["cdylib"]
 
 [dependencies]
-siphon-control-client = { path = "../siphon-control-client", version = "0.1.3" }
-siphon-control-proto = { path = "../siphon-control-proto", version = "0.1.3" }
+siphon-control-client = { path = "../siphon-control-client", version = "0.2.0" }
+siphon-control-proto = { path = "../siphon-control-proto", version = "0.2.0" }
 # No abi3: the target interpreter is free-threaded CPython 3.14t (the SIPhon
 # runtime), and the stable ABI (abi3) is not available on free-threaded builds.
 # A standard version-tagged wheel loads on both GIL and free-threaded 3.14.

--- a/siphon-control-sdk/typescript/package-lock.json
+++ b/siphon-control-sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siphon-project/control",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siphon-project/control",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/siphon-control-sdk/typescript/package.json
+++ b/siphon-control-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siphon-project/control",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "TypeScript client for the SIPhon external control plane (siphon-control.v1) — an ARI/ESL-class rail for driving handed-over calls out of process.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump only — no code. Prepares the `control-sdk-v0.2.0` tag.

**Minor, not patch.** #299 added public API to all four artifacts, not just
behaviour:

| artifact | new surface |
|---|---|
| `siphon-control-client` (crates.io) | `Call::answer_anchored` |
| `siphon-control` (PyPI) | `answer_anchored`, `is_transfer_final`, `transfer_outcome` |
| `@siphon-project/control` (npm) | `answerAnchored`, `transferOutcome`, `AnchoredAnswerOptions` |

The four release off one `control-sdk-v*` tag, so everything that carries the
version moves together: the cargo workspace version, the **three internal
path-dep pins** (a stale `^0.1.3` pin fails resolution against a `0.2.0` sibling
locally, long before crates.io sees it), both lockfiles, and `package.json`.

Worth noting the asymmetry between the two publish gates: `release-control-sdk.yaml`
compares `siphon-control-sdk/Cargo.toml`'s version against the tag and hard-fails
on a mismatch, but `release-control-sdk-ts.yaml` only reads `package.json` — so a
forgotten npm bump publishes the old version silently rather than failing.

The CHANGELOG entry for the API itself is already on `main` under `## [Unreleased]`
from #299; there is no SDK-specific changelog.

`cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` (54 passed) in
`siphon-control-sdk`, `tsc --noEmit` and `vitest` (28 passed) in `typescript`.
