### PR TITLE
fix(transport): fail startup when a configured listener cannot bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ the `siphon-sip` crate and the `siphon-sip` Python SDK, driven by the git tag.
   request actually carried. The HSS-backed path (`auth.require_ims_digest()`)
   was unaffected.
 
+- **A listener that cannot bind now fails startup instead of logging.**
+  `tcp`, `tls`, `ws`, `wss` and the mux returned `()` and reported a failed bind
+  through `error!`, so siphon came up reporting healthy while silently missing a
+  transport — an operator learned of it from a customer. `listen()` now returns
+  `io::Result<()>` and a failed bind on a configured listener exits, naming the
+  transport and address, the way every other SIP proxy behaves.
+
 - **Stream listeners now bind before returning.** `tcp`, `tls`, `ws`, `wss` and
   the protocol mux all bound inside the spawned accept task, so `listen()`
   returned before the socket existed: a peer connecting in that window was

--- a/src/server.rs
+++ b/src/server.rs
@@ -1619,7 +1619,10 @@ impl SiphonServer {
                 continue; // served by the TCP+WS mux listener below
             }
             info!(addr = %addr, dscp = ?dscp, "starting TCP transport");
-            transport::tcp::listen(
+            // A configured listener that cannot bind is fatal. Coming up
+            // "healthy" while silently missing a transport is how an operator
+            // learns of it from a customer instead of from us.
+            if let Err(error) = transport::tcp::listen(
                 addr,
                 inbound_tx.clone(),
                 tcp_outbound_rx.clone(),
@@ -1630,7 +1633,11 @@ impl SiphonServer {
                 crlf_pong_tracker.clone(),
                 connection_close_tx.clone(),
             )
-            .await;
+            .await
+            {
+                error!(%addr, "failed to bind TCP listener: {error}");
+                std::process::exit(1);
+            }
         }
 
         if let Some(ref tls_config) = config.tls {
@@ -1660,7 +1667,10 @@ impl SiphonServer {
                 }
                 let tos = resolve_tos(entry);
                 info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting TLS transport");
-                transport::tls::listen(
+                // A configured listener that cannot bind is fatal. Coming up
+                // "healthy" while silently missing a transport is how an operator
+                // learns of it from a customer instead of from us.
+                if let Err(error) = transport::tls::listen(
                     addr,
                     tls_config,
                     inbound_tx.clone(),
@@ -1673,7 +1683,11 @@ impl SiphonServer {
                     crlf_pong_tracker.clone(),
                     connection_close_tx.clone(),
                 )
-                .await;
+                .await
+                {
+                    error!(%addr, "failed to bind TLS listener: {error}");
+                    std::process::exit(1);
+                }
             }
         }
 
@@ -1704,7 +1718,10 @@ impl SiphonServer {
             }
             let tos = resolve_tos(entry);
             info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting WS transport");
-            transport::ws::listen(
+            // A configured listener that cannot bind is fatal. Coming up
+            // "healthy" while silently missing a transport is how an operator
+            // learns of it from a customer instead of from us.
+            if let Err(error) = transport::ws::listen(
                 addr,
                 inbound_tx.clone(),
                 ws_outbound_rx.clone(),
@@ -1714,7 +1731,11 @@ impl SiphonServer {
                 tos,
                 connection_close_tx.clone(),
             )
-            .await;
+            .await
+            {
+                error!(%addr, "failed to bind WS listener: {error}");
+                std::process::exit(1);
+            }
         }
 
         // WSS
@@ -1745,7 +1766,10 @@ impl SiphonServer {
                 }
                 let tos = resolve_tos(entry);
                 info!(addr = %addr, dscp = ?entry.dscp().or(global_dscp), "starting WSS transport");
-                transport::ws::listen_secure(
+                // A configured listener that cannot bind is fatal. Coming up
+                // "healthy" while silently missing a transport is how an operator
+                // learns of it from a customer instead of from us.
+                if let Err(error) = transport::ws::listen_secure(
                     addr,
                     tls_config,
                     inbound_tx.clone(),
@@ -1756,7 +1780,11 @@ impl SiphonServer {
                     tos,
                     connection_close_tx.clone(),
                 )
-                .await;
+                .await
+                {
+                    error!(%addr, "failed to bind WSS listener: {error}");
+                    std::process::exit(1);
+                }
             }
         }
 
@@ -1774,7 +1802,10 @@ impl SiphonServer {
             }
             info!(addr = %addr, dscp = ?tcp_listen[&addr].dscp().or(global_dscp),
                 "starting TCP+WS mux transport");
-            transport::mux::listen(
+            // A configured listener that cannot bind is fatal. Coming up
+            // "healthy" while silently missing a transport is how an operator
+            // learns of it from a customer instead of from us.
+            if let Err(error) = transport::mux::listen(
                 addr,
                 None,
                 transport::mux::MuxChannels {
@@ -1791,7 +1822,11 @@ impl SiphonServer {
                 crlf_pong_tracker.clone(),
                 connection_close_tx.clone(),
             )
-            .await;
+            .await
+            {
+                error!(%addr, "failed to bind mux listener: {error}");
+                std::process::exit(1);
+            }
         }
         if let Some(ref tls_config) = config.tls {
             for addr in tls_wss_mux {
@@ -1803,7 +1838,10 @@ impl SiphonServer {
                 }
                 info!(addr = %addr, dscp = ?tls_listen[&addr].dscp().or(global_dscp),
                     "starting TLS+WSS mux transport");
-                transport::mux::listen(
+                // A configured listener that cannot bind is fatal. Coming up
+                // "healthy" while silently missing a transport is how an operator
+                // learns of it from a customer instead of from us.
+                if let Err(error) = transport::mux::listen(
                     addr,
                     Some(tls_config),
                     transport::mux::MuxChannels {
@@ -1820,7 +1858,11 @@ impl SiphonServer {
                     crlf_pong_tracker.clone(),
                     connection_close_tx.clone(),
                 )
-                .await;
+                .await
+                {
+                    error!(%addr, "failed to bind mux listener: {error}");
+                    std::process::exit(1);
+                }
             }
         }
 

--- a/src/transport/mux.rs
+++ b/src/transport/mux.rs
@@ -78,7 +78,7 @@ pub async fn listen(
     pool: Option<Arc<ConnectionPool>>,
     crlf_pong_tracker: Option<Arc<CrlfPongTracker>>,
     close_tx: Option<flume::Sender<u64>>,
-) {
+) -> std::io::Result<()> {
     let secure = tls_config.is_some();
     let (sip_transport, websocket_transport) = if secure {
         (Transport::Tls, Transport::WebSocketSecure)
@@ -118,13 +118,7 @@ pub async fn listen(
     // a peer (or a test) could connect in between and be refused. It also
     // means a bind failure is ordered before the caller continues instead of
     // surfacing as a listener that silently never exists.
-    let listener = match bind_tcp_listener(local_addr, tos) {
-        Ok(listener) => listener,
-        Err(error) => {
-            tracing::error!("failed to bind {sip_transport}+{websocket_transport} mux listener on {local_addr}: {error}");
-            return;
-        }
-    };
+    let listener = bind_tcp_listener(local_addr, tos)?;
     info!("{sip_transport}+{websocket_transport} mux listener on {local_addr}");
 
     tokio::spawn(async move {
@@ -227,6 +221,8 @@ pub async fn listen(
             });
         }
     });
+
+    Ok(())
 }
 
 /// Sniff one accepted (and, for `tls`/`wss`, already-decrypted) stream and run
@@ -383,7 +379,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("mux listener must bind");
         // listen() binds inside a spawned task.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -44,7 +44,7 @@ pub async fn listen(
     pool: Option<Arc<ConnectionPool>>,
     crlf_pong_tracker: Option<Arc<CrlfPongTracker>>,
     close_tx: Option<flume::Sender<u64>>,
-) {
+) -> std::io::Result<()> {
     // Distribute outbound messages to per-connection senders. When no existing
     // connection matches (`ConnectionId::default()` from fire-and-forget UAC
     // sends, or a connection that has since closed), the distributor falls back
@@ -60,13 +60,7 @@ pub async fn listen(
     // a peer (or a test) could connect in between and be refused. It also
     // means a bind failure is ordered before the caller continues instead of
     // surfacing as a listener that silently never exists.
-    let listener = match bind_tcp_listener(local_addr, tos) {
-        Ok(listener) => listener,
-        Err(error) => {
-            error!("failed to bind TCP listener to {local_addr}: {error}");
-            return;
-        }
-    };
+    let listener = bind_tcp_listener(local_addr, tos)?;
     info!("TCP listener on {}", local_addr);
 
     tokio::spawn(async move {
@@ -145,6 +139,8 @@ pub async fn listen(
             }
         }
     });
+
+    Ok(())
 }
 
 /// Determine the total length of a complete SIP message in the buffer.
@@ -813,7 +809,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("tcp listener must bind");
         // listen() binds inside a spawned task.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         (addr, inbound_rx)

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -516,7 +516,7 @@ pub async fn listen(
     pool: Option<Arc<ConnectionPool>>,
     crlf_pong_tracker: Option<Arc<CrlfPongTracker>>,
     close_tx: Option<flume::Sender<u64>>,
-) {
+) -> std::io::Result<()> {
     let acceptor = build_hot_reload_acceptor(tls_config).unwrap_or_else(|error| {
         eprintln!("Failed to build TLS acceptor: {error}");
         std::process::exit(1);
@@ -533,13 +533,7 @@ pub async fn listen(
     // a peer (or a test) could connect in between and be refused. It also
     // means a bind failure is ordered before the caller continues instead of
     // surfacing as a listener that silently never exists.
-    let listener = match bind_tcp_listener(local_addr, tos) {
-        Ok(listener) => listener,
-        Err(error) => {
-            error!("failed to bind TLS listener on {local_addr}: {error}");
-            return;
-        }
-    };
+    let listener = bind_tcp_listener(local_addr, tos)?;
     info!("TLS listener on {}", local_addr);
 
     tokio::spawn(async move {
@@ -657,6 +651,8 @@ pub async fn listen(
             }
         }
     });
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -956,7 +952,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("tls listener must bind");
 
         // We need the actual bound port. Since listen() binds inside a spawned task,
         // give it a moment to bind.
@@ -1008,7 +1005,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("tls listener must bind");
 
         // Give the listener time to bind
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -1085,7 +1083,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("tls listener must bind");
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -230,7 +230,7 @@ pub async fn listen(
     stream_connections: StreamConnections,
     tos: Option<u32>,
     close_tx: Option<flume::Sender<u64>>,
-) {
+) -> std::io::Result<()> {
     spawn_outbound_distributor(
         outbound_rx,
         connection_map.clone(),
@@ -244,13 +244,7 @@ pub async fn listen(
     // a peer (or a test) could connect in between and be refused. It also
     // means a bind failure is ordered before the caller continues instead of
     // surfacing as a listener that silently never exists.
-    let listener = match bind_tcp_listener(local_addr, tos) {
-        Ok(listener) => listener,
-        Err(error) => {
-            error!("failed to bind WS listener on {local_addr}: {error}");
-            return;
-        }
-    };
+    let listener = bind_tcp_listener(local_addr, tos)?;
     info!("WS listener on {}", local_addr);
 
     tokio::spawn(async move {
@@ -302,6 +296,8 @@ pub async fn listen(
             }
         }
     });
+
+    Ok(())
 }
 
 /// Spawn a secure WebSocket (WSS) listener. Reuses the TLS cert from
@@ -316,7 +312,7 @@ pub async fn listen_secure(
     stream_connections: StreamConnections,
     tos: Option<u32>,
     close_tx: Option<flume::Sender<u64>>,
-) {
+) -> std::io::Result<()> {
     let acceptor =
         crate::transport::tls::build_hot_reload_acceptor(tls_config).unwrap_or_else(|error| {
             eprintln!("Failed to build TLS acceptor for WSS: {error}");
@@ -336,13 +332,7 @@ pub async fn listen_secure(
     // a peer (or a test) could connect in between and be refused. It also
     // means a bind failure is ordered before the caller continues instead of
     // surfacing as a listener that silently never exists.
-    let listener = match bind_tcp_listener(local_addr, tos) {
-        Ok(listener) => listener,
-        Err(error) => {
-            error!("failed to bind WSS listener on {local_addr}: {error}");
-            return;
-        }
-    };
+    let listener = bind_tcp_listener(local_addr, tos)?;
     info!("WSS listener on {}", local_addr);
 
     tokio::spawn(async move {
@@ -420,6 +410,8 @@ pub async fn listen_secure(
             }
         }
     });
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -451,7 +443,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("ws listener must bind");
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Connect as a WebSocket client
@@ -516,7 +509,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("ws listener must bind");
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let url = format!("ws://127.0.0.1:{}", addr.port());
@@ -580,7 +574,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("ws listener must bind");
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let mut request = format!("ws://127.0.0.1:{}", addr.port())
@@ -620,7 +615,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("ws listener must bind");
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let url = format!("ws://127.0.0.1:{}", addr.port());
@@ -671,7 +667,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("ws listener must bind");
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let url = format!("ws://127.0.0.1:{}", addr.port());
@@ -720,7 +717,8 @@ mod tests {
             None,
             None,
         )
-        .await;
+        .await
+        .expect("ws listener must bind");
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Build a TLS client config that trusts our self-signed cert

--- a/tests/integration/transport_tests.rs
+++ b/tests/integration/transport_tests.rs
@@ -27,6 +27,38 @@ fn test_acl() -> Arc<TransportAcl> {
     Arc::new(TransportAcl::new(vec![], vec![]))
 }
 
+/// A bind that cannot succeed has to reach the caller.
+///
+/// It used to be logged inside the spawned accept task and swallowed, so
+/// `listen()` returned as if all was well and the socket simply never existed.
+/// An operator got one `error!` line and a node that looked healthy while
+/// missing a transport; a test got a connect timeout pointing at the wrong
+/// thing entirely. Port 1 is privileged, so this bind always fails unprivileged.
+#[tokio::test]
+async fn bind_failure_reaches_the_caller() {
+    let privileged: SocketAddr = "127.0.0.1:1".parse().expect("addr");
+    let (inbound_tx, _inbound_rx) = flume::unbounded();
+    let (_outbound_tx, outbound_rx) = flume::unbounded::<OutboundMessage>();
+
+    let result = tcp::listen(
+        privileged,
+        inbound_tx,
+        outbound_rx,
+        Arc::new(DashMap::new()),
+        test_acl(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a bind that cannot succeed must return Err, not log and carry on"
+    );
+}
+
 /// Helper: find a free port by binding and releasing.
 /// A loopback address reserved for this test, on a port the kernel will not
 /// hand to anything else.
@@ -211,7 +243,8 @@ async fn tcp_roundtrip() {
         None,
         None,
     )
-    .await;
+    .await
+    .expect("tcp listener must bind");
     tokio::time::sleep(SETTLE).await;
 
     // Client: connect and send OPTIONS
@@ -287,7 +320,8 @@ async fn tcp_close_notifies_flow_failure() {
         None,
         Some(close_tx),
     )
-    .await;
+    .await
+    .expect("tcp listener must bind");
     tokio::time::sleep(SETTLE).await;
 
     // Connect and send a request so we learn the assigned ConnectionId.
@@ -385,7 +419,8 @@ async fn tcp_outbound_fallback_to_pool_when_no_connection() {
         None,
         None,
     )
-    .await;
+    .await
+    .expect("tcp listener must bind");
     tokio::time::sleep(SETTLE).await;
 
     // 4) Fire-and-forget: send the OutboundMessage UacSender::send_request()
@@ -469,7 +504,8 @@ async fn tcp_responds_to_peer_crlf_ping_with_pong() {
         Some(Arc::clone(&tracker)),
         None,
     )
-    .await;
+    .await
+    .expect("tcp listener must bind");
     tokio::time::sleep(SETTLE).await;
 
     let mut client = connect_with_retry("tcp listener", || TcpStream::connect(addr)).await;
@@ -543,7 +579,8 @@ async fn tls_roundtrip() {
         None,
         None,
     )
-    .await;
+    .await
+    .expect("tls listener must bind");
     tokio::time::sleep(SETTLE).await;
 
     // Build a TLS client that trusts our self-signed cert
@@ -626,7 +663,8 @@ async fn ws_roundtrip() {
         None,
         None,
     )
-    .await;
+    .await
+    .expect("ws listener must bind");
     tokio::time::sleep(SETTLE).await;
 
     // Client: connect via WebSocket
@@ -714,7 +752,8 @@ async fn wss_roundtrip() {
         None,
         None,
     )
-    .await;
+    .await
+    .expect("ws listener must bind");
     tokio::time::sleep(SETTLE).await;
 
     // Manual TLS connect then WebSocket upgrade
@@ -828,7 +867,8 @@ async fn multi_transport_shared_inbound_channel() {
         None,
         None,
     )
-    .await;
+    .await
+    .expect("tcp listener must bind");
     ws::listen(
         ws_addr,
         inbound_tx.clone(),
@@ -839,7 +879,8 @@ async fn multi_transport_shared_inbound_channel() {
         None,
         None,
     )
-    .await;
+    .await
+    .expect("ws listener must bind");
     drop(inbound_tx); // Only transport workers hold clones now
     tokio::time::sleep(SETTLE).await;
 


### PR DESCRIPTION
Stacked on #325. Finishes the flake work from #324 by fixing the defect underneath it.

#324 moved the bind ahead of the spawn, which removed the scheduling race. What it did not fix: a failed bind was still only an `error!` line. `listen()` returned `()` either way, so siphon came up reporting healthy with a transport silently missing, and an operator learned of it from a customer. In the tests it showed as "never became connectable within 3s: Connection refused", which points at the wrong thing entirely — the listener was never going to exist.

`tcp`, `tls`, `ws`, `ws::listen_secure` and the mux now return `io::Result<()>`. A configured listener that cannot bind exits at startup, naming the transport and address, matching how the rest of `run_async` treats unusable config and how every other SIP proxy behaves on a failed listen.

**This is a deliberate behaviour change**: a box that previously came up with three of four listeners now refuses to start. That is the point — a SIP proxy missing a configured transport is not serving, and the old behaviour is the same "reads as done" shape as the other findings in this series.

- 6 production call sites in `server.rs` exit with the address and transport named.
- 20 test call sites assert the bind, so a failed bind is an immediate clear error rather than a timeout.
- New regression test `bind_failure_reaches_the_caller` binds privileged port 1 and asserts `Err`.

Six consecutive full-suite runs green, no flakes. clippy and fmt clean.
