### PR TITLE
release: promote the unreleased section to 1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+## [1.8.6] — 2026-09-08
+
 ### Added
 > The embedded dashboard and everything below that feeds it stay
 > **EXPERIMENTAL and a work in progress**: the views, the admin JSON shapes and


### PR DESCRIPTION
Changelog promote only, no code. Prepares the `v1.8.6` tag — `cut-release.sh` and `release.yaml`'s version gate both refuse to publish without a matching `## [1.8.6]` heading.