### PR TITLE
fix(registrar): probe a liveness binding over the route an mt request takes, and bind the protected source on the tcp pool fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ### Fixed
 
+- **The registrar liveness probe for an IPsec-protected binding now goes over
+  SA #3, from `port_pc` to the UE's protected server port, instead of back down
+  the UE's own client flow.**
+
+  The idle-liveness sweep addressed its OPTIONS to the binding's source address,
+  which is the UE's protected *client* port where the REGISTER came from, and
+  for a stream registration it rode the captured inbound connection. But the
+  flow-close handler deliberately *retains* an IPsec binding when its TCP flow
+  closes, so that a UE whose SIP-over-TCP flow FINs at the radio inactivity
+  timer can still be paged. The SA is the liveness authority, not the flow. So
+  by the time the sweep probed such a binding, the flow it rode was already
+  gone. The send fell back to a fresh connection from an ephemeral port toward
+  the UE's client port. No SA selector matches an ephemeral source port, and a
+  UE does not listen on its client port, so the probe could never be answered.
+  Every sweep missed, and a live but idle UE was network-deregistered and its SA
+  torn down, only to re-register from scratch minutes later. A UE whose TCP flow
+  happened to stay up answered normally, which is why this showed up on some
+  handsets and not others.
+
+  The probe now goes to the UE's protected server port from `port_pc` over SA
+  #3. That is 3GPP TS 33.203's path for P-CSCF-originated requests, the one an
+  MT INVITE or NOTIFY takes. It uses UDP, which every SIP UE must accept (RFC
+  3261 §18) and which needs no connection state. Probing the path an MT request
+  actually uses is also the better liveness signal, since it is exactly the
+  reachability the retained binding exists to preserve. A UDP registration moves
+  from the SA #2 response path to SA #3 as well. A TCP-pinned SA can't carry a
+  UDP probe and keeps the captured-flow route unchanged.
+
 - **A UAS answering a dialog-forming request now echoes the full `Record-Route`
   into its response, and scripts can finally read a multi-value header at all
   (`get_headers`).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,22 +27,24 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   up answered normally, which is why this showed up on some handsets and not
   others.
 
-  The probe now asks where an MT request to the binding goes and sends there. A
-  binding that still has a flow (UDP, or TCP while the connection is up) keeps
-  the route it always had, the one `relay(flow=...)` takes. A detached binding
-  is probed the way MT reaches it: over its own SA from `port_pc` to the UE's
-  protected server port, with the SA's transport pin applied exactly as the
-  relay applies it. The SA is looked up from the binding's own client port
-  rather than by UE address, so a re-authentication overlap can no longer route
-  the probe over the wrong pair.
+  The probe now takes the route an MT request to the binding takes, wherever
+  that route can be determined. A binding that still has a flow (UDP, or TCP
+  while the connection is up) keeps the route it always had, the one
+  `relay(flow=...)` takes. A detached binding is probed the way MT reaches it:
+  over its own SA from `port_pc` to the UE's protected server port, on the
+  transport the Contact's `;transport=` names, under the SA's transport pin as
+  the relay applies it. A bare Contact is the one case MT itself leaves open,
+  because MT then follows the transport its own request arrived on; there the
+  probe uses the transport the binding registered over. The SA is looked up
+  from the binding's own client port rather than by UE address, so a
+  re-authentication overlap can no longer route the probe over the wrong pair.
 
   Underneath that, the stream distributor's pool fallback ignored the source a
   message asked to leave from. It now honours it when it is an IPsec-protected
   P-CSCF port, where an ESP-over-TCP SA selector requires that exact source, so
   any TCP send toward a UE whose captured connection has closed goes out inside
-  the SA instead of from an ephemeral port. Every other send stays ephemeral as
-  before, since reconnecting from a listen port collides with a TIME_WAIT
-  4-tuple.
+  the SA instead of from an ephemeral port. Every other send keeps the pool's
+  existing ephemeral bind.
 
 - **A UAS answering a dialog-forming request now echoes the full `Record-Route`
   into its response, and scripts can finally read a multi-value header at all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,33 +8,41 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ### Fixed
 
-- **The registrar liveness probe for an IPsec-protected binding now goes over
-  SA #3, from `port_pc` to the UE's protected server port, instead of back down
-  the UE's own client flow.**
+- **The registrar liveness probe now takes the route an MT request to the
+  binding would take, and a TCP send from an IPsec-protected port whose
+  connection has gone now leaves from that port.**
 
-  The idle-liveness sweep addressed its OPTIONS to the binding's source address,
-  which is the UE's protected *client* port where the REGISTER came from, and
-  for a stream registration it rode the captured inbound connection. But the
-  flow-close handler deliberately *retains* an IPsec binding when its TCP flow
-  closes, so that a UE whose SIP-over-TCP flow FINs at the radio inactivity
-  timer can still be paged. The SA is the liveness authority, not the flow. So
-  by the time the sweep probed such a binding, the flow it rode was already
-  gone. The send fell back to a fresh connection from an ephemeral port toward
-  the UE's client port. No SA selector matches an ephemeral source port, and a
-  UE does not listen on its client port, so the probe could never be answered.
-  Every sweep missed, and a live but idle UE was network-deregistered and its SA
-  torn down, only to re-register from scratch minutes later. A UE whose TCP flow
-  happened to stay up answered normally, which is why this showed up on some
-  handsets and not others.
+  The idle-liveness sweep probed an IPsec-protected binding by sending OPTIONS
+  to the binding's source address and, for a stream registration, riding the
+  captured inbound connection. But the flow-close handler deliberately
+  *retains* an IPsec binding when its TCP flow closes, detaching it so that a UE
+  whose SIP-over-TCP flow FINs at the radio inactivity timer can still be paged.
+  By the time the sweep probed such a binding, the connection it rode was gone.
+  The send fell through the stream distributor to the connection pool, which
+  opened a fresh connection from an ephemeral port toward the UE's client port.
+  No SA selector matches an ephemeral source port and nothing listens on a
+  client port, so the probe could never be answered. Every sweep missed, and a
+  live but idle UE was network-deregistered and its SA torn down, only to
+  re-register from scratch minutes later. A UE whose TCP flow happened to stay
+  up answered normally, which is why this showed up on some handsets and not
+  others.
 
-  The probe now goes to the UE's protected server port from `port_pc` over SA
-  #3. That is 3GPP TS 33.203's path for P-CSCF-originated requests, the one an
-  MT INVITE or NOTIFY takes. It uses UDP, which every SIP UE must accept (RFC
-  3261 §18) and which needs no connection state. Probing the path an MT request
-  actually uses is also the better liveness signal, since it is exactly the
-  reachability the retained binding exists to preserve. A UDP registration moves
-  from the SA #2 response path to SA #3 as well. A TCP-pinned SA can't carry a
-  UDP probe and keeps the captured-flow route unchanged.
+  The probe now asks where an MT request to the binding goes and sends there. A
+  binding that still has a flow (UDP, or TCP while the connection is up) keeps
+  the route it always had, the one `relay(flow=...)` takes. A detached binding
+  is probed the way MT reaches it: over its own SA from `port_pc` to the UE's
+  protected server port, with the SA's transport pin applied exactly as the
+  relay applies it. The SA is looked up from the binding's own client port
+  rather than by UE address, so a re-authentication overlap can no longer route
+  the probe over the wrong pair.
+
+  Underneath that, the stream distributor's pool fallback ignored the source a
+  message asked to leave from. It now honours it when it is an IPsec-protected
+  P-CSCF port, where an ESP-over-TCP SA selector requires that exact source, so
+  any TCP send toward a UE whose captured connection has closed goes out inside
+  the SA instead of from an ephemeral port. Every other send stays ephemeral as
+  before, since reconnecting from a listen port collides with a TIME_WAIT
+  4-tuple.
 
 - **A UAS answering a dialog-forming request now echoes the full `Record-Route`
   into its response, and scripts can finally read a multi-value header at all

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2824,34 +2824,59 @@ struct LivenessProbeRoute {
     connection_id: ConnectionId,
 }
 
-/// The SA #3 route for an IPsec binding's idle-liveness OPTIONS — the way
-/// every other P-CSCF-originated request to the UE goes: from `port_pc` to the
-/// UE's protected server port `port_us` (3GPP TS 33.203), the path an MT INVITE
-/// or NOTIFY takes and so the reachability the retained binding exists to
-/// preserve.
+/// Where an MT request to this binding goes, as the idle-liveness OPTIONS
+/// route.  The probe answers "can an MT request reach this binding?", so it
+/// has to take the MT route in every binding state, or it can pass while MT
+/// fails (and fail while MT works).
 ///
-/// `sa3` is what `ipsec::outbound_for(ue:port_us, Udp)` resolved: the P-CSCF
-/// egress for SA #3 and the transport the SA allows.  Yields a route only when
-/// that is UDP — every SIP UE must accept it (RFC 3261 §18) and it needs no
-/// connection state, which is the point: [`liveness_on_flow_close`] retains an
-/// IPsec binding precisely *because* its TCP flow has closed, so a probe that
-/// rides that flow is probing a socket that is gone by design.  `None` (a
-/// TCP-pinned SA, or no SA resolved) leaves the caller on the captured-flow
-/// route.
-fn liveness_probe_sa3_route(
-    ue_ip: std::net::IpAddr,
-    ue_port_s: u16,
-    sa3: Option<(SocketAddr, Transport)>,
+/// - The binding still has a flow (UDP, or TCP while the connection is up):
+///   what `relay(flow=...)` does, the UE's source address from the listener
+///   the REGISTER landed on, on the captured connection, with the SA's
+///   transport pin applied as the relay applies it.
+/// - It has no flow: a stream binding [`registrar::Registrar::close_flow`]
+///   detached because its socket closed.  MT to it is relayed without a flow
+///   to its Contact, the UE's protected server port, so the probe goes the
+///   same way: over the binding's own SA from `port_pc` (SA #3), with the
+///   binding's transport under the SA pin.
+///
+/// `sa` is the binding's own SA pair.  `None` when a detached binding has no
+/// SA to route over, or a transport an SA cannot carry.
+fn liveness_probe_route(
+    contact: &crate::registrar::Contact,
+    sa: Option<&crate::ipsec::SecurityAssociationPair>,
 ) -> Option<LivenessProbeRoute> {
-    match sa3 {
-        Some((source_local_addr, Transport::Udp)) => Some(LivenessProbeRoute {
-            destination: SocketAddr::new(ue_ip, ue_port_s),
-            source_local_addr,
-            transport: Transport::Udp,
-            connection_id: ConnectionId::default(),
-        }),
-        _ => None,
+    if let Some(flow) = contact.flow() {
+        let transport = match (sa, flow.transport) {
+            (Some(sa), Transport::Udp | Transport::Tcp) => {
+                crate::script::api::ipsec::outbound_for_sa(
+                    sa,
+                    flow.source_addr.port(),
+                    flow.transport,
+                )
+                .map_or(flow.transport, |(_, pinned)| pinned)
+            }
+            _ => flow.transport,
+        };
+        return Some(LivenessProbeRoute {
+            destination: flow.source_addr,
+            source_local_addr: flow.local_addr,
+            transport,
+            connection_id: ConnectionId(flow.connection_id),
+        });
     }
+    let sa = sa?;
+    let binding_transport = contact.source_transport.unwrap_or(Transport::Udp);
+    if !matches!(binding_transport, Transport::Udp | Transport::Tcp) {
+        return None;
+    }
+    let (source_local_addr, transport) =
+        crate::script::api::ipsec::outbound_for_sa(sa, sa.ue_port_s, binding_transport)?;
+    Some(LivenessProbeRoute {
+        destination: SocketAddr::new(sa.ue_addr, sa.ue_port_s),
+        source_local_addr,
+        transport,
+        connection_id: ConnectionId::default(),
+    })
 }
 
 /// Hysteresis decision after a suspect binding fails its in-sweep OPTIONS probe
@@ -3153,46 +3178,27 @@ async fn sweep_registrar_liveness(state: &DispatcherState) {
             continue;
         }
 
-        // Suspect.  Probe over SA #3 — port_pc → the UE's protected server
-        // port, the way an MT request reaches it — whenever the SA allows UDP
-        // (`liveness_probe_sa3_route` explains why not the captured flow).  Only
-        // a TCP-pinned SA keeps the old route: the binding's actual transport,
-        // riding the captured inbound connection, so a dead half-open socket
-        // yields no answer within probe_timeout.  Detach so a slow UE can't
+        // Suspect.  Probe the route an MT request to this binding takes
+        // (`liveness_probe_route`): its flow while it has one, else its own SA
+        // from port_pc to the UE's protected server port.  The SA is the
+        // binding's own pair, looked up by its client port; the per-IP row above
+        // only decides eligibility and activity.  Detach so a slow UE can't
         // stall the sweep.
         suspects += 1;
         let binding_transport = contact.source_transport.unwrap_or(Transport::Udp);
-        let sa3 = crate::script::api::ipsec::outbound_for(
-            SocketAddr::new(ue_addr.ip(), row.ue_port_s),
-            Transport::Udp,
-        );
-        let route =
-            liveness_probe_sa3_route(ue_addr.ip(), row.ue_port_s, sa3).unwrap_or_else(|| {
-                let (source_local_addr, transport) =
-                    crate::script::api::ipsec::outbound_for(ue_addr, binding_transport).unwrap_or(
-                        (
-                            contact.inbound_local_addr.unwrap_or(ue_addr),
-                            binding_transport,
-                        ),
-                    );
-                // Stream: ride the captured inbound connection (a dead half-open
-                // socket times out → dereg).  UDP routes by source_local_addr, so
-                // the sentinel id is correct there.
-                let connection_id = if matches!(transport, Transport::Udp) {
-                    ConnectionId::default()
-                } else {
-                    contact
-                        .inbound_connection_id
-                        .map(ConnectionId)
-                        .unwrap_or_default()
-                };
-                LivenessProbeRoute {
-                    destination: ue_addr,
-                    source_local_addr,
-                    transport,
-                    connection_id,
-                }
-            });
+        let sa = manager.get_sa(&ue_addr.ip(), ue_addr.port());
+        let Some(route) = liveness_probe_route(&contact, sa.as_ref()) else {
+            // No SA to route a detached binding over (a re-authentication
+            // overlap, a stale port): skip it this sweep rather than count a
+            // miss.  A binding whose SA is really gone is reaped by the
+            // abandoned-SA sweep.
+            debug!(
+                aor = %aor,
+                ue = %ue_addr,
+                "registrar liveness: no MT route for idle binding, skipping this sweep"
+            );
+            continue;
+        };
         debug!(
             aor = %aor,
             ue = %ue_addr,
@@ -3206,7 +3212,9 @@ async fn sweep_registrar_liveness(state: &DispatcherState) {
         let context = context.clone();
         let aor = aor.clone();
         let contact = contact.clone();
-        let ue_port_c = row.ue_port_c;
+        // Tear down the binding's own SA pair on a reap, not whichever pair
+        // the per-IP row happened to index during a re-auth overlap.
+        let ue_port_c = sa.as_ref().map_or(row.ue_port_c, |sa| sa.ue_port_c);
         tokio::spawn(async move {
             liveness_probe_then_dereg(context, aor, contact, ue_port_c, route, probe_timeout).await;
         });
@@ -5437,6 +5445,36 @@ fn handle_request(
     flush_deferred_sends(state);
 }
 
+/// Where `request.relay(flow=...)` sends: the UE's source address, over the
+/// flow's transport, egressing the listener the REGISTER landed on, on the
+/// captured connection.  An unrecognised transport name falls back to
+/// `fallback` (the inbound transport) with a warning.
+///
+/// Named so the registrar-liveness probe's agreement test builds the MT route
+/// from the relay's own mapping rather than from a copy of it.
+fn flow_relay_egress(
+    flow: &crate::script::api::registrar::PyFlow,
+    fallback: Transport,
+) -> (SocketAddr, Transport, SocketAddr, ConnectionId) {
+    let transport = match flow.transport.as_str() {
+        "udp" => Transport::Udp,
+        "tcp" => Transport::Tcp,
+        "tls" => Transport::Tls,
+        "ws" => Transport::WebSocket,
+        "wss" => Transport::WebSocketSecure,
+        other => {
+            warn!(transport = %other, "flow-relay: unknown transport, falling back to inbound");
+            fallback
+        }
+    };
+    (
+        flow.source_addr,
+        transport,
+        flow.local_addr,
+        ConnectionId(flow.connection_id),
+    )
+}
+
 /// Relay a SIP request to its destination.
 ///
 /// 1. Determine target address (explicit next_hop, or Request-URI)
@@ -5472,17 +5510,8 @@ fn relay_request(
     //   b) flow=None — resolve the next_hop / top Route / R-URI as usual.
     let (target_uri_string, mut destination, mut outbound_transport, flow_local_addr) =
         if let Some(flow) = flow {
-            let transport = match flow.transport.as_str() {
-                "udp" => Transport::Udp,
-                "tcp" => Transport::Tcp,
-                "tls" => Transport::Tls,
-                "ws" => Transport::WebSocket,
-                "wss" => Transport::WebSocketSecure,
-                other => {
-                    warn!(transport = %other, "flow-relay: unknown transport, falling back to inbound");
-                    inbound.transport
-                }
-            };
+            let (flow_destination, transport, flow_local, _) =
+                flow_relay_egress(flow, inbound.transport);
             // For diagnostics only — the URI isn't used to pick the destination.
             let uri_string = match &message.start_line {
                 StartLine::Request(request_line) => request_line.request_uri.to_string(),
@@ -5491,12 +5520,7 @@ fn relay_request(
                     return;
                 }
             };
-            (
-                uri_string,
-                flow.source_addr,
-                transport,
-                Some(flow.local_addr),
-            )
+            (uri_string, flow_destination, transport, Some(flow_local))
         } else {
             // Determine target URI string (RFC 3261 §16.6 step 6):
             // 1. Explicit next-hop from script
@@ -32592,72 +32616,194 @@ mod tests {
         assert!(liveness_recently_active(now, now + 10, 90));
     }
 
-    #[test]
-    fn liveness_probe_takes_sa3_to_port_us_when_the_sa_allows_udp() {
-        // The probe must go the way every P-CSCF-originated request to the UE
-        // goes (TS 33.203 SA #3: port_pc -> port_us), not back to the UE's
-        // client port, and on a fresh send rather than a captured flow — the
-        // flow-close handler retains an IPsec binding *because* its flow is gone.
-        let pcscf_port_c: std::net::SocketAddr = "192.0.2.10:5064".parse().expect("fixture");
-        let route = liveness_probe_sa3_route(
-            ip("198.51.100.20"),
-            50002,
-            Some((pcscf_port_c, Transport::Udp)),
-        )
-        .expect("a UDP-capable SA must yield an SA #3 route");
-        assert_eq!(
-            route.destination,
-            "198.51.100.20:50002"
-                .parse::<std::net::SocketAddr>()
-                .expect("fixture")
-        );
-        assert_eq!(route.source_local_addr, pcscf_port_c);
-        assert_eq!(route.transport, Transport::Udp);
-        assert_eq!(
-            route.connection_id,
-            ConnectionId::default(),
-            "must not ride a captured flow"
-        );
+    /// The SA pair for the probe/MT agreement test: UE 198.51.100.20 with
+    /// port_uc 50001 / port_us 50002, P-CSCF 192.0.2.10 with port_pc 5064 /
+    /// port_ps 5066.
+    fn agreement_sa(protocol: crate::ipsec::SaProtocol) -> crate::ipsec::SecurityAssociationPair {
+        crate::ipsec::SecurityAssociationPair {
+            ue_addr: ip("198.51.100.20"),
+            pcscf_addr: ip("192.0.2.10"),
+            ue_port_c: 50001,
+            ue_port_s: 50002,
+            pcscf_port_c: 5064,
+            pcscf_port_s: 5066,
+            spi_uc: 1000,
+            spi_us: 1001,
+            spi_pc: 10000,
+            spi_ps: 10001,
+            ealg: crate::ipsec::EncryptionAlgorithm::Null,
+            aalg: crate::ipsec::IntegrityAlgorithm::HmacSha1,
+            encryption_key: String::new(),
+            integrity_key: "deadbeefdeadbeefdeadbeefdeadbeef".into(),
+            hard_lifetime_secs: None,
+            protocol,
+            expires_at: std::time::Instant::now(),
+            created_at: std::time::Instant::now(),
+            role: crate::ipsec::SaRole::PCscf,
+        }
     }
 
-    #[test]
-    fn liveness_probe_sa3_route_carries_ipv6() {
-        let pcscf_port_c: std::net::SocketAddr = "[2001:db8::10]:5064".parse().expect("fixture");
-        let route = liveness_probe_sa3_route(
-            ip("2001:db8::20"),
-            50002,
-            Some((pcscf_port_c, Transport::Udp)),
-        )
-        .expect("a UDP-capable SA must yield an SA #3 route");
-        assert_eq!(
-            route.destination,
-            "[2001:db8::20]:50002"
-                .parse::<std::net::SocketAddr>()
-                .expect("fixture")
-        );
-        assert_eq!(route.source_local_addr, pcscf_port_c);
+    /// Save the agreement test's binding the way the P-CSCF does (a REGISTER
+    /// from port_uc landing on port_ps, flow captured, Contact on port_us) and
+    /// hand back the stored contact.  `detach` runs the real `close_flow`, the
+    /// path a TCP FIN takes for an IPsec binding.
+    fn agreement_binding(transport: Transport, detach: bool) -> crate::registrar::Contact {
+        let registrar = crate::registrar::Registrar::default();
+        let mut uri = SipUri::new("198.51.100.20".to_string())
+            .with_user("alice".to_string())
+            .with_port(50002);
+        if transport == Transport::Tcp {
+            uri = uri.with_param("transport".to_string(), Some("tcp".to_string()));
+        }
+        registrar
+            .save_full(
+                "sip:alice@ims.example.com",
+                uri,
+                3600,
+                1.0,
+                "call-agreement".to_string(),
+                1,
+                Some("198.51.100.20:50001".parse().expect("fixture")),
+                Some(transport),
+                None,
+                None,
+                vec![],
+                crate::registrar::FlowCapture {
+                    flow_token: Some("tok-agreement".into()),
+                    inbound_local_addr: Some("192.0.2.10:5066".parse().expect("fixture")),
+                    inbound_connection_id: (transport == Transport::Tcp).then_some(7),
+                },
+                Vec::new(),
+            )
+            .expect("fixture binding saves");
+        if detach {
+            let keep: std::collections::HashSet<String> = registrar
+                .bindings_for_connection(7)
+                .iter()
+                .map(|(_, contact)| contact.uri.to_string())
+                .collect();
+            assert!(
+                registrar.close_flow(7, &keep).is_empty(),
+                "an IPsec binding detaches on a flow close, it is not removed"
+            );
+        }
+        registrar
+            .all_contacts()
+            .into_iter()
+            .next()
+            .expect("the fixture binding is stored")
+            .1
     }
 
-    #[test]
-    fn liveness_probe_keeps_the_flow_route_for_a_tcp_pinned_sa() {
-        // A TCP-pinned SA cannot carry a UDP probe: leave the caller on the
-        // captured-flow route, exactly as before.
-        let pcscf_port_c: std::net::SocketAddr = "192.0.2.10:5064".parse().expect("fixture");
-        assert_eq!(
-            liveness_probe_sa3_route(
-                ip("198.51.100.20"),
-                50002,
-                Some((pcscf_port_c, Transport::Tcp)),
+    /// Where an MT request to `contact` goes, built from the relay's own code and
+    /// never from the probe's: the flow the script hands `relay(flow=...)`
+    /// (`binding.flow`) through the relay's flow mapping, or with no flow, the
+    /// Contact URI resolved as `relay(uri)` resolves it; then the SA's transport
+    /// pin, as the relay's IPsec egress step applies it.  UDP stands in for the
+    /// inbound transport on both paths: the adversarial choice, since a mapping
+    /// that lost the binding's own transport then shows up as a mismatch.
+    fn mt_route(
+        contact: &crate::registrar::Contact,
+        sa: &crate::ipsec::SecurityAssociationPair,
+    ) -> (SocketAddr, SocketAddr, Transport, ConnectionId) {
+        match crate::script::api::registrar::PyContact::from_rust_contact(contact).flow() {
+            Some(flow) => {
+                let (destination, transport, local, connection_id) =
+                    flow_relay_egress(&flow, Transport::Udp);
+                let transport =
+                    crate::script::api::ipsec::outbound_for_sa(sa, destination.port(), transport)
+                        .map_or(transport, |(_, pinned)| pinned);
+                (destination, local, transport, connection_id)
+            }
+            None => {
+                let target = resolve_target(&contact.uri.to_string(), &test_resolver())
+                    .expect("the contact URI resolves");
+                let (source, transport) = crate::script::api::ipsec::outbound_for_sa(
+                    sa,
+                    target.address.port(),
+                    target.transport.unwrap_or(Transport::Udp),
+                )
+                .expect("the contact port is one of the SA's ports");
+                (target.address, source, transport, ConnectionId::default())
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn liveness_probe_route_agrees_with_the_mt_route_in_every_binding_state() {
+        use crate::ipsec::SaProtocol;
+        // The probe exists to answer "can an MT request reach this binding?",
+        // so it has to take exactly the route MT takes, in every binding state.
+        // Each row also pins the MT route to concrete values, so a fault shared
+        // by both sides (the flow tuple is common to them on purpose) cannot
+        // hide behind an agreement.
+        let rows = [
+            (
+                "UDP",
+                Transport::Udp,
+                false,
+                SaProtocol::Any,
+                "198.51.100.20:50001",
+                "192.0.2.10:5066",
+                Transport::Udp,
             ),
-            None
-        );
-    }
-
-    #[test]
-    fn liveness_probe_keeps_the_flow_route_when_no_sa_resolves() {
-        assert_eq!(
-            liveness_probe_sa3_route(ip("198.51.100.20"), 50002, None),
-            None
+            (
+                "live TCP",
+                Transport::Tcp,
+                false,
+                SaProtocol::Any,
+                "198.51.100.20:50001",
+                "192.0.2.10:5066",
+                Transport::Tcp,
+            ),
+            (
+                "detached TCP",
+                Transport::Tcp,
+                true,
+                SaProtocol::Any,
+                "198.51.100.20:50002",
+                "192.0.2.10:5064",
+                Transport::Tcp,
+            ),
+            (
+                "detached TCP, TCP-pinned SA",
+                Transport::Tcp,
+                true,
+                SaProtocol::Tcp,
+                "198.51.100.20:50002",
+                "192.0.2.10:5064",
+                Transport::Tcp,
+            ),
+        ];
+        let mut failures = Vec::new();
+        for (state, transport, detach, protocol, destination, source, expected_transport) in rows {
+            let contact = agreement_binding(transport, detach);
+            let sa = agreement_sa(protocol);
+            let mt = mt_route(&contact, &sa);
+            let expected = (
+                destination.parse::<SocketAddr>().expect("fixture"),
+                source.parse::<SocketAddr>().expect("fixture"),
+                expected_transport,
+            );
+            if (mt.0, mt.1, mt.2) != expected {
+                failures.push(format!("{state}: MT route {mt:?}, expected {expected:?}"));
+            }
+            let probe = liveness_probe_route(&contact, Some(&sa)).map(|route| {
+                (
+                    route.destination,
+                    route.source_local_addr,
+                    route.transport,
+                    route.connection_id,
+                )
+            });
+            if probe != Some(mt) {
+                failures.push(format!("{state}: probe {probe:?}, MT {mt:?}"));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "the liveness probe must take the MT route:\n{}",
+            failures.join("\n")
         );
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2811,6 +2811,49 @@ fn liveness_recently_active(now: u64, last_active: u64, idle_window: u64) -> boo
     now.saturating_sub(last_active) <= idle_window
 }
 
+/// Where and how one idle-liveness OPTIONS is sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LivenessProbeRoute {
+    /// Where the OPTIONS is addressed.
+    destination: SocketAddr,
+    /// The P-CSCF listener it leaves from — what the kernel XFRM egress policy
+    /// keys on, so it must be the SA's own port.
+    source_local_addr: SocketAddr,
+    transport: Transport,
+    /// A captured stream connection to ride, or the default for a fresh send.
+    connection_id: ConnectionId,
+}
+
+/// The SA #3 route for an IPsec binding's idle-liveness OPTIONS — the way
+/// every other P-CSCF-originated request to the UE goes: from `port_pc` to the
+/// UE's protected server port `port_us` (3GPP TS 33.203), the path an MT INVITE
+/// or NOTIFY takes and so the reachability the retained binding exists to
+/// preserve.
+///
+/// `sa3` is what `ipsec::outbound_for(ue:port_us, Udp)` resolved: the P-CSCF
+/// egress for SA #3 and the transport the SA allows.  Yields a route only when
+/// that is UDP — every SIP UE must accept it (RFC 3261 §18) and it needs no
+/// connection state, which is the point: [`liveness_on_flow_close`] retains an
+/// IPsec binding precisely *because* its TCP flow has closed, so a probe that
+/// rides that flow is probing a socket that is gone by design.  `None` (a
+/// TCP-pinned SA, or no SA resolved) leaves the caller on the captured-flow
+/// route.
+fn liveness_probe_sa3_route(
+    ue_ip: std::net::IpAddr,
+    ue_port_s: u16,
+    sa3: Option<(SocketAddr, Transport)>,
+) -> Option<LivenessProbeRoute> {
+    match sa3 {
+        Some((source_local_addr, Transport::Udp)) => Some(LivenessProbeRoute {
+            destination: SocketAddr::new(ue_ip, ue_port_s),
+            source_local_addr,
+            transport: Transport::Udp,
+            connection_id: ConnectionId::default(),
+        }),
+        _ => None,
+    }
+}
+
 /// Hysteresis decision after a suspect binding fails its in-sweep OPTIONS probe
 /// loop.  Given the prior consecutive-miss count and the configured threshold,
 /// returns `(new_count, reap)`: within grace it bumps the counter and keeps the
@@ -3110,52 +3153,62 @@ async fn sweep_registrar_liveness(state: &DispatcherState) {
             continue;
         }
 
-        // Suspect.  Probe over the binding's *actual* transport — for a stream
-        // binding the OPTIONS rides the captured inbound connection, so a dead
-        // half-open socket simply yields no answer within probe_timeout.
-        // Detach so a slow UE can't stall the sweep.
+        // Suspect.  Probe over SA #3 — port_pc → the UE's protected server
+        // port, the way an MT request reaches it — whenever the SA allows UDP
+        // (`liveness_probe_sa3_route` explains why not the captured flow).  Only
+        // a TCP-pinned SA keeps the old route: the binding's actual transport,
+        // riding the captured inbound connection, so a dead half-open socket
+        // yields no answer within probe_timeout.  Detach so a slow UE can't
+        // stall the sweep.
         suspects += 1;
         let binding_transport = contact.source_transport.unwrap_or(Transport::Udp);
+        let sa3 = crate::script::api::ipsec::outbound_for(
+            SocketAddr::new(ue_addr.ip(), row.ue_port_s),
+            Transport::Udp,
+        );
+        let route =
+            liveness_probe_sa3_route(ue_addr.ip(), row.ue_port_s, sa3).unwrap_or_else(|| {
+                let (source_local_addr, transport) =
+                    crate::script::api::ipsec::outbound_for(ue_addr, binding_transport).unwrap_or(
+                        (
+                            contact.inbound_local_addr.unwrap_or(ue_addr),
+                            binding_transport,
+                        ),
+                    );
+                // Stream: ride the captured inbound connection (a dead half-open
+                // socket times out → dereg).  UDP routes by source_local_addr, so
+                // the sentinel id is correct there.
+                let connection_id = if matches!(transport, Transport::Udp) {
+                    ConnectionId::default()
+                } else {
+                    contact
+                        .inbound_connection_id
+                        .map(ConnectionId)
+                        .unwrap_or_default()
+                };
+                LivenessProbeRoute {
+                    destination: ue_addr,
+                    source_local_addr,
+                    transport,
+                    connection_id,
+                }
+            });
         debug!(
             aor = %aor,
             ue = %ue_addr,
-            transport = %binding_transport,
+            binding_transport = %binding_transport,
+            probe_destination = %route.destination,
+            probe_transport = %route.transport,
             idle_secs = now.saturating_sub(last_active),
             idle_window,
             "registrar liveness: binding idle past window — probing with OPTIONS"
         );
-        let (source_local_addr, transport) =
-            crate::script::api::ipsec::outbound_for(ue_addr, binding_transport).unwrap_or((
-                contact.inbound_local_addr.unwrap_or(ue_addr),
-                binding_transport,
-            ));
-        // Stream: ride the captured inbound connection (a dead half-open socket
-        // times out → dereg).  UDP routes by source_local_addr, so the sentinel
-        // id is correct there.
-        let connection_id = if matches!(transport, Transport::Udp) {
-            ConnectionId::default()
-        } else {
-            contact
-                .inbound_connection_id
-                .map(ConnectionId)
-                .unwrap_or_default()
-        };
         let context = context.clone();
         let aor = aor.clone();
         let contact = contact.clone();
         let ue_port_c = row.ue_port_c;
         tokio::spawn(async move {
-            liveness_probe_then_dereg(
-                context,
-                aor,
-                contact,
-                ue_port_c,
-                source_local_addr,
-                transport,
-                connection_id,
-                probe_timeout,
-            )
-            .await;
+            liveness_probe_then_dereg(context, aor, contact, ue_port_c, route, probe_timeout).await;
         });
     }
 
@@ -3179,7 +3232,7 @@ async fn sweep_registrar_liveness(state: &DispatcherState) {
     );
 }
 
-/// Send one OPTIONS over the captured flow (with a single retry); if the UE
+/// Send one OPTIONS along `route` (with a single retry); if the UE
 /// answers, stamp its SIP-layer last-seen and clear any miss strike so the next
 /// sweep skips it for a full idle window.  On no answer, apply consecutive-miss
 /// hysteresis: keep the binding for `miss_threshold` failed sweeps (a UE racing
@@ -3190,23 +3243,18 @@ async fn liveness_probe_then_dereg(
     aor: String,
     contact: crate::registrar::Contact,
     ue_port_c: u16,
-    source_local_addr: SocketAddr,
-    transport: Transport,
-    connection_id: ConnectionId,
+    route: LivenessProbeRoute,
     probe_timeout: std::time::Duration,
 ) {
-    let destination = match contact.source_addr {
-        Some(addr) => addr,
-        None => return,
-    };
+    let destination = route.destination;
     let request_uri = contact.uri.clone();
 
     for attempt in 0..2 {
         let receiver = context.uac_sender.send_options_over_flow(
             destination,
-            source_local_addr,
-            transport,
-            connection_id,
+            route.source_local_addr,
+            route.transport,
+            route.connection_id,
             request_uri.clone(),
         );
         if let Ok(Ok(crate::uac::UacResult::Response(_))) =
@@ -32542,6 +32590,75 @@ mod tests {
         assert!(!liveness_recently_active(now, now - 91, 90));
         // A last_active in the future (clock skew) is never idle.
         assert!(liveness_recently_active(now, now + 10, 90));
+    }
+
+    #[test]
+    fn liveness_probe_takes_sa3_to_port_us_when_the_sa_allows_udp() {
+        // The probe must go the way every P-CSCF-originated request to the UE
+        // goes (TS 33.203 SA #3: port_pc -> port_us), not back to the UE's
+        // client port, and on a fresh send rather than a captured flow — the
+        // flow-close handler retains an IPsec binding *because* its flow is gone.
+        let pcscf_port_c: std::net::SocketAddr = "192.0.2.10:5064".parse().expect("fixture");
+        let route = liveness_probe_sa3_route(
+            ip("198.51.100.20"),
+            50002,
+            Some((pcscf_port_c, Transport::Udp)),
+        )
+        .expect("a UDP-capable SA must yield an SA #3 route");
+        assert_eq!(
+            route.destination,
+            "198.51.100.20:50002"
+                .parse::<std::net::SocketAddr>()
+                .expect("fixture")
+        );
+        assert_eq!(route.source_local_addr, pcscf_port_c);
+        assert_eq!(route.transport, Transport::Udp);
+        assert_eq!(
+            route.connection_id,
+            ConnectionId::default(),
+            "must not ride a captured flow"
+        );
+    }
+
+    #[test]
+    fn liveness_probe_sa3_route_carries_ipv6() {
+        let pcscf_port_c: std::net::SocketAddr = "[2001:db8::10]:5064".parse().expect("fixture");
+        let route = liveness_probe_sa3_route(
+            ip("2001:db8::20"),
+            50002,
+            Some((pcscf_port_c, Transport::Udp)),
+        )
+        .expect("a UDP-capable SA must yield an SA #3 route");
+        assert_eq!(
+            route.destination,
+            "[2001:db8::20]:50002"
+                .parse::<std::net::SocketAddr>()
+                .expect("fixture")
+        );
+        assert_eq!(route.source_local_addr, pcscf_port_c);
+    }
+
+    #[test]
+    fn liveness_probe_keeps_the_flow_route_for_a_tcp_pinned_sa() {
+        // A TCP-pinned SA cannot carry a UDP probe: leave the caller on the
+        // captured-flow route, exactly as before.
+        let pcscf_port_c: std::net::SocketAddr = "192.0.2.10:5064".parse().expect("fixture");
+        assert_eq!(
+            liveness_probe_sa3_route(
+                ip("198.51.100.20"),
+                50002,
+                Some((pcscf_port_c, Transport::Tcp)),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn liveness_probe_keeps_the_flow_route_when_no_sa_resolves() {
+        assert_eq!(
+            liveness_probe_sa3_route(ip("198.51.100.20"), 50002, None),
+            None
+        );
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -2826,8 +2826,8 @@ struct LivenessProbeRoute {
 
 /// Where an MT request to this binding goes, as the idle-liveness OPTIONS
 /// route.  The probe answers "can an MT request reach this binding?", so it
-/// has to take the MT route in every binding state, or it can pass while MT
-/// fails (and fail while MT works).
+/// has to take the route MT takes wherever MT's route is determined, or it can
+/// pass while MT fails (and fail while MT works).
 ///
 /// - The binding still has a flow (UDP, or TCP while the connection is up):
 ///   what `relay(flow=...)` does, the UE's source address from the listener
@@ -2836,8 +2836,12 @@ struct LivenessProbeRoute {
 /// - It has no flow: a stream binding [`registrar::Registrar::close_flow`]
 ///   detached because its socket closed.  MT to it is relayed without a flow
 ///   to its Contact, the UE's protected server port, so the probe goes the
-///   same way: over the binding's own SA from `port_pc` (SA #3), with the
-///   binding's transport under the SA pin.
+///   same way: over the binding's own SA from `port_pc` (SA #3), on the
+///   transport the Contact's `;transport=` names (mapped as the relay maps
+///   it), under the SA pin.  A bare Contact is the one case MT leaves open,
+///   because MT then follows the transport its own request arrived on; the
+///   probe cannot know that, and uses the transport the binding registered
+///   over.
 ///
 /// `sa` is the binding's own SA pair.  `None` when a detached binding has no
 /// SA to route over, or a transport an SA cannot carry.
@@ -2865,12 +2869,16 @@ fn liveness_probe_route(
         });
     }
     let sa = sa?;
-    let binding_transport = contact.source_transport.unwrap_or(Transport::Udp);
-    if !matches!(binding_transport, Transport::Udp | Transport::Tcp) {
+    let transport = contact
+        .uri
+        .get_param("transport")
+        .and_then(transport_from_token)
+        .unwrap_or_else(|| contact.source_transport.unwrap_or(Transport::Udp));
+    if !matches!(transport, Transport::Udp | Transport::Tcp) {
         return None;
     }
     let (source_local_addr, transport) =
-        crate::script::api::ipsec::outbound_for_sa(sa, sa.ue_port_s, binding_transport)?;
+        crate::script::api::ipsec::outbound_for_sa(sa, sa.ue_port_s, transport)?;
     Some(LivenessProbeRoute {
         destination: SocketAddr::new(sa.ue_addr, sa.ue_port_s),
         source_local_addr,
@@ -32645,15 +32653,20 @@ mod tests {
 
     /// Save the agreement test's binding the way the P-CSCF does (a REGISTER
     /// from port_uc landing on port_ps, flow captured, Contact on port_us) and
-    /// hand back the stored contact.  `detach` runs the real `close_flow`, the
-    /// path a TCP FIN takes for an IPsec binding.
-    fn agreement_binding(transport: Transport, detach: bool) -> crate::registrar::Contact {
+    /// hand back the stored contact.  `contact_transport` is the Contact's
+    /// `;transport=` parameter, `None` for a bare Contact.  `detach` runs the
+    /// real `close_flow`, the path a TCP FIN takes for an IPsec binding.
+    fn agreement_binding(
+        transport: Transport,
+        contact_transport: Option<&str>,
+        detach: bool,
+    ) -> crate::registrar::Contact {
         let registrar = crate::registrar::Registrar::default();
         let mut uri = SipUri::new("198.51.100.20".to_string())
             .with_user("alice".to_string())
             .with_port(50002);
-        if transport == Transport::Tcp {
-            uri = uri.with_param("transport".to_string(), Some("tcp".to_string()));
+        if let Some(param) = contact_transport {
+            uri = uri.with_param("transport".to_string(), Some(param.to_string()));
         }
         registrar
             .save_full(
@@ -32699,13 +32712,17 @@ mod tests {
     /// never from the probe's: the flow the script hands `relay(flow=...)`
     /// (`binding.flow`) through the relay's flow mapping, or with no flow, the
     /// Contact URI resolved as `relay(uri)` resolves it; then the SA's transport
-    /// pin, as the relay's IPsec egress step applies it.  UDP stands in for the
-    /// inbound transport on both paths: the adversarial choice, since a mapping
-    /// that lost the binding's own transport then shows up as a mismatch.
+    /// pin, as the relay's IPsec egress step applies it.
+    ///
+    /// The transport comes back `None` where MT itself leaves it open: with no
+    /// flow and no `;transport=` on the Contact, the relay falls back to the MT
+    /// request's own inbound transport, which only an SA pin overrides.  That is
+    /// found by resolving against both inbound transports, not by restating the
+    /// rule.
     fn mt_route(
         contact: &crate::registrar::Contact,
         sa: &crate::ipsec::SecurityAssociationPair,
-    ) -> (SocketAddr, SocketAddr, Transport, ConnectionId) {
+    ) -> (SocketAddr, SocketAddr, Option<Transport>, ConnectionId) {
         match crate::script::api::registrar::PyContact::from_rust_contact(contact).flow() {
             Some(flow) => {
                 let (destination, transport, local, connection_id) =
@@ -32713,90 +32730,150 @@ mod tests {
                 let transport =
                     crate::script::api::ipsec::outbound_for_sa(sa, destination.port(), transport)
                         .map_or(transport, |(_, pinned)| pinned);
-                (destination, local, transport, connection_id)
+                (destination, local, Some(transport), connection_id)
             }
             None => {
                 let target = resolve_target(&contact.uri.to_string(), &test_resolver())
                     .expect("the contact URI resolves");
-                let (source, transport) = crate::script::api::ipsec::outbound_for_sa(
-                    sa,
-                    target.address.port(),
-                    target.transport.unwrap_or(Transport::Udp),
-                )
-                .expect("the contact port is one of the SA's ports");
+                let egress = |inbound: Transport| {
+                    crate::script::api::ipsec::outbound_for_sa(
+                        sa,
+                        target.address.port(),
+                        target.transport.unwrap_or(inbound),
+                    )
+                    .expect("the contact port is one of the SA's ports")
+                };
+                let (source, over_udp) = egress(Transport::Udp);
+                let (_, over_tcp) = egress(Transport::Tcp);
+                let transport = (over_udp == over_tcp).then_some(over_udp);
                 (target.address, source, transport, ConnectionId::default())
             }
         }
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn liveness_probe_route_agrees_with_the_mt_route_in_every_binding_state() {
+    async fn liveness_probe_route_agrees_with_the_mt_route_wherever_it_is_determined() {
         use crate::ipsec::SaProtocol;
-        // The probe exists to answer "can an MT request reach this binding?",
-        // so it has to take exactly the route MT takes, in every binding state.
-        // Each row also pins the MT route to concrete values, so a fault shared
-        // by both sides (the flow tuple is common to them on purpose) cannot
-        // hide behind an agreement.
+        // The probe answers "can an MT request reach this binding?", so it has
+        // to take the route MT takes.  MT does not always fix the transport: for
+        // a detached binding with a bare Contact it follows the MT request's own
+        // inbound transport, which the probe cannot know.  There the probe uses
+        // the binding's transport, and the row checks exactly that.  Each row
+        // also pins the MT route to concrete values, so a fault shared by both
+        // sides (the flow tuple is common to them on purpose) cannot hide behind
+        // an agreement.
         let rows = [
             (
                 "UDP",
                 Transport::Udp,
+                None,
                 false,
                 SaProtocol::Any,
                 "198.51.100.20:50001",
                 "192.0.2.10:5066",
-                Transport::Udp,
+                Some(Transport::Udp),
             ),
             (
                 "live TCP",
                 Transport::Tcp,
+                Some("tcp"),
                 false,
                 SaProtocol::Any,
                 "198.51.100.20:50001",
                 "192.0.2.10:5066",
-                Transport::Tcp,
+                Some(Transport::Tcp),
             ),
             (
-                "detached TCP",
+                "detached TCP, Contact ;transport=tcp",
                 Transport::Tcp,
+                Some("tcp"),
                 true,
                 SaProtocol::Any,
                 "198.51.100.20:50002",
                 "192.0.2.10:5064",
-                Transport::Tcp,
+                Some(Transport::Tcp),
             ),
             (
-                "detached TCP, TCP-pinned SA",
+                "detached TCP, Contact ;transport=tcp, TCP-pinned SA",
                 Transport::Tcp,
+                Some("tcp"),
                 true,
                 SaProtocol::Tcp,
                 "198.51.100.20:50002",
                 "192.0.2.10:5064",
+                Some(Transport::Tcp),
+            ),
+            (
+                "detached TCP, Contact ;transport=udp",
                 Transport::Tcp,
+                Some("udp"),
+                true,
+                SaProtocol::Any,
+                "198.51.100.20:50002",
+                "192.0.2.10:5064",
+                Some(Transport::Udp),
+            ),
+            (
+                "detached TCP, bare Contact",
+                Transport::Tcp,
+                None,
+                true,
+                SaProtocol::Any,
+                "198.51.100.20:50002",
+                "192.0.2.10:5064",
+                None,
+            ),
+            (
+                "detached TCP, bare Contact, TCP-pinned SA",
+                Transport::Tcp,
+                None,
+                true,
+                SaProtocol::Tcp,
+                "198.51.100.20:50002",
+                "192.0.2.10:5064",
+                Some(Transport::Tcp),
             ),
         ];
         let mut failures = Vec::new();
-        for (state, transport, detach, protocol, destination, source, expected_transport) in rows {
-            let contact = agreement_binding(transport, detach);
+        for (
+            state,
+            transport,
+            contact_transport,
+            detach,
+            protocol,
+            destination,
+            source,
+            expected,
+        ) in rows
+        {
+            let contact = agreement_binding(transport, contact_transport, detach);
             let sa = agreement_sa(protocol);
             let mt = mt_route(&contact, &sa);
             let expected = (
                 destination.parse::<SocketAddr>().expect("fixture"),
                 source.parse::<SocketAddr>().expect("fixture"),
-                expected_transport,
+                expected,
             );
             if (mt.0, mt.1, mt.2) != expected {
                 failures.push(format!("{state}: MT route {mt:?}, expected {expected:?}"));
             }
-            let probe = liveness_probe_route(&contact, Some(&sa)).map(|route| {
-                (
-                    route.destination,
-                    route.source_local_addr,
-                    route.transport,
-                    route.connection_id,
-                )
-            });
-            if probe != Some(mt) {
+            let Some(probe) = liveness_probe_route(&contact, Some(&sa)) else {
+                failures.push(format!("{state}: no probe route, MT {mt:?}"));
+                continue;
+            };
+            // Where MT fixes the transport the probe must match it; where MT
+            // follows its own inbound transport, the probe uses the binding's.
+            let transport_agrees = match mt.2 {
+                Some(mt_transport) => probe.transport == mt_transport,
+                None => probe.transport == transport,
+            };
+            if (
+                probe.destination,
+                probe.source_local_addr,
+                probe.connection_id,
+            ) != (mt.0, mt.1, mt.3)
+                || !transport_agrees
+            {
                 failures.push(format!("{state}: probe {probe:?}, MT {mt:?}"));
             }
         }

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -278,7 +278,48 @@ fn sort_by_preference(contacts: &mut [Contact]) {
     });
 }
 
+/// The inbound flow a binding's REGISTER arrived on: where an MT request
+/// relayed with `relay(flow=...)` goes.  One definition, shared by the script's
+/// `Contact.flow` view and the registrar-liveness probe, so the two can never
+/// disagree about whether a binding still has a flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContactFlow {
+    /// Transport the REGISTER arrived on.
+    pub transport: Transport,
+    /// The UE's source address (where the REGISTER came from).
+    pub source_addr: SocketAddr,
+    /// The listener the REGISTER landed on.
+    pub local_addr: SocketAddr,
+    /// `ConnectionId.0` of the accepted inbound connection; for UDP, the
+    /// deterministic `(local_addr, source_addr)` hash.
+    pub connection_id: u64,
+}
+
 impl Contact {
+    /// The captured inbound flow, or `None` when there is no usable one: an
+    /// address is missing, or a stream binding has no connection id, which is
+    /// what `close_flow` leaves behind when it detaches an IPsec binding whose
+    /// socket closed.  A UDP binding with no stored id gets one recomputed,
+    /// since a UDP connection id is a deterministic hash.
+    pub fn flow(&self) -> Option<ContactFlow> {
+        let source_addr = self.source_addr?;
+        let local_addr = self.inbound_local_addr?;
+        let transport = self.source_transport.unwrap_or(Transport::Udp);
+        let connection_id = match self.inbound_connection_id {
+            Some(id) => id,
+            None if transport == Transport::Udp => {
+                crate::transport::udp::udp_connection_id(local_addr, source_addr).0
+            }
+            None => return None,
+        };
+        Some(ContactFlow {
+            transport,
+            source_addr,
+            local_addr,
+            connection_id,
+        })
+    }
+
     /// Seconds remaining until this contact expires.
     pub fn remaining_seconds(&self) -> u64 {
         let elapsed = self.registered_at.elapsed();

--- a/src/script/api/ipsec.rs
+++ b/src/script/api/ipsec.rs
@@ -238,7 +238,7 @@ fn outbound_endpoint_for_sa(
 /// single-transport pins the SA's protocol wins, since a UDP-over-TCP
 /// or TCP-over-UDP mismatch silently drops the frame at the kernel
 /// XFRM selector.
-fn outbound_for_sa(
+pub(crate) fn outbound_for_sa(
     sa: &SecurityAssociationPair,
     dst_port: u16,
     current_transport: crate::transport::Transport,

--- a/src/script/api/registrar.rs
+++ b/src/script/api/registrar.rs
@@ -320,7 +320,7 @@ impl PyContact {
     /// `inbound_local_addr`/`inbound_connection_id` fields were absent
     /// in the persisted record).
     #[getter]
-    fn flow(&self) -> Option<PyFlow> {
+    pub(crate) fn flow(&self) -> Option<PyFlow> {
         self.flow_value.clone()
     }
 
@@ -411,56 +411,16 @@ impl PyContact {
         let is_local_value = registrar
             .map(|registrar| registrar.is_local_contact(contact))
             .unwrap_or(false);
-        // Reconstitute the `Flow` view from the stored tuple.  Requires
-        // both source_addr (the UE) and inbound_local_addr (our listener)
-        // to be present — otherwise the flow is incomplete and we can't
-        // honor `relay(flow=...)`, so expose `None`.
-        let flow_value = match (contact.source_addr, contact.inbound_local_addr) {
-            (Some(source_addr), Some(local_addr)) => {
-                let transport = contact
-                    .source_transport
-                    .unwrap_or(crate::transport::Transport::Udp);
-                let connection_id = match contact.inbound_connection_id {
-                    Some(id) => id,
-                    // For UDP, the connection_id is a deterministic hash of
-                    // `(local_addr, remote_addr)` — recompute on demand if
-                    // the stored binding lacks it (older record).  For
-                    // stream transports, no captured id means no flow.
-                    None if transport == crate::transport::Transport::Udp => {
-                        use std::collections::hash_map::DefaultHasher;
-                        use std::hash::{Hash, Hasher};
-                        let mut hasher = DefaultHasher::new();
-                        local_addr.hash(&mut hasher);
-                        source_addr.hash(&mut hasher);
-                        hasher.finish()
-                    }
-                    None => {
-                        return Self {
-                            uri_string: contact.uri.to_string(),
-                            q_value: contact.q,
-                            expires_remaining: contact.remaining_seconds(),
-                            age_seconds: contact.age_seconds(),
-                            received_string,
-                            path_headers: contact.path.iter().map(|v| v.to_string()).collect(),
-                            instance_id_value: contact.instance_id().map(str::to_string),
-                            instance_epoch_value: contact.instance_epoch().map(str::to_string),
-                            is_local_value,
-                            flow_token_value: contact.flow_token.as_ref().map(|v| v.to_string()),
-                            flow_value: None,
-                            params_value: contact.params.clone(),
-                            kind_value: contact.kind,
-                        }
-                    }
-                };
-                Some(PyFlow {
-                    transport: transport.as_scheme().to_string(),
-                    source_addr,
-                    local_addr,
-                    connection_id,
-                })
-            }
-            _ => None,
-        };
+        // The `Flow` view of the binding's captured inbound flow.  One
+        // definition, `Contact::flow`, shared with the registrar-liveness
+        // probe: `None` when an address is missing or a stream binding has no
+        // connection id (detached after its socket closed).
+        let flow_value = contact.flow().map(|flow| PyFlow {
+            transport: flow.transport.as_scheme().to_string(),
+            source_addr: flow.source_addr,
+            local_addr: flow.local_addr,
+            connection_id: flow.connection_id,
+        });
         Self {
             uri_string: contact.uri.to_string(),
             q_value: contact.q,

--- a/src/transport/stream.rs
+++ b/src/transport/stream.rs
@@ -77,6 +77,25 @@ pub(crate) struct StreamContext {
     pub remote_addr: SocketAddr,
 }
 
+/// The source a pool-fallback TCP connect must bind, if any.
+///
+/// Only an IPsec-protected P-CSCF port.  An ESP-over-TCP SA selector keys on
+/// the P-CSCF's exact source port, so a connect toward a UE whose captured flow
+/// has closed has to leave from that port, or it matches no SA and never
+/// arrives (3GPP TS 33.203).  Everything else stays ephemeral, as the pool has
+/// always bound it: `source_local_addr` is stamped on responses too (the
+/// listener they arrived on), and reconnecting from a listen port collides with
+/// a TIME_WAIT 4-tuple (see `ConnectionPool::establish_tcp_connection`).  A
+/// source of the other address family can never be bound for the connect.
+fn pool_tcp_source(
+    source_local_addr: Option<SocketAddr>,
+    destination: SocketAddr,
+    is_protected: fn(u16) -> bool,
+) -> Option<SocketAddr> {
+    source_local_addr
+        .filter(|source| source.is_ipv4() == destination.is_ipv4() && is_protected(source.port()))
+}
+
 /// Spawn the outbound distributor for one stream listener.
 ///
 /// Routes each [`OutboundMessage`] to its connection's bounded sender; when no
@@ -88,6 +107,24 @@ pub(crate) fn spawn_outbound_distributor(
     connection_map: Arc<DashMap<ConnectionId, mpsc::Sender<Bytes>>>,
     transport: Transport,
     pool: Option<Arc<ConnectionPool>>,
+) {
+    spawn_outbound_distributor_with(
+        outbound_rx,
+        connection_map,
+        transport,
+        pool,
+        crate::script::api::ipsec::is_protected_local_port,
+    );
+}
+
+/// [`spawn_outbound_distributor`] with the IPsec protected-port predicate
+/// injected, so tests do not depend on the process-wide IPsec config.
+fn spawn_outbound_distributor_with(
+    outbound_rx: flume::Receiver<OutboundMessage>,
+    connection_map: Arc<DashMap<ConnectionId, mpsc::Sender<Bytes>>>,
+    transport: Transport,
+    pool: Option<Arc<ConnectionPool>>,
+    is_protected: fn(u16) -> bool,
 ) {
     tokio::spawn(async move {
         while let Ok(outbound) = outbound_rx.recv_async().await {
@@ -125,6 +162,7 @@ pub(crate) fn spawn_outbound_distributor(
                 let destination = outbound.destination;
                 let server_name = outbound.server_name.clone();
                 let requested_connection_id = outbound.connection_id;
+                let source = pool_tcp_source(outbound.source_local_addr, destination, is_protected);
                 // Sequential await per frame — the pool coalesces to one
                 // connection per destination, so frames stay in order on it.
                 for frame in outbound.into_frames() {
@@ -133,7 +171,10 @@ pub(crate) fn spawn_outbound_distributor(
                             pool.send_tls(destination, server_name.as_deref(), frame)
                                 .await
                         }
-                        Transport::Tcp => pool.send_tcp(destination, frame).await,
+                        Transport::Tcp => match source {
+                            Some(source) => pool.send_tcp_from(source, destination, frame).await,
+                            None => pool.send_tcp(destination, frame).await,
+                        },
                         // WS/WSS are client-initiated (RFC 7118 §5): there is no
                         // outbound-connect path, so a miss here is a dead UE.
                         other => {
@@ -665,6 +706,98 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for PrefixedStream<S> {
 mod tests {
     use super::*;
     use crate::transport::tcp::extract_sip_message_length;
+
+    // --- pool fallback: protected source binding ---------------------------
+
+    fn ensure_crypto_provider() {
+        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+    }
+
+    #[test]
+    fn pool_tcp_source_binds_only_a_protected_same_family_source() {
+        let protected: fn(u16) -> bool = |port| port == 5064;
+        let destination: SocketAddr = "198.51.100.20:50002".parse().unwrap();
+        // An IPsec SA's own port: the only source its selector matches.
+        let pcscf_port_c: SocketAddr = "192.0.2.10:5064".parse().unwrap();
+        assert_eq!(
+            pool_tcp_source(Some(pcscf_port_c), destination, protected),
+            Some(pcscf_port_c)
+        );
+        // Any other listener stays ephemeral, as the pool always bound it, so a
+        // reconnect never collides with a TIME_WAIT 4-tuple on the listen port.
+        let plain: SocketAddr = "192.0.2.10:5060".parse().unwrap();
+        assert_eq!(pool_tcp_source(Some(plain), destination, protected), None);
+        // A v6 listener cannot be bound for a v4 connect.
+        let v6: SocketAddr = "[2001:db8::10]:5064".parse().unwrap();
+        assert_eq!(pool_tcp_source(Some(v6), destination, protected), None);
+        assert_eq!(pool_tcp_source(None, destination, protected), None);
+    }
+
+    #[tokio::test]
+    async fn tcp_pool_fallback_leaves_from_a_protected_source() {
+        // What a closed flow leaves behind: a send with no live connection (the
+        // default id) that names the protected port it has to leave from.
+        ensure_crypto_provider();
+        // Reserve a port to stand in for pcscf_port_c; SO_REUSEADDR lets the
+        // pool rebind it once it is released.
+        let reserve = tokio::net::TcpSocket::new_v4().unwrap();
+        reserve.set_reuseaddr(true).unwrap();
+        reserve.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let source = reserve.local_addr().unwrap();
+        drop(reserve);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let server = listener.local_addr().unwrap();
+        let accepted = tokio::spawn(async move {
+            let (socket, peer) = listener.accept().await.unwrap();
+            // Hold the socket so the pool's reader sees no EOF mid-send.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            drop(socket);
+            peer
+        });
+
+        let pool = Arc::new(ConnectionPool::new(
+            Arc::new(DashMap::new()),
+            flume::unbounded().0,
+            "127.0.0.1:5060".parse().unwrap(),
+            None,
+            None,
+            None,
+            crate::transport::pool::build_outbound_tls_config(
+                None,
+                crate::config::TlsMethod::default(),
+            )
+            .expect("outbound tls config"),
+        ));
+        let (outbound_tx, outbound_rx) = flume::unbounded();
+        spawn_outbound_distributor_with(
+            outbound_rx,
+            Arc::new(DashMap::new()),
+            Transport::Tcp,
+            Some(pool),
+            |_| true,
+        );
+        outbound_tx
+            .send(OutboundMessage {
+                connection_id: ConnectionId::default(),
+                transport: Transport::Tcp,
+                destination: server,
+                data: Bytes::from_static(b"OPTIONS sip:ue.example.invalid SIP/2.0\r\n\r\n"),
+                source_local_addr: Some(source),
+                server_name: None,
+                followups: None,
+            })
+            .unwrap();
+
+        let peer = tokio::time::timeout(Duration::from_secs(2), accepted)
+            .await
+            .expect("the pool fallback must connect within 2 s")
+            .unwrap();
+        assert_eq!(
+            peer, source,
+            "the pool fallback must leave from the protected source, not an ephemeral port"
+        );
+    }
 
     const INVITE: &[u8] = concat!(
         "INVITE sip:bob@biloxi.com SIP/2.0\r\n",

--- a/src/transport/stream.rs
+++ b/src/transport/stream.rs
@@ -84,9 +84,11 @@ pub(crate) struct StreamContext {
 /// has closed has to leave from that port, or it matches no SA and never
 /// arrives (3GPP TS 33.203).  Everything else stays ephemeral, as the pool has
 /// always bound it: `source_local_addr` is stamped on responses too (the
-/// listener they arrived on), and reconnecting from a listen port collides with
-/// a TIME_WAIT 4-tuple (see `ConnectionPool::establish_tcp_connection`).  A
-/// source of the other address family can never be bound for the connect.
+/// listener they arrived on), and a reconnect from a listen port fails with
+/// EADDRNOTAVAIL while an earlier connection to a peer that negotiated no TCP
+/// timestamps sits in TIME_WAIT on the same 4-tuple (see
+/// `ConnectionPool::establish_tcp_connection`).  A source of the other address
+/// family can never be bound for the connect.
 fn pool_tcp_source(
     source_local_addr: Option<SocketAddr>,
     destination: SocketAddr,
@@ -724,7 +726,8 @@ mod tests {
             Some(pcscf_port_c)
         );
         // Any other listener stays ephemeral, as the pool always bound it, so a
-        // reconnect never collides with a TIME_WAIT 4-tuple on the listen port.
+        // reconnect to a peer without TCP timestamps never lands on our
+        // TIME_WAIT 4-tuple on the listen port.
         let plain: SocketAddr = "192.0.2.10:5060".parse().unwrap();
         assert_eq!(pool_tcp_source(Some(plain), destination, protected), None);
         // A v6 listener cannot be bound for a v4 connect.

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -149,7 +149,7 @@ pub async fn listen(
 }
 
 /// Compute a stable ConnectionId for a UDP (local, remote) pair.
-fn udp_connection_id(local: SocketAddr, remote: SocketAddr) -> ConnectionId {
+pub(crate) fn udp_connection_id(local: SocketAddr, remote: SocketAddr) -> ConnectionId {
     let mut hasher = DefaultHasher::new();
     local.hash(&mut hasher);
     remote.hash(&mut hasher);


### PR DESCRIPTION
## Problem

The registrar idle-liveness sweep probed an IPsec-protected binding by sending OPTIONS to the binding's source address, which is the UE's protected client port, and for a stream registration it rode the captured inbound connection.

The flow-close handler retains an IPsec binding when its TCP flow closes, on purpose, detaching it so a UE whose SIP-over-TCP flow FINs at the radio inactivity timer stays pageable. So by the time the sweep got to such a binding, the connection it rode was gone. The send fell through the stream distributor to the connection pool, which opened a fresh connection from an ephemeral port toward the UE's client port. No SA selector matches an ephemeral source port and nothing listens on a client port, so the probe could never be answered. The binding hit the miss threshold and the UE was network-deregistered with its SA torn down while it was still alive.

A UE that keeps its TCP flow up answers the old probe fine, which is why this looks handset-dependent.

## Fix

The probe now takes the route an MT request to the binding takes, wherever that route is determined.

- A binding with a live flow (UDP, or TCP while the connection is up) keeps its route, the one `relay(flow=...)` takes, with the SA transport pin applied as the relay applies it.
- A detached binding goes over its own SA from `pcscf_port_c` to `ue_port_s`, the way MT reaches it without a flow. The transport is the one the Contact's `;transport=` names, mapped with the relay's own `transport_from_token`, under the SA pin from `outbound_for_sa`.
- A bare Contact is the one case MT leaves open: MT then follows the transport its own request arrived on, which the probe can't know. There the probe uses the transport the binding registered over.
- The SA is the binding's own pair from `get_sa(ue_ip, contact.source_addr.port())`, not the per-IP row. The SA teardown on a reap uses the same pair.
- `Contact::flow()` is now the one definition of the flow tuple, used by `PyContact.flow` and by the probe. The relay's flow mapping is named `flow_relay_egress`.
- The stream distributor's pool fallback honours `source_local_addr` when it's an IPsec-protected P-CSCF port, so a TCP send toward a UE whose captured connection has closed leaves inside the SA instead of from an ephemeral port. Every other send keeps the pool's existing ephemeral bind.

Response matching is unaffected, the UAC matches on the Via branch only.

On TIME_WAIT for the protected ports: the pool's idle close leaves our end in TIME_WAIT on (port_pc, ue:port_us). Tested in a Linux netns with `tcp_tw_reuse=2`, across a veth: reconnecting from the explicitly bound port onto that 4-tuple succeeds. That fits how the kernel treats an already-bound socket, allowing the TIME_WAIT to be reused when TCP timestamps were in use, independent of `tcp_tw_reuse`. A peer that doesn't negotiate timestamps is still exposed, and at least one UE on a test network doesn't: a reconnect inside the TIME_WAIT fails with EADDRNOTAVAIL. That send used to leave from an ephemeral port and never reach the UE at all, so this is narrower than before. It goes in its own issue.

## Testing

- One agreement test, seven rows: UDP, live TCP, and a detached TCP binding with a Contact `;transport=tcp`, the same on a TCP-pinned SA, a Contact `;transport=udp`, a bare Contact, and a bare Contact on a TCP-pinned SA. The MT side is built from the relay's own code (`binding.flow` through `flow_relay_egress`, or `resolve_target` on the Contact, then the SA pin), and reports the transport as undetermined where MT follows its own inbound transport, found by resolving against both. The probe has to match MT on destination, source and connection id, and on transport wherever MT fixes it. Each row also pins MT's route to concrete values.
- A `pool_tcp_source` table, and a real-listener test that the pool fallback leaves from the protected source.
- `cargo test`: all green.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
