### PR TITLE
feat(originate): take a body with its own content_type, and refuse one carrying no offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ## [Unreleased]
 
+### Added
+
+- **`originate` now takes a `body` with its own `content_type`, so an INVITE can
+  carry its offer inside a `multipart/*` body** — `b2bua.originate(body=…,
+  content_type=…)` in a script, `args.body` / `args.content_type` on the control
+  rail.
+
+  RFC 5621 §3 lets the session description travel as one part of a multipart
+  body, beside a part SIP itself does not interpret: ISUP on a SIP-I trunk
+  (RFC 3204), a PIDF-LO location object (RFC 6442), an operator-specific
+  document. `originate` had one body slot named `sdp`, so the only way to place
+  such a call was to pass the assembled multipart as `sdp=` and overwrite the
+  framework's `Content-Type` through `headers` — which worked, but only as an
+  accident of header ordering that nothing tested and nothing checked.
+
+  `sdp=` keeps its meaning and its behaviour (it is the body, carried as
+  `application/sdp`), `body=` is the same slot with the type spelled out, and
+  passing both is an error. Scripts can hand `body=` `bytes` as well as `str`;
+  `args.body` on the control rail is JSON text, the same limit `answer` and
+  `progress` already have.
+
 ### Fixed
 
 - **A re-INVITE or UPDATE from the callee no longer addresses the media engine as
@@ -39,6 +60,25 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   client that changed network mid-call (Wi-Fi to mobile data) stayed gated on its
   old public address paired with its new port, and every packet from the new
   address was dropped.
+
+- **An `originate` body that carries no SDP offer is now refused instead of
+  placing a call that can never have audio.**
+
+  The offer plan promises siphon has an offer to send, and the callee answers a
+  genuinely offerless INVITE by offering in its own 2xx — which that plan has
+  nothing to answer with (RFC 3261 §13.2.2.4), so the call connects mute. A
+  `Content-Type` naming neither SDP nor a multipart carrying it now fails the
+  command (`bad_request` on the control rail, `ValueError` in a script), and the
+  check runs again after `headers` has been applied, so rewriting the header
+  cannot strip the offer off the INVITE. Wrapping the offer in a multipart that
+  does contain it is unaffected, and an anchored (offerless) originate now
+  refuses a `Content-Type` in `headers` describing a body it does not send.
+
+- **An originated leg records only the SDP as its media description, not the
+  whole multipart body.**
+
+  `last_sdp` is what a later re-INVITE re-offers (hold, bridge), and the other
+  parts of a multipart body belong to the initial INVITE alone.
 
 - **A TCP or TLS send that has to open a new connection no longer holds up
   every other send while it connects.**

--- a/docs/reference/call.md
+++ b/docs/reference/call.md
@@ -42,7 +42,11 @@ def reminders():
 
 Exactly one media plan is required — an INVITE with no offer and no way to answer
 the callee's would connect a call with no audio: `sdp=` (your own offer, any
-backend) or `media=True` (siphon anchors it; `siphon-rtp` backend). The full
+backend), `body=` + `content_type=` (the same slot with the type spelled out,
+for an offer travelling inside a `multipart/*` body per RFC 5621 §3), or
+`media=True` (siphon anchors it; `siphon-rtp` backend). Whichever spelling, the
+body has to carry an SDP offer — a body that carries none raises rather than
+placing a call the callee can only answer by offering into silence. The full
 argument set and its failure modes are below; the out-of-process twin is the
 control plane's [`originate` verb](control-plane.md#placing-a-call-originate).
 

--- a/docs/reference/control-plane.md
+++ b/docs/reference/control-plane.md
@@ -251,7 +251,7 @@ chunk, so logs join Homer and billing with no mapping table.
 
 | verb | module | args | notes |
 |---|---|---|---|
-| `originate` | sip | `{channel, to, from?, from_display?, to_display?, next_hop?, p_asserted_identity?, privacy?, headers?, sdp \| media, profile?, ws_uri?, timeout?, on_lost?, vars?}` | place an outbound call under a **caller-supplied** channel id; returns as soon as the INVITE is on the wire |
+| `originate` | sip | `{channel, to, from?, from_display?, to_display?, next_hop?, p_asserted_identity?, privacy?, headers?, sdp \| body + content_type? \| media, profile?, ws_uri?, timeout?, on_lost?, vars?}` | place an outbound call under a **caller-supplied** channel id; returns as soon as the INVITE is on the wire |
 | `answer` | sip | `{code, reason?, body?, content_type?, anchor?, profile?, ws_uri?}` | UAS 2xx to the parked A-leg. With `anchor` (or a `profile` / `ws_uri`, which imply it) siphon synthesizes the RFC 3264 answer against the media engine and anchors the leg's audio to it in the same act — the verb form of `call.handover(answer=True, …)`, and the only way an app that took the call **un-answered** can connect it. `siphon-rtp` only: on rtpengine / rtpproxy it answers `unavailable` rather than a 200 with nothing behind it, and on any media failure the 2xx is never sent, so the call stays parked and answerable |
 | `ring` | sip | `{reason?}` | `180 Ringing` — alerting only (RFC 3261 §13.2.1); a body is refused |
 | `progress` | sip | `{code, reason?, body?, content_type?}` | a UAS 1xx, optionally opening an early-media path with SDP (RFC 3960 §3.1); defaults to `183 Session Progress` |
@@ -431,7 +431,26 @@ events on your id:
 way to answer the callee's leaves its 2xx unanswerable (RFC 3261 §13.2.2.4) — a
 connected call with no audio:
 
-- `sdp` — your own offer, carried verbatim. Works on any backend, or none.
+- `sdp` — your own offer, carried verbatim as `application/sdp`. Works on any
+  backend, or none.
+- `body` + `content_type` — the same slot with the type spelled out, for an
+  INVITE whose offer travels as one part of a `multipart/*` body (RFC 5621 §3)
+  beside a part SIP does not interpret: ISUP on a SIP-I trunk (RFC 3204), a
+  PIDF-LO location object (RFC 6442), an operator-specific document. You
+  assemble the multipart; siphon carries it verbatim and derives Content-Length
+  from it. `content_type` defaults to `application/sdp`, which makes `body`
+  alone identical to `sdp`.
+
+    The body must still carry an SDP offer — `application/sdp`, or a
+    `multipart/*` with an `application/sdp` part in it. One that does not is
+    `bad_request` at the command, because a callee reading the INVITE as
+    offerless offers in its own 2xx and this plan has nothing to answer that
+    with (RFC 3261 §13.2.2.4). The same check runs on the Content-Type after
+    `headers` is applied, so rewriting the header cannot strip the offer off the
+    INVITE either. Note that `args.body` is JSON text: a part whose bytes are
+    not UTF-8 (raw ISUP, say) cannot be spelled on this rail today, the same
+    limit `answer` and `progress` have.
+
 - `media: true` — siphon anchors the leg on the media backend: the INVITE goes
   out offerless, the callee offers in its 2xx and siphon answers it locally with
   the answer on the ACK. The session is keyed on the leg's SIP Call-ID, so

--- a/sdk/siphon_sdk/mock_module.py
+++ b/sdk/siphon_sdk/mock_module.py
@@ -673,6 +673,8 @@ class MockB2bua:
         profile: Optional[str] = None,
         ws_uri: Optional[str] = None,
         timeout: int = 30,
+        body: Optional[Union[str, bytes]] = None,
+        content_type: Optional[str] = None,
     ) -> str:
         """Place an outbound call siphon owns, with no inbound INVITE behind it.
 
@@ -690,10 +692,23 @@ class MockB2bua:
         Exactly one media plan is required — an INVITE with no offer and no way
         to answer the callee's would connect a call with no audio:
 
-        * ``sdp="v=0..."`` — your own offer, carried verbatim (any backend);
+        * ``sdp="v=0..."`` — your own offer, carried verbatim as
+          ``application/sdp`` (any backend);
+        * ``body=…, content_type=…`` — the same slot with the type spelled out,
+          for an INVITE whose offer travels as one part of a ``multipart/*``
+          body (RFC 5621 §3) beside a part SIP does not interpret: ISUP on a
+          SIP-I trunk, a PIDF-LO location object, an operator-specific document.
+          You assemble the multipart; siphon carries it verbatim and derives
+          Content-Length from it;
         * ``media=True`` — siphon anchors the leg on the configured media
           backend (siphon-rtp), so ``rtpengine.play_media()``, DTMF and the
           WebSocket tee all work against it.
+
+        Whichever spelling, the body must carry an SDP offer — bare
+        ``application/sdp``, or a ``multipart/*`` with an ``application/sdp``
+        part in it. Live siphon raises for one that carries none, because a
+        callee that reads the INVITE as offerless offers in its own 2xx and this
+        plan has nothing to answer that with (RFC 3261 §13.2.2.4).
 
         Args:
             to: called party — the Request-URI and the To URI.
@@ -709,22 +724,29 @@ class MockB2bua:
                 ``P-Asserted-Identity``.
             headers: dict of extra headers applied last. Dialog-defining headers
                 (Via/From/To/Call-ID/CSeq/Contact/Route/…) are ignored.
-            sdp: your own SDP offer.
+            sdp: your own SDP offer, carried as ``application/sdp``.
             media: True to have siphon anchor the leg on the media backend.
             profile: media profile for ``media=True`` (default
                 ``"rtp_passthrough"``).
             ws_uri: per-call WebSocket bridge URI for ``media=True``.
             timeout: ring timeout in seconds; the call is CANCELled when it
                 elapses. 0 disables it.
+            body: the INVITE body, ``str`` or ``bytes`` — the offer itself, or a
+                multipart carrying it. Mutually exclusive with ``sdp``.
+            content_type: Content-Type for ``body`` (e.g.
+                ``"multipart/mixed;boundary=…"``). Defaults to
+                ``"application/sdp"``, which makes ``body`` identical to ``sdp``.
 
         Returns:
             str: the new leg's SIP Call-ID.
 
         Raises:
-            ValueError: no media plan, both media plans, or an unrecognised
-                ``privacy`` value. Live siphon also raises for unparseable URIs,
-                no route, and a media plan the backend cannot serve — never a
-                silent ``None`` for a call that was never placed.
+            ValueError: no media plan, two media plans, both spellings of the
+                offer, a ``content_type`` with nothing to describe, or an
+                unrecognised ``privacy`` value. Live siphon also raises for
+                unparseable URIs, no route, a media plan the backend cannot
+                serve, and a body carrying no offer — never a silent ``None``
+                for a call that was never placed.
 
         In the mock, records the full argument set on ``originates`` and returns
         a synthetic Call-ID. Inspect via ``siphon.get_b2bua().originates``.
@@ -740,17 +762,35 @@ class MockB2bua:
                         media=True,
                     )
         """
-        if sdp is not None and media:
+        if sdp is not None and body is not None:
             raise ValueError(
-                "b2bua.originate takes either sdp= (your own offer) or "
+                "b2bua.originate takes either sdp= (an SDP offer) or body= "
+                "(a body with its own content_type=), not both"
+            )
+        if sdp is not None and content_type is not None:
+            raise ValueError(
+                "b2bua.originate content_type= goes with body= — sdp= is "
+                "application/sdp by definition"
+            )
+        offer = sdp if sdp is not None else body
+        if offer is not None and media:
+            raise ValueError(
+                "b2bua.originate takes either your own offer (sdp= / body=) or "
                 "media=True (siphon anchors the leg), not both"
             )
-        if sdp is not None and not sdp.strip():
-            raise ValueError("b2bua.originate sdp= must not be empty")
-        if sdp is None and not media:
+        if offer is not None:
+            probe = offer.decode("utf-8", "replace") if isinstance(offer, bytes) else offer
+            if not probe.strip():
+                raise ValueError("b2bua.originate sdp= / body= must not be empty")
+        if offer is None and media and content_type is not None:
             raise ValueError(
-                "b2bua.originate needs a media plan: sdp= (your own offer) or "
-                "media=True (siphon anchors the leg)"
+                "b2bua.originate content_type= needs body= — media=True sends "
+                "an offerless INVITE"
+            )
+        if offer is None and not media:
+            raise ValueError(
+                "b2bua.originate needs a media plan: sdp= / body= (your own "
+                "offer) or media=True (siphon anchors the leg)"
             )
         if privacy is not None and privacy not in (
             "allowed", "allow", "present", "presented",
@@ -778,6 +818,14 @@ class MockB2bua:
             "profile": profile,
             "ws_uri": ws_uri,
             "timeout": timeout,
+            "body": body,
+            # What the INVITE would actually carry the body under, so a test can
+            # assert the wire shape without restating the default.
+            "content_type": (
+                content_type
+                if content_type is not None
+                else ("application/sdp" if offer is not None else None)
+            ),
         })
         return call_id
 

--- a/sdk/tests/test_b2bua_originate.py
+++ b/sdk/tests/test_b2bua_originate.py
@@ -73,6 +73,71 @@ class TestB2buaOriginate:
         placed = harness.b2bua.originates[-1]
         assert placed["sdp"] == offer
         assert placed["media"] is False
+        # sdp= is the body carried as application/sdp — the same slot body= fills.
+        assert placed["content_type"] == "application/sdp"
+
+    def test_a_multipart_body_carries_its_own_content_type(self, harness):
+        # RFC 5621 §3: the offer may ride as one part of a multipart body, beside
+        # a part SIP does not interpret. The script assembles that body and names
+        # its type.
+        import siphon
+
+        body = (
+            "--siphon-1\r\n"
+            "Content-Type: application/sdp\r\n"
+            "\r\n"
+            "v=0\r\nm=audio 40000 RTP/AVP 0\r\n"
+            "\r\n--siphon-1\r\n"
+            "Content-Type: application/vnd.example+xml\r\n"
+            "\r\n"
+            "<additional-data/>\r\n"
+            "--siphon-1--\r\n"
+        )
+        siphon.b2bua.originate(
+            to="sip:1@carrier.example",
+            body=body,
+            content_type="multipart/mixed;boundary=siphon-1",
+        )
+        placed = harness.b2bua.originates[-1]
+        assert placed["body"] == body
+        assert placed["content_type"] == "multipart/mixed;boundary=siphon-1"
+        assert placed["sdp"] is None
+        assert placed["media"] is False
+
+    def test_a_bytes_body_is_accepted(self, harness):
+        # Live siphon takes str or bytes, so the mock must not reject bytes.
+        import siphon
+
+        siphon.b2bua.originate(
+            to="sip:1@carrier.example", body=b"v=0\r\nm=audio 40000 RTP/AVP 0\r\n"
+        )
+        placed = harness.b2bua.originates[-1]
+        assert placed["body"] == b"v=0\r\nm=audio 40000 RTP/AVP 0\r\n"
+        assert placed["content_type"] == "application/sdp"
+
+    def test_both_spellings_of_the_offer_is_a_hard_error(self, harness):
+        # One slot, two spellings — passing both leaves it ambiguous which body
+        # goes on the wire.
+        import siphon
+
+        with pytest.raises(ValueError, match="not both"):
+            siphon.b2bua.originate(
+                to="sip:1@carrier.example", sdp="v=0\r\n", body="v=0\r\n"
+            )
+        assert harness.b2bua.originates == []
+
+    def test_a_content_type_with_nothing_to_describe_is_a_hard_error(self, harness):
+        import siphon
+
+        with pytest.raises(ValueError, match="content_type"):
+            siphon.b2bua.originate(
+                to="sip:1@carrier.example", sdp="v=0\r\n", content_type="text/plain"
+            )
+        with pytest.raises(ValueError, match="content_type"):
+            siphon.b2bua.originate(
+                to="sip:1@carrier.example", media=True, content_type="application/sdp"
+            )
+        assert harness.b2bua.originates == []
 
     def test_no_media_plan_is_a_hard_error(self, harness):
         # An INVITE with no offer and no anchor cannot answer the callee's own

--- a/src/control/sip_adapter.rs
+++ b/src/control/sip_adapter.rs
@@ -1088,8 +1088,15 @@ fn string_arg(args: &serde_json::Value, name: &str) -> Option<String> {
         .map(|value| value.to_string())
 }
 
-/// Parse the media plan: exactly one of `args.sdp` (a controller-supplied
-/// offer) or `args.media: true` (siphon anchors the leg on the media backend).
+/// Parse the media plan: exactly one of a controller-supplied offer
+/// (`args.sdp`, or `args.body` with its own `args.content_type`) or
+/// `args.media: true` (siphon anchors the leg on the media backend).
+///
+/// `args.sdp` is the shorthand — the body, carried as `application/sdp`.
+/// `args.body` is the same slot with the type spelled out, for an INVITE whose
+/// offer travels as one part of a `multipart/*` body (RFC 5621 §3) beside a
+/// part SIP does not interpret. Either spelling has to carry an SDP offer; the
+/// dispatcher refuses a body that does not.
 ///
 /// Neither is a `bad_request` rather than a default, because an INVITE with no
 /// offer and no plan to answer the callee's leaves its 2xx un-answerable
@@ -1099,19 +1106,40 @@ fn parse_originate_media(
     args: &serde_json::Value,
 ) -> Result<crate::dispatcher::OriginateMedia, String> {
     let sdp = args.get("sdp").and_then(|value| value.as_str());
+    let body = args.get("body").and_then(|value| value.as_str());
+    let content_type = args.get("content_type").and_then(|value| value.as_str());
     let anchor = args
         .get("media")
         .and_then(|value| value.as_bool())
         .unwrap_or(false);
-    match (sdp, anchor) {
+
+    if sdp.is_some() && body.is_some() {
+        return Err(
+            "originate takes either args.sdp (an SDP offer) or args.body (a body with its own args.content_type), not both"
+                .to_string(),
+        );
+    }
+    match (sdp.or(body), anchor) {
         (Some(_), true) => Err(
-            "originate takes either args.sdp (your own offer) or args.media=true (siphon anchors the leg), not both"
+            "originate takes either your own offer (args.sdp / args.body) or args.media=true (siphon anchors the leg), not both"
                 .to_string(),
         ),
-        (Some(sdp), false) if sdp.trim().is_empty() => {
-            Err("originate args.sdp must not be empty".to_string())
-        }
-        (Some(sdp), false) => Ok(crate::dispatcher::OriginateMedia::Offer(sdp.to_string())),
+        (Some(offer), false) if offer.trim().is_empty() => Err(format!(
+            "originate {} must not be empty",
+            if sdp.is_some() { "args.sdp" } else { "args.body" }
+        )),
+        (Some(_), false) if sdp.is_some() && content_type.is_some() => Err(
+            "originate args.content_type goes with args.body — args.sdp is application/sdp by definition"
+                .to_string(),
+        ),
+        (Some(offer), false) => Ok(crate::dispatcher::OriginateMedia::Offer {
+            body: offer.as_bytes().to_vec(),
+            content_type: content_type.unwrap_or("application/sdp").to_string(),
+        }),
+        (None, true) if content_type.is_some() => Err(
+            "originate args.content_type needs args.body — args.media=true sends an offerless INVITE"
+                .to_string(),
+        ),
         (None, true) => Ok(crate::dispatcher::OriginateMedia::Anchor {
             profile: args
                 .get("profile")
@@ -1124,7 +1152,7 @@ fn parse_originate_media(
                 .map(|value| value.to_string()),
         }),
         (None, false) => Err(
-            "originate requires a media plan: args.sdp (your own offer) or args.media=true (siphon anchors the leg)"
+            "originate requires a media plan: args.sdp / args.body (your own offer) or args.media=true (siphon anchors the leg)"
                 .to_string(),
         ),
     }
@@ -1156,7 +1184,9 @@ fn originate_error(error: crate::dispatcher::OriginateError) -> ControlResult {
     use crate::dispatcher::OriginateError;
     let message = error.to_string();
     match error {
-        OriginateError::InvalidUri { .. } => {
+        // A malformed argument either way: the URI does not parse, or the body
+        // is not one an INVITE can carry an offer in.
+        OriginateError::InvalidUri { .. } | OriginateError::InvalidBody(_) => {
             ControlResult::error(ControlErrorCode::BadRequest, message)
         }
         // No reachable destination for the target: the request was well formed
@@ -2443,7 +2473,10 @@ mod tests {
         use crate::dispatcher::OriginateMedia;
         assert_eq!(
             parse_originate_media(&serde_json::json!({ "sdp": "v=0\r\n" })),
-            Ok(OriginateMedia::Offer("v=0\r\n".to_string()))
+            Ok(OriginateMedia::Offer {
+                body: b"v=0\r\n".to_vec(),
+                content_type: "application/sdp".to_string(),
+            })
         );
         assert_eq!(
             parse_originate_media(&serde_json::json!({ "media": true })),
@@ -2466,6 +2499,68 @@ mod tests {
         assert!(
             parse_originate_media(&serde_json::json!({ "sdp": "v=0", "media": true })).is_err()
         );
+    }
+
+    #[test]
+    fn parse_originate_media_takes_a_body_with_its_own_content_type() {
+        // RFC 5621 §3: the offer may ride as one part of a multipart body. The
+        // controller assembles that body and names its type; siphon carries it.
+        use crate::dispatcher::OriginateMedia;
+        assert_eq!(
+            parse_originate_media(&serde_json::json!({
+                "body": "--b\r\nContent-Type: application/sdp\r\n\r\nv=0\r\n--b--\r\n",
+                "content_type": "multipart/mixed;boundary=b",
+            })),
+            Ok(OriginateMedia::Offer {
+                body: b"--b\r\nContent-Type: application/sdp\r\n\r\nv=0\r\n--b--\r\n".to_vec(),
+                content_type: "multipart/mixed;boundary=b".to_string(),
+            })
+        );
+        // A body with no content_type is SDP, exactly like args.sdp.
+        assert_eq!(
+            parse_originate_media(&serde_json::json!({ "body": "v=0\r\n" })),
+            Ok(OriginateMedia::Offer {
+                body: b"v=0\r\n".to_vec(),
+                content_type: "application/sdp".to_string(),
+            })
+        );
+
+        // Two spellings of the same slot, an empty body, a content_type with no
+        // body to describe, and a content_type contradicting args.sdp are each
+        // a malformed request rather than a guess.
+        assert!(
+            parse_originate_media(&serde_json::json!({ "sdp": "v=0\r\n", "body": "v=0\r\n" }))
+                .is_err()
+        );
+        assert!(parse_originate_media(&serde_json::json!({ "body": "  " })).is_err());
+        assert!(
+            parse_originate_media(&serde_json::json!({ "body": "v=0", "media": true })).is_err()
+        );
+        assert!(parse_originate_media(
+            &serde_json::json!({ "media": true, "content_type": "application/sdp" })
+        )
+        .is_err());
+        assert!(parse_originate_media(
+            &serde_json::json!({ "sdp": "v=0", "content_type": "multipart/mixed;boundary=b" })
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn originate_error_maps_an_invalid_body_to_bad_request() {
+        // A body that carries no offer is the caller's frame to fix, not a
+        // missing resource and not a backend that cannot do it.
+        use crate::dispatcher::OriginateError;
+        match originate_error(OriginateError::InvalidBody(
+            "Content-Type 'text/plain' is neither application/sdp nor a multipart body carrying one"
+                .to_string(),
+        )) {
+            ControlResult::Error { code, ref message } => {
+                assert_eq!(code, ControlErrorCode::BadRequest);
+                assert!(message.contains("text/plain"), "message was: {message}");
+            }
+            other => panic!("expected bad_request, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -24295,10 +24295,23 @@ pub fn b2bua_progress_call(
 /// no offer), i.e. a connected call with no media.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OriginateMedia {
-    /// The controller supplied the SDP offer; it rides on the INVITE verbatim
-    /// and the callee's answer arrives in the 2xx (RFC 3264 §5). Works on every
-    /// media backend, and on none at all.
-    Offer(String),
+    /// The controller supplied the body; it rides on the INVITE verbatim under
+    /// `content_type`, and the callee's answer arrives in the 2xx (RFC 3264 §5).
+    /// Works on every media backend, and on none at all.
+    ///
+    /// `content_type` is `application/sdp` for a plain offer, or a `multipart/*`
+    /// carrying the offer as one of its parts (RFC 5621 §3) — beside ISUP on a
+    /// SIP-I trunk, a PIDF-LO location object, an operator-specific document.
+    /// Either way the body has to carry an SDP offer, and
+    /// [`build_originate_invite`] refuses one that does not: a callee that reads
+    /// the INVITE as offerless offers in its own 2xx, and this plan has nothing
+    /// to answer that with (RFC 3261 §13.2.2.4).
+    Offer {
+        /// The bytes carried on the INVITE.
+        body: Vec<u8>,
+        /// The `Content-Type` they are carried under.
+        content_type: String,
+    },
     /// siphon anchors the leg on the configured media backend: the INVITE goes
     /// out **offerless**, the callee's 2xx carries the offer, and siphon answers
     /// it locally (`answer_local`) with the answer riding on the ACK — RFC 3261
@@ -24363,6 +24376,10 @@ pub enum OriginateError {
     Unroutable(String),
     /// The configured backend cannot serve the requested media plan.
     Unsupported(String),
+    /// The supplied body is not one an INVITE can carry an offer in: a
+    /// `Content-Type` naming neither SDP nor a multipart carrying it, a
+    /// multipart body that does not parse, or one with no SDP part in it.
+    InvalidBody(String),
     /// The INVITE could not be built (should not happen; surfaced, never panicked).
     BuildFailed(String),
 }
@@ -24376,6 +24393,7 @@ impl std::fmt::Display for OriginateError {
             }
             OriginateError::Unroutable(detail) => write!(formatter, "{detail}"),
             OriginateError::Unsupported(detail) => write!(formatter, "{detail}"),
+            OriginateError::InvalidBody(detail) => write!(formatter, "{detail}"),
             OriginateError::BuildFailed(detail) => write!(formatter, "{detail}"),
         }
     }
@@ -24493,7 +24511,13 @@ pub fn b2bua_originate_prepare(
     leg.dialog.local_from_uri = invite.headers.from().cloned();
     leg.dialog.remote_to_uri = invite.headers.to().cloned();
     if !invite.body.is_empty() {
-        leg.last_sdp = Some(invite.body.clone());
+        // The SDP alone, never the whole body: `last_sdp` is this leg's current
+        // media description and a later re-INVITE (hold, bridge) re-offers it,
+        // while the other parts of a multipart body belong to the initial
+        // INVITE only. `build_originate_invite` has already refused a body with
+        // no SDP in it, so this cannot quietly drop an offer.
+        leg.last_sdp =
+            crate::media::body::sdp_from_body(message_content_type(&invite), &invite.body).ok();
     }
 
     let internal_call_id = state.call_actors.create_call(leg);
@@ -24599,10 +24623,11 @@ fn build_originate_invite(
         builder = builder.header("P-Asserted-Identity", format!("<{asserted}>"));
     }
     let builder = match &params.media {
-        OriginateMedia::Offer(sdp) => builder
-            .content_type("application/sdp".to_string())
-            .content_length(sdp.len())
-            .body(sdp.as_bytes().to_vec()),
+        OriginateMedia::Offer { body, content_type } => builder
+            .content_type(content_type.clone())
+            // `body` derives Content-Length from the bytes themselves, so the
+            // framing always describes what is actually carried.
+            .body(body.clone()),
         // Offerless: the callee offers in its 2xx and we answer in the ACK.
         OriginateMedia::Anchor { .. } => builder.content_length(0),
     };
@@ -24624,6 +24649,16 @@ fn build_originate_invite(
         invite.headers.set(name, value.clone());
     }
 
+    // The body and the Content-Type describing it have to still agree once
+    // `headers` has had its say. Content-Type is deliberately not reserved —
+    // rewriting it is how a caller wraps its offer in a `multipart/*` beside a
+    // part SIP does not interpret (RFC 5621 §3) — but rewriting it to something
+    // that carries no offer at all is a different act: the callee then reads an
+    // offerless INVITE and offers in its own 2xx, which an `Offer` plan has
+    // nothing to answer with (RFC 3261 §13.2.2.4). That is a connected call
+    // with no audio, so it is refused here rather than placed.
+    originate_check_body(&invite, &params.media)?;
+
     // CLIR last of all — anonymisation is the final identity step, or a custom
     // From / P-Asserted-Identity header set after it would undo it
     // (RFC 3323 §4.1 / TS 24.607).
@@ -24631,6 +24666,37 @@ fn build_originate_invite(
         crate::sip::privacy::restrict_calling_identity(&mut invite);
     }
     Ok(invite)
+}
+
+/// The `Content-Type` a built message carries, compact form included: a caller
+/// can spell the header either way in `headers` (RFC 3261 §7.3.1, §20).
+fn message_content_type(message: &SipMessage) -> &str {
+    message
+        .headers
+        .get("Content-Type")
+        .or_else(|| message.headers.get("c"))
+        .map(String::as_str)
+        .unwrap_or_default()
+}
+
+/// Refuse an originate whose body and `Content-Type` no longer match its media
+/// plan once `headers` has been applied. See the call site for why this runs
+/// after the custom headers rather than before them.
+fn originate_check_body(invite: &SipMessage, media: &OriginateMedia) -> Result<(), OriginateError> {
+    let content_type = message_content_type(invite);
+    match media {
+        OriginateMedia::Offer { .. } => crate::media::body::sdp_from_body(content_type, &invite.body)
+            .map(|_| ())
+            .map_err(OriginateError::InvalidBody),
+        // An anchored originate sends no body at all, so a Content-Type on it
+        // describes a body that is not there.
+        OriginateMedia::Anchor { .. } if !content_type.is_empty() => {
+            Err(OriginateError::InvalidBody(format!(
+                "originate with media anchoring sends an offerless INVITE, so the Content-Type '{content_type}' supplied in headers describes a body that is not there"
+            )))
+        }
+        OriginateMedia::Anchor { .. } => Ok(()),
+    }
 }
 
 /// Headers an `originate` caller must not set: the dialog identity and framing
@@ -38424,9 +38490,42 @@ mod originate_tests {
         }
     }
 
-    fn build(params: &OriginateParams) -> SipMessage {
+    fn build_result(params: &OriginateParams) -> Result<SipMessage, OriginateError> {
         let uri = parse_uri_standalone(&params.to).expect("target parses");
-        build_originate_invite(params, uri, identity()).expect("invite builds")
+        build_originate_invite(params, uri, identity())
+    }
+
+    fn build(params: &OriginateParams) -> SipMessage {
+        build_result(params).expect("invite builds")
+    }
+
+    /// A plain SDP offer — what the `sdp=` / `args.sdp` shorthand produces.
+    fn offer(sdp: &str) -> OriginateMedia {
+        OriginateMedia::Offer {
+            body: sdp.as_bytes().to_vec(),
+            content_type: "application/sdp".to_string(),
+        }
+    }
+
+    /// A `multipart/mixed` body of the shape a SIP-I / PIDF-LO INVITE carries:
+    /// the SDP offer plus one part SIP itself does not interpret.
+    fn multipart_offer_body() -> &'static str {
+        concat!(
+            "--siphon-1\r\n",
+            "Content-Type: application/sdp\r\n",
+            "\r\n",
+            "v=0\r\n",
+            "o=- 1 1 IN IP4 198.51.100.10\r\n",
+            "s=-\r\n",
+            "c=IN IP4 198.51.100.10\r\n",
+            "t=0 0\r\n",
+            "m=audio 40000 RTP/AVP 0\r\n",
+            "\r\n--siphon-1\r\n",
+            "Content-Type: application/vnd.example+xml\r\n",
+            "\r\n",
+            "<additional-data/>\r\n",
+            "--siphon-1--\r\n",
+        )
     }
 
     #[test]
@@ -38634,7 +38733,7 @@ mod originate_tests {
     #[test]
     fn a_caller_supplied_offer_rides_on_the_invite() {
         let sdp = "v=0\r\no=- 1 1 IN IP4 198.51.100.10\r\ns=-\r\nc=IN IP4 198.51.100.10\r\nt=0 0\r\nm=audio 40000 RTP/AVP 0\r\n";
-        let invite = build(&params(OriginateMedia::Offer(sdp.to_string())));
+        let invite = build(&params(offer(sdp)));
         assert_eq!(invite.body, sdp.as_bytes());
         assert_eq!(
             invite.headers.get("Content-Type").unwrap(),
@@ -38644,6 +38743,106 @@ mod originate_tests {
             invite.headers.get("Content-Length").unwrap(),
             &sdp.len().to_string()
         );
+    }
+
+    #[test]
+    fn a_multipart_offer_keeps_its_own_content_type_and_rides_whole() {
+        // RFC 5621 §3: the offer may travel as one part of a multipart body,
+        // beside a part SIP does not interpret. The whole body goes on the wire
+        // under the caller's Content-Type, MIME framing and all.
+        let body = multipart_offer_body();
+        let invite = build(&params(OriginateMedia::Offer {
+            body: body.as_bytes().to_vec(),
+            content_type: "multipart/mixed;boundary=siphon-1".to_string(),
+        }));
+
+        assert_eq!(invite.body, body.as_bytes());
+        assert_eq!(
+            invite.headers.get("Content-Type").unwrap(),
+            "multipart/mixed;boundary=siphon-1"
+        );
+        assert_eq!(
+            invite.headers.get("Content-Length").unwrap(),
+            &body.len().to_string()
+        );
+        // What the leg records as its media description is the SDP part alone —
+        // `b2bua_originate_prepare` stores exactly this expression's result.
+        let recorded =
+            crate::media::body::sdp_from_body(message_content_type(&invite), &invite.body)
+                .expect("the offer is found inside the multipart body");
+        let recorded = String::from_utf8(recorded).expect("SDP is text");
+        assert!(recorded.starts_with("v=0\r\n"), "got: {recorded:?}");
+        assert!(!recorded.contains("additional-data"));
+        assert!(!recorded.contains("--siphon-1"));
+    }
+
+    #[test]
+    fn an_offer_body_carrying_no_sdp_is_refused() {
+        // The plan says the caller supplied the offer while the body supplies
+        // none, so the callee would offer in its 2xx with nothing here able to
+        // answer it.
+        let error = build_result(&params(OriginateMedia::Offer {
+            body: b"hello".to_vec(),
+            content_type: "text/plain".to_string(),
+        }))
+        .expect_err("a non-SDP body is not an offer");
+        assert!(
+            matches!(&error, OriginateError::InvalidBody(detail) if detail.contains("text/plain")),
+            "got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn a_multipart_offer_without_an_sdp_part_is_refused() {
+        let body = concat!(
+            "--siphon-1\r\n",
+            "Content-Type: application/vnd.example+xml\r\n",
+            "\r\n",
+            "<additional-data/>\r\n",
+            "--siphon-1--\r\n",
+        );
+        let error = build_result(&params(OriginateMedia::Offer {
+            body: body.as_bytes().to_vec(),
+            content_type: "multipart/mixed;boundary=siphon-1".to_string(),
+        }))
+        .expect_err("a multipart body with no SDP part is not an offer");
+        assert!(
+            matches!(&error, OriginateError::InvalidBody(_)),
+            "got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn a_content_type_header_cannot_strip_the_offer_off_the_invite() {
+        // Content-Type is settable on purpose, but not to the point of leaving
+        // an INVITE the callee reads as offerless while the plan still says the
+        // caller supplied the offer.
+        let mut params = params(offer("v=0\r\nm=audio 40000 RTP/AVP 0\r\n"));
+        params.headers = vec![("Content-Type".to_string(), "text/plain".to_string())];
+        let error = build_result(&params).expect_err("the offer was rewritten away");
+        assert!(
+            matches!(&error, OriginateError::InvalidBody(_)),
+            "got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn a_content_type_header_may_still_wrap_the_offer_in_multipart() {
+        // The other half of the same rule: a caller that assembles the
+        // multipart body itself and names it in `headers` keeps working,
+        // because what comes out does carry an offer.
+        let body = multipart_offer_body();
+        let mut params = params(offer(body));
+        params.headers = vec![(
+            "Content-Type".to_string(),
+            "multipart/mixed;boundary=siphon-1".to_string(),
+        )];
+        let invite = build(&params);
+        assert_eq!(
+            invite.headers.get("Content-Type").unwrap(),
+            "multipart/mixed;boundary=siphon-1"
+        );
+        assert_eq!(invite.body, body.as_bytes());
     }
 
     #[test]
@@ -38657,6 +38856,22 @@ mod originate_tests {
         assert!(invite.body.is_empty());
         assert_eq!(invite.headers.get("Content-Length").unwrap(), "0");
         assert!(!invite.headers.has("Content-Type"));
+    }
+
+    #[test]
+    fn an_anchored_originate_refuses_a_content_type_header() {
+        // An anchored originate carries no body, so a Content-Type from
+        // `headers` describes one that is not there.
+        let mut params = params(OriginateMedia::Anchor {
+            profile: "rtp_passthrough".to_string(),
+            ws_uri: None,
+        });
+        params.headers = vec![("Content-Type".to_string(), "application/sdp".to_string())];
+        let error = build_result(&params).expect_err("a body-less INVITE has no content type");
+        assert!(
+            matches!(&error, OriginateError::InvalidBody(_)),
+            "got: {error:?}"
+        );
     }
 
     #[test]

--- a/src/media/body.rs
+++ b/src/media/body.rs
@@ -1,0 +1,204 @@
+//! Finding the SDP in a SIP message body.
+//!
+//! The body of a message that carries an offer or an answer is not always SDP
+//! and nothing else. RFC 5621 §3 lets a UA carry the session description as one
+//! part of a `multipart/*` body, alongside parts SIP itself does not interpret:
+//! ISUP on a SIP-I trunk (RFC 3204), a PIDF-LO location object (RFC 6442), an
+//! operator-specific XML document. The session description is still there, one
+//! level down.
+//!
+//! Every surface that reaches for "the SDP" therefore has to ask the same
+//! question of a body, and the answer has to be the same everywhere — which is
+//! what this module is for.
+
+use crate::siprec::multipart::parse_multipart;
+
+/// The media type an SDP body is carried under.
+const SDP_MEDIA_TYPE: &str = "application/sdp";
+
+/// The bare media type of a `Content-Type` value: lowercased, with parameters
+/// (`;charset=…`, `;boundary=…`) and surrounding whitespace removed.
+///
+/// RFC 3261 §7.3.1 makes the type and subtype case-insensitive, so a peer
+/// spelling it `Application/SDP` means the same thing we do.
+pub fn media_type(content_type: &str) -> String {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+}
+
+/// Whether a `Content-Type` names SDP.
+pub fn is_sdp(content_type: &str) -> bool {
+    media_type(content_type) == SDP_MEDIA_TYPE
+}
+
+/// Whether a `Content-Type` names a multipart body.
+///
+/// `multipart/mixed` is the one SIP uses in practice, but `multipart/related`
+/// and `multipart/alternative` are equally legal and parse identically, so the
+/// test is on the type rather than on one subtype.
+pub fn is_multipart(content_type: &str) -> bool {
+    media_type(content_type).starts_with("multipart/")
+}
+
+/// The SDP a body carries: the body itself when the `Content-Type` is
+/// `application/sdp`, or the `application/sdp` part of a `multipart/*` body.
+///
+/// `Err` carries a human reason, and callers surface it verbatim — a content
+/// type that is neither, a multipart body that does not parse, and a multipart
+/// body with no SDP part in it are three different mistakes and the caller
+/// should be told which one they made.
+pub fn sdp_from_body(content_type: &str, body: &[u8]) -> Result<Vec<u8>, String> {
+    if is_sdp(content_type) {
+        return Ok(body.to_vec());
+    }
+    if !is_multipart(content_type) {
+        return Err(format!(
+            "Content-Type '{}' is neither {SDP_MEDIA_TYPE} nor a multipart body carrying one",
+            content_type.trim()
+        ));
+    }
+    let parts = parse_multipart(content_type, body)
+        .map_err(|error| format!("multipart body does not parse: {error}"))?;
+    parts
+        .iter()
+        .find(|part| is_sdp(&part.content_type))
+        .map(|part| part.body.clone())
+        .ok_or_else(|| format!("multipart body has no {SDP_MEDIA_TYPE} part"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A two-part body of the shape a SIP-I / PIDF-LO INVITE carries: the offer
+    /// plus one part SIP does not interpret.
+    fn multipart_body() -> &'static str {
+        concat!(
+            "--siphon-1\r\n",
+            "Content-Type: application/sdp\r\n",
+            "\r\n",
+            "v=0\r\n",
+            "o=- 1 1 IN IP4 198.51.100.10\r\n",
+            "s=-\r\n",
+            "c=IN IP4 198.51.100.10\r\n",
+            "t=0 0\r\n",
+            "m=audio 40000 RTP/AVP 0\r\n",
+            "\r\n--siphon-1\r\n",
+            "Content-Type: application/vnd.example+xml\r\n",
+            "\r\n",
+            "<additional-data/>\r\n",
+            "--siphon-1--\r\n",
+        )
+    }
+
+    #[test]
+    fn media_type_drops_parameters_and_case() {
+        assert_eq!(media_type("application/sdp"), "application/sdp");
+        assert_eq!(media_type("Application/SDP"), "application/sdp");
+        assert_eq!(
+            media_type("application/sdp; charset=utf-8"),
+            "application/sdp"
+        );
+        assert_eq!(
+            media_type(" multipart/mixed;boundary=siphon-1"),
+            "multipart/mixed"
+        );
+        assert_eq!(media_type(""), "");
+    }
+
+    #[test]
+    fn is_sdp_matches_the_type_not_a_prefix_of_it() {
+        assert!(is_sdp("application/sdp"));
+        assert!(is_sdp("APPLICATION/SDP;charset=utf-8"));
+        // A different type that merely starts the same way is not SDP.
+        assert!(!is_sdp("application/sdp-ng"));
+        assert!(!is_sdp("text/plain"));
+        assert!(!is_sdp(""));
+    }
+
+    #[test]
+    fn is_multipart_covers_every_multipart_subtype() {
+        assert!(is_multipart("multipart/mixed;boundary=siphon-1"));
+        assert!(is_multipart("MULTIPART/RELATED; boundary=\"x\""));
+        assert!(is_multipart("multipart/alternative;boundary=x"));
+        assert!(!is_multipart("application/sdp"));
+        assert!(!is_multipart(""));
+    }
+
+    #[test]
+    fn a_bare_sdp_body_is_its_own_sdp() {
+        let sdp = b"v=0\r\no=- 1 1 IN IP4 198.51.100.10\r\n";
+        assert_eq!(
+            sdp_from_body("application/sdp", sdp).expect("plain SDP"),
+            sdp.to_vec()
+        );
+    }
+
+    #[test]
+    fn a_multipart_body_yields_only_its_sdp_part() {
+        let extracted = sdp_from_body(
+            "multipart/mixed;boundary=siphon-1",
+            multipart_body().as_bytes(),
+        )
+        .expect("the SDP part is found");
+        let extracted = String::from_utf8(extracted).expect("SDP is text");
+
+        assert!(extracted.starts_with("v=0\r\n"), "got: {extracted:?}");
+        assert!(extracted.contains("m=audio 40000 RTP/AVP 0"));
+        // The point of extracting: nothing from the other part comes along, and
+        // neither does the MIME framing.
+        assert!(!extracted.contains("additional-data"));
+        assert!(!extracted.contains("--siphon-1"));
+        assert!(!extracted.contains("Content-Type"));
+    }
+
+    #[test]
+    fn the_sdp_part_is_found_wherever_it_sits_and_however_it_is_spelled() {
+        // RFC 5621 fixes no part order, and RFC 3261 §7.3.1 makes the media type
+        // case-insensitive — an SDP part that arrives second, spelled in caps,
+        // is still the SDP part.
+        let body = concat!(
+            "--b\r\n",
+            "Content-Type: application/vnd.example+xml\r\n",
+            "\r\n",
+            "<additional-data/>\r\n",
+            "--b\r\n",
+            "Content-Type: Application/SDP\r\n",
+            "\r\n",
+            "v=0\r\nm=audio 40000 RTP/AVP 0\r\n",
+            "--b--\r\n",
+        );
+        let extracted =
+            sdp_from_body("multipart/mixed;boundary=b", body.as_bytes()).expect("SDP part found");
+        assert!(String::from_utf8_lossy(&extracted).starts_with("v=0"));
+    }
+
+    #[test]
+    fn a_body_that_is_not_sdp_and_not_multipart_names_itself_in_the_error() {
+        let error = sdp_from_body("text/plain", b"hello").expect_err("not an SDP body");
+        assert!(error.contains("text/plain"), "message was: {error}");
+        assert!(error.contains("application/sdp"), "message was: {error}");
+    }
+
+    #[test]
+    fn a_multipart_body_with_no_sdp_part_is_distinct_from_one_that_does_not_parse() {
+        let no_sdp = concat!(
+            "--b\r\n",
+            "Content-Type: application/vnd.example+xml\r\n",
+            "\r\n",
+            "<additional-data/>\r\n",
+            "--b--\r\n",
+        );
+        let error =
+            sdp_from_body("multipart/mixed;boundary=b", no_sdp.as_bytes()).expect_err("no SDP");
+        assert!(error.contains("no application/sdp part"), "was: {error}");
+
+        // No boundary parameter at all: the body cannot even be split.
+        let error = sdp_from_body("multipart/mixed", no_sdp.as_bytes()).expect_err("unparseable");
+        assert!(error.contains("does not parse"), "was: {error}");
+    }
+}

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,3 +1,4 @@
-//! Media handling — SDP parsing, codec filtering.
+//! Media handling — SDP parsing, codec filtering, finding the SDP in a body.
 
+pub mod body;
 pub mod sdp;

--- a/src/script/api/b2bua.rs
+++ b/src/script/api/b2bua.rs
@@ -67,10 +67,25 @@ impl PyB2buaControl {
     ///
     /// Exactly one media plan is required, because an INVITE with no offer and
     /// no way to answer the callee's leaves a connected call with no audio:
-    ///   * `sdp="v=0..."` — your own offer, carried verbatim; or
+    ///   * `sdp="v=0..."` — your own offer, carried verbatim as
+    ///     `application/sdp`; or
+    ///   * `body=…, content_type=…` — the same slot with the type spelled out,
+    ///     for an INVITE whose offer travels as one part of a `multipart/*`
+    ///     body (RFC 5621 §3) beside a part SIP does not interpret: ISUP on a
+    ///     SIP-I trunk, a PIDF-LO location object, an operator-specific
+    ///     document. You assemble the multipart, siphon carries it verbatim and
+    ///     derives Content-Length from it. `body=` takes `str` or `bytes`, and
+    ///     `content_type=` defaults to `application/sdp` (so `body=` alone is
+    ///     `sdp=`); or
     ///   * `media=True` — siphon anchors the leg on the configured media
     ///     backend (siphon-rtp), so `rtpengine.play_media()`, DTMF and the
     ///     WebSocket tee all work against it.
+    ///
+    /// Whichever spelling, the body has to carry an SDP offer — bare
+    /// `application/sdp`, or a `multipart/*` with an `application/sdp` part in
+    /// it. One that carries none raises, because a callee that reads the INVITE
+    /// as offerless offers in its own 2xx and this plan has nothing to answer
+    /// that with (RFC 3261 §13.2.2.4).
     ///
     /// ```python
     /// call_id = b2bua.originate(
@@ -84,9 +99,9 @@ impl PyB2buaControl {
     /// ```
     ///
     /// Raises `ValueError` when the target/identity URIs do not parse, no route
-    /// exists, the media plan is not one the configured backend can serve, or
-    /// the B2BUA is not running — never a silent `None` for a call that was
-    /// never placed.
+    /// exists, the media plan is not one the configured backend can serve, the
+    /// body carries no offer, or the B2BUA is not running — never a silent
+    /// `None` for a call that was never placed.
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
         to,
@@ -102,6 +117,8 @@ impl PyB2buaControl {
         profile=None,
         ws_uri=None,
         timeout=30,
+        body=None,
+        content_type=None,
     ))]
     fn originate(
         &self,
@@ -118,28 +135,59 @@ impl PyB2buaControl {
         profile: Option<&str>,
         ws_uri: Option<&str>,
         timeout: u32,
+        body: Option<&Bound<'_, pyo3::types::PyAny>>,
+        content_type: Option<&str>,
     ) -> PyResult<String> {
         use pyo3::exceptions::PyValueError;
 
-        let media_plan = match (sdp, media) {
+        // `sdp=` and `body=` are one slot with two spellings — `sdp=` is the
+        // body carried as application/sdp, `body=` is the body with its type
+        // named — so supplying both leaves it ambiguous what goes on the wire.
+        let supplied_offer = match (sdp, body) {
+            (Some(_), Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "b2bua.originate takes either sdp= (an SDP offer) or body= (a body with its own content_type=), not both",
+                ));
+            }
+            (Some(_), None) if content_type.is_some() => {
+                return Err(PyValueError::new_err(
+                    "b2bua.originate content_type= goes with body= — sdp= is application/sdp by definition",
+                ));
+            }
+            (Some(sdp), None) => Some((sdp.as_bytes().to_vec(), "application/sdp".to_string())),
+            (None, Some(body)) => Some((
+                super::request::extract_body_bytes(body)?,
+                content_type.unwrap_or("application/sdp").to_string(),
+            )),
+            (None, None) => None,
+        };
+
+        let media_plan = match (supplied_offer, media) {
             (Some(_), true) => {
                 return Err(PyValueError::new_err(
-                    "b2bua.originate takes either sdp= (your own offer) or media=True (siphon anchors the leg), not both",
+                    "b2bua.originate takes either your own offer (sdp= / body=) or media=True (siphon anchors the leg), not both",
                 ));
             }
-            (Some(sdp), false) if sdp.trim().is_empty() => {
+            (Some((body, _)), false) if body.iter().all(u8::is_ascii_whitespace) => {
                 return Err(PyValueError::new_err(
-                    "b2bua.originate sdp= must not be empty",
+                    "b2bua.originate sdp= / body= must not be empty",
                 ));
             }
-            (Some(sdp), false) => crate::dispatcher::OriginateMedia::Offer(sdp.to_string()),
+            (Some((body, content_type)), false) => {
+                crate::dispatcher::OriginateMedia::Offer { body, content_type }
+            }
+            (None, true) if content_type.is_some() => {
+                return Err(PyValueError::new_err(
+                    "b2bua.originate content_type= needs body= — media=True sends an offerless INVITE",
+                ));
+            }
             (None, true) => crate::dispatcher::OriginateMedia::Anchor {
                 profile: profile.unwrap_or("rtp_passthrough").to_string(),
                 ws_uri: ws_uri.map(str::to_string),
             },
             (None, false) => {
                 return Err(PyValueError::new_err(
-                    "b2bua.originate needs a media plan: sdp= (your own offer) or media=True (siphon anchors the leg)",
+                    "b2bua.originate needs a media plan: sdp= / body= (your own offer) or media=True (siphon anchors the leg)",
                 ));
             }
         };

--- a/src/script/api/rtpengine.rs
+++ b/src/script/api/rtpengine.rs
@@ -2608,10 +2608,10 @@ fn lock_message(
     })
 }
 
-/// Extract the SDP body from a SIP message, handling multipart/mixed bodies.
+/// Extract the SDP body from a SIP message, handling multipart bodies.
 ///
-/// If the Content-Type is `multipart/mixed`, extracts the `application/sdp`
-/// part from the multipart body. Otherwise returns the raw body as-is.
+/// If the Content-Type is a `multipart/*`, extracts the `application/sdp` part
+/// from it (RFC 5621 §3). Otherwise returns the raw body as-is.
 pub(super) fn extract_sdp_body(message: &SipMessage) -> PyResult<Vec<u8>> {
     let body = &message.body;
     if body.is_empty() {
@@ -2627,25 +2627,12 @@ pub(super) fn extract_sdp_body(message: &SipMessage) -> PyResult<Vec<u8>> {
         .or_else(|| message.headers.get("c"))
         .unwrap_or(&empty_string);
 
-    if content_type
-        .to_ascii_lowercase()
-        .contains("multipart/mixed")
-    {
-        // Parse multipart body and extract the SDP part.
-        let parts =
-            crate::siprec::multipart::parse_multipart(content_type, body).map_err(|error| {
-                pyo3::exceptions::PyValueError::new_err(format!(
-                    "failed to parse multipart body: {error}"
-                ))
-            })?;
-        let sdp_part =
-            crate::siprec::multipart::find_part(&parts, "application/sdp").ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err(
-                    "multipart body has no application/sdp part",
-                )
-            })?;
-        Ok(sdp_part.body.clone())
+    if crate::media::body::is_multipart(content_type) {
+        crate::media::body::sdp_from_body(content_type, body)
+            .map_err(pyo3::exceptions::PyValueError::new_err)
     } else {
+        // Unchanged for every other body: handed over as-is, including one that
+        // arrived with no Content-Type at all.
         Ok(body.clone())
     }
 }

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -206,6 +206,8 @@ class _B2buaNamespace:
         profile=None,
         ws_uri=None,
         timeout=30,
+        body=None,
+        content_type=None,
     ):
         """Place an outbound call siphon owns, with no inbound INVITE behind it.
 
@@ -223,10 +225,21 @@ class _B2buaNamespace:
         Exactly one media plan is required — an INVITE with no offer and no way
         to answer the callee's would connect a call with no audio:
 
-        * ``sdp="v=0..."`` — your own offer, carried verbatim (any backend);
+        * ``sdp="v=0..."`` — your own offer, carried verbatim as
+          ``application/sdp`` (any backend);
+        * ``body=…, content_type=…`` — the same slot with the type spelled out,
+          for an INVITE whose offer travels as one part of a ``multipart/*``
+          body (RFC 5621 §3) beside a part SIP does not interpret: ISUP on a
+          SIP-I trunk, a PIDF-LO location object, an operator-specific document;
         * ``media=True`` — siphon anchors the leg on the configured media
           backend (siphon-rtp), so ``rtpengine.play_media()``, DTMF and the
           WebSocket tee all work against it.
+
+        Whichever spelling, the body must carry an SDP offer — bare
+        ``application/sdp``, or a ``multipart/*`` with an ``application/sdp``
+        part in it. One that carries none raises, because a callee that reads
+        the INVITE as offerless offers in its own 2xx and this plan has nothing
+        to answer that with (RFC 3261 §13.2.2.4).
 
         Args:
             to: called party — the Request-URI and the To URI.
@@ -243,21 +256,27 @@ class _B2buaNamespace:
             headers: dict of extra headers applied last. Dialog-defining headers
                 (Via/From/To/Call-ID/CSeq/Contact/…) are ignored — the stack owns
                 them.
-            sdp: your own SDP offer.
+            sdp: your own SDP offer, carried as ``application/sdp``.
             media: True to have siphon anchor the leg on the media backend.
             profile: media profile for ``media=True`` (default
                 ``"rtp_passthrough"``).
             ws_uri: per-call WebSocket bridge URI for ``media=True``.
             timeout: ring timeout in seconds; the call is CANCELled when it
                 elapses. 0 disables it.
+            body: the INVITE body, ``str`` or ``bytes`` — the offer itself, or a
+                multipart carrying it. Mutually exclusive with ``sdp``.
+            content_type: Content-Type for ``body`` (e.g.
+                ``"multipart/mixed;boundary=…"``). Defaults to
+                ``"application/sdp"``, which makes ``body`` identical to ``sdp``.
 
         Returns:
             str: the new leg's SIP Call-ID.
 
         Raises:
             ValueError: the URIs do not parse, no route exists, the media plan
-                is not one the configured backend can serve, or the B2BUA is not
-                running. Never a silent None for a call that was never placed.
+                is not one the configured backend can serve, the body carries no
+                offer, or the B2BUA is not running. Never a silent None for a
+                call that was never placed.
 
         Usage:
             @timer.every(seconds=60)
@@ -286,6 +305,8 @@ class _B2buaNamespace:
             profile,
             ws_uri,
             timeout,
+            body,
+            content_type,
         )
 
     def bridge(self, call_id, with_call_id, on_peer_hangup="hangup"):


### PR DESCRIPTION
Raised in #316. `originate` had one body slot, named `sdp`, so an INVITE whose offer rides inside a `multipart/*` body (RFC 5621 §3 — ISUP on SIP-I, PIDF-LO) could only be placed by passing the assembled multipart as `sdp=` and overwriting `Content-Type` through `headers=`. That worked as an accident of header ordering that nothing tested and nothing checked.

- `body=` / `content_type=` beside `sdp=`, on both surfaces (`b2bua.originate`, `args.body` on the control rail). `sdp=` unchanged; the new params are appended to the Python signature, so positional callers are unaffected. `str` or `bytes` from a script, JSON text on the rail (same limit `answer` / `progress` have).
- A body carrying no SDP is refused (`bad_request` / `ValueError`), re-checked after `headers=` is applied so rewriting `Content-Type` cannot strip the offer off the INVITE. Wrapping the offer in a multipart that does contain it still passes. **Behaviour change:** such an originate used to be placed, and connected mute (RFC 3261 §13.2.2.4).
- `last_sdp` on an originated leg records the SDP part only, not the whole multipart — it is what a later re-INVITE re-offers.
- New `media::body` owns the one "find the SDP in this body" rule; `extract_sdp_body` delegates to it and now handles any `multipart/*`, not just `multipart/mixed`.

Rebased onto #318. 4885 tests pass, clippy / fmt / `mkdocs --strict` clean, SDK suite 718. SIPp baseline and the mem-leak pair not run — nothing here is on the per-message datapath.
