### PR TITLE
ci: gate production file size and function length, both ratcheting down

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,18 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  # ── File-size gate ──────────────────────────────────────────────────────
+  # Production lines only (inline `#[cfg(test)]` stripped), so the gate cannot
+  # push tests out of a file to satisfy a number. Needs no toolchain at all —
+  # it reads the source, so it fails in seconds next to rustfmt.
+  file-size:
+    name: file size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: scripts/check_file_size.py
+      - run: scripts/check_too_many_lines_allows.py
+
   # ── Clippy lint gate ────────────────────────────────────────────────────
   # Mirrors the rust-tests build env (free-threaded Python 3.14 + libsctp-dev
   # are needed for the crate to compile at all). `-D warnings` turns any

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,6 +270,9 @@ unused = "warn"
 
 [lints.clippy]
 all = "warn"
+# Pedantic, so `all` does not enable it. See clippy.toml for the threshold and
+# why this matters more than the file-size gate.
+too_many_lines = "warn"
 
 [profile.release]
 strip = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,3 +8,18 @@
 # domain's inherently-wide protocol functions. This replaces the scattered
 # per-function `#[allow(clippy::too_many_arguments)]` attributes.
 too-many-arguments-threshold = 12
+
+# too-many-lines-threshold: the rule that would actually have prevented
+# dispatcher.rs. That file did not grow by adding functions, it grew by adding
+# to them — handle_b2bua_response passed 500 lines long before the file passed
+# 10,000, and no file-size gate catches that.
+#
+# 300 is where a match with a dozen arms still reads top to bottom. Twelve
+# functions exceed it today and each carries an #[allow] naming why: ten are in
+# dispatcher.rs and one is server.rs::run_async, all decomposed by the 1.9.0
+# module split, and the twelfth is metrics::SiphonMetrics::new, a flat table of
+# one registration per metric and a permanent exemption for the same reason its
+# file is on the size allowlist.
+#
+# scripts/check_too_many_lines_allows.py pins that count so it can only fall.
+too-many-lines-threshold = 300

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Fail when a Rust file carries more production lines than it should.
+
+Why production lines and not total LOC: a third of the files over 1,000 lines in
+this tree are 40-60% inline `#[cfg(test)]`. Counting those would flag the
+best-tested modules first and reward moving tests out of the file to satisfy a
+number, which is exactly backwards for a codebase whose test rule is
+non-negotiable.
+
+Why 1,500: it is where this tree's cohesive single-purpose modules actually sit
+(`script/engine.rs` 1,574, `admin/mod.rs` 1,572, `registrant/mod.rs` 1,504,
+`control/registry.rs` 1,493, `registrar/backend.rs` 1,485). A lower bar would
+flag modules that are fine and the allowlist would become noise; a higher one
+misses the files that genuinely need splitting.
+
+This is a *file* gate. The thing that actually produced `dispatcher.rs` was
+function length, not file length — the file grew by adding to functions, not by
+adding functions. `clippy::too_many_lines` covers that and is the more important
+of the two.
+
+Usage:
+    scripts/check_file_size.py            # gate (CI)
+    scripts/check_file_size.py --list     # print every file's production count
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+THRESHOLD = 1500
+ALLOWLIST = Path(__file__).with_name("file_size_allowlist.txt")
+
+CFG_TEST = re.compile(r"^\s*#\[cfg\(test\)\]")
+
+
+def production_lines(path: Path) -> int:
+    """Total lines minus every `#[cfg(test)]`-gated item.
+
+    Walks brace depth from the attribute to the end of the item it guards, so a
+    `#[cfg(test)] mod tests` and a lone `#[cfg(test)] const` are both excluded.
+    Braces inside string literals can skew the walk; that only ever *over*-counts
+    production lines, so the gate errs toward flagging rather than hiding.
+    """
+    lines = path.read_text(encoding="utf-8", errors="replace").split("\n")
+    total = len(lines)
+    test_lines = 0
+
+    index = 0
+    while index < total:
+        if not CFG_TEST.match(lines[index]):
+            index += 1
+            continue
+        end = index
+        depth = 0
+        opened = False
+        while end < total:
+            depth += lines[end].count("{") - lines[end].count("}")
+            if "{" in lines[end]:
+                opened = True
+            if opened and depth <= 0:
+                break
+            # A `#[cfg(test)]` on a one-line item (a const, a use) never opens a
+            # brace; stop at the end of that statement rather than running on.
+            if not opened and end > index and lines[end].rstrip().endswith(";"):
+                break
+            end += 1
+        test_lines += end - index + 1
+        index = end + 1
+
+    return total - test_lines
+
+
+def load_allowlist() -> dict[str, int]:
+    """`path  max_lines  # justification` per line."""
+    allowed: dict[str, int] = {}
+    if not ALLOWLIST.is_file():
+        return allowed
+    for raw in ALLOWLIST.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            sys.exit(f"error: malformed allowlist entry: {raw!r}")
+        allowed[parts[0]] = int(parts[1])
+    return allowed
+
+
+# `tests/` and `benches/` are test code end to end — there is no production
+# half to measure, and a long scenario file is not the problem this gate exists
+# for. `fuzz/` likewise.
+EXCLUDED_ROOTS = ("tests/", "benches/", "fuzz/")
+
+
+def tracked_rust_files() -> list[Path]:
+    listed = subprocess.run(
+        ["git", "ls-files", "*.rs"], capture_output=True, text=True, check=True
+    ).stdout.split()
+    return [
+        Path(p)
+        for p in listed
+        if Path(p).is_file()
+        and not any(part in p for part in ("/tests/", "/benches/", "/fuzz/"))
+        and not p.startswith(EXCLUDED_ROOTS)
+    ]
+
+
+def main() -> int:
+    counts = {str(p): production_lines(p) for p in tracked_rust_files()}
+
+    if "--list" in sys.argv:
+        for path, count in sorted(counts.items(), key=lambda kv: -kv[1])[:40]:
+            print(f"{count:>7}  {path}")
+        return 0
+
+    allowed = load_allowlist()
+    over: list[tuple[str, int, int]] = []
+    shrunk: list[tuple[str, int, int]] = []
+
+    for path, count in sorted(counts.items()):
+        cap = allowed.get(path)
+        if cap is None:
+            if count > THRESHOLD:
+                over.append((path, count, THRESHOLD))
+        elif count > cap:
+            over.append((path, count, cap))
+        elif count <= THRESHOLD:
+            # It no longer needs an exemption at all.
+            shrunk.append((path, count, cap))
+
+    for path in sorted(set(allowed) - set(counts)):
+        print(f"warning: allowlist names {path}, which no longer exists — drop the entry")
+
+    if shrunk:
+        print("These files are now under the threshold; remove their allowlist entries:")
+        for path, count, cap in shrunk:
+            print(f"  {path}: {count} production lines (allowed {cap}, threshold {THRESHOLD})")
+        print()
+
+    if over:
+        print(f"FAIL: {len(over)} file(s) over their production-line budget:")
+        for path, count, cap in over:
+            print(f"  {path}: {count} production lines (budget {cap})")
+        print()
+        print(
+            "Split the file, or add it to scripts/file_size_allowlist.txt with a\n"
+            "one-line justification. Raising an existing entry's number needs that\n"
+            "justification edited in the same diff — that edit is the review hook."
+        )
+        return 1
+
+    print(
+        f"OK: no file over {THRESHOLD} production lines "
+        f"({len(allowed)} allowlisted, {len(counts)} files checked)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_too_many_lines_allows.py
+++ b/scripts/check_too_many_lines_allows.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Pin the number of `#[allow(clippy::too_many_lines)]` so it can only fall.
+
+The lint is set at its target (300). Twelve functions exceed it and are allowed
+individually with a reason. Without this the easy way past the gate is another
+`#[allow]`, which is how a lint ends up enabled and meaningless.
+
+Lower BUDGET whenever the split removes one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+BUDGET = 12
+NEEDLE = "#[allow(clippy::too_many_lines)]"
+
+
+def main() -> int:
+    tracked = subprocess.run(
+        ["git", "ls-files", "*.rs"], capture_output=True, text=True, check=True
+    ).stdout.split()
+
+    found: list[str] = []
+    for path in tracked:
+        file = Path(path)
+        if not file.is_file():
+            continue
+        for number, line in enumerate(
+            file.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+        ):
+            if NEEDLE in line:
+                found.append(f"{path}:{number}")
+
+    if len(found) > BUDGET:
+        print(f"FAIL: {len(found)} {NEEDLE} (budget {BUDGET}).")
+        print("Split the function instead of allowing it. Current sites:")
+        for site in found:
+            print(f"  {site}")
+        return 1
+
+    if len(found) < BUDGET:
+        print(
+            f"{len(found)} {NEEDLE} — below the budget of {BUDGET}. "
+            f"Lower BUDGET in this script to lock the gain in."
+        )
+        return 0
+
+    print(f"OK: {len(found)} {NEEDLE}, at the budget of {BUDGET}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/file_size_allowlist.txt
+++ b/scripts/file_size_allowlist.txt
@@ -1,0 +1,45 @@
+# Files permitted above the 1,500 production-line threshold.
+#
+#   <path>  <max production lines>  # why
+#
+# The number is a ceiling, not a target: the gate fails if a listed file grows
+# past its own entry, so an exemption cannot quietly become a licence. Raising a
+# number means editing the justification in the same diff, and that edit is the
+# review hook. Shrinking a file below 1,500 should remove its entry — the gate
+# prints a reminder when that happens.
+#
+# Two entries below are permanent. The rest each name the split that retires
+# them; most are scheduled by the 1.9.0 module split.
+
+# ── Permanent ───────────────────────────────────────────────────────────────
+# Data, not logic. Splitting a table costs greppability and buys nothing.
+src/diameter/dictionary.rs  2400  # AVP dictionary (TS 29.229/32.299/29.272); a table
+src/metrics/mod.rs          1850  # metric registry: one struct field + one registration per metric
+
+# ── Scheduled for the 1.9.0 module split ────────────────────────────────────
+src/dispatcher.rs           30900  # THE reason this gate exists; splits into src/dispatcher/**
+src/config.rs                5050  # splits by YAML top-level key into src/config/**
+src/server.rs                3900  # run_async is one 2,214-line fn; splits into src/server/**
+src/b2bua/actor.rs           3550  # splits into actor/{leg,helpers,call,store,leg_actor}
+
+# ── PyO3 binding layer ──────────────────────────────────────────────────────
+# One `#[pymethods]` block per class without the `multiple-pymethods` feature,
+# which pulls the `inventory` crate — a new dependency for a navigation win, so
+# rejected. Splitting needs the thin-wrapper restructure, scheduled post-1.9.0.
+# A large share of each is `///` docstrings, which are the SDK's LLM context and
+# are load-bearing rather than padding.
+src/script/api/diameter.rs   3350  # single #[pymethods] block; kwargs marshalling per interface
+src/script/api/rtpengine.rs  2800  # same; profile-precedence extraction scheduled post-1.9.0
+src/script/api/call.rs       2600  # same; ~40% docstrings
+src/script/api/request.rs    1950  # same
+src/script/api/auth.rs       2050  # UAS digest authenticator moves to src/auth/server.rs post-1.9.0
+src/script/api/ipsec.rs      1600  # runtime lookups move to src/ipsec/runtime.rs
+
+# ── Cohesive today, split when next touched ─────────────────────────────────
+src/registrar/mod.rs         2250  # one impl Registrar over one store; contact/store split when touched
+src/rtpengine/siphon_rtp.rs  2200  # one backend; client/set/events/connection split when touched
+src/ipsec/mod.rs             2100  # types + impl IpsecManager; manager.rs split when touched
+src/control/sip_adapter.rs   2000  # 56 private fns, 1 pub item; splits by verb when touched
+src/script/engine.rs         1600  # 74 lines over; ratchet down on next touch
+src/admin/mod.rs             1600  # axum handlers; split by handler group when touched
+src/registrant/mod.rs        1550  # 4 lines over; ratchet down on next touch

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -667,6 +667,7 @@ where
 // Wide by necessity: the dispatcher loop is wired to every transport channel,
 // store, and engine handle at startup, exceeding the configured threshold.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. run: construction plus four event-drain loops; becomes dispatcher/{bootstrap,events}
 pub async fn run(
     inbound_rx: flume::Receiver<InboundMessage>,
     outbound: Arc<OutboundRouter>,
@@ -4281,6 +4282,7 @@ fn invite_action_target_gone(call_id: &str, calls: &crate::b2bua::actor::CallAct
 }
 
 /// Handle an inbound SIP request — run through Python handlers.
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. handle_request: security, method intercepts, script dispatch, action arms
 fn handle_request(
     inbound: InboundMessage,
     message: SipMessage,
@@ -5498,6 +5500,7 @@ fn flow_relay_egress(
 /// REGISTER.  Via host/port are derived from `flow.local_addr` so
 /// the UE's response routes back to the right port (load-bearing for
 /// IPSec sec-agree port pairs — 3GPP TS 33.203 §7.4).
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. relay_request: shares most of its body with relay_fork_branch; dedupe pending
 fn relay_request(
     message: &SipMessage,
     next_hop: Option<&str>,
@@ -6976,6 +6979,7 @@ fn fail_branch_locally(
 }
 
 /// Handle an inbound SIP response — route back to the original sender.
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. handle_response: pre-session guards + session forwarding; splits in two
 fn handle_response(
     inbound: InboundMessage,
     mut message: SipMessage,
@@ -15484,6 +15488,7 @@ impl InviteHandlerOutcome {
 ///
 /// Creates a Call object, invokes `@b2bua.on_invite`, and processes the
 /// script's action (dial, fork, reject).
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. handle_b2bua_invite: guards, call creation, script dispatch, action arms
 fn handle_b2bua_invite(inbound: InboundMessage, message: SipMessage, state: &DispatcherState) {
     let sip_call_id = message
         .headers
@@ -16947,6 +16952,7 @@ fn advertise_option_tag(headers: &mut crate::sip::headers::SipHeaders, tag: &str
 /// never saw a packet for). The proxy's own relay answers `502` the moment a
 /// target will not resolve; this is the B2BUA half of that.
 #[must_use = "an unsent B-leg INVITE must fail the call now, not at the ring timeout"]
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. b2bua_send_b_leg_invite
 fn b2bua_send_b_leg_invite(
     call_id: &str,
     target_uri: &str,
@@ -18130,6 +18136,7 @@ fn collect_route_set(message: &SipMessage, header_name: &str) -> Vec<String> {
 const MAX_B2BUA_AUTH_RETRIES: u32 = 2;
 
 /// Handle a response to a B2BUA B-leg INVITE.
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. handle_b2bua_response: guards + a three-arm match; becomes dispatcher/b2bua/response/*
 fn handle_b2bua_response(
     call_id: &str,
     branch: &str,
@@ -26743,6 +26750,7 @@ fn reject_unanchorable_offer(
     );
 }
 
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. handle_b2bua_reinvite
 fn handle_b2bua_reinvite(inbound: InboundMessage, message: SipMessage, state: &DispatcherState) {
     let sip_call_id = message
         .headers
@@ -27397,6 +27405,7 @@ fn handle_b2bua_reinvite(inbound: InboundMessage, message: SipMessage, state: &D
 /// Tracking uses the `update:` / `update_done:` target_uri prefixes so that
 /// concurrent re-INVITE and UPDATE on the same dialog don't collide on a
 /// single B-leg slot.
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. handle_b2bua_update
 fn handle_b2bua_update(inbound: InboundMessage, message: SipMessage, state: &DispatcherState) {
     let sip_call_id = message
         .headers
@@ -30537,6 +30546,7 @@ fn is_siprec_invite(message: &SipMessage) -> bool {
 /// Parses the multipart body, extracts SDP and recording metadata,
 /// creates an SRS session, optionally sets up RTPEngine recording,
 /// and sends 200 OK back to the SRC.
+#[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. handle_srs_invite
 fn handle_srs_invite(
     inbound: InboundMessage,
     message: SipMessage,

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -587,6 +587,7 @@ pub struct SiphonMetrics {
 }
 
 impl SiphonMetrics {
+    #[allow(clippy::too_many_lines)] // Permanent: SiphonMetrics::new: one registration per metric — a table, like the struct it fills
     fn new() -> Result<Self, prometheus::Error> {
         let registry = Registry::new();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -346,6 +346,7 @@ impl SiphonServer {
     }
 
     /// Async entry point — all the real work happens here.
+    #[allow(clippy::too_many_lines)] // TODO(1.9.0 split): decomposed by the dispatcher module split. run_async: 60 bootstrap sections; becomes src/server/{logging,components,...}
     async fn run_async(mut self) {
         let product_name = self.product_name.unwrap_or("SIPhon");
         let product_version = self.product_version.unwrap_or(env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
Phase 0 guard 2 of 3. Two ratcheting gates, both in the existing `file-size` CI job.

File size at 1,500 *production* lines (inline `#[cfg(test)]` stripped, otherwise the best-tested modules flag first). 19 files allowlisted, each with its own ceiling and a justification; raising one means editing the justification in the same diff.

Function length via `clippy::too_many_lines` at 300, the rule that would actually have prevented dispatcher.rs — it grew by adding to functions, not by adding functions. Twelve `#[allow]`s today, pinned by a script so the count can only fall.

Verified both halves fail when they should. Suite, clippy, fmt green.
