### PR TITLE
fix(transport): bind listeners before spawning the accept task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   request actually carried. The HSS-backed path (`auth.require_ims_digest()`)
   was unaffected.
 
+- **Stream listeners now bind before returning.** `tcp`, `tls`, `ws`, `wss` and
+  the protocol mux all bound inside the spawned accept task, so `listen()`
+  returned before the socket existed: a peer connecting in that window was
+  refused for no reason but scheduling, and a bind failure surfaced only as a
+  log line while the caller carried on believing the listener was up. The bind
+  now happens before the spawn, so awaiting `listen` means the socket is
+  accepting.
+
 - **The criterion gate no longer skips benchmarks silently.** It iterates the
   baseline's ids, so a benchmark with no baseline row ran and was never
   compared — `framing/*` and `traffic_counters/*` had been ungated since they

--- a/src/li/x2.rs
+++ b/src/li/x2.rs
@@ -882,11 +882,13 @@ mod tests {
     /// cost that record.
     #[tokio::test]
     async fn a_collector_that_accepts_late_still_gets_the_first_record() {
-        // Claim a port, then release it, so the address is real but nothing is
-        // listening when the first record is delivered.
-        let scout = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let address = scout.local_addr().expect("addr");
-        drop(scout);
+        // The address has to be real but unbound: the point is that nothing is
+        // listening when the first record is delivered. Port 0 would put it in
+        // the kernel's ephemeral range, where any outbound socket in this
+        // process can claim it in the window before the rebind below — which is
+        // what made this test flap. `free_port` hands out from a reserved range
+        // the kernel never auto-assigns.
+        let address = crate::transport::testutil::free_port();
 
         let config = Arc::new(LiX2Config {
             delivery_address: address.to_string(),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -29,10 +29,11 @@ pub(crate) mod testutil {
     /// * the kernel auto-assigns from the ephemeral range (32768-60999 here),
     ///   so between the probe closing and the real bind, any outbound socket in
     ///   this process can take that exact port, and
-    /// * `listen()` binds on a **spawned task** and merely logs on failure, so
-    ///   the caller never learns. The test then sits waiting on a listener that
-    ///   was never created and fails as a connect timeout, pointing at the
-    ///   wrong thing entirely.
+    /// * `listen()` used to bind on a **spawned task**, so the caller returned
+    ///   before the socket existed and a connect could be refused for no reason
+    ///   but scheduling. The listeners now bind before spawning, so awaiting
+    ///   `listen` means the socket is accepting; this helper still matters for
+    ///   the collision above.
     ///
     /// Handing out ports from a counter *below* the ephemeral range removes the
     /// collision at its source: nothing is auto-assigned there, so only an

--- a/src/transport/mux.rs
+++ b/src/transport/mux.rs
@@ -112,16 +112,22 @@ pub async fn listen(
     let sip_connection_map = channels.sip_connection_map;
     let websocket_connection_map = channels.websocket_connection_map;
 
-    tokio::spawn(async move {
-        let listener = match bind_tcp_listener(local_addr, tos) {
-            Ok(listener) => listener,
-            Err(error) => {
-                tracing::error!("failed to bind {sip_transport}+{websocket_transport} mux listener on {local_addr}: {error}");
-                return;
-            }
-        };
-        info!("{sip_transport}+{websocket_transport} mux listener on {local_addr}");
+    // Bind before spawning, so that awaiting `listen` means the socket is
+    // already accepting. With the bind inside the task, the caller returned
+    // first and the listener appeared whenever the runtime got round to it —
+    // a peer (or a test) could connect in between and be refused. It also
+    // means a bind failure is ordered before the caller continues instead of
+    // surfacing as a listener that silently never exists.
+    let listener = match bind_tcp_listener(local_addr, tos) {
+        Ok(listener) => listener,
+        Err(error) => {
+            tracing::error!("failed to bind {sip_transport}+{websocket_transport} mux listener on {local_addr}: {error}");
+            return;
+        }
+    };
+    info!("{sip_transport}+{websocket_transport} mux listener on {local_addr}");
 
+    tokio::spawn(async move {
         loop {
             let (tcp_stream, remote_addr) = match listener.accept().await {
                 Ok(accepted) => accepted,

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -54,16 +54,22 @@ pub async fn listen(
     // Route header pointed at a destination with no live inbound connection.
     spawn_outbound_distributor(outbound_rx, connection_map.clone(), Transport::Tcp, pool);
 
-    tokio::spawn(async move {
-        let listener = match bind_tcp_listener(local_addr, tos) {
-            Ok(listener) => listener,
-            Err(error) => {
-                error!("failed to bind TCP listener to {local_addr}: {error}");
-                return;
-            }
-        };
-        info!("TCP listener on {}", local_addr);
+    // Bind before spawning, so that awaiting `listen` means the socket is
+    // already accepting. With the bind inside the task, the caller returned
+    // first and the listener appeared whenever the runtime got round to it —
+    // a peer (or a test) could connect in between and be refused. It also
+    // means a bind failure is ordered before the caller continues instead of
+    // surfacing as a listener that silently never exists.
+    let listener = match bind_tcp_listener(local_addr, tos) {
+        Ok(listener) => listener,
+        Err(error) => {
+            error!("failed to bind TCP listener to {local_addr}: {error}");
+            return;
+        }
+    };
+    info!("TCP listener on {}", local_addr);
 
+    tokio::spawn(async move {
         loop {
             match listener.accept().await {
                 Ok((mut socket, remote_addr)) => {

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -527,16 +527,22 @@ pub async fn listen(
     // create a new outbound TLS connection (registrant, probes, etc.).
     spawn_outbound_distributor(outbound_rx, connection_map.clone(), Transport::Tls, pool);
 
-    tokio::spawn(async move {
-        let listener = match bind_tcp_listener(local_addr, tos) {
-            Ok(listener) => listener,
-            Err(error) => {
-                error!("failed to bind TLS listener on {local_addr}: {error}");
-                return;
-            }
-        };
-        info!("TLS listener on {}", local_addr);
+    // Bind before spawning, so that awaiting `listen` means the socket is
+    // already accepting. With the bind inside the task, the caller returned
+    // first and the listener appeared whenever the runtime got round to it —
+    // a peer (or a test) could connect in between and be refused. It also
+    // means a bind failure is ordered before the caller continues instead of
+    // surfacing as a listener that silently never exists.
+    let listener = match bind_tcp_listener(local_addr, tos) {
+        Ok(listener) => listener,
+        Err(error) => {
+            error!("failed to bind TLS listener on {local_addr}: {error}");
+            return;
+        }
+    };
+    info!("TLS listener on {}", local_addr);
 
+    tokio::spawn(async move {
         loop {
             match listener.accept().await {
                 Ok((tcp_stream, remote_addr)) => {

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -238,16 +238,22 @@ pub async fn listen(
         None,
     );
 
-    tokio::spawn(async move {
-        let listener = match bind_tcp_listener(local_addr, tos) {
-            Ok(listener) => listener,
-            Err(error) => {
-                error!("failed to bind WS listener on {local_addr}: {error}");
-                return;
-            }
-        };
-        info!("WS listener on {}", local_addr);
+    // Bind before spawning, so that awaiting `listen` means the socket is
+    // already accepting. With the bind inside the task, the caller returned
+    // first and the listener appeared whenever the runtime got round to it —
+    // a peer (or a test) could connect in between and be refused. It also
+    // means a bind failure is ordered before the caller continues instead of
+    // surfacing as a listener that silently never exists.
+    let listener = match bind_tcp_listener(local_addr, tos) {
+        Ok(listener) => listener,
+        Err(error) => {
+            error!("failed to bind WS listener on {local_addr}: {error}");
+            return;
+        }
+    };
+    info!("WS listener on {}", local_addr);
 
+    tokio::spawn(async move {
         loop {
             match listener.accept().await {
                 Ok((tcp_stream, remote_addr)) => {
@@ -324,16 +330,22 @@ pub async fn listen_secure(
         None,
     );
 
-    tokio::spawn(async move {
-        let listener = match bind_tcp_listener(local_addr, tos) {
-            Ok(listener) => listener,
-            Err(error) => {
-                error!("failed to bind WSS listener on {local_addr}: {error}");
-                return;
-            }
-        };
-        info!("WSS listener on {}", local_addr);
+    // Bind before spawning, so that awaiting `listen` means the socket is
+    // already accepting. With the bind inside the task, the caller returned
+    // first and the listener appeared whenever the runtime got round to it —
+    // a peer (or a test) could connect in between and be refused. It also
+    // means a bind failure is ordered before the caller continues instead of
+    // surfacing as a listener that silently never exists.
+    let listener = match bind_tcp_listener(local_addr, tos) {
+        Ok(listener) => listener,
+        Err(error) => {
+            error!("failed to bind WSS listener on {local_addr}: {error}");
+            return;
+        }
+    };
+    info!("WSS listener on {}", local_addr);
 
+    tokio::spawn(async move {
         loop {
             match listener.accept().await {
                 Ok((tcp_stream, remote_addr)) => {


### PR DESCRIPTION
Stacked on #323.

The suite had two intermittent failures (`transport_tests::ws_roundtrip`, `li::x2::tests::a_collector_that_accepts_late_still_gets_the_first_record`). Both had real causes, and one of them is a production defect rather than a test problem.

**Listeners bound inside the spawned accept task.** `tcp`, `tls`, `ws`, `wss` and the protocol mux all did `tokio::spawn(async move { let listener = bind_tcp_listener(...) ... })`, so `listen()` returned before the socket existed. Two consequences:

- A peer connecting in that window is refused for no reason but scheduling. That is what the test hit under load — "never became connectable within 3s: Connection refused" — and what a real client can hit against a busy box during startup.
- A bind failure logs and exits the task, so the caller carries on believing the listener is up. A failed WS bind leaves siphon running with no WS listener and only a log line.

The bind now happens before the spawn, so awaiting `listen` means the socket is accepting and a bind failure is ordered before the caller continues.

This was already diagnosed once: the doc comment on `transport::testutil::free_port` describes both hazards, including "`listen()` binds on a spawned task and merely logs on failure, so the caller never learns". The helper was written; the underlying listener was never fixed. Doc updated to match.

**The X2 test used the pattern that helper exists to avoid** — bind port 0, drop, rebind 300ms later. Port 0 lands in the kernel's ephemeral range, so anything in the process can claim it in the window. Now uses the reserved-range helper.

Verified by five consecutive full-suite runs, zero failures. Before the change I hit a flake in two of four runs.

clippy and fmt green.
