### PR TITLE
fix(media): four media-path conformance and default fixes — rfc4566 §5 line order in the sdp serializer, an o= session-id inside the signed 64-bit range rfc3264 §5 requires, barge-in shipped whole in the voice_ai built-in, and a teardown delete that stops warning on the ordinary already-released race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,26 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   metric names rather than a bare assertion.
 
 ### Changed
+- **The built-in `voice_ai` media profile ships barge-in whole.** It set
+  `ws_barge_in` while leaving `ws_vad_engine` and `ws_vad_min_speech_ms` unset,
+  which is the energy detector with no leading-speech requirement — the exact
+  combination the voice-AI cookbook tells operators not to use. The speech-start
+  edge then fires on the first frame that reads as loud, so a cough, a door, a
+  keyboard or one burst of uncancelled echo cuts the prompt: the agent
+  interrupts itself and the caller's transcript comes back as what the agent
+  just said. The built-in now sets `ws_vad_engine: neural` (which answers "is
+  this speech" rather than "is this loud") and `ws_vad_min_speech_ms: 100`,
+  inside the 60–120 ms band that stays under the turn-start latency a caller
+  notices. It also now asserts `received_from`, which is *policy* — the per-call
+  address is injected from the message source and the flag is inert where there
+  is none — because this profile exists for app clients answering to an AI, and
+  those are the clients behind NAT: without it their media is gated out on the
+  private address in their own `c=`, and the failure presents as an agent that
+  never speaks on a call whose signalling is clean. An operator wanting the
+  cheap detector still says so on a `media.profiles` override. **Note that such
+  an override replaces the built-in outright rather than merging into it**, so
+  it has to restate every flag it still wants; the cookbook and `siphon.yaml`
+  examples now show the full set and say so.
 - **The embedded operator dashboard (experimental) is restructured.** Nine views
   — Overview, Calls, Registrations, Gateways, Signalling, Media, Control,
   Security, System — replacing seven, with the new ones covering subsystems that
@@ -187,6 +207,47 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   reaches the auto-ban the way it already does on the control plane.
 
 ### Fixed
+- **`SdpBody` emits a media section in RFC 4566 §5 line order.** §5 fixes the
+  order inside a media description — `m=`, `i=`, `c=`, `b=`, `k=`, then `a=` —
+  and the parser bucketed every line that is not an `a=rtpmap` / `a=fmtp` into
+  one arrival-ordered vector that the serializer replayed as it stood. So a body
+  whose `c=` arrived behind an attribute was re-emitted in that same illegal
+  order, and a script written specifically to normalise a carrier-facing body
+  could not: `sdp.parse(request)` then `s.apply(request)` reproduced the
+  violation exactly. Line-oriented parsers shrug this off, which is why it can
+  sit in production for a long time; strict grammar-driven ones answer `400 Bad
+  Request`, having read the section as carrying no connection address at all,
+  and a body every other carrier accepts then fails against one. The serializer
+  now partitions on the way out, preserving relative order *within* each group
+  because §5 fixes where the groups sit and not what the sender puts inside one
+  — the order of repeated `b=` lines and of the attribute sequence carries
+  meaning. A section already in §5 order comes back byte-identical, so nothing
+  that was on the wire before this changes shape. Session-level lines are still
+  emitted as they arrived; only media sections are repaired.
+- **The SDP `o=` session-id fits a signed 64-bit integer.** RFC 3264 §5 requires
+  the `o=` session-id and version to be "representable with a 64 bit signed
+  integer". The generator drew a full-range `u64` from a v4 UUID, so roughly
+  every second dialog emitted an id above `i64::MAX` — and it is stamped onto
+  every SDP siphon emits toward a leg, so this was the common path and not an
+  edge case. A peer parsing the field with `strtoll` / `ParseInt` overflows on a
+  body that is otherwise fine, and because the value is random per call the
+  symptom is intermittent: the same route works, then does not, with nothing in
+  any log to separate the two calls. Now masked into the non-negative signed
+  range; 63 bits of a v4 UUID is far more collision resistance than a field that
+  only has to be unique among one peer's live sessions. The companion version
+  starts at 0 and only ever increments, so it was never at risk.
+- **`rtpengine.delete()` on a session the engine has already released logs at
+  debug, not warn.** Deleting an already-released call is not a script bug: the
+  engine releases the media session itself on two paths a script also runs
+  teardown on — the media-timeout reaper drops the call *before* emitting the
+  event `@rtpengine.on_media_timeout` fires on, and the `on_answer`-failure path
+  releases it before `@b2bua.on_failure` runs. On both, the script's `delete` is
+  correct, ordinary, and warned. The cost was not the line but what it taught:
+  teardown warnings become noise to skim, and a delete that fails for a reason
+  worth acting on — engine unreachable, a leaked session — was indistinguishable
+  from the ordinary race. Every other failure still warns. This brings the
+  script-facing verb in line with the rule the dispatcher already applied at its
+  own safety-net deletes.
 - **An in-dialog REFER or NOTIFY on a call with no far leg is answered instead
   of dropped.** A call with one leg is not an error state: a UAS-mode answer, a
   `call.handover()`, an IVR and a WebSocket-takeover leg all have exactly one

--- a/docs/cookbook/media-rtp.md
+++ b/docs/cookbook/media-rtp.md
@@ -251,11 +251,14 @@ media:
         ws_uri: "wss://ai.example.com/stream/{call_id}"
         ws_vad: true           # emit speech_started / speech_stopped edges
         ws_barge_in: true      # cut playout locally on the caller's speech
+        ws_vad_engine: neural  # "is this speech", not "is this loud"
+        ws_vad_min_speech_ms: 100  # leading run before the speech-start edge
         ws_vad_threshold: 2000000
         ws_vad_hangover_ms: 300
         noise_suppression: true
         echo_cancellation: true
         echo_delay_search_ms: 400
+        received_from: true    # gate on the real post-NAT source
       answer: *voice_ai_flags
 ```
 
@@ -280,9 +283,12 @@ async def on_invite(call):
         call.answer(200, "OK", body=sdp, content_type="application/sdp")
 ```
 
-The built-in `voice_ai` profile sets the DSP and VAD flags but deliberately
-leaves `ws_uri` unset — there is no sensible default endpoint, so supply it in
-YAML or per call as above.
+The built-in `voice_ai` profile sets the DSP and VAD flags (including
+`ws_vad_engine: neural`, `ws_vad_min_speech_ms: 100` and `received_from`) but
+deliberately leaves `ws_uri` unset — there is no sensible default endpoint, so
+supply it in YAML or per call as above. An entry of the same name under
+`media.profiles` **replaces** the built-in rather than merging with it, so
+restate every flag the override still wants.
 
 `ws_uri`, the `ws_*` knobs, `noise_suppression` and the `echo_*` knobs are
 **`siphon-rtp` only**. siphon refuses to start if a `media.profiles` entry sets

--- a/docs/cookbook/voice-ai.md
+++ b/docs/cookbook/voice-ai.md
@@ -54,7 +54,12 @@ the most common mistake here:
 
 ## The profile
 
-The built-in `voice_ai` profile sets everything except the endpoint:
+The built-in `voice_ai` profile sets everything except the endpoint. A
+`media.profiles` entry of the same name **replaces** it outright rather than
+merging into it, so an override has to restate every flag below that it still
+wants — dropping `ws_vad_engine` or `ws_vad_min_speech_ms` puts barge-in back on
+the energy detector with no leading run, which is the self-interrupting agent
+described further down:
 
 ```yaml
 media:
@@ -73,7 +78,10 @@ media:
         echo_delay_search_ms: 400         # widen past a carrier/mobile leg
         ws_vad: true                      # turn boundaries without server-side VAD
         ws_barge_in: true                 # cut playout on the caller's speech edge
+        ws_vad_engine: neural             # "is this speech", not "is this loud"
+        ws_vad_min_speech_ms: 100         # leading run before the speech-start edge
         ws_vad_hangover_ms: 300
+        received_from: true               # gate on the real post-NAT source
       answer: *voice_ai_flags
 ```
 

--- a/siphon.yaml
+++ b/siphon.yaml
@@ -791,9 +791,17 @@ auth:
 #   srs_recording   — Recording sink: plain RTP, media handover + port latching
 #   siprec_src      — SIPREC SRC subscription leg toward the recorder
 #   voice_ai        — Plain RTP toward the caller, audio bridged to a WebSocket
-#                     media server. NS + AEC + VAD + barge-in on; ws_uri is left
-#                     unset (no sensible default endpoint) — set it here or pass
-#                     ws_uri= per call. siphon-rtp backend only.
+#                     media server. NS + AEC on; barge-in on with the neural
+#                     detector and a 100 ms leading-speech run (the energy
+#                     detector with no leading run turn-starts on one loud frame,
+#                     so the bot cuts itself off on its own echo); received_from
+#                     on, so a NATed app client is gated on its real post-NAT
+#                     source and not on the private address in its own c=.
+#                     ws_uri is left unset (no sensible default endpoint) — set
+#                     it here or pass ws_uri= per call. siphon-rtp backend only.
+#                     NOTE: a media.profiles entry named voice_ai REPLACES this
+#                     built-in outright, it does not merge — so an override has
+#                     to restate every flag above that it still wants.
 #
 # Define custom profiles under media.profiles:
 # media:
@@ -1024,6 +1032,7 @@ auth:
 #         ws_vad_engine: neural         # energy (default) | neural
 #         ws_vad_min_speech_ms: 80      # leading: continuous speech before barge-in
 #         ws_sample_rate: 16000         # multiple of 1000, 8000-48000
+#         received_from: true           # gate ingress on the real post-NAT source
 #         noise_suppression: true
 #         echo_cancellation: true
 #         echo_delay_search_ms: 400     # 16-1000; widen for a carrier leg

--- a/src/b2bua/actor.rs
+++ b/src/b2bua/actor.rs
@@ -140,8 +140,21 @@ pub struct Dialog {
 }
 
 /// Generate a fresh SDP `o=` session-id (RFC 4566 §5.2 — a numeric identifier).
+///
+/// Masked into the non-negative signed range: RFC 3264 §5 requires the `o=`
+/// session-id and version to be "representable with a 64 bit signed integer",
+/// and a full-range `u64` puts about half of all dialogs above [`i64::MAX`],
+/// where a peer parsing the field with `strtoll` / `ParseInt` overflows on a
+/// body that is otherwise fine.  Because the value is random per call, that
+/// fails intermittently — the same route works, then does not, with nothing in
+/// any log to separate the two calls.
+///
+/// 63 bits of a v4 UUID is far more collision resistance than the field needs;
+/// it only has to be unique among the sessions one peer holds at once.  The
+/// companion version starts at 0 and is only ever incremented, so it stays in
+/// range without help.
 pub fn generate_sdp_session_id() -> u64 {
-    uuid::Uuid::new_v4().as_u128() as u64
+    (uuid::Uuid::new_v4().as_u128() as u64) & (i64::MAX as u64)
 }
 
 impl Dialog {
@@ -3808,6 +3821,33 @@ mod tests {
         // Distinct dialogs get distinct session-ids (overwhelmingly — u64 from a
         // v4 UUID).
         assert_ne!(a.sdp_session_id, b.sdp_session_id);
+    }
+
+    #[test]
+    fn generated_sdp_session_id_fits_a_signed_64_bit_integer() {
+        // RFC 3264 §5: the o= session-id MUST be representable in a signed
+        // 64-bit integer.  The generator drew from the whole unsigned range, so
+        // roughly every second dialog emitted one a peer parsing it as i64
+        // overflows on.  Sample enough that the old behaviour cannot pass by
+        // luck (2^-4096), and keep the range assertion rather than a bit-mask
+        // one so it still holds if the generator is ever re-implemented.
+        for _ in 0..4096 {
+            let id = generate_sdp_session_id();
+            assert!(
+                id <= i64::MAX as u64,
+                "session-id {id} exceeds i64::MAX and overflows a peer parsing o= as a signed 64-bit integer"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_sdp_session_ids_are_distinct() {
+        // Masking the top bit must not have collapsed the space: the id has to
+        // stay unique across the sessions one peer holds at once (RFC 4566
+        // §5.2).
+        let ids: std::collections::HashSet<u64> =
+            (0..1024).map(|_| generate_sdp_session_id()).collect();
+        assert_eq!(ids.len(), 1024);
     }
 
     #[test]

--- a/src/media/sdp.rs
+++ b/src/media/sdp.rs
@@ -24,7 +24,9 @@ pub struct MediaLine {
     pub rtpmap: Vec<(u16, String)>,
     /// fmtp attributes keyed by payload type.
     pub fmtp: Vec<(u16, String)>,
-    /// Other attributes (not rtpmap/fmtp) for this media section.
+    /// Other lines of this media section (everything but rtpmap/fmtp), kept in
+    /// arrival order.  The serializer, not this vector, is what puts them into
+    /// RFC 4566 §5 order — see [`PRE_ATTRIBUTE_PREFIXES`].
     pub other_attrs: Vec<String>,
 }
 
@@ -433,6 +435,19 @@ impl SdpBody {
     }
 }
 
+/// The media-description lines RFC 4566 §5 places between `m=` and the
+/// attribute region, in the order it fixes for them.  `k=` is deprecated by
+/// RFC 8866 but still has a defined slot, and a body that carries one has to be
+/// re-emitted somewhere legal.
+const PRE_ATTRIBUTE_PREFIXES: [&str; 4] = ["i=", "c=", "b=", "k="];
+
+/// Whether `line` belongs ahead of the `a=` region rather than in it.
+fn is_pre_attribute_line(line: &str) -> bool {
+    PRE_ATTRIBUTE_PREFIXES
+        .iter()
+        .any(|prefix| line.starts_with(prefix))
+}
+
 impl std::fmt::Display for SdpBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for line in &self.session_lines {
@@ -459,9 +474,39 @@ impl std::fmt::Display for SdpBody {
                 )?;
             }
 
-            // Other attributes first (c=, b=, etc.)
-            for attr in &media.other_attrs {
-                write!(f, "{attr}\r\n")?;
+            // RFC 4566 §5 fixes the order inside a media description: m=,
+            // i=, c=, b=, k=, then a=.  The parser buckets every line that is
+            // not an rtpmap/fmtp into `other_attrs` in arrival order, so a body
+            // that arrived with its c= behind an attribute would otherwise be
+            // re-emitted in that same illegal order.  A strict parser (several
+            // vendor SBCs) then reads the section as carrying no connection
+            // address at all and answers 400 Bad Request on a body every
+            // lenient parser accepts, which makes it a per-carrier mystery
+            // rather than an obvious defect.  Partition on the way out instead.
+            //
+            // Relative order is preserved *within* each group: §5 fixes where
+            // the groups go, not what the sender puts inside one, and the order
+            // of repeated b= lines and of the attribute sequence carries
+            // meaning.
+            for prefix in PRE_ATTRIBUTE_PREFIXES {
+                for line in media
+                    .other_attrs
+                    .iter()
+                    .filter(|line| line.starts_with(prefix))
+                {
+                    write!(f, "{line}\r\n")?;
+                }
+            }
+
+            // The attribute region.  A line legal nowhere in a media
+            // description rides here rather than being dropped — this is a
+            // serializer, not a validator.
+            for line in media
+                .other_attrs
+                .iter()
+                .filter(|line| !is_pre_attribute_line(line))
+            {
+                write!(f, "{line}\r\n")?;
             }
 
             // rtpmap attributes
@@ -683,6 +728,139 @@ mod tests {
             .rtpmap
             .iter()
             .any(|(_, c)| c.contains("telephone-event")));
+    }
+
+    /// The media block of `sdp`, as emitted lines, from its `m=` onward.
+    fn emitted_media_lines(sdp: &str) -> Vec<String> {
+        let output = SdpBody::parse(sdp).to_string();
+        let lines: Vec<&str> = output.lines().collect();
+        let start = lines
+            .iter()
+            .position(|line| line.starts_with("m="))
+            .expect("no media section in the emitted body");
+        lines[start..].iter().map(|line| line.to_string()).collect()
+    }
+
+    #[test]
+    fn serialize_repairs_a_connection_line_behind_an_attribute() {
+        // RFC 4566 §5 fixes m=, i=, c=, b=, k=, then a= inside a media
+        // description.  This offer carries its c= behind an attribute, which
+        // several vendor SBCs reject with 400 Bad Request because they read the
+        // section as having no connection address.  A parse/apply round-trip
+        // has to repair that, not reproduce it.
+        let raw = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=-\r\n",
+            "t=0 0\r\n",
+            "m=audio 30168 RTP/AVP 8 101\r\n",
+            "a=rtcp:30169\r\n",
+            "c=IN IP4 192.0.2.10\r\n",
+            "a=mid:audio\r\n",
+            "a=sendrecv\r\n",
+            "a=rtpmap:8 PCMA/8000\r\n",
+            "a=rtpmap:101 telephone-event/8000\r\n",
+        );
+
+        // Asserted as an exact line sequence: a `contains` check passes just as
+        // happily on the broken order, which is why the ordering bug survived
+        // the serializer tests that were already here.
+        assert_eq!(
+            emitted_media_lines(raw),
+            vec![
+                "m=audio 30168 RTP/AVP 8 101",
+                "c=IN IP4 192.0.2.10",
+                "a=rtcp:30169",
+                "a=mid:audio",
+                "a=sendrecv",
+                "a=rtpmap:8 PCMA/8000",
+                "a=rtpmap:101 telephone-event/8000",
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_orders_information_bandwidth_and_key_ahead_of_attributes() {
+        // i=, b= and k= are displaced by the same arm as c= and need the same
+        // repair.  Repeated b= lines keep their relative order — §5 fixes where
+        // the group sits, not what the sender puts inside it.
+        let raw = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=-\r\n",
+            "t=0 0\r\n",
+            "m=audio 30168 RTP/AVP 8\r\n",
+            "a=sendrecv\r\n",
+            "b=TIAS:64000\r\n",
+            "k=prompt\r\n",
+            "c=IN IP4 192.0.2.10\r\n",
+            "b=AS:64\r\n",
+            "i=voice\r\n",
+            "a=ptime:20\r\n",
+        );
+
+        assert_eq!(
+            emitted_media_lines(raw),
+            vec![
+                "m=audio 30168 RTP/AVP 8",
+                "i=voice",
+                "c=IN IP4 192.0.2.10",
+                "b=TIAS:64000",
+                "b=AS:64",
+                "k=prompt",
+                "a=sendrecv",
+                "a=ptime:20",
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_leaves_a_conformant_media_section_untouched() {
+        // The reorder is a repair, not a reshuffle: a section already in §5
+        // order comes back byte-identical, so nothing that was on the wire
+        // before this changes shape.
+        let raw = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=-\r\n",
+            "t=0 0\r\n",
+            "m=audio 30168 RTP/AVP 8 101\r\n",
+            "c=IN IP4 192.0.2.10\r\n",
+            "a=sendrecv\r\n",
+            "a=rtpmap:8 PCMA/8000\r\n",
+            "a=fmtp:101 0-15\r\n",
+        );
+        assert_eq!(SdpBody::parse(raw).to_string(), raw);
+    }
+
+    #[test]
+    fn serialize_orders_every_media_section_independently() {
+        // A second section is partitioned on its own lines, not against the
+        // first one's — the audio c= must not migrate into the video block.
+        let raw = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=-\r\n",
+            "t=0 0\r\n",
+            "m=audio 30168 RTP/AVP 8\r\n",
+            "a=sendrecv\r\n",
+            "c=IN IP4 192.0.2.10\r\n",
+            "m=video 30170 RTP/AVP 96\r\n",
+            "a=recvonly\r\n",
+            "c=IN IP4 192.0.2.11\r\n",
+        );
+
+        assert_eq!(
+            emitted_media_lines(raw),
+            vec![
+                "m=audio 30168 RTP/AVP 8",
+                "c=IN IP4 192.0.2.10",
+                "a=sendrecv",
+                "m=video 30170 RTP/AVP 96",
+                "c=IN IP4 192.0.2.11",
+                "a=recvonly",
+            ],
+        );
     }
 
     #[test]

--- a/src/rtpengine/profile.rs
+++ b/src/rtpengine/profile.rs
@@ -311,6 +311,25 @@ impl ProfileRegistry {
         // let the bridge cut playout locally on the caller's speech edge without
         // a server round-trip.
         //
+        // Barge-in is shipped whole or not at all.  `ws_barge_in` on its own
+        // runs the energy detector with no leading-speech requirement, so the
+        // speech-start edge fires on the first frame that reads as loud and a
+        // cough, a door, a keyboard or one burst of uncancelled echo cuts the
+        // prompt — the bot interrupts itself and the caller's transcript comes
+        // back as what the bot just said.  The neural detector answers "is this
+        // speech" rather than "is this loud", and the 100 ms leading run is
+        // inside the 60–120 ms band that stays under the turn-start latency a
+        // caller notices.  An operator wanting the cheap detector still says so
+        // on a `media.profiles` override; this is the default, not a ceiling.
+        //
+        // `carry_received_from` is policy, not an address: the script API
+        // injects the real post-NAT source per call and the flag is inert where
+        // there is none.  It is asserted here because this profile exists for
+        // app clients answering to an AI, which are exactly the clients behind
+        // NAT — without it their media is gated out on the private address in
+        // their own `c=`, and the failure presents as a bot that never speaks
+        // on a call whose signalling is clean.
+        //
         // `siphon-rtp` backend only; the rtpengine and rtpproxy backends have no
         // equivalent for any of these and reject the profile at config load.
         ProfileEntry {
@@ -323,6 +342,9 @@ impl ProfileRegistry {
                 echo_cancellation: true,
                 ws_vad: true,
                 ws_barge_in: true,
+                ws_vad_engine: Some(WsVadEngine::Neural),
+                ws_vad_min_speech_ms: Some(100),
+                carry_received_from: true,
                 ..NgFlags::default()
             },
             answer: NgFlags {
@@ -334,6 +356,9 @@ impl ProfileRegistry {
                 echo_cancellation: true,
                 ws_vad: true,
                 ws_barge_in: true,
+                ws_vad_engine: Some(WsVadEngine::Neural),
+                ws_vad_min_speech_ms: Some(100),
+                carry_received_from: true,
                 ..NgFlags::default()
             },
         }
@@ -1149,6 +1174,39 @@ mod tests {
         assert!(registry.get("srs_recording").is_some());
         assert!(registry.get("siprec_src").is_some());
         assert!(registry.get("voice_ai").is_some());
+    }
+
+    #[test]
+    fn builtin_voice_ai_ships_barge_in_whole() {
+        // `ws_barge_in` without a detector and a leading-speech run is the
+        // combination the voice-AI cookbook tells operators not to use: the
+        // energy detector fires the speech-start edge on the first loud frame,
+        // so the bot interrupts itself on its own echo.  A built-in named for
+        // the use case must not ship a third of the feature.
+        let registry = ProfileRegistry::new();
+        let profile = registry.get("voice_ai").expect("voice_ai built-in");
+        for (half, flags) in [("offer", &profile.offer), ("answer", &profile.answer)] {
+            assert!(flags.ws_barge_in, "{half}: barge-in");
+            assert_eq!(
+                flags.ws_vad_engine,
+                Some(WsVadEngine::Neural),
+                "{half}: barge-in needs the speech classifier, not the energy detector"
+            );
+            assert_eq!(
+                flags.ws_vad_min_speech_ms,
+                Some(100),
+                "{half}: barge-in needs a leading-speech run, or one loud frame cuts the prompt"
+            );
+            // Policy only — the per-call address is injected by the script API,
+            // so this is inert where the proxy has none.  Without it a NATed app
+            // client is gated out on the private address in its own c= and the
+            // bot is never heard.
+            assert!(flags.carry_received_from, "{half}: received-from policy");
+            assert!(
+                flags.received_from.is_none(),
+                "{half}: a built-in must never carry a per-call address"
+            );
+        }
     }
 
     #[test]

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -1125,8 +1125,23 @@ impl PyRtpEngine {
                 Ok(()) => {
                     debug!(call_id = %call_id, "RTPEngine session deleted");
                 }
+                Err(error) if error.is_call_not_found() => {
+                    // Not a failure: the engine had already released the
+                    // session.  A script's teardown legitimately reaches this
+                    // on both paths that release the media before the handler
+                    // runs — the media-timeout reaper drops the call before it
+                    // emits the event `@rtpengine.on_media_timeout` fires on,
+                    // and the `on_answer`-failure path releases it before
+                    // `@b2bua.on_failure` runs.  Warning on the ordinary race
+                    // trains operators to skim teardown warnings, which buries
+                    // the delete failures that do mean something (engine
+                    // unreachable, a leaked session).  Same rule the dispatcher
+                    // already applies at its own safety-net deletes.
+                    debug!(call_id = %call_id, "RTPEngine session already released");
+                }
                 Err(error) => {
-                    // Log but don't fail — the session may already be gone.
+                    // Log but don't fail — teardown is best-effort here, but
+                    // this one is worth an operator's attention.
                     warn!(call_id = %call_id, error = %error, "RTPEngine delete failed");
                 }
             }


### PR DESCRIPTION
Four independent fixes on the media path, found together while chasing a `400 Bad Request` from a strict SBC on an outbound INVITE.

## `SdpBody` could not express RFC 4566 §5 line order

The parser buckets `c=` into `media.other_attrs` in arrival order, in the same catch-all arm as the `a=` lines, and `Display` replayed that vector as it stood between `m=` and the rtpmap block. So a body whose connection line arrived behind an attribute was re-emitted in that same illegal order, and a script written specifically to normalise a carrier-facing body could not — `sdp.parse(request)` then `s.apply(request)` reproduced the violation exactly.

Line-oriented parsers shrug this off, which is how it sits in production unnoticed. Strict grammar-driven ones answer `400 Bad Request`, having read the media section as carrying no connection address at all, so a body every other carrier accepts fails against one and it presents as a per-carrier mystery rather than as a defect.

The serializer now partitions on the way out and emits `m=`, `i=`, `c=`, `b=`, `k=`, then `a=`. Relative order is preserved *within* each group, because §5 fixes where the groups sit and not what the sender puts inside one — the order of repeated `b=` lines and of the attribute sequence both carry meaning. A section already in §5 order comes back byte-identical, so nothing that was on the wire before changes shape.

This reaches the two non-script users of `SdpBody` as well: the classic rtpproxy backend's anchored rewrite (`rtpengine/rtpproxy.rs`) and `set_media_direction` on every bridge hold/unhold (`b2bua/bridge.rs`). Both re-serialized an inbound violation and now repair it. Session-level lines are still emitted as they arrived; only media sections are reordered.

## The `o=` session-id left the signed 64-bit range

RFC 3264 §5 requires the `o=` session-id and version to be "representable with a 64 bit signed integer". `generate_sdp_session_id` drew a full-range `u64` out of a v4 UUID, so roughly every second dialog emitted an id above `i64::MAX` — and `stamp_sdp_origin` writes it onto every SDP siphon emits toward a leg, which makes this the common path and not an edge case.

A peer parsing the field with `strtoll` / `ParseInt` overflows on a body that is otherwise fine, and because the value is random per call the symptom is intermittent: the same route works, then does not, with nothing in any log to separate the two calls. Now masked into the non-negative signed range. 63 bits of a v4 UUID is still far more collision resistance than a field that only has to be unique among the sessions one peer holds at once, and the companion version starts at 0 and is only ever incremented, so it was never at risk.

## The built-in `voice_ai` profile shipped a third of barge-in

It set `ws_barge_in` while leaving `ws_vad_engine` and `ws_vad_min_speech_ms` unset, which is the energy detector with no leading-speech requirement — the exact combination `docs/cookbook/voice-ai.md` tells operators not to use. The speech-start edge then fires on the first frame that reads as loud, so a cough, a door, a keyboard or one burst of uncancelled echo cuts the prompt: the agent interrupts itself and the caller's transcript comes back as what the agent just said.

The built-in now carries `ws_vad_engine: neural` (which answers "is this speech" rather than "is this loud") and `ws_vad_min_speech_ms: 100`, inside the 60–120 ms band that stays under the turn-start latency a caller notices. The cheap detector is still one `media.profiles` override away.

It also now asserts `carry_received_from`. That is **policy, not an address** — the per-call value is injected from the message source and the flag is inert without one — and this profile exists for app clients answering to an inference server, which are exactly the clients behind NAT. Without it their media is gated out on the private address in their own `c=`, and the failure presents as an agent that never speaks on a call whose signalling is clean.

Both cookbooks and `siphon.yaml` now also state that a `media.profiles` entry of the same name **replaces** the built-in outright rather than merging into it. The YAML block readers copy as "what the built-in sets" was about to silently drop all three of these.

## `rtpengine.delete()` warned on an ordinary race

Deleting an already-released media session is not a script bug: the media-timeout reaper drops the call *before* emitting the event `@rtpengine.on_media_timeout` fires on, and the `on_answer`-failure path releases the session before `@b2bua.on_failure` runs. On both, a script's teardown `delete` is correct, ordinary, and warned.

The cost was not the line but what it taught — teardown warnings become noise to skim, and a delete that fails for a reason worth acting on (engine unreachable, control-plane error, a leaked session) was indistinguishable from the ordinary race. It is now `debug` when the engine reports the call unknown and `warn` for everything else, on the same `is_call_not_found` predicate the dispatcher already applies at its own safety-net deletes. This only brings the script-facing verb in line with the rest of the tree.

## Verification

- `cargo test`: 4367 lib + 368 integration, 0 failed. Clippy clean under `-D warnings`, `cargo fmt --check` exit 0.
- The seven new tests were checked adversarially: with all three code fixes reverted and the tests in place, five fail. The two that pass either way are the no-reshuffle guard and the id-collision guard, which is what they are for.
- The SDP ordering tests assert **exact line sequences**, not counts and not `contains` — a `contains` check passes just as happily on the broken order, which is why the serializer tests already present never caught this.
- SIPp: `--rtpproxy`, `--rtpengine` and the base pass are green.

### Known pre-existing failure, not from this branch

`scripts/run-tests.sh --b2bua` fails, but it fails identically on a clean `main` worktree in a clean Docker environment. Across four runs the failure alternates between the `sipp-b2bua-refer` step (UAC gets 100, then a 408 at 30 s — the B-leg never answers) and `b2bua-rtpengine-refer`, on both trees. The B2BUA REFER family is flaky or broken on `main` independently of this work and wants its own investigation.

The 16-row throughput baseline and the memory-leak pair have not been run — nothing here is on the per-message path, but they are still outstanding on the reference hardware.
