### PR TITLE
fix(diameter): honour send_request timeout_ms, drop the undispatched decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   request actually carried. The HSS-backed path (`auth.require_ims_digest()`)
   was unaffected.
 
+- **`diameter.send_request(timeout_ms=...)` is now honoured.** It was accepted,
+  documented as a per-request timeout, and discarded, so every call waited the
+  peer's fixed 10 s. Values below 100 ms are floored, matching `forward_to`, so
+  a `timeout_ms=0` cannot mean "give up before the request can be answered".
+
+### Removed
+
+- **The `@diameter.on_rtr` / `on_rar` / `on_asr` / `on_pnr` decorators.** They
+  registered handlers nothing dispatched: with `diameter:` configured they
+  raised `AttributeError` at import, and without it they registered a handler
+  that never fired. Use `@diameter.on_request` and match on
+  `req.command_name`. Not present in the SDK or the docs.
+
+### Fixed
+
 - **A `backend:` selector nothing dispatches to is now rejected at config
   load.** `registrar.backend: python` named `@registrar.on_save` /
   `@registrar.on_lookup` hooks that do not exist and silently behaved as

--- a/src/script/api/diameter.rs
+++ b/src/script/api/diameter.rs
@@ -829,6 +829,16 @@ fn credit_control_answer_to_dict<'py>(
     Ok(dict)
 }
 
+/// Clamp a script-supplied per-request timeout.
+///
+/// `forward_to` already floors its timeout, and for the same reason: a zero
+/// would otherwise mean "give up before the request can be answered", which is
+/// never what a script passing `timeout_ms=0` intends. The floor matches
+/// `forward_to`'s 100 ms.
+fn request_timeout(timeout_ms: u64) -> std::time::Duration {
+    std::time::Duration::from_millis(timeout_ms.max(100))
+}
+
 #[pymethods]
 impl PyDiameter {
     /// Check if a peer is connected.
@@ -1697,7 +1707,8 @@ impl PyDiameter {
     ///
     /// Used by an Application Server to subscribe (or unsubscribe) for
     /// notifications about a user's profile changes. The HSS will later push
-    /// updates via PNR — register a handler via ``@diameter.on_pnr``.
+    /// updates via PNR — handle them with ``@diameter.on_request`` and match
+    /// on ``req.command_name == "PNR"``.
     ///
     /// Args:
     ///     public_identity: Target user's public identity.
@@ -2002,8 +2013,6 @@ impl PyDiameter {
         timeout_ms: u64,
         avps: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Option<Bound<'py, PyDict>>> {
-        let _ = timeout_ms; // forwarded peer applies its own timeout today
-
         let command_code = dictionary::command_code_by_name(command).ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(format!(
                 "unknown Diameter command name: {command}"
@@ -2082,7 +2091,11 @@ impl PyDiameter {
             &avp_bytes,
         );
 
-        let answer = crate::script::detach_block_on(client.peer().send_request(wire));
+        let answer = crate::script::detach_block_on(
+            client
+                .peer()
+                .send_request_timeout(wire, request_timeout(timeout_ms)),
+        );
         let message = match answer {
             Ok(message) => message,
             Err(error) => {
@@ -3715,6 +3728,20 @@ mod tests {
                 "MSISDN must not be raw ASCII on the wire"
             );
         });
+    }
+
+    /// `timeout_ms` was accepted, documented as per-request, and then dropped
+    /// on the floor (`let _ = timeout_ms`), so every call waited the peer's
+    /// fixed 10 s. It now reaches `send_request_timeout`, with a floor so that
+    /// a zero cannot mean "give up before the request can be answered".
+    #[test]
+    fn request_timeout_honours_the_value_and_floors_zero() {
+        assert_eq!(request_timeout(2_000), std::time::Duration::from_secs(2));
+        assert_eq!(request_timeout(10_000), std::time::Duration::from_secs(10));
+        assert_eq!(request_timeout(150), std::time::Duration::from_millis(150));
+        // Floor, matching `forward_to`.
+        assert_eq!(request_timeout(0), std::time::Duration::from_millis(100));
+        assert_eq!(request_timeout(50), std::time::Duration::from_millis(100));
     }
 
     #[test]

--- a/src/script/api/siphon_package.py
+++ b/src/script/api/siphon_package.py
@@ -1123,92 +1123,20 @@ class _DiameterNamespace:
     """Stub diameter namespace with decorator support.
 
     When ``diameter:`` is configured, the Rust DiameterNamespace replaces this.
-    The ``@on_rtr`` decorator still needs to be available for registration even
-    before the Rust instance is injected (decorators run at import time).
+    The decorator still needs to be available for registration even before the
+    Rust instance is injected (decorators run at import time).
     """
 
     @staticmethod
-    def on_rtr(fn):
-        """Register handler for incoming RTR (Registration-Termination-Request).
+    def on_request(fn):
+        """Register a handler for any inbound Diameter request.
 
-        Handler receives (public_identity, reason_code, reason_info).
-        Siphon auto-sends RTA (result 2001) after the handler returns.
-
-        Reason codes: 0=PERMANENT_TERMINATION, 1=NEW_SERVER_ASSIGNED,
-                      2=SERVER_CHANGE, 3=REMOVE_SCSCF
-
-        Usage:
-            @diameter.on_rtr
-            def handle_rtr(public_identity, reason_code, reason_info):
-                registrar.remove(public_identity)
+        There are no per-command decorators: read ``req.command_name`` and
+        answer with ``req.answer(code)`` / ``req.reject(code)`` /
+        ``await req.forward_to(peer)``.
         """
         is_async = _asyncio.iscoroutinefunction(fn)
-        _registry.register("diameter.on_rtr", None, fn, is_async)
-        return fn
-
-    @staticmethod
-    def on_rar(fn):
-        """Register handler for incoming RAR (Re-Auth-Request) from PCRF.
-
-        Handler receives (session_id, abort_cause, specific_actions).
-        Siphon auto-sends RAA (result 2001) after the handler returns.
-
-        specific_actions is a list of int values (TS 29.214 Specific-Action):
-            1=CHARGING_CORRELATION_EXCHANGE
-            2=INDICATION_OF_LOSS_OF_BEARER
-            3=INDICATION_OF_RECOVERY_OF_BEARER
-            4=INDICATION_OF_RELEASE_OF_BEARER
-            6=INDICATION_OF_ESTABLISHMENT_OF_BEARER
-            7=IP_CAN_CHANGE
-
-        Usage:
-            @diameter.on_rar
-            def handle_rar(session_id, abort_cause, specific_actions):
-                if 2 in specific_actions:
-                    log.warn(f"Bearer lost for session {session_id}")
-        """
-        is_async = _asyncio.iscoroutinefunction(fn)
-        _registry.register("diameter.on_rar", None, fn, is_async)
-        return fn
-
-    @staticmethod
-    def on_asr(fn):
-        """Register handler for incoming ASR (Abort-Session-Request) from PCRF.
-
-        Handler receives (session_id, abort_cause, origin_host).
-        Siphon auto-sends ASA (result 2001) after the handler returns.
-
-        abort_cause values (TS 29.214):
-            0=BEARER_RELEASED
-            1=INSUFFICIENT_SERVER_RESOURCES
-            2=INSUFFICIENT_BEARER_RESOURCES
-
-        Usage:
-            @diameter.on_asr
-            def handle_asr(session_id, abort_cause, origin_host):
-                log.info(f"Session abort from {origin_host}: {session_id}")
-        """
-        is_async = _asyncio.iscoroutinefunction(fn)
-        _registry.register("diameter.on_asr", None, fn, is_async)
-        return fn
-
-    @staticmethod
-    def on_pnr(fn):
-        """Register handler for incoming Sh PNR (Push-Notification-Request) from HSS.
-
-        Handler receives (public_identity, user_data_xml).
-        Siphon auto-sends PNA (result 2001) after the handler returns.
-
-        The HSS sends PNR when a user's profile changes (simservs edit,
-        iFC update, etc.) after the AS subscribed via ``diameter.sh_snr``.
-
-        Usage:
-            @diameter.on_pnr
-            def handle_pnr(public_identity, user_data_xml):
-                cache.put("simservs", public_identity, user_data_xml)
-        """
-        is_async = _asyncio.iscoroutinefunction(fn)
-        _registry.register("diameter.on_pnr", None, fn, is_async)
+        _registry.register("diameter.on_request", None, fn, is_async)
         return fn
 
 


### PR DESCRIPTION
Stacked on #320.

- `send_request(timeout_ms=)` was accepted, documented as per-request, then discarded (`let _ = timeout_ms`), so every call waited the peer's fixed 10s. Now reaches `send_request_timeout`, floored at 100ms to match `forward_to`.
- Removed `@diameter.on_rtr` / `on_rar` / `on_asr` / `on_pnr`. They registered handlers nothing dispatched: `AttributeError` at import with `diameter:` configured, silently never firing without it. Use `@diameter.on_request` + `req.command_name`. Absent from the SDK and docs, so no mirror needed.

Full suite + SDK green, clippy and fmt clean. Note: `transport_tests::ws_roundtrip` flaked once under parallel run, passes 3/3 isolated and on re-run; it's the known TOCTOU-flaky test, not from this change.