### PR TITLE
fix(config): range-check echo_delay_search_ms against the bound that applies to it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,9 +3096,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "siphon-rtp-proto"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448114be88170ae2e569c9d97b279a0be8e35bd8913036431498de52e5ba037c"
+checksum = "1d116c63e6e26d19dbc455d85c25b938ce33eb6a25301370fe524d2e38415986"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ futures-util = "0.3"
 # with the siphon-rtp media engine. Only the tiny `proto` crate is pulled in
 # (serde types + length-prefixed framing); the engine/codec/datapath crates
 # stay out of siphon. Used by the `media.backend: siphon-rtp` path.
-siphon-rtp-proto = "0.5.0"
+siphon-rtp-proto = "0.5.2"
 # SIP-over-SCTP (RFC 4168) + Diameter-over-SCTP transport. Optional because it
 # links the `libsctp` system library (libsctp-dev to build, libsctp1 at runtime)
 # and needs the kernel SCTP module — most SIP proxy/B2BUA deployments never use
@@ -204,7 +204,7 @@ rcgen = "0.14"
 # Build siphon-rtp control frames in the integration test's in-process fake
 # engine (the lib already depends on this crate; integration-test crates need
 # it listed here to name it directly).
-siphon-rtp-proto = "0.5.0"
+siphon-rtp-proto = "0.5.2"
 # Per-message hot-path microbenchmarks (benches/sip_hot_path.rs). The
 # release-cut gate (scripts/cut-release.sh) runs these via `critcmp` against a
 # committed baseline; CI only proves they compile (`cargo bench --no-run`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -3038,8 +3038,10 @@ pub struct NgFlagsConfig {
     #[serde(default)]
     pub echo_cancellation: bool,
     /// How far from the reference the echo canceller searches for the returning
-    /// echo, in milliseconds (16–1000, default 256).  `siphon-rtp` backend only,
-    /// and inert without `echo_cancellation`.
+    /// echo, in milliseconds (16–1000, default 256).  With `echo_long_tail` set
+    /// this is a **tail length** instead, checked against its own bound — both
+    /// are read from `siphon-rtp-proto` rather than restated here.
+    /// `siphon-rtp` backend only, and inert without `echo_cancellation`.
     ///
     /// The window has to span the whole media path twice, not an acoustic
     /// loudspeaker-to-microphone hop, so a carrier or mobile leg can sit past
@@ -3052,8 +3054,16 @@ pub struct NgFlagsConfig {
     pub echo_delay_search_ms: Option<u32>,
     /// Span the echo path with the adaptive filter itself instead of estimating
     /// a bulk delay first, which makes `echo_delay_search_ms` a tail length
-    /// rather than a search window.  `siphon-rtp` backend only, and inert
-    /// without `echo_cancellation`.
+    /// rather than a search window (16–1000 ms in that reading).  `siphon-rtp`
+    /// backend only, and inert without `echo_cancellation`.
+    ///
+    /// The two postures differ in **how they fail**.  Estimation is cheap and
+    /// exact when it works, but commits the tallest correlation peak inside its
+    /// window whatever that peak is, so an echo beyond the window leaves the
+    /// filter adapting against a reference that is not the echo.  A long tail
+    /// makes no alignment decision, so it has nothing to get wrong; it is
+    /// slower to converge and materially more expensive per frame, so ask for
+    /// the tail the path needs rather than the ceiling.
     #[serde(default)]
     pub echo_long_tail: bool,
     /// Chain the residual-echo suppressor after the linear canceller.
@@ -4538,18 +4548,43 @@ impl Config {
                     )));
                 }
 
-                // 16..=1000 ms is the engine's own accepted range, and it
-                // refuses an out-of-range value at the control plane — that is,
-                // on every media offer, at call time, on a node that came up
-                // reporting perfectly healthy. Catching it here turns "every
-                // call fails" into a boot failure that names the profile.
+                // The engine refuses an out-of-range value at the control
+                // plane — that is, on every media offer, at call time, on a
+                // node that came up reporting perfectly healthy. Catching it
+                // here turns "every call fails" into a boot failure that names
+                // the profile.
+                //
+                // Which range applies depends on echo_long_tail: with it set
+                // the field is a tail length rather than a search window, and
+                // the engine checks it against a different bound. This used to
+                // check one hardcoded 16..=1000 for both, which was the engine's
+                // window range and not its tail range — so a long-tail profile
+                // asking for 513-1000 passed here, loaded, registered, reported
+                // healthy, and then failed every call with a 503, while the
+                // error text named a range the engine did not accept. The
+                // bounds now come from the proto crate both sides already
+                // depend on: the two happen to coincide today, and restating
+                // the digits is exactly how they came to disagree before.
                 if let Some(window) = flags.echo_delay_search_ms {
-                    if !(16..=1000).contains(&window) {
+                    let (low, high, meaning) = if flags.echo_long_tail {
+                        (
+                            siphon_rtp_proto::ECHO_LONG_TAIL_MS_MIN,
+                            siphon_rtp_proto::ECHO_LONG_TAIL_MS_MAX,
+                            "a tail length, because echo_long_tail is set",
+                        )
+                    } else {
+                        (
+                            siphon_rtp_proto::ECHO_DELAY_SEARCH_MS_MIN,
+                            siphon_rtp_proto::ECHO_DELAY_SEARCH_MS_MAX,
+                            "a search window",
+                        )
+                    };
+                    if !(low..=high).contains(&window) {
                         return Err(SiphonError::Config(format!(
                             "media profile {name:?} sets echo_delay_search_ms to {window} on its \
-                             {direction} flags, outside the 16-1000 ms the engine accepts — it \
-                             refuses the value on every offer, so a node carrying this config \
-                             starts healthy and then fails every call"
+                             {direction} flags, outside the {low}-{high} ms the engine accepts \
+                             for {meaning} — it refuses the value on every offer, so a node \
+                             carrying this config starts healthy and then fails every call"
                         )));
                     }
                 }
@@ -6867,6 +6902,11 @@ media:
 
     /// The three echo-tuning knobs reach the config, and the search window is
     /// carried as a number rather than being flattened into the `flags` list.
+    ///
+    /// The 600 ms here is deliberately a *long-tail* value above the old 512 ms
+    /// tail ceiling.  This fixture used to assert that a profile the engine
+    /// refused on every offer loaded cleanly, which is precisely the mismatch
+    /// the mode-dependent bounds close.
     #[test]
     fn parses_media_profile_echo_tuning() {
         let yaml = ws_profile_yaml(
@@ -6900,42 +6940,85 @@ media:
         assert!(!offer.echo_residual_suppression);
     }
 
-    /// Out of range is refused at load. The engine refuses it too, but only per
-    /// offer — which is a node that boots healthy and then fails every call, so
-    /// the boot failure is the one worth having.
+    /// Out of range is refused at load, in **both** readings of the field. The
+    /// engine refuses it too, but only per offer — which is a node that boots
+    /// healthy and then fails every call, so the boot failure is the one worth
+    /// having.
     #[test]
     fn rejects_media_profile_echo_delay_search_out_of_range() {
-        for window in ["15", "1001"] {
-            let yaml = ws_profile_yaml(
-                SIPHON_RTP_BACKEND,
-                &format!(
-                    "      offer:\n        echo_cancellation: true\n        \
-                     echo_delay_search_ms: {window}\n      answer: {{}}\n"
-                ),
-            );
-            let error = Config::from_str(&yaml)
-                .expect_err("a window outside 16-1000 ms must be refused at load");
-            assert!(
-                error.to_string().contains("echo_delay_search_ms"),
-                "error should name the field: {error}"
-            );
+        for long_tail in [false, true] {
+            for window in ["15", "1001"] {
+                let yaml = ws_profile_yaml(
+                    SIPHON_RTP_BACKEND,
+                    &format!(
+                        "      offer:\n        echo_cancellation: true\n        \
+                         echo_long_tail: {long_tail}\n        \
+                         echo_delay_search_ms: {window}\n      answer: {{}}\n"
+                    ),
+                );
+                let error = Config::from_str(&yaml)
+                    .expect_err("a value outside the accepted range must be refused at load");
+                assert!(
+                    error.to_string().contains("echo_delay_search_ms"),
+                    "error should name the field: {error}"
+                );
+            }
         }
     }
 
-    /// The bounds themselves are accepted — the check is inclusive, so a config
-    /// sitting exactly on 16 or 1000 is not refused by an off-by-one.
+    /// The refusal names which reading it applied, because the two bounds are
+    /// separate and an operator otherwise cannot tell why their value was
+    /// rejected — the failure this whole check exists to make legible.
     #[test]
-    fn accepts_media_profile_echo_delay_search_at_the_bounds() {
-        for window in ["16", "1000"] {
+    fn the_echo_delay_search_refusal_names_the_reading_it_applied() {
+        let refuse = |long_tail: bool| {
             let yaml = ws_profile_yaml(
                 SIPHON_RTP_BACKEND,
                 &format!(
                     "      offer:\n        echo_cancellation: true\n        \
-                     echo_delay_search_ms: {window}\n      answer: {{}}\n"
+                     echo_long_tail: {long_tail}\n        \
+                     echo_delay_search_ms: 1001\n      answer: {{}}\n"
                 ),
             );
-            Config::from_str(&yaml).expect("the range bounds must be accepted");
+            Config::from_str(&yaml)
+                .expect_err("out of range")
+                .to_string()
+        };
+        assert!(refuse(true).contains("tail length"), "{}", refuse(true));
+        assert!(refuse(false).contains("search window"), "{}", refuse(false));
+    }
+
+    /// The bounds themselves are accepted — the check is inclusive, so a config
+    /// sitting exactly on 16 or 1000 is not refused by an off-by-one — and that
+    /// holds for the tail reading too, which is the one that used to be checked
+    /// against the wrong number.
+    #[test]
+    fn accepts_media_profile_echo_delay_search_at_the_bounds() {
+        for long_tail in [false, true] {
+            for window in ["16", "1000"] {
+                let yaml = ws_profile_yaml(
+                    SIPHON_RTP_BACKEND,
+                    &format!(
+                        "      offer:\n        echo_cancellation: true\n        \
+                         echo_long_tail: {long_tail}\n        \
+                         echo_delay_search_ms: {window}\n      answer: {{}}\n"
+                    ),
+                );
+                Config::from_str(&yaml).expect("the range bounds must be accepted");
+            }
         }
+    }
+
+    /// The validator checks against the engine's own published constants rather
+    /// than a copy of the digits. Restating them is what let a long-tail profile
+    /// load, register and report healthy while the engine refused it on every
+    /// offer, so this pins the source rather than the value.
+    #[test]
+    fn the_echo_bounds_come_from_the_engine_contract() {
+        assert_eq!(siphon_rtp_proto::ECHO_DELAY_SEARCH_MS_MIN, 16);
+        assert_eq!(siphon_rtp_proto::ECHO_DELAY_SEARCH_MS_MAX, 1_000);
+        assert_eq!(siphon_rtp_proto::ECHO_LONG_TAIL_MS_MIN, 16);
+        assert_eq!(siphon_rtp_proto::ECHO_LONG_TAIL_MS_MAX, 1_000);
     }
 
     /// All three are native siphon-rtp extensions with no NG or rtpproxy


### PR DESCRIPTION
> **Draft: blocked on `siphon-rtp-proto` 0.5.2 being published.** The exported constants this reads do not exist in any released version yet, so CI cannot build this until then. Verified locally against the unreleased crate via a temporary `[patch.crates-io]` (removed before commit): 4369 lib tests pass, fmt and clippy clean. The lockfile is deliberately untouched and needs `cargo update -p siphon-rtp-proto` after the publish.

## The bug

`echo_delay_search_ms` means two different things, and this validator checked one hardcoded `16..=1000` for both.

That range is the engine's **search window** range. With `echo_long_tail` set the field is a *tail length*, which the engine checks against a different bound — `16..=512` at the time. So a long-tail profile asking for anything from 513 to 1000:

- passed config validation
- loaded, registered, and reported healthy
- failed **every** call with a 503 from the control plane

That is precisely the failure this check exists to prevent, quoting its own comment: "a node carrying this config starts healthy and then fails every call". It was reintroduced by the check's own bound being wrong, and compounded by an error string that confidently named a range the engine does not accept.

It was not merely possible — it was committed and green. `parses_media_profile_echo_tuning` pins exactly that shape (`echo_delay_search_ms: 600` with `echo_long_tail: true`) and asserts it loads cleanly.

## The fix

Both pairs of bounds now come from `siphon-rtp-proto` — where `ProfileFlags` already lives, so both sides already depend on it — and the validator picks the pair that matches the reading `echo_long_tail` selects.

Copying the engine's mode-dependent bounds into `config.rs` would restore the same defect the moment either number moved again. The mismatch existed because the number was duplicated; removing the duplicate removes the class rather than this instance of it.

The refusal also now names which reading it applied. With two bounds an operator otherwise cannot tell why the value they used was rejected, which is the whole point of failing at load rather than per call.

## One thing worth being explicit about

The engine has since raised the tail ceiling to 1000, so the two ranges **currently coincide** and this check is momentarily equivalent to the one it replaces. That is a coincidence of the present values, not the property being fixed — treating it as one is how the bounds diverged unnoticed in the first place.

## Tests

- `rejects_media_profile_echo_delay_search_out_of_range` and `accepts_..._at_the_bounds` now cover **both** readings, so the branch that was wrong is the one under test.
- New: the refusal names the reading it applied.
- New: the bounds are asserted to come from the engine contract rather than a local copy.
- `parses_media_profile_echo_tuning` keeps its 600 ms long-tail fixture, which stops being a profile the engine refuses.
