### PR TITLE
fix(b2bua): name the re-offering party by its own tag, answer 488 when the media engine refuses an in-dialog offer, and carry received-from across a renegotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
 
 ### Fixed
 
+- **A re-INVITE or UPDATE from the callee no longer addresses the media engine as
+  the caller, and one the engine refuses is answered 488 instead of being
+  forwarded around the anchor.**
+
+  Three faults on the same path, each ending in media that nothing reports as
+  broken.
+
+  The tag naming the offering party fell back to the caller's tag whenever the
+  callee re-INVITEd on a session whose answerer tag had never been recorded. The
+  engine resolves the re-offering party *by* that tag, so the fallback did not
+  name the callee — it claimed to be the caller, and the rewritten SDP came back
+  describing the wrong leg. There is no safe substitute, so such a request is now
+  rejected with 488 (RFC 3261 §14.2; under §14.1 the offerer then keeps the
+  session it already had). The answer direction follows the same rule, except a
+  2xx cannot be refused: there the SDP is left unanchored and the gap logged
+  rather than quietly attributed to the wrong party. The caller-offers direction
+  is unchanged, including its empty answerer tag, which is load-bearing — on a
+  session with no recorded answerer, that 2xx is the first answer the engine sees.
+
+  When the engine refused an offer, the re-INVITE was forwarded anyway carrying
+  the offerer's own SDP, signalling both parties around the anchor with each given
+  the other's real address, and only a warning logged. It is now answered 488, and
+  the glare flag the path had already taken is released so the dialog does not
+  answer 491 to every later re-INVITE.
+
+  `received_from` is now filled on in-dialog offers and answers from the address
+  the request or response actually arrived from, as the initial offer already
+  does. The engine gates a leg's media ingress on the last hint it was given, so a
+  client that changed network mid-call (Wi-Fi to mobile data) stayed gated on its
+  old public address paired with its new port, and every packet from the new
+  address was dropped.
+
 - **A TCP or TLS send that has to open a new connection no longer holds up
   every other send while it connects.**
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -18806,44 +18806,45 @@ fn handle_b2bua_response(
                 let a_sip_call_id = &a_leg.dialog.call_id;
                 if let Some(session) = media_sessions.get(a_sip_call_id) {
                     if let Some(profile) = profiles.get(&session.profile) {
-                        // The answer comes from the opposite side of the offer.
-                        // In RTPEngine: from_tag = offerer, to_tag = answerer.
-                        let (answer_from, answer_to) = if is_a2b {
-                            // A→B re-INVITE: A offered (from_tag), B answers (to_tag)
-                            (
-                                session.from_tag.as_str(),
-                                session.to_tag.as_deref().unwrap_or(""),
-                            )
+                        // The answer comes from the opposite side of the offer, and the engine keys
+                        // the exchange on the offerer. A B→A answer must therefore name the callee
+                        // as offerer: the caller's tag would claim the exchange ran the other way
+                        // round and re-point the wrong leg's media. A 2xx cannot be refused, so when
+                        // the pair cannot be named the SDP is left alone and the gap is logged.
+                        if let Some((answer_from, answer_to)) = session.answer_tags(is_a2b) {
+                            let mut answer_flags = profile.answer.clone();
+                            // Pin the answering party's ingress to where its own 2xx arrived from,
+                            // as the offer side now does for the offerer.
+                            if answer_flags.carry_received_from {
+                                answer_flags.received_from = Some(response_source.ip());
+                            }
+                            match tokio::task::block_in_place(|| {
+                                tokio::runtime::Handle::current().block_on(rtpengine_set.answer(
+                                    session.rtpengine_id(),
+                                    answer_from,
+                                    answer_to,
+                                    &message.body,
+                                    &answer_flags,
+                                ))
+                            }) {
+                                Ok(rewritten_sdp) => {
+                                    message.body = rewritten_sdp;
+                                    message
+                                        .headers
+                                        .set("Content-Length", message.body.len().to_string());
+                                    debug!(call_id = %call_id, "RTPEngine: rewrote re-INVITE response SDP (answer)");
+                                }
+                                Err(error) => {
+                                    warn!(call_id = %call_id, "RTPEngine answer for re-INVITE failed: {error}");
+                                }
+                            }
                         } else {
-                            // B→A re-INVITE: B offered (to_tag), A answers (from_tag)
-                            (
-                                session
-                                    .to_tag
-                                    .as_deref()
-                                    .unwrap_or(session.from_tag.as_str()),
-                                session.from_tag.as_str(),
-                            )
-                        };
-                        let answer_flags = profile.answer.clone();
-                        match tokio::task::block_in_place(|| {
-                            tokio::runtime::Handle::current().block_on(rtpengine_set.answer(
-                                session.rtpengine_id(),
-                                answer_from,
-                                answer_to,
-                                &message.body,
-                                &answer_flags,
-                            ))
-                        }) {
-                            Ok(rewritten_sdp) => {
-                                message.body = rewritten_sdp;
-                                message
-                                    .headers
-                                    .set("Content-Length", message.body.len().to_string());
-                                debug!(call_id = %call_id, "RTPEngine: rewrote re-INVITE response SDP (answer)");
-                            }
-                            Err(error) => {
-                                warn!(call_id = %call_id, "RTPEngine answer for re-INVITE failed: {error}");
-                            }
+                            error!(
+                                call_id = %call_id,
+                                "re-INVITE from the callee answered on a media session with no \
+                                 recorded answerer tag — leaving the answer SDP unanchored rather \
+                                 than naming the caller to the media engine"
+                            );
                         }
                     }
                 }
@@ -19184,40 +19185,41 @@ fn handle_b2bua_response(
                 let a_sip_call_id = &a_leg.dialog.call_id;
                 if let Some(session) = media_sessions.get(a_sip_call_id) {
                     if let Some(profile) = profiles.get(&session.profile) {
-                        let (answer_from, answer_to) = if is_a2b {
-                            (
-                                session.from_tag.as_str(),
-                                session.to_tag.as_deref().unwrap_or(""),
-                            )
+                        // Same rule as the re-INVITE answer above: a B→A answer must name the callee
+                        // as offerer, and a 2xx cannot be refused, so an unnameable pair leaves the
+                        // SDP alone rather than attributing it to the wrong party.
+                        if let Some((answer_from, answer_to)) = session.answer_tags(is_a2b) {
+                            let mut answer_flags = profile.answer.clone();
+                            if answer_flags.carry_received_from {
+                                answer_flags.received_from = Some(response_source.ip());
+                            }
+                            match tokio::task::block_in_place(|| {
+                                tokio::runtime::Handle::current().block_on(rtpengine_set.answer(
+                                    session.rtpengine_id(),
+                                    answer_from,
+                                    answer_to,
+                                    &message.body,
+                                    &answer_flags,
+                                ))
+                            }) {
+                                Ok(rewritten_sdp) => {
+                                    message.body = rewritten_sdp;
+                                    message
+                                        .headers
+                                        .set("Content-Length", message.body.len().to_string());
+                                    debug!(call_id = %call_id, "RTPEngine: rewrote UPDATE response SDP (answer)");
+                                }
+                                Err(error) => {
+                                    warn!(call_id = %call_id, "RTPEngine answer for UPDATE failed: {error}");
+                                }
+                            }
                         } else {
-                            (
-                                session
-                                    .to_tag
-                                    .as_deref()
-                                    .unwrap_or(session.from_tag.as_str()),
-                                session.from_tag.as_str(),
-                            )
-                        };
-                        let answer_flags = profile.answer.clone();
-                        match tokio::task::block_in_place(|| {
-                            tokio::runtime::Handle::current().block_on(rtpengine_set.answer(
-                                session.rtpengine_id(),
-                                answer_from,
-                                answer_to,
-                                &message.body,
-                                &answer_flags,
-                            ))
-                        }) {
-                            Ok(rewritten_sdp) => {
-                                message.body = rewritten_sdp;
-                                message
-                                    .headers
-                                    .set("Content-Length", message.body.len().to_string());
-                                debug!(call_id = %call_id, "RTPEngine: rewrote UPDATE response SDP (answer)");
-                            }
-                            Err(error) => {
-                                warn!(call_id = %call_id, "RTPEngine answer for UPDATE failed: {error}");
-                            }
+                            error!(
+                                call_id = %call_id,
+                                "UPDATE from the callee answered on a media session with no \
+                                 recorded answerer tag — leaving the answer SDP unanchored rather \
+                                 than naming the caller to the media engine"
+                            );
                         }
                     }
                 }
@@ -26638,6 +26640,43 @@ fn handle_b2bua_prack(inbound: InboundMessage, message: SipMessage, state: &Disp
 ///
 /// Re-INVITEs are used for session timer refreshes (RFC 4028), hold/resume,
 /// and codec renegotiation. They are forwarded to the other leg transparently.
+/// Answer an in-dialog offer the media engine will not anchor with 488 Not Acceptable Here (RFC 3261
+/// §14.2; under §14.1 the offerer then keeps the session exactly as it was, which is the safe
+/// outcome). Forwarding the offer with its own SDP instead would route both parties around the
+/// anchor — each told the other's real address — and nothing downstream reports a fault.
+///
+/// `clear_pending_on_a_leg` names the leg whose glare flag the caller took before reaching this
+/// point (`Some(!from_a_leg)` on the re-INVITE path, `None` on UPDATE, which takes none): leaving it
+/// set would have the dialog answer 491 to every later re-INVITE.
+fn reject_unanchorable_offer(
+    message: &SipMessage,
+    inbound: &InboundMessage,
+    state: &DispatcherState,
+    call_id: &str,
+    clear_pending_on_a_leg: Option<bool>,
+) {
+    if let Some(on_a_leg) = clear_pending_on_a_leg {
+        state
+            .call_actors
+            .set_pending_reinvite(call_id, on_a_leg, false);
+    }
+    let response = build_response(
+        message,
+        488,
+        "Not Acceptable Here",
+        state.server_header.as_deref(),
+        &[],
+    );
+    send_message_from(
+        response,
+        inbound.transport,
+        inbound.remote_addr,
+        inbound.connection_id,
+        Some(inbound.local_addr),
+        state,
+    );
+}
+
 fn handle_b2bua_reinvite(inbound: InboundMessage, message: SipMessage, state: &DispatcherState) {
     let sip_call_id = message
         .headers
@@ -27052,16 +27091,34 @@ fn handle_b2bua_reinvite(inbound: InboundMessage, message: SipMessage, state: &D
                 let a_sip_call_id = &a_leg.dialog.call_id;
                 if let Some(session) = media_sessions.get(a_sip_call_id) {
                     if let Some(profile) = profiles.get(&session.profile) {
-                        // Use the tag of whichever side is sending the offer
-                        let offer_tag = if from_a_leg {
-                            session.from_tag.as_str()
-                        } else {
-                            session
-                                .to_tag
-                                .as_deref()
-                                .unwrap_or(session.from_tag.as_str())
+                        // The tag of whichever side is sending the offer. A re-offer from the callee
+                        // must carry the callee's own tag: the engine resolves the re-offering party
+                        // by tag and answers with the leg facing the *other* one, so substituting
+                        // the caller's tag does not identify the callee — it claims to be the caller
+                        // and comes back wired to the wrong leg.
+                        let Some(offer_tag) = session.offer_tag(from_a_leg) else {
+                            warn!(
+                                call_id = %call_id,
+                                "B2BUA re-INVITE from the callee on a media session with no \
+                                 recorded answerer tag — rejecting with 488 rather than naming the \
+                                 caller to the media engine"
+                            );
+                            reject_unanchorable_offer(
+                                &message,
+                                &inbound,
+                                state,
+                                &call_id,
+                                Some(!from_a_leg),
+                            );
+                            return;
                         };
-                        let offer_flags = profile.offer.clone();
+                        let mut offer_flags = profile.offer.clone();
+                        // Pin media ingress to where this re-INVITE actually came from, the way the
+                        // initial offer does: a client that changed network re-INVITEs from a new
+                        // public address, and the engine gates the leg on the last hint it was given.
+                        if offer_flags.carry_received_from {
+                            offer_flags.received_from = Some(inbound.remote_addr.ip());
+                        }
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(rtpengine_set.reoffer(
                                 session.rtpengine_id(),
@@ -27075,7 +27132,20 @@ fn handle_b2bua_reinvite(inbound: InboundMessage, message: SipMessage, state: &D
                                 debug!(call_id = %call_id, "RTPEngine: rewrote re-INVITE SDP (offer)");
                             }
                             Err(error) => {
-                                warn!(call_id = %call_id, "RTPEngine offer for re-INVITE failed: {error}");
+                                error!(
+                                    call_id = %call_id,
+                                    "RTPEngine offer for re-INVITE failed: {error} — rejecting the \
+                                     re-INVITE with 488 rather than forwarding SDP that routes both \
+                                     parties around the anchor"
+                                );
+                                reject_unanchorable_offer(
+                                    &message,
+                                    &inbound,
+                                    state,
+                                    &call_id,
+                                    Some(!from_a_leg),
+                                );
+                                return;
                             }
                         }
                     }
@@ -27584,15 +27654,22 @@ fn handle_b2bua_update(inbound: InboundMessage, message: SipMessage, state: &Dis
                 let a_sip_call_id = &a_leg.dialog.call_id;
                 if let Some(session) = media_sessions.get(a_sip_call_id) {
                     if let Some(profile) = profiles.get(&session.profile) {
-                        let offer_tag = if from_a_leg {
-                            session.from_tag.as_str()
-                        } else {
-                            session
-                                .to_tag
-                                .as_deref()
-                                .unwrap_or(session.from_tag.as_str())
+                        // Same tag rule as the re-INVITE path: an UPDATE from the callee needs the
+                        // callee's own tag, and there is no substitute for it.
+                        let Some(offer_tag) = session.offer_tag(from_a_leg) else {
+                            warn!(
+                                call_id = %call_id,
+                                "B2BUA UPDATE from the callee on a media session with no recorded \
+                                 answerer tag — rejecting with 488 rather than naming the caller to \
+                                 the media engine"
+                            );
+                            reject_unanchorable_offer(&message, &inbound, state, &call_id, None);
+                            return;
                         };
-                        let offer_flags = profile.offer.clone();
+                        let mut offer_flags = profile.offer.clone();
+                        if offer_flags.carry_received_from {
+                            offer_flags.received_from = Some(inbound.remote_addr.ip());
+                        }
                         match tokio::task::block_in_place(|| {
                             tokio::runtime::Handle::current().block_on(rtpengine_set.reoffer(
                                 session.rtpengine_id(),
@@ -27606,7 +27683,16 @@ fn handle_b2bua_update(inbound: InboundMessage, message: SipMessage, state: &Dis
                                 debug!(call_id = %call_id, "RTPEngine: rewrote UPDATE SDP (offer)");
                             }
                             Err(error) => {
-                                warn!(call_id = %call_id, "RTPEngine offer for UPDATE failed: {error}");
+                                error!(
+                                    call_id = %call_id,
+                                    "RTPEngine offer for UPDATE failed: {error} — rejecting the \
+                                     UPDATE with 488 rather than forwarding SDP that routes both \
+                                     parties around the anchor"
+                                );
+                                reject_unanchorable_offer(
+                                    &message, &inbound, state, &call_id, None,
+                                );
+                                return;
                             }
                         }
                     }

--- a/src/rtpengine/session.rs
+++ b/src/rtpengine/session.rs
@@ -65,6 +65,90 @@ impl MediaSession {
             &self.rtpengine_call_id
         }
     }
+
+    /// The tag naming the party that is **sending** an in-dialog offer, for the media engine's
+    /// re-offer: the A-leg's `from_tag` when the offer came from A, the B-leg's `to_tag` when it came
+    /// from B.
+    ///
+    /// `None` when B is offering on a session whose `to_tag` was never recorded. The engine resolves
+    /// the re-offering party *by tag*, so substituting A's tag there does not name B — it claims to be
+    /// A, and the engine then answers with the leg facing the wrong party and re-points that party's
+    /// media. There is no safe guess, so the caller refuses the request instead.
+    #[must_use]
+    pub fn offer_tag(&self, from_a_leg: bool) -> Option<&str> {
+        if from_a_leg {
+            Some(self.from_tag.as_str())
+        } else {
+            self.to_tag.as_deref()
+        }
+    }
+
+    /// The `(offerer, answerer)` tag pair naming both parties of an in-dialog **answer**; `is_a2b`
+    /// says the A-leg made the offer.
+    ///
+    /// The B→A direction returns `None` on a session with no recorded `to_tag`, for the reason
+    /// [`MediaSession::offer_tag`] gives — naming B is exactly what the pair is for. The A→B direction
+    /// keeps an empty answerer tag rather than refusing: on a session whose `to_tag` was never
+    /// recorded, that answer is the *first* one the engine sees for the original offer, and dropping
+    /// it would leave the call unanchored.
+    #[must_use]
+    pub fn answer_tags(&self, is_a2b: bool) -> Option<(&str, &str)> {
+        if is_a2b {
+            Some((self.from_tag.as_str(), self.to_tag.as_deref().unwrap_or("")))
+        } else {
+            Some((self.to_tag.as_deref()?, self.from_tag.as_str()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod media_session_tests {
+    use super::*;
+
+    fn session(to_tag: Option<&str>) -> MediaSession {
+        MediaSession {
+            call_id: "call-1".to_string(),
+            rtpengine_call_id: String::new(),
+            from_tag: "tag-a".to_string(),
+            to_tag: to_tag.map(str::to_string),
+            profile: "default".to_string(),
+            ws_uri: None,
+            ws_tee: None,
+            ws_bridge_attached: false,
+            created_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn offer_tag_names_the_offering_party() {
+        let answered = session(Some("tag-b"));
+        assert_eq!(answered.offer_tag(true), Some("tag-a"));
+        assert_eq!(answered.offer_tag(false), Some("tag-b"));
+    }
+
+    #[test]
+    fn an_offer_from_b_without_a_recorded_answerer_tag_has_no_tag_to_use() {
+        // The caller must refuse: A's tag would name the wrong party to the engine.
+        let unanswered = session(None);
+        assert_eq!(unanswered.offer_tag(true), Some("tag-a"));
+        assert_eq!(unanswered.offer_tag(false), None);
+    }
+
+    #[test]
+    fn answer_tags_put_the_offerer_first() {
+        let answered = session(Some("tag-b"));
+        assert_eq!(answered.answer_tags(true), Some(("tag-a", "tag-b")));
+        assert_eq!(answered.answer_tags(false), Some(("tag-b", "tag-a")));
+    }
+
+    #[test]
+    fn an_answer_to_b_without_a_recorded_answerer_tag_is_refused_only_in_the_b_to_a_direction() {
+        let unanswered = session(None);
+        // A→B keeps the empty answerer tag: this is the first answer the engine sees.
+        assert_eq!(unanswered.answer_tags(true), Some(("tag-a", "")));
+        // B→A cannot name the offerer at all.
+        assert_eq!(unanswered.answer_tags(false), None);
+    }
 }
 
 /// Thread-safe store of active media sessions, keyed by SIP Call-ID.


### PR DESCRIPTION
Three faults on the in-dialog media path, each ending in media that nothing reports as broken. They
are the control-plane half of siphon-project/siphon-rtp#260, which fixes the engine side of the same
exchange; this PR is what makes a callee-originated re-INVITE reach the engine correctly at all.

## The tag naming the offering party

`handle_b2bua_reinvite` and `handle_b2bua_update` chose the tag like this:

```rust
let offer_tag = if from_a_leg {
    session.from_tag.as_str()
} else {
    session.to_tag.as_deref().unwrap_or(session.from_tag.as_str())
};
```

The engine resolves the re-offering party *by* that tag. So on a session whose answerer tag was never
recorded, the fallback did not name the callee — it claimed to be the caller, and the SDP came back
describing the wrong leg, re-pointing the wrong party's media.

There is no safe substitute for the tag, so the choice moves onto `MediaSession` as `offer_tag` /
`answer_tags`, which return `None` for exactly that case, and the callers refuse rather than guess:

- a **request** is rejected with 488 Not Acceptable Here (RFC 3261 §14.2; under §14.1 the offerer then
  keeps the session it already had);
- a **2xx** cannot be refused, so the SDP is left unanchored and logged at error level rather than
  quietly attributed to the wrong party.

The caller-offers direction is deliberately unchanged, **including its empty answerer tag**. That is
load-bearing: on a session with no recorded answerer, that 2xx is the first answer the engine ever
sees for the original offer, and dropping it would leave the call unanchored. Only the direction that
genuinely cannot be named is refused.

## A refused offer was forwarded anyway

When the engine refused, the code warned and fell through — the re-INVITE went out carrying the
offerer's own SDP, so both parties were signalled around the anchor, each handed the other's real
address, and nothing downstream reported a fault. It is answered 488 now.

The refusal also releases the glare flag. The re-INVITE path takes `set_pending_reinvite` on the
target leg *before* the media block, so returning early without clearing it would leave the dialog
answering 491 to every later re-INVITE. The UPDATE path takes no such flag (RFC 3311 §5.2 has no glare
gate), so it has nothing to release.

## `received_from` on a renegotiation

It was filled only on the initial offer (`answer_first_prepare`, and the script API). Every in-dialog
offer and answer cloned the profile straight from YAML, where the address is deliberately `None`, so
the engine kept gating the leg on whatever hint it was last given. A client that changes network
mid-call — Wi-Fi to mobile data — was therefore gated on its *old* public address paired with its
*new* port, and every packet from the new address was dropped. Both directions now fill it from the
address the request or response actually arrived from (`inbound.remote_addr` / `response_source`),
using the same `carry_received_from` policy check as the initial offer.

## Tests

`MediaSession::offer_tag` / `answer_tags` ship with unit tests covering both directions, the refusal
case, and the deliberate A→B exception. Full suite green (4432 + 368 + 45 + 4 + 3 + 5 + 9 + 3 passed,
0 failed), clippy `--all-targets --all-features -D warnings` clean, `fmt --check` clean.

Worth stating plainly: the dispatcher-level behaviour — the 488 itself, the glare-flag release, and
the `received_from` fill — has **no** unit coverage, because there is no harness that drives
`handle_b2bua_reinvite` (the b2bua integration tests work against the stores, not the handler). The
tag decision was extracted specifically so the part that can be tested is. The end-to-end path is
covered by the SIPp `reoffer` scenario under `sipp/`, which is a manual acceptance run rather than CI.
